### PR TITLE
Fix ETH balance doesn't show on vault view

### DIFF
--- a/clients/desktop/src/coin/query/useCoinPricesQuery.ts
+++ b/clients/desktop/src/coin/query/useCoinPricesQuery.ts
@@ -91,11 +91,15 @@ export const useCoinPricesQuery = (input: UseCoinPricesQueryInput) => {
         const result: Record<string, number> = {};
 
         Object.entries(prices).forEach(([priceProviderId, price]) => {
-          const coin = shouldBePresent(
+          // multiple coins can have the same price provider
+          // so we need to find all coins with the same price provider
+          // for example: ETH.ETH, ARBITRUM.ETH, OPTIMISM.ETH there are all ETH , so they have the same price provider
+          const matchedCoins = shouldBePresent(
             findBy(regularCoins, 'priceProviderId', priceProviderId)
           );
-
-          result[coinKeyToString(coin)] = price;
+          matchedCoins.forEach(coin => {
+            result[coinKeyToString(coin)] = price;
+          });
         });
 
         return result;

--- a/clients/desktop/src/coin/query/useCoinPricesQuery.ts
+++ b/clients/desktop/src/coin/query/useCoinPricesQuery.ts
@@ -95,7 +95,7 @@ export const useCoinPricesQuery = (input: UseCoinPricesQueryInput) => {
           // so we need to find all coins with the same price provider
           // for example: ETH.ETH, ARBITRUM.ETH, OPTIMISM.ETH there are all ETH , so they have the same price provider
           const matchedCoins = shouldBePresent(
-            findBy(regularCoins, 'priceProviderId', priceProviderId)
+            regularCoins.filter(coin => coin.priceProviderId == priceProviderId)
           );
           matchedCoins.forEach(coin => {
             result[coinKeyToString(coin)] = price;

--- a/clients/desktop/src/vault/queries/useVaultChainsBalancesQuery.ts
+++ b/clients/desktop/src/vault/queries/useVaultChainsBalancesQuery.ts
@@ -49,9 +49,7 @@ export const useVaultChainsBalancesQuery = (): EagerQuery<
           return BigInt(0);
         };
 
-        const price = pricesQuery.data && pricesQuery.data[coinKeyToString(coin)] !== undefined
-          ? pricesQuery.data[coinKeyToString(coin)]
-          : 0;
+        const price = pricesQuery?.data?.[coinKeyToString(coin)] ?? 0;
         return {
           ...coin,
           amount: getAmount(),

--- a/clients/desktop/src/vault/queries/useVaultChainsBalancesQuery.ts
+++ b/clients/desktop/src/vault/queries/useVaultChainsBalancesQuery.ts
@@ -49,10 +49,9 @@ export const useVaultChainsBalancesQuery = (): EagerQuery<
           return BigInt(0);
         };
 
-        const price = pricesQuery.data
+        const price = pricesQuery.data && pricesQuery.data[coinKeyToString(coin)] !== undefined
           ? pricesQuery.data[coinKeyToString(coin)]
           : 0;
-
         return {
           ...coin,
           amount: getAmount(),

--- a/clients/desktop/src/vault/queries/useVaultTotalBalanceQuery.ts
+++ b/clients/desktop/src/vault/queries/useVaultTotalBalanceQuery.ts
@@ -40,7 +40,6 @@ export const useVaultTotalBalanceQuery = () => {
           if (price === undefined || amount === undefined) {
             return 0;
           }
-
           return getCoinValue({
             amount,
             decimals: coin.decimals,

--- a/lib/utils/array/findBy.ts
+++ b/lib/utils/array/findBy.ts
@@ -2,6 +2,6 @@ export const findBy = <T>(
   items: readonly T[],
   key: keyof T,
   value: T[keyof T],
-): T | undefined => {
-  return items.find((item) => item[key] === value);
+): T[] | undefined => {
+  return items.filter((item) => item[key] === value);
 };

--- a/lib/utils/array/findBy.ts
+++ b/lib/utils/array/findBy.ts
@@ -2,6 +2,6 @@ export const findBy = <T>(
   items: readonly T[],
   key: keyof T,
   value: T[keyof T],
-): T[] | undefined => {
-  return items.filter((item) => item[key] === value);
+): T | undefined => {
+  return items.find((item) => item[key] === value);
 };


### PR DESCRIPTION
fixes #994 
Root cause:   when we query coingecko for the price of ethereum , it will only return 1 item , however there are ethereum on many L2 chains , for example , it will have arbitrum.ETH, optimism.ETH , ETH.ETH

Solution is to make sure Ethereum price get mapped to all the L2 ETH as well

fixes #993 

Root cause: Solana SPL token doesn't have price yet, which cause price to return `undefined` , thus mess up the sorting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced coin pricing to include all coins associated with a given price provider for a more complete display.
- **Bug Fixes**
  - Improved error handling for coin price lookups, ensuring that missing data safely defaults to zero.
  - Simplified vault balance calculations to avoid miscomputed totals when data is incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->