### PR TITLE
fix: get cosmos account info missing fallback

### DIFF
--- a/frontend/src/chain/cosmos/account/getCosmosAccountInfo.ts
+++ b/frontend/src/chain/cosmos/account/getCosmosAccountInfo.ts
@@ -67,6 +67,6 @@ export const getCosmosAccountInfo = async (
 
   return {
     accountNumber: Number(account_number),
-    sequence: Number(sequence),
+    sequence: Number(sequence ?? 0),
   };
 };


### PR DESCRIPTION
fix: add missing fallback for getCosmosAccount's sequence when no CACAO tokens are owned by user to avoid failing