### PR TITLE
fix: vault qr being saved with wrong extension

### DIFF
--- a/app.go
+++ b/app.go
@@ -48,7 +48,9 @@ func (a *App) SaveFileBkp(suggestedFilename string, base64Data string) (string, 
 func (a *App) SaveFile(suggestedFilename string, base64Data string) (string, error) {
 	filename, err := runtime.SaveFileDialog(a.ctx, runtime.SaveDialogOptions{
 		Title:           "Save File",
-		Filters:         []runtime.FileFilter{{DisplayName: "All Files(*)", Pattern: "*.bak;*.dat;*.vult"}},
+		Filters:         []runtime.FileFilter{
+            {DisplayName: "All Supported Files (*.png;*.bak;*.dat;*.vult)", Pattern: "*.png;*.bak;*.dat;*.vult"},
+        },
 		DefaultFilename: suggestedFilename,
 	})
 	if err != nil {


### PR DESCRIPTION
Vault QR being saved with the wrong extension as per: https://github.com/vultisig/vultisig-windows/issues/365