### PR TITLE
Avoid urlencode QR code parameters

### DIFF
--- a/frontend/src/lib/utils/query/addQueryParams.ts
+++ b/frontend/src/lib/utils/query/addQueryParams.ts
@@ -3,7 +3,7 @@ export const addQueryParams = (
   params: Record<string, string | number | boolean>
 ) => {
   const query = Object.entries(params)
-    .map(pair => pair.map(encodeURIComponent).join('='))
+    .map(pair => pair.join('='))
     .join('&');
 
   return [baseUrl, query].join(baseUrl.includes('?') ? '&' : '?');


### PR DESCRIPTION
URL encoded all the parameters , which cause android to break
There is no need to URL encode it 