### PR TITLE
Make sure server join session before continue

### DIFF
--- a/clients/desktop/src/vault/keygen/shared/peerDiscovery/queries/usePeerOptionsQuery.ts
+++ b/clients/desktop/src/vault/keygen/shared/peerDiscovery/queries/usePeerOptionsQuery.ts
@@ -17,7 +17,9 @@ export const usePeerOptionsQuery = ({ enabled = true } = {}) => {
     queryKey: ['peerOptions', sessionId, serverUrl],
     queryFn: async () => {
       const response = await queryUrl<string[]>(`${serverUrl}/${sessionId}`)
-
+      if (response.length === 0) {
+        throw new Error('No peers found')
+      }
       return without(withoutDuplicates(response), localPartyId)
     },
     enabled,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error feedback during peer discovery by clearly notifying users when no available connections are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->