### PR TITLE
Fix prioritize button in vulticonnect

### DIFF
--- a/clients/extension/src/content/index.ts
+++ b/clients/extension/src/content/index.ts
@@ -912,7 +912,6 @@ window.vultisig = vultisigProvider;
 window.xfi = xfiProvider;
 window.xfi.kepler = keplrProvider;
 
-if (!window.ethereum) window.ethereum = ethereumProvider;
 
 announceProvider({
   info: {


### PR DESCRIPTION
Fix #966 

Currently, if `window.ethereum` is empty (Metamask is not installed), we ignore the prioritize button and automatically load our extension before others (e.g., ctrl) on `window.ethereum`, even if the user has disabled prioritization. This behavior is incorrect, as we should always respect the prioritize button's value.
