### PR TITLE
Fix network fee

### DIFF
--- a/clients/desktop/src/chain/tx/fee/utils/formatFee.ts
+++ b/clients/desktop/src/chain/tx/fee/utils/formatFee.ts
@@ -12,6 +12,7 @@ import { polkadotConfig } from '../../../polkadot/config'
 import { tonConfig } from '../../../ton/config'
 import { gwei } from './evm'
 import { getFeeUnit } from './feeUnit'
+import { solanaConfig } from '@core/chain/chains/solana/solanaConfig'
 
 type FormatFeeInput = {
   chain: Chain
@@ -27,7 +28,7 @@ export const formatFee = ({ chain, chainSpecific }: FormatFeeInput) => {
       utxoSpecific: ({ byteFee }) => BigInt(byteFee),
       ethereumSpecific: ({ maxFeePerGasWei }) => BigInt(maxFeePerGasWei),
       suicheSpecific: ({ referenceGasPrice }) => BigInt(referenceGasPrice),
-      solanaSpecific: ({ priorityFee }) => BigInt(priorityFee),
+      solanaSpecific: ({ priorityFee }) => BigInt(priorityFee) == BigInt(0) ? BigInt(solanaConfig.priorityFeeLimit) : BigInt(priorityFee), // currently we hardcode the priority fee to 100_000 lamports
       thorchainSpecific: ({ fee }) => BigInt(fee),
       mayaSpecific: () => BigInt(cosmosGasLimitRecord[Chain.MayaChain]),
       cosmosSpecific: ({ gas }) => BigInt(gas),

--- a/clients/desktop/src/chain/tx/fee/utils/getFeeAmount.ts
+++ b/clients/desktop/src/chain/tx/fee/utils/getFeeAmount.ts
@@ -6,14 +6,15 @@ import { matchDiscriminatedUnion } from '@lib/utils/matchDiscriminatedUnion'
 
 import { polkadotConfig } from '../../../polkadot/config'
 import { tonConfig } from '../../../ton/config'
+import { solanaConfig } from '@core/chain/chains/solana/solanaConfig'
 
 export const getFeeAmount = (chainSpecific: KeysignChainSpecific): bigint =>
   matchDiscriminatedUnion(chainSpecific, 'case', 'value', {
-    utxoSpecific: ({ byteFee }) => BigInt(byteFee),
+    utxoSpecific: ({ byteFee }) => BigInt(byteFee) * BigInt(250), // assume the average size of an UTXO transaction is 250 vbytes
     ethereumSpecific: ({ maxFeePerGasWei, gasLimit }) =>
       BigInt(maxFeePerGasWei) * BigInt(gasLimit),
     suicheSpecific: ({ referenceGasPrice }) => BigInt(referenceGasPrice),
-    solanaSpecific: ({ priorityFee }) => BigInt(priorityFee),
+    solanaSpecific: ({ priorityFee }) => BigInt(priorityFee) == BigInt(0) ? BigInt(solanaConfig.priorityFeeLimit) : BigInt(priorityFee), // currently we hardcode the priority fee to 100_000 lamports
     thorchainSpecific: ({ fee }) => BigInt(fee),
     mayaSpecific: () => BigInt(cosmosGasLimitRecord[Chain.MayaChain]),
     cosmosSpecific: ({ gas }) => BigInt(gas),

--- a/core/chain/chains/solana/solanaConfig.ts
+++ b/core/chain/chains/solana/solanaConfig.ts
@@ -1,0 +1,4 @@
+export const solanaConfig = {
+  priorityFeeLimit: Number(100_000),// Turbo fee in lamports, around 5 cents
+  priorityFeePrice: 1_000_000, // Turbo fee in lamports, around 5 cents
+}

--- a/core/keysign/preSignedInputData/solana.ts
+++ b/core/keysign/preSignedInputData/solana.ts
@@ -3,6 +3,7 @@ import Long from "long";
 
 import { assertField } from "@lib/utils/record/assertField";
 import { PreSignedInputDataResolver } from "./PreSignedInputDataResolver";
+import { solanaConfig } from "@core/chain/chains/solana/solanaConfig";
 
 export const getSolanaPreSignedInputData: PreSignedInputDataResolver<
   "solanaSpecific"
@@ -15,8 +16,6 @@ export const getSolanaPreSignedInputData: PreSignedInputDataResolver<
     toTokenAssociatedAddress,
   } = chainSpecific;
 
-  const priorityFeePrice = 1_000_000; // Turbo fee in lamports, around 5 cents
-  const priorityFeeLimit = Number(100_000); // Turbo fee in lamports, around 5 cents
   const newRecentBlockHash = recentBlockHash; // DKLS should fix it. Using the same, since fetching the latest block hash won't match with IOS and Android
 
   if (coin.isNativeToken) {
@@ -30,10 +29,10 @@ export const getSolanaPreSignedInputData: PreSignedInputDataResolver<
       recentBlockhash: newRecentBlockHash,
       sender: coin.address,
       priorityFeePrice: TW.Solana.Proto.PriorityFeePrice.create({
-        price: Long.fromString(priorityFeePrice.toString()),
+        price: Long.fromString(solanaConfig.priorityFeePrice.toString()),
       }),
       priorityFeeLimit: TW.Solana.Proto.PriorityFeeLimit.create({
-        limit: priorityFeeLimit,
+        limit: solanaConfig.priorityFeeLimit,
       }),
     });
 
@@ -58,10 +57,10 @@ export const getSolanaPreSignedInputData: PreSignedInputDataResolver<
         recentBlockhash: newRecentBlockHash,
         sender: coin.address,
         priorityFeePrice: TW.Solana.Proto.PriorityFeePrice.create({
-          price: Long.fromString(priorityFeePrice.toString()),
+          price: Long.fromString(solanaConfig.priorityFeePrice.toString()),
         }),
         priorityFeeLimit: TW.Solana.Proto.PriorityFeeLimit.create({
-          limit: priorityFeeLimit,
+          limit: solanaConfig.priorityFeeLimit,
         }),
       });
 
