### PR TITLE
Update Thorchain and Mayachain Block Explorer

### DIFF
--- a/core/chain/utils/getBlockExplorerUrl/index.ts
+++ b/core/chain/utils/getBlockExplorerUrl/index.ts
@@ -39,8 +39,8 @@ const blockExplorerBaseUrl: Record<Chain, string> = {
   [Chain.TerraClassic]: 'https://finder.terra.money/classic',
   [Chain.Noble]: `${cosmosBlockExplorer}/noble`,
   [Chain.Ripple]: 'https://xrpscan.com',
-  [Chain.THORChain]: 'https://www.xscanner.org',
-  [Chain.MayaChain]: 'https://www.xscanner.org',
+  [Chain.THORChain]: 'https://thorchain.net',
+  [Chain.MayaChain]: 'https://www.mayascan.org',
   [Chain.Akash]: `${cosmosBlockExplorer}/akash`,
   [Chain.Tron]: 'https://tronscan.org/#',
 }


### PR DESCRIPTION
We used https://thorchain.net as Thorchain explorer and https://www.mayascan.org as Mayachain explorer in Both Android and iOS

### Thorchain
#### Android
https://github.com/vultisig/vultisig-android/blob/772725e08be833645b9266b4bd47292a5d91405b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ExplorerLinkRepository.kt#L102

#### iOS
https://github.com/vultisig/vultisig-ios/blob/b415c7282f4b19190a1fc5e2e795a1314542a93f/VultisigApp/VultisigApp/Utils/Endpoint.swift#L377C1-L378C1

### Mayachain

#### Android
https://github.com/vultisig/vultisig-android/blob/772725e08be833645b9266b4bd47292a5d91405b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ExplorerLinkRepository.kt#L98

#### iOS
https://github.com/vultisig/vultisig-ios/blob/b415c7282f4b19190a1fc5e2e795a1314542a93f/VultisigApp/VultisigApp/Utils/Endpoint.swift#L393





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated block explorer URLs for THORChain and MayaChain so that users are directed to the official and current network explorers. These changes improve the accuracy of explorer links when accessing blockchain data, ensuring a reliable and up-to-date reference for users reviewing chain information. This update helps maintain our service quality and ensures seamless transitions when users explore chain transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->