### PR TITLE
fix: backup page color

### DIFF
--- a/clients/desktop/src/vault/setup/shared/vaultBackupSettings/VaultBackupPage.styles.tsx
+++ b/clients/desktop/src/vault/setup/shared/vaultBackupSettings/VaultBackupPage.styles.tsx
@@ -9,14 +9,15 @@ import { getColor } from '../../../../lib/ui/theme/getters'
 export const InputFieldWrapper = styled.div`
   position: relative;
   background-color: ${getColor('foreground')};
-  padding: 12px;
   ${borderRadius.m};
 `
 
 export const InputField = styled.input`
+  padding: 12px;
   background-color: transparent;
   display: block;
   width: 100%;
+  color: ${getColor('text')};
 
   &::placeholder {
     font-size: 13px;


### PR DESCRIPTION
Fix the text color when inputting password on the Backup page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced the backup page’s input field appearance by refining spacing and updating text color for improved readability and a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->