### PR TITLE
fix polkadot balance

### DIFF
--- a/frontend/src/services/Rpc/polkadot/RpcServicePolkadot.ts
+++ b/frontend/src/services/Rpc/polkadot/RpcServicePolkadot.ts
@@ -76,7 +76,9 @@ export class RpcServicePolkadot extends RpcService implements IRpcService {
         const result = await response.json();
 
         if (result.data?.account?.balance) {
-          const balance = BigInt(Number(result.data.account.balance) * 10e10);
+          const balance = BigInt(
+            Number(result.data.account.balance) * 10 ** 10
+          );
           return balance;
         }
       } catch (error) {


### PR DESCRIPTION
10e10 is equal to 10 ** 11 which is wrong.

The fix is 10 ** 10 instead, which is correct.

The balance on Explorer
<img width="707" alt="image" src="https://github.com/user-attachments/assets/11959086-59ad-47e3-a712-8056f56d778e">

Our fixed balance:
<img width="1029" alt="image" src="https://github.com/user-attachments/assets/c4c878b1-159e-4cc3-91cb-efeaf4fb11e5">