@@ -96,10 +95,10 @@ export const getSolanaPreSignedInputData: PreSignedInputDataResolver<
         recentBlockhash: newRecentBlockHash,
         sender: coin.address,
         priorityFeePrice: TW.Solana.Proto.PriorityFeePrice.create({
-          price: Long.fromString(priorityFeePrice.toString()),
+          price: Long.fromString(solanaConfig.priorityFeePrice.toString()),
         }),
         priorityFeeLimit: TW.Solana.Proto.PriorityFeeLimit.create({
-          limit: priorityFeeLimit,
+          limit: solanaConfig.priorityFeeLimit,
         }),
       });
 

--- a/lib/utils/formatAmount.ts
+++ b/lib/utils/formatAmount.ts
@@ -1,7 +1,7 @@
 const million = 1000000;
 const billion = 1000000000;
 
-const fiatDecimalPlaces = 2;
+const fiatMaxDecimalPlaces = 3;
 const tokenMaxDecimalPlaces = 8;
 
 export const formatAmount = (
@@ -15,8 +15,6 @@ export const formatAmount = (
   if (amount > million) {
     return `${formatAmount(amount / million, currency, locale)}M`;
   }
-
-  const fractionDigits = fiatDecimalPlaces; 
 
   // Validate and set locale safely
   let validLocale = 'en-US';
@@ -33,15 +31,13 @@ export const formatAmount = (
       const formatter = new Intl.NumberFormat(validLocale, {
         style: 'currency',
         currency: currency,
-        minimumFractionDigits: fractionDigits,
-        maximumFractionDigits: fractionDigits,
+        maximumFractionDigits: fiatMaxDecimalPlaces,
       });
 
       return formatter.format(amount);
     } catch {
       const formatter = new Intl.NumberFormat(validLocale, {
-        minimumFractionDigits: fractionDigits,
-        maximumFractionDigits: fractionDigits,
+        maximumFractionDigits: tokenMaxDecimalPlaces,
       });
 
       return `${formatter.format(amount)} ${currency}`;
@@ -49,7 +45,6 @@ export const formatAmount = (
   }
 
   const formatter = new Intl.NumberFormat(validLocale, {
-    minimumFractionDigits: fiatDecimalPlaces,
     maximumFractionDigits: tokenMaxDecimalPlaces,
   });
 


### PR DESCRIPTION
fixes #1034 

Currently the way how we calculate network fee is not correct
for UTXO - we display sats/vbyte as network fee , however for fiat value , then we need to guess a transaction size
For Solana - we hardcode a priority fee because the network often get congestion , we want to commit it asap

For some EVM L2 chain , the fee is so low , like sometimes it is less than 1 cents , thus we need display 3 decimal places , otherwise it will be 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced fee calculations for transactions on select chains. Transactions now apply a fallback minimum fee when no priority fee is set, and fee computations better reflect average transaction sizes.
  - Improved currency formatting for fiat values, now displaying amounts with up to three decimal places for increased precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->