### PR TITLE
fix: decompress function overriding

### DIFF
--- a/clients/desktop/src/vault/qr/upload/utils/decompressQrPayload.tsx
+++ b/clients/desktop/src/vault/qr/upload/utils/decompressQrPayload.tsx
@@ -4,6 +4,6 @@ export async function decompressQrPayload(value: string): Promise<Uint8Array> {
   const bufferData = Buffer.from(value, 'base64')
   const sevenZip = await getSevenZip()
   sevenZip.FS.writeFile('data.xz', bufferData)
-  sevenZip.callMain(['x', 'data.xz'])
+  sevenZip.callMain(['x', 'data.xz', '-y'])
   return sevenZip.FS.readFile('data')
 }


### PR DESCRIPTION
Fixes: https://github.com/vultisig/vultisig-windows/issues/1308

Problem :The QR code scanning triggered an unwanted browser prompt asking for user input ("Would you like to replace the existing file?"). This occurred because the WebAssembly 7zip decompression command (sevenZip.callMain(['x', 'data.xz'])) attempted to overwrite a previously extracted file, prompting for manual confirmation.

Solution: Added -y flag to force overwrite without prompting:




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the decompression process to automatically handle file overwrites during extraction, ensuring a smoother and more reliable experience for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->