### PR TITLE
feat: improve README/scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ This monorepo contains two main components:
 
 ## Desktop Application
 
+### Technical Requirements
+
+This project uses Wails. Please refer to https://wails.io/docs/gettingstarted/installation/ for installation instructions.
+
+### For Linux Users
+
+Vultisig under Linux requires `libwebkit2gtk-4.0-dev`. Install it with:
+
+```bash
+sudo apt update
+sudo apt install libwebkit2gtk-4.0-dev
+```
+
 ### Development
 
 To run the desktop application in development mode:
@@ -23,19 +36,6 @@ To build the desktop app dist:
 
 ```bash
 yarn build:desktop
-```
-
-### Technical Requirements
-
-This project uses Wails. Please refer to https://wails.io/docs/gettingstarted/installation/ for installation instructions.
-
-### For Linux Users
-
-Vultisig under Linux requires `libwebkit2gtk-4.0-dev`. Install it with:
-
-```bash
-sudo apt update
-sudo apt install libwebkit2gtk-4.0-dev
 ```
 
 For Ubuntu 24.4 users who can't find `libwebkit2gtk-4.0-dev`:

--- a/README.md
+++ b/README.md
@@ -82,17 +82,3 @@ yarn build:extension
 2. Enable "Developer mode" (top-right corner)
 3. Click "Load unpacked" and select the `dist` folder from the extension
 4. The extension should now be installed and ready to use
-
-## Linux Users
-
-Vultisig under linux require `libwebkit2gtk-4.0-dev` , usually you can run the following commands to install it:
-
-```
-sudo apt update
-sudo apt install libwebkit2gtk-4.0-dev
-```
-
-If you are using Ubuntu 24.4 and it can't find `libwebkit2gtk-4.0-dev`, then here is the workaround:
-
-1. add `deb http://gb.archive.ubuntu.com/ubuntu jammy main` to `/etc/apt/sources.list`
-2. and run `sudo apt update` and `sudo apt install libwebkit2gtk-4.0-dev`

--- a/README.md
+++ b/README.md
@@ -1,75 +1,98 @@
-# README
+# Vultisig Desktop & VultiConnect
 
-This is Vultisig windows application
+This monorepo contains two main components:
+1. The Vultisig Desktop Application (currently Windows-only, with support for other platforms coming soon)
+2. The VultiConnect Browser Extension - A Chrome extension for bridging your Vultisig vaults to dApps
 
-## Install wails
+## Desktop Application
 
-This project is using a tool call wails, please refer to https://wails.io/docs/gettingstarted/installation/ to install wails
+### Development
 
-## Live Development
-
-To run in live development mode, run `wails dev` in the project directory. This will run a Vite development
-server that will provide very fast hot reload of your frontend changes. If you want to develop in a browser
-and have access to your Go methods, there is also a dev server that runs on http://localhost:34115. Connect
-to this in your browser, and you can call your Go code from devtools.
-
-## Building
-
-To build a redistributable, production mode package, use `wails build`.
-
-## Generate protobuf files for type script
-
-The keysign / keygen related messages are defined in https://github.com/vultisig/commondata , it is shared between IOS/Android/Windows , and also other projects
-If you need to make an update to the proto file, make sure you raise a PR in https://github.com/vultisig/commondata
-
-To generate the proto files for typescript, run the following command in the frontend directory
+To run the desktop application in development mode:
 
 ```bash
-. ./scripts/sync_protobuf.sh
+yarn dev:desktop
 ```
 
-## Update protobuf files for type script
+**Important Note:** This will expose two dev servers: one on 34115 (the Wails development server) and a Vite development server on port 5173.
+Always use the former, as the Vite development server won't have the requited Wails-injected scripts.
 
-To git pull for a submodule, you have a few options:
+### Building
 
-1. Pull for the specific submodule:
+To build the desktop app dist:
 
 ```bash
-git submodule update --remote frontend/commondata
+yarn build:desktop
 ```
 
-2. Pull for all submodules:
+### Technical Requirements
+
+This project uses Wails. Please refer to https://wails.io/docs/gettingstarted/installation/ for installation instructions.
+
+### For Linux Users
+
+Vultisig under Linux requires `libwebkit2gtk-4.0-dev`. Install it with:
 
 ```bash
-git submodule update --remote
+sudo apt update
+sudo apt install libwebkit2gtk-4.0-dev
 ```
 
-3. If you want to pull and also initialize/update nested submodules:
+For Ubuntu 24.4 users who can't find `libwebkit2gtk-4.0-dev`:
+1. Add `deb http://gb.archive.ubuntu.com/ubuntu jammy main` to `/etc/apt/sources.list`
+2. Run `sudo apt update && sudo apt install libwebkit2gtk-4.0-dev`
+
+## VultiConnect Extension
+
+> Note: The VultiConnect repository has been moved into this monorepo (https://github.com/vultisig/vultisig-windows) to enable code sharing between the extension and desktop application.
+
+### What is VultiConnect?
+
+VultiConnect is a Chrome extension similar to MetaMask but much safer. It does not store any critical information such as private keys or passwords. Instead, it acts as a bridge that allows you to connect your Vultisig app to DeFi applications, enabling you to interact with them and sign transactions securely on your devices.
+
+### How Safe is VultiConnect?
+
+You only need to import public keys and vault information into VultiConnect. Unlike MetaMask, if someone hacks your Chrome or the extension, they cannot execute transactions without your approval on your Vultisig devices, as they only have access to public information.
+
+### Requirements
+
+Before building VultiConnect, ensure you have the following installed:
+- `Node.js` (version 18.10.0 or later)
+- `yarn` (for managing packages)
+
+### Development
+
+To run the Vulticonnect extension in development mode:
 
 ```bash
-git submodule update --init --recursive
+yarn dev:extension
 ```
 
-4. If you want to pull the main repository and all its submodules in one command:
+### Building
+
+To build the extension:
 
 ```bash
-git pull --recurse-submodules
+yarn build:extension
 ```
 
-Each of these commands will fetch and update the submodule to its latest commit on the remote branch.
+### Installing in Chrome
 
-Tip: Make sure you're in the root directory of your main repository when running these commands.
+1. Open Chrome and navigate to `chrome://extensions`
+2. Enable "Developer mode" (top-right corner)
+3. Click "Load unpacked" and select the `dist` folder from the extension
+4. The extension should now be installed and ready to use
 
-## FOR Linux user
+## Linux Users
 
-Vultisig under linux require `libwebkit2gtk-4.0-dev` , usually you can run the following command to install it
+Vultisig under linux require `libwebkit2gtk-4.0-dev` , usually you can run the following commands to install it:
 
 ```
 sudo apt update
 sudo apt install libwebkit2gtk-4.0-dev
 ```
 
-If you are using ubuntu 24.4 and it can't find `libwebkit2gtk-4.0-dev` , then here is the workaround
+If you are using Ubuntu 24.4 and it can't find `libwebkit2gtk-4.0-dev`, then here is the workaround:
 
 1. add `deb http://gb.archive.ubuntu.com/ubuntu jammy main` to `/etc/apt/sources.list`
 2. and run `sudo apt update` and `sudo apt install libwebkit2gtk-4.0-dev`

--- a/clients/desktop/index.html
+++ b/clients/desktop/index.html
@@ -4,8 +4,6 @@
     <meta charset="UTF-8" />
     <meta content="width=device-width, initial-scale=1.0" name="viewport" />
     <title>vultisig-win</title>
-    <script src="/wails/ipc.js"></script>
-    <script src="/wails/runtime.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,11 @@
     "./**"
   ],
   "scripts": {
-    "build": "yarn workspace @clients/desktop build"
+    "dev:desktop": "wails dev",
+    "dev:desktop:vite": "yarn workspace @clients/desktop dev",
+    "build:desktop": "yarn workspace @clients/desktop build",
+    "build:extension": "yarn workspace @clients/extension build",
+    "dev:extension": "yarn workspace @clients/extension dev"
   },
   "dependencies": {
     "7z-wasm": "^1.1.0",


### PR DESCRIPTION
This PR:

1. improves README following addition of extension to vultisig-windows as a now monorepo
  - Adds explicit desktop app / extension sections
  - Adds note re: using Wails port vs. Vite port for local dev
  - Removes unused protobuf bits
2. Adds package.json scripts in monorepo's root for both desktop app and extension
3. Removes explicit Wails scripts injection ([automatically-injected by Wails](https://wails.io/docs/guides/frontend/#script-injection), but will 404 if trying to run the app outside of Wails context e.g within Capacitor or as a regular Vite webapp)