### PR TITLE
Add absolute path to @lib

### DIFF
--- a/clients/mobile/tsconfig.json
+++ b/clients/mobile/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
-    "types": ["styled-components-react-native"]
+    "types": ["styled-components-react-native"],
+    "baseUrl": "src",
+    "paths": {
+      "@lib/*": ["lib/*"]
+    }
   },
   "include": [
     "**/*.ts",


### PR DESCRIPTION
This allows us to use imports like:
```js
import { Text } from '@lib/ui/components/Text'
```
instead of relative paths:
```js
import { Text } from '../../../lib/ui/components/Text'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Made internal updates to streamline how app resources are referenced, supporting enhanced maintainability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->