### PR TITLE
fix/evm-tokens-remove-nil-address

### DIFF
--- a/frontend/src/services/Rpc/evm/RpcServiceEvm.ts
+++ b/frontend/src/services/Rpc/evm/RpcServiceEvm.ts
@@ -344,7 +344,11 @@ export class RpcServiceEvm implements IRpcService, ITokenService {
       // Filter tokens with non-zero balance
       const nonZeroBalanceTokenAddresses = Object.entries(balanceData)
         .filter(([_, balance]) => BigInt(balance as string) > 0n) // Ensure the balance is non-zero
-        .map(([tokenAddress]) => tokenAddress);
+        .map(([tokenAddress]) => tokenAddress)
+        .filter(
+          tokenAddress =>
+            tokenAddress !== '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+        );
 
       if (nonZeroBalanceTokenAddresses.length === 0) {
         return [];


### PR DESCRIPTION
Following the same rules of IOS we should not add nil addresses from 1Inch. 

Swift

```
 private var nullAddress: String {
        return "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
    }
    
    let nonZeroBalanceTokenAddresses = balanceDictionary.compactMap { tokenAddress, balance in
            (Int64(balance) ?? 0) > 0 && tokenAddress != nullAddress ? tokenAddress : nil
        }

```

Issue
https://github.com/vultisig/vultisig-windows/issues/242