### PR TITLE
Fix Incorrect Swap Provider Display on Result Page 

### DIFF
--- a/clients/desktop/src/chain/swap/general/GeneralSwapQuote.ts
+++ b/clients/desktop/src/chain/swap/general/GeneralSwapQuote.ts
@@ -10,5 +10,6 @@ export type GeneralSwapQuote = {
     value: string
     gasPrice: string
     gas: number
+    swapFee?: string
   }
 }

--- a/clients/desktop/src/chain/swap/general/lifi/api/getLifiSwapQuote.ts
+++ b/clients/desktop/src/chain/swap/general/lifi/api/getLifiSwapQuote.ts
@@ -63,6 +63,8 @@ export const getLifiSwapQuote = async ({
         evm: () => ({
           from: shouldBePresent(from),
           to: shouldBePresent(to),
+          // TODO:  Extract swap fee from lifi quote response
+          swapFee: '0',
           data: shouldBePresent(data),
           value: BigInt(shouldBePresent(value)).toString(),
           gasPrice: BigInt(shouldBePresent(gasPrice)).toString(),

--- a/clients/desktop/src/chain/swap/keysign/getSwapKeysignPayloadFields.ts
+++ b/clients/desktop/src/chain/swap/keysign/getSwapKeysignPayloadFields.ts
@@ -48,6 +48,7 @@ export const getSwapKeysignPayloadFields = ({
           tx: create(OneInchTransactionSchema, {
             ...quote.tx,
             gas: BigInt(quote.tx.gas),
+            swapFee: quote.tx.swapFee,
           }),
         }),
       })

--- a/clients/desktop/src/vault/swap/keysign/KeysignSwapTxInfo.tsx
+++ b/clients/desktop/src/vault/swap/keysign/KeysignSwapTxInfo.tsx
@@ -1,5 +1,6 @@
 import { fromChainAmount } from '@core/chain/amount/fromChainAmount'
 import { Chain } from '@core/chain/Chain'
+import { OneInchSwapPayload } from '@core/communication/vultisig/keysign/v1/1inch_swap_payload_pb'
 import { KeysignPayload } from '@core/communication/vultisig/keysign/v1/keysign_message_pb'
 import { withoutUndefined } from '@lib/utils/array/withoutUndefined'
 import { formatTokenAmount } from '@lib/utils/formatTokenAmount'
@@ -50,7 +51,14 @@ export const KeysignSwapTxInfo = ({ value }: ValueProp<KeysignPayload>) => {
     {
       thorchainSwapPayload: () => Chain.THORChain,
       mayachainSwapPayload: () => Chain.MayaChain,
-      oneinchSwapPayload: () => generalSwapProviderName.oneinch,
+      oneinchSwapPayload: () => {
+        const oneInchPayload = swapPayload?.value as OneInchSwapPayload
+        if (oneInchPayload?.quote?.tx?.swapFee) {
+          return generalSwapProviderName.lifi
+        } else {
+          return generalSwapProviderName.oneinch
+        }
+      },
     }
   )
 


### PR DESCRIPTION
Fix #1165 

Although both 1inch and LiFi quote results are stored in the same data structure within the swap payload, they can be distinguished by the presence of the swapFee field:

1inch quote results do not contain the swapFee field.
LiFi quote results do contain the swapFee field.
This fix ensures that the correct swap provider is displayed based on the distinguishing swapFee field.
(This is the sampe approach used in android and ios)

Next Steps:
In a separate PR, we need to use the swapQuote response from LiFi to correctly calculate the swapFee value.

 
![telegram-cloud-photo-size-4-5936117378779825329-y](https://github.com/user-attachments/assets/30d454c0-876e-4079-abb6-859b0162b3f3)
https://basescan.org/tx/0xc93c6c804978cf6821d37ffb8b17a1c5adc8fb6dcf4f6e80765b420b20fba24c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced swap transactions now include additional fee details, providing clearer financial breakdowns.
	- Improved swap provider selection automatically optimizes processing based on fee information, ensuring a more streamlined user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->