### PR TITLE
feat: extend vault backup logic

### DIFF
--- a/frontend/src/components/vaultBackupBanner/VaultBackupBanner.styles.tsx
+++ b/frontend/src/components/vaultBackupBanner/VaultBackupBanner.styles.tsx
@@ -20,4 +20,6 @@ export const Wrapper = styled.div`
 
 export const ChevronIconButton = styled(UnstyledButton)`
   color: ${({ theme }) => theme.colors.contrast.toCssValue()};
+  display: grid;
+  place-items: center;
 `;

--- a/frontend/src/components/vaultBackupBanner/VaultBackupBanner.tsx
+++ b/frontend/src/components/vaultBackupBanner/VaultBackupBanner.tsx
@@ -21,7 +21,7 @@ const VaultBackupBanner = () => {
           Backup your vault now!
         </Text>
         <ChevronIconButton onClick={() => navigate(appPaths.vaultBackup)}>
-          <ChevronRightIcon />
+          <ChevronRightIcon size={24} />
         </ChevronIconButton>
       </Content>
     </Wrapper>

--- a/frontend/src/lib/ui/icons/ChevronRightIcon.tsx
+++ b/frontend/src/lib/ui/icons/ChevronRightIcon.tsx
@@ -1,9 +1,13 @@
-export const ChevronRightIcon = () => {
+export const ChevronRightIcon = ({
+  size = '1em',
+}: {
+  size?: number | string;
+}) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="1em"
-      height="1em"
+      width={size}
+      height={size}
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"

--- a/frontend/src/services/Vault/IVaultService.ts
+++ b/frontend/src/services/Vault/IVaultService.ts
@@ -19,6 +19,8 @@ export interface IVaultService {
 
   importVault(buffer: Buffer): Promise<void>;
 
+  saveVault(vault: storage.Vault): Promise<void>;
+
   encryptVault(passwd: string, vault: Buffer): Buffer;
 
   decryptVault(passwd: string, vault: Buffer): Buffer;

--- a/frontend/src/services/Vault/VaultService.ts
+++ b/frontend/src/services/Vault/VaultService.ts
@@ -27,6 +27,10 @@ export class VaultService implements IVaultService {
     this.walletCore = walletCore;
   }
 
+  async saveVault(vault: storage.Vault): Promise<void> {
+    return await SaveVault(vault);
+  }
+
   async getVaultSettings(): Promise<storage.Settings[]> {
     return await GetSettings();
   }

--- a/frontend/src/vault/mutations/useBackupVaultMutation.ts
+++ b/frontend/src/vault/mutations/useBackupVaultMutation.ts
@@ -18,7 +18,11 @@ export const useBackupVaultMutation = () => {
       vault: storage.Vault;
       password: string;
     }) => {
-      return await vaultService.createAndSaveBackup(vault, password);
+      await vaultService.createAndSaveBackup(vault, password);
+      await vaultService.saveVault({
+        ...vault,
+        is_backed_up: true,
+      } as storage.Vault);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({


### PR DESCRIPTION
Extend vault backup logic to include a second step which is invoking saveVault() endpoint to manually modify the vault's _is_backed_up_ property to **true**.