### PR TITLE
Vault service

### DIFF
--- a/frontend/src/components/keygen/KeygenView.tsx
+++ b/frontend/src/components/keygen/KeygenView.tsx
@@ -60,7 +60,7 @@ const KeygenView: React.FC<KeygenViewProps> = ({
     async function kickoffKeygen() {
       const newVault =
         await vaultService
-          .StartKeygen(vault, sessionID, hexEncryptionKey, serverURL)
+          .startKeygen(vault, sessionID, hexEncryptionKey, serverURL)
           .catch(err => {
             console.log(err);
             onError(err);
@@ -76,7 +76,7 @@ const KeygenView: React.FC<KeygenViewProps> = ({
     async function kickoffReshare() {
       const newVault =
         await vaultService
-          .Reshare(vault, sessionID, hexEncryptionKey, serverURL)
+          .reshare(vault, sessionID, hexEncryptionKey, serverURL)
           .catch(err => {
             console.log(err);
             onError(err);

--- a/frontend/src/services/Vault/IVaultService.ts
+++ b/frontend/src/services/Vault/IVaultService.ts
@@ -1,0 +1,17 @@
+import { storage } from "../../../wailsjs/go/models";
+
+export interface IVaultService {
+    Reshare(
+        vault: any,
+        sessionID: any,
+        hexEncryptionKey: any,
+        serverURL: any): Promise<storage.Vault | undefined>;
+
+    StartKeygen(
+        vault: any,
+        sessionID: any,
+        hexEncryptionKey: any,
+        serverURL: any
+    ): Promise<storage.Vault | undefined>;
+
+}

--- a/frontend/src/services/Vault/IVaultService.ts
+++ b/frontend/src/services/Vault/IVaultService.ts
@@ -1,17 +1,23 @@
 import { storage } from "../../../wailsjs/go/models";
 
 export interface IVaultService {
-    Reshare(
+    reshare(
         vault: any,
         sessionID: any,
         hexEncryptionKey: any,
         serverURL: any): Promise<storage.Vault | undefined>;
 
-    StartKeygen(
+    startKeygen(
         vault: any,
         sessionID: any,
         hexEncryptionKey: any,
         serverURL: any
     ): Promise<storage.Vault | undefined>;
+
+    importVault(buffer: Buffer): Promise<void>;
+
+    encryptVault(passwd: string, vault: Buffer): Buffer;
+
+    decryptVault(passwd: string, vault: Buffer): Buffer;
 
 }

--- a/frontend/src/services/Vault/VaultService.ts
+++ b/frontend/src/services/Vault/VaultService.ts
@@ -1,0 +1,50 @@
+import { WalletCore } from "@trustwallet/wallet-core";
+import { storage } from "../../../wailsjs/go/models";
+import { SaveVault } from "../../../wailsjs/go/storage/Store";
+import { Reshare, StartKeygen } from "../../../wailsjs/go/tss/TssService";
+import { DefaultCoinsService } from "../Coin/DefaultCoinsService";
+import { IVaultService } from "./IVaultService";
+
+export class VaultService implements IVaultService {
+
+    private walletCore: WalletCore;
+    constructor(walletCore: WalletCore) {
+        this.walletCore = walletCore;
+    }
+
+    async StartKeygen(vault: any, sessionID: any, hexEncryptionKey: any, serverURL: any): Promise<storage.Vault | undefined> {
+        const newVault = await StartKeygen(
+            vault.name,
+            vault.local_party_id,
+            sessionID,
+            vault.hex_chain_code,
+            hexEncryptionKey,
+            serverURL
+        ).catch(err => {
+            console.log(err);
+        });
+
+        if (newVault !== undefined) {
+            await SaveVault(newVault);
+            new DefaultCoinsService(this.walletCore).applyDefaultCoins(newVault);
+            return newVault;
+        }
+    }
+
+    async Reshare(vault: any, sessionID: any, hexEncryptionKey: any, serverURL: any): Promise<storage.Vault | undefined> {
+        const newVault = await Reshare(
+            vault,
+            sessionID,
+            hexEncryptionKey,
+            serverURL
+        ).catch(err => {
+            console.log(err);
+        });
+
+        if (newVault !== undefined) {
+            await SaveVault(newVault);
+            new DefaultCoinsService(this.walletCore).applyDefaultCoins(newVault);
+            return newVault;
+        }
+    }
+}

--- a/frontend/src/services/Vault/VaultService.ts
+++ b/frontend/src/services/Vault/VaultService.ts
@@ -4,6 +4,8 @@ import { SaveVault } from "../../../wailsjs/go/storage/Store";
 import { Reshare, StartKeygen } from "../../../wailsjs/go/tss/TssService";
 import { DefaultCoinsService } from "../Coin/DefaultCoinsService";
 import { IVaultService } from "./IVaultService";
+import crypto from 'crypto';
+import { Vault } from "../../gen/vultisig/vault/v1/vault_pb";
 
 export class VaultService implements IVaultService {
 
@@ -12,7 +14,7 @@ export class VaultService implements IVaultService {
         this.walletCore = walletCore;
     }
 
-    async StartKeygen(vault: any, sessionID: any, hexEncryptionKey: any, serverURL: any): Promise<storage.Vault | undefined> {
+    async startKeygen(vault: any, sessionID: any, hexEncryptionKey: any, serverURL: any): Promise<storage.Vault | undefined> {
         const newVault = await StartKeygen(
             vault.name,
             vault.local_party_id,
@@ -31,7 +33,7 @@ export class VaultService implements IVaultService {
         }
     }
 
-    async Reshare(vault: any, sessionID: any, hexEncryptionKey: any, serverURL: any): Promise<storage.Vault | undefined> {
+    async reshare(vault: any, sessionID: any, hexEncryptionKey: any, serverURL: any): Promise<storage.Vault | undefined> {
         const newVault = await Reshare(
             vault,
             sessionID,
@@ -47,4 +49,76 @@ export class VaultService implements IVaultService {
             return newVault;
         }
     }
+
+    async importVault(buffer: Buffer) {
+        const vault = Vault.fromBinary(buffer);
+        const storageVault = {
+            name: vault.name,
+            public_key_ecdsa: vault.publicKeyEcdsa,
+            public_key_eddsa: vault.publicKeyEddsa,
+            signers: vault.signers,
+            created_at: vault.createdAt,
+            hex_chain_code: vault.hexChainCode,
+            keyshares: vault.keyShares.map(share => ({
+                public_key: share.publicKey,
+                keyshare: share.keyshare,
+            })),
+            local_party_id: vault.localPartyId,
+            reshare_prefix: vault.resharePrefix,
+            order: 0,
+            is_backed_up: true,
+            coins: [],
+            convertValues: () => { },
+        };
+        await SaveVault(storageVault);
+        new DefaultCoinsService(this.walletCore).applyDefaultCoins(storageVault);
+    }
+
+    encryptVault(passwd: string, vault: Buffer): Buffer {
+        // Hash the password to create a key
+        const key = crypto.createHash('sha256').update(passwd).digest();
+
+        // Generate a random nonce (12 bytes for GCM)
+        const nonce = crypto.randomBytes(12);
+
+        // Create a new AES cipher using the key and nonce
+        const cipher = crypto.createCipheriv('aes-256-gcm', key, nonce);
+
+        // Encrypt the vault
+        const ciphertext = Buffer.concat([cipher.update(vault), cipher.final()]);
+
+        // Get the authentication tag (16 bytes)
+        const authTag = cipher.getAuthTag();
+
+        // Combine nonce, ciphertext, and authTag into a single buffer
+        return Buffer.concat([nonce, ciphertext, authTag]);
+    };
+
+    decryptVault(passwd: string, vault: Buffer): Buffer {
+        // Hash the password to create a key
+        const key = crypto.createHash('sha256').update(passwd).digest();
+
+        // Create a new AES cipher using the key
+        const decipher = crypto.createDecipheriv(
+            'aes-256-gcm',
+            key,
+            vault.slice(0, 12)
+        );
+
+        // Extract the nonce from the vault
+        // const nonce = vault.slice(0, 12);
+        const ciphertext = vault.slice(12, -16); // Exclude the nonce and the auth tag
+        const authTag = vault.slice(-16); // Last 16 bytes is the auth tag
+
+        // Set the authentication tag
+        decipher.setAuthTag(authTag);
+
+        // Decrypt the vault
+        const decrypted = Buffer.concat([
+            decipher.update(ciphertext),
+            decipher.final(),
+        ]);
+
+        return decrypted;
+    };
 }

--- a/frontend/src/services/Vault/VaultServiceFactory.ts
+++ b/frontend/src/services/Vault/VaultServiceFactory.ts
@@ -1,0 +1,9 @@
+import { WalletCore } from "@trustwallet/wallet-core";
+import { IVaultService } from "./IVaultService";
+import { VaultService } from "./VaultService";
+
+export class VaultServiceFactory {
+    static getService(walletCore: WalletCore): IVaultService {
+        return new VaultService(walletCore);
+    }
+}

--- a/frontend/src/utils/util.ts
+++ b/frontend/src/utils/util.ts
@@ -1,4 +1,3 @@
-import crypto from 'crypto';
 import { TFunction } from 'i18next';
 
 export const isBase64Encoded = (str: string): boolean => {
@@ -8,34 +7,6 @@ export const isBase64Encoded = (str: string): boolean => {
 
   // Check if the string matches the base64 pattern
   return base64Regex.test(str);
-};
-
-export const decryptVault = (passwd: string, vault: Buffer): Buffer => {
-  // Hash the password to create a key
-  const key = crypto.createHash('sha256').update(passwd).digest();
-
-  // Create a new AES cipher using the key
-  const decipher = crypto.createDecipheriv(
-    'aes-256-gcm',
-    key,
-    vault.slice(0, 12)
-  );
-
-  // Extract the nonce from the vault
-  // const nonce = vault.slice(0, 12);
-  const ciphertext = vault.slice(12, -16); // Exclude the nonce and the auth tag
-  const authTag = vault.slice(-16); // Last 16 bytes is the auth tag
-
-  // Set the authentication tag
-  decipher.setAuthTag(authTag);
-
-  // Decrypt the vault
-  const decrypted = Buffer.concat([
-    decipher.update(ciphertext),
-    decipher.final(),
-  ]);
-
-  return decrypted;
 };
 
 export function generateRandomNumber(): number {


### PR DESCRIPTION
We have to move any logic communicating with HTTP/WebSockets, and Databases from the UI. 

Why do we reuse it in different views? Also, we can create and expose APIs to the external world if we want. 

Here I am moving the:

- [x] Keysign
- [x] Reshare
- [x] Import

I will have to create the logic to backup in another PR

- [ ] Backup

For backup, we have to get the logic from here. 

https://github.com/vultisig/vultisig-ios/blob/main/VultisigApp/VultisigApp/View%20Models/EncryptedBackupViewModel.swift#L22