### PR TITLE
fix: send form asset logo

### DIFF
--- a/clients/desktop/src/coin/ui/inputs/CoinInputContainer.tsx
+++ b/clients/desktop/src/coin/ui/inputs/CoinInputContainer.tsx
@@ -16,6 +16,7 @@ import { HStack, hStack } from '../../../lib/ui/layout/Stack'
 import { ChildrenProp, ValueProp } from '../../../lib/ui/props'
 import { Text, text } from '../../../lib/ui/text'
 import { IconWrapper } from '../../../pages/edItVault/EditVaultPage.styles'
+import { shouldDisplayChainLogo } from '../../../vault/chain/utils'
 import { getCoinLogoSrc } from '../../logo/getCoinLogoSrc'
 
 const Container = styled(UnstyledButton)`
@@ -49,13 +50,21 @@ export const CoinInputContainer = ({
   value,
   ...rest
 }: CoinInputContainerProps) => {
+  const { ticker, chain, id } = value
+
   return (
     <Container {...rest}>
       <HStack alignItems="center" gap={8}>
         <ChainCoinIcon
           coinSrc={getCoinLogoSrc(value.logo)}
           chainSrc={
-            isFeeCoin(value) ? undefined : getChainEntityIconSrc(value.chain)
+            shouldDisplayChainLogo({
+              ticker,
+              chain,
+              isNative: isFeeCoin({ id, chain }),
+            })
+              ? getChainEntityIconSrc(chain)
+              : undefined
           }
           style={{ fontSize: 32 }}
         />

--- a/clients/desktop/src/coin/ui/inputs/CoinOption.tsx
+++ b/clients/desktop/src/coin/ui/inputs/CoinOption.tsx
@@ -10,6 +10,7 @@ import { HStack, VStack } from '../../../lib/ui/layout/Stack'
 import { panel } from '../../../lib/ui/panel/Panel'
 import { IsActiveProp, OnClickProp, ValueProp } from '../../../lib/ui/props'
 import { Text } from '../../../lib/ui/text'
+import { shouldDisplayChainLogo } from '../../../vault/chain/utils'
 import { getCoinLogoSrc } from '../../logo/getCoinLogoSrc'
 
 const Container = styled(UnstyledButton)<IsActiveProp>`
@@ -30,14 +31,22 @@ export const CoinOption = ({
   onClick,
   isActive,
 }: ValueProp<Coin> & OnClickProp & IsActiveProp) => {
-  const { chain, logo, ticker } = value
+  const { chain, logo, ticker, id } = value
 
   return (
     <Container isActive={isActive} onClick={onClick}>
       <HStack fullWidth alignItems="center" gap={12}>
         <ChainCoinIcon
           coinSrc={getCoinLogoSrc(logo)}
-          chainSrc={isFeeCoin(value) ? undefined : getChainEntityIconSrc(chain)}
+          chainSrc={
+            shouldDisplayChainLogo({
+              ticker,
+              chain,
+              isNative: isFeeCoin({ id, chain }),
+            })
+              ? getChainEntityIconSrc(chain)
+              : undefined
+          }
           style={{ fontSize: 32 }}
         />
         <VStack alignItems="start">

--- a/clients/desktop/src/vault/chain/VaultChainPage.tsx
+++ b/clients/desktop/src/vault/chain/VaultChainPage.tsx
@@ -225,21 +225,17 @@ export const VaultChainPage = () => {
                 (one, another) => one.ticker === another.ticker
               )
 
-              return (
-                <>
-                  {orderedCoins.map(coin => (
-                    <Link
-                      key={coin.id}
-                      to={makeAppPath('vaultChainCoinDetail', {
-                        chain: chain,
-                        coin: coin.id,
-                      })}
-                    >
-                      <VaultChainCoinItem value={coin} />
-                    </Link>
-                  ))}
-                </>
-              )
+              return orderedCoins.map(coin => (
+                <Link
+                  key={coin.id}
+                  to={makeAppPath('vaultChainCoinDetail', {
+                    chain: chain,
+                    coin: coin.id,
+                  })}
+                >
+                  <VaultChainCoinItem value={coin} />
+                </Link>
+              ))
             }}
           />
         </Panel>


### PR DESCRIPTION
Fixes: https://github.com/vultisig/vultisig-windows/issues/1036
<img width="878" alt="Screenshot 2025-02-20 at 21 45 45" src="https://github.com/user-attachments/assets/4532b3a2-fafc-4842-963d-0aea7eca7db7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced coin input and selection interfaces with refined chain logo display logic for more accurate visual representation.

- **Refactor**
  - Streamlined the rendering structure for coin listings on the vault chain page for a simpler, more efficient display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->