### PR TITLE
fix: issue with backup flow shares showing a wrong number of shares

### DIFF
--- a/clients/desktop/src/vault/setup/secure/backup/BackupOverviewSlidesPartOne/AnimationDescription.tsx
+++ b/clients/desktop/src/vault/setup/secure/backup/BackupOverviewSlidesPartOne/AnimationDescription.tsx
@@ -20,7 +20,7 @@ export const AnimationDescription: FC<AnimationDescriptionProps> = ({
     () => (
       <Text size={32}>
         {t('secureVaultSetup.backup.shares', {
-          shares: vault.keyshares.length,
+          shares: vault.signers.length,
         })}{' '}
         <GradientText as="span">
           {t('secureVaultSetup.backup.eachDeviceNeedsBackup')}

--- a/clients/desktop/src/vault/setup/secure/backup/PairingDeviceBackupOverviewSlidesPartOne/AnimationDescription.tsx
+++ b/clients/desktop/src/vault/setup/secure/backup/PairingDeviceBackupOverviewSlidesPartOne/AnimationDescription.tsx
@@ -20,7 +20,7 @@ export const AnimationDescription: FC<AnimationDescriptionProps> = ({
     () => (
       <Text size={32}>
         {t('secureVaultSetup.backup.shares', {
-          shares: vault.keyshares.length,
+          shares: vault.signers.length,
         })}{' '}
         <GradientText as="span">
           {t('secureVaultSetup.backup.eachDeviceNeedsBackup')}


### PR DESCRIPTION
Fixes: https://github.com/vultisig/vultisig-windows/issues/1138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated backup overview slides now show the number of signers instead of keyshares, ensuring that the backup instructions present the correct figures. This change improves clarity and consistency, enabling users to confidently verify backup details during the setup process and enjoy an overall enhanced interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->