### PR TITLE
Fix Vulticonnect forcing connection to the active vault

### DIFF
--- a/clients/extension/src/pages/accounts/index.scss
+++ b/clients/extension/src/pages/accounts/index.scss
@@ -27,7 +27,7 @@
   }
 
   > .content {
-    .ant-checkbox {
+    .ant-radio {
       + span {
         padding-right: 0;
         width: 100%;

--- a/clients/extension/src/pages/accounts/index.tsx
+++ b/clients/extension/src/pages/accounts/index.tsx
@@ -1,6 +1,6 @@
 import { StrictMode, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Button, Checkbox, Form } from "antd";
+import { Button, Form, Radio } from "antd";
 import ReactDOM from "react-dom/client";
 
 import { ChainKey } from "../../utils/constants";
@@ -24,7 +24,7 @@ import "../../styles/index.scss";
 import "../accounts/index.scss";
 
 interface FormProps {
-  uids: string[];
+  uid: string;
 }
 
 interface InitialState {
@@ -49,20 +49,21 @@ const Component = () => {
   };
 
   const handleSubmit = () => {
-    form.validateFields().then(({ uids }: FormProps) => {
+    form.validateFields().then(({ uid }: FormProps) => {
       if (sender) {
         getStoredVaults().then((vaults) => {
           setStoredVaults(
             vaults.map((vault) => ({
               ...vault,
               apps:
-                uids.indexOf(vault.uid) >= 0
+                uid === vault.uid
                   ? [
                       sender,
                       ...(vault.apps?.filter((app) => app !== sender) ?? []),
                     ]
-                  : vault.apps?.filter((app) => app !== sender) ?? [],
-            }))
+                  : (vault.apps?.filter((app) => app !== sender) ?? []),
+              active: uid === vault.uid ? true : false,
+            })),
           ).then(() => {
             handleClose();
           });
@@ -127,14 +128,14 @@ const Component = () => {
             <div className="content">
               <Form form={form} onFinish={handleSubmit}>
                 <Form.Item<FormProps>
-                  name="uids"
+                  name="uid"
                   rules={[
                     { required: true, message: t(messageKeys.SELECT_A_VAULT) },
                   ]}
                 >
-                  <Checkbox.Group>
+                  <Radio.Group>
                     {vaults.map(({ chains, name, uid }) => (
-                      <Checkbox key={uid} value={uid}>
+                      <Radio key={uid} value={uid}>
                         <span className="name">{name}</span>
                         <MiddleTruncate
                           text={
@@ -142,9 +143,9 @@ const Component = () => {
                               ?.address ?? ""
                           }
                         />
-                      </Checkbox>
+                      </Radio>
                     ))}
-                  </Checkbox.Group>
+                  </Radio.Group>
                 </Form.Item>
                 <Button htmlType="submit" />
               </Form>
@@ -169,5 +170,5 @@ const Component = () => {
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <Component />
-  </StrictMode>
+  </StrictMode>,
 );

--- a/clients/extension/src/pages/vaults/index.scss
+++ b/clients/extension/src/pages/vaults/index.scss
@@ -29,5 +29,21 @@
         }
       }
     }
+
+    .ant-radio {
+      + span {
+        padding-right: 0;
+        width: 100%;
+
+        .name {
+          display: block;
+          font-size: rem(14);
+          line-height: rem(20);
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+      }
+    }
   }
 }

--- a/clients/extension/src/styles/_global.scss
+++ b/clients/extension/src/styles/_global.scss
@@ -194,6 +194,53 @@ body {
   }
 }
 
+.ant-radio-group {
+  border-radius: rem(12);
+  overflow: hidden;
+
+  .ant-radio-wrapper {
+    background-color: $blue-base;
+    line-height: rem(24);
+    padding: rem(16) rem(20);
+    position: relative;
+    transition: background-color 0.3s;
+    width: 100%;
+
+    .ant-radio-input {
+      height: rem(20);
+      width: rem(20);
+    }
+
+    .ant-radio-inner {
+      background-color: transparent;
+      border-color: $blue-light;
+      border-width: rem(2);
+      height: rem(20);
+      width: rem(20);
+    }
+
+    .ant-radio-checked {
+      .ant-radio-inner {
+        background-color: $cyan-base;
+        border-color: $cyan-base;
+      }
+    }
+
+    + .ant-radio-wrapper {
+      &::before {
+        background-color: $blue-light;
+        content: "";
+        height: rem(1);
+        left: rem(20);
+        position: absolute;
+        right: rem(20);
+        top: 0;
+        transition: background-color 0.3s;
+      }
+    }
+  }
+}
+
 .ant-modal {
   .ant-modal-content {
     background-color: $blue-dark;


### PR DESCRIPTION
Fix #974 

Currently, VaultConnect only allows connecting to the active vault, even if the user selects a different vault for the dApp connection. This behavior restricts users from properly managing multiple vaults.

With this fix, when a user selects a vault that is not active, we will automatically switch to that vault before establishing the connection, ensuring the selected vault is used as intended.