### PR TITLE
We have to set to always auto discover

### DIFF
--- a/clients/desktop/src/coin/query/useTokensAutoDiscoveryQuery.ts
+++ b/clients/desktop/src/coin/query/useTokensAutoDiscoveryQuery.ts
@@ -15,6 +15,6 @@ export const useTokensAutoDiscoveryQuery = (account: ChainAccount) => {
       const coins = await findAccountCoins(account)
       return coins
     },
-    enabled: true,
+    staleTime: 5 * 60 * 1000,
   })
 }

--- a/clients/desktop/src/coin/query/useTokensAutoDiscoveryQuery.ts
+++ b/clients/desktop/src/coin/query/useTokensAutoDiscoveryQuery.ts
@@ -1,10 +1,6 @@
 import { ChainAccount } from '@core/chain/ChainAccount'
 import { useQuery } from '@tanstack/react-query'
 
-import {
-  PersistentStateKey,
-  usePersistentState,
-} from '../../state/persistentState'
 import { findAccountCoins } from '../balance/find/findAccountCoins'
 
 export const getTokensAutoDiscoveryQueryKey = (account: ChainAccount) => [
@@ -13,28 +9,12 @@ export const getTokensAutoDiscoveryQueryKey = (account: ChainAccount) => [
 ]
 
 export const useTokensAutoDiscoveryQuery = (account: ChainAccount) => {
-  const [
-    hasAutoDiscoveryBeenDoneForChain,
-    setHasAutoDiscoveryBeenDoneForChain,
-  ] = usePersistentState<Record<string, boolean>>(
-    PersistentStateKey.HasAutoDiscoveryBeenDoneForChain,
-    {}
-  )
-
-  const isFirstVisit = !hasAutoDiscoveryBeenDoneForChain[account.chain]
-
   return useQuery({
     queryKey: getTokensAutoDiscoveryQueryKey(account),
     queryFn: async () => {
       const coins = await findAccountCoins(account)
-
-      setHasAutoDiscoveryBeenDoneForChain({
-        ...hasAutoDiscoveryBeenDoneForChain,
-        [account.chain]: true,
-      })
-
       return coins
     },
-    enabled: isFirstVisit,
+    enabled: true,
   })
 }

--- a/clients/desktop/src/vault/chain/VaultChainPage.tsx
+++ b/clients/desktop/src/vault/chain/VaultChainPage.tsx
@@ -85,29 +85,24 @@ export const VaultChainPage = () => {
     },
   })
 
-  // It's a bad solution, but better than what we had before
-  // TODO: Implement an abstraction auto-discovery mechanism at the root of the app
   useEffect(() => {
-    if (
-      findTokensQuery.data &&
-      publicKeyQuery.data &&
-      publicKeyQuery.data != null &&
-      Object.keys(publicKeyQuery.data).length > 0
-    ) {
-      const publicKey = publicKeyQuery.data
-      const address = deriveAddress({
-        chain,
-        publicKey,
-        walletCore,
-      })
+    // Ensure findTokensQuery.data is an array
+    const tokens = Array.isArray(findTokensQuery.data)
+      ? findTokensQuery.data
+      : []
 
-      const hexPublicKey = toHexPublicKey({
-        publicKey,
-        walletCore,
-      })
+    const isValidPublicKey =
+      publicKeyQuery.data &&
+      typeof publicKeyQuery.data.data === 'function' &&
+      publicKeyQuery.data.data().length > 0 // Ensure it contains meaningful data
+
+    if (tokens.length > 0 && publicKeyQuery.isSuccess && isValidPublicKey) {
+      const publicKey = publicKeyQuery.data
+      const address = deriveAddress({ chain, publicKey, walletCore })
+      const hexPublicKey = toHexPublicKey({ publicKey, walletCore })
 
       saveCoins(
-        findTokensQuery.data.map(coin =>
+        tokens.map(coin =>
           toStorageCoin({
             ...coin,
             address,
@@ -116,7 +111,14 @@ export const VaultChainPage = () => {
         )
       )
     }
-  }, [chain, findTokensQuery.data, publicKeyQuery.data, saveCoins, walletCore])
+  }, [
+    chain,
+    findTokensQuery.data,
+    publicKeyQuery.data,
+    publicKeyQuery.isSuccess,
+    saveCoins,
+    walletCore,
+  ])
 
   const hasMultipleCoinsSupport = chain in chainTokens
 


### PR DESCRIPTION
I had to set the auto discover to always. So whenever the user go to the chain details we check if they received new tokens. 
I also fixed some issues with the pk that was sometimes again causing issues. 

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/a9d6c734-415a-459b-97e9-ad760dafcf0e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Revised the token auto-discovery process to run unconditionally for a more consistent experience.
  - Improved token data handling and public key validation, ensuring that token processing on the vault page is more reliable and robust.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->