### PR TITLE
Add dat extension to vault backup

### DIFF
--- a/clients/desktop/src/vault/import/VaultBackupExtension.ts
+++ b/clients/desktop/src/vault/import/VaultBackupExtension.ts
@@ -2,7 +2,7 @@ import { getLastItem } from '@lib/utils/array/getLastItem'
 import { isOneOf } from '@lib/utils/array/isOneOf'
 import { shouldBePresent } from '@lib/utils/assert/shouldBePresent'
 
-export const vaultBackupExtensions = ['bak', 'vult']
+export const vaultBackupExtensions = ['bak', 'vult', 'dat']
 
 export type VaultBackupExtension = (typeof vaultBackupExtensions)[number]
 


### PR DESCRIPTION
Fix https://github.com/vultisig/vultisig-windows/issues/1134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded backup file support by adding .dat as an accepted file extension, enhancing compatibility for vault backups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->