### PR TITLE
Fix gas setting in vulticonnect

### DIFF
--- a/clients/extension/src/utils/tx/getStandardTx.ts
+++ b/clients/extension/src/utils/tx/getStandardTx.ts
@@ -4,6 +4,7 @@ import {
   TransactionDetails,
   TransactionType,
 } from '@clients/extension/src/utils/interfaces'
+import { ethers } from 'ethers'
 import { chainFeeCoin } from '@core/chain/coin/chainFeeCoin'
 
 type TransactionHandlers = {
@@ -71,9 +72,9 @@ const transactionHandlers: TransactionHandlers = {
       : undefined,
     data: tx.data,
     gasSettings: {
-      maxFeePerGas: tx.maxFeePerGas,
-      maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
-      gasLimit: tx.gas,
+      maxFeePerGas: ethers.isHexString(tx.maxFeePerGas)?ethers.toBigInt(tx.maxFeePerGas).toString(): tx.maxFeePerGas,
+      maxPriorityFeePerGas: ethers.isHexString(tx.maxPriorityFeePerGas)?ethers.toBigInt(tx.maxPriorityFeePerGas).toString(): tx.maxPriorityFeePerGas,
+      gasLimit: ethers.isHexString(tx.gas)?ethers.toBigInt(tx.gas).toString(): tx.gas,
     },
   }),
 

--- a/clients/extension/src/utils/tx/getStandardTx.ts
+++ b/clients/extension/src/utils/tx/getStandardTx.ts
@@ -4,8 +4,8 @@ import {
   TransactionDetails,
   TransactionType,
 } from '@clients/extension/src/utils/interfaces'
-import { ethers } from 'ethers'
 import { chainFeeCoin } from '@core/chain/coin/chainFeeCoin'
+import { ethers } from 'ethers'
 
 type TransactionHandlers = {
   [K in TransactionType.WalletTransaction['txType']]: (
@@ -72,9 +72,15 @@ const transactionHandlers: TransactionHandlers = {
       : undefined,
     data: tx.data,
     gasSettings: {
-      maxFeePerGas: ethers.isHexString(tx.maxFeePerGas)?ethers.toBigInt(tx.maxFeePerGas).toString(): tx.maxFeePerGas,
-      maxPriorityFeePerGas: ethers.isHexString(tx.maxPriorityFeePerGas)?ethers.toBigInt(tx.maxPriorityFeePerGas).toString(): tx.maxPriorityFeePerGas,
-      gasLimit: ethers.isHexString(tx.gas)?ethers.toBigInt(tx.gas).toString(): tx.gas,
+      maxFeePerGas: ethers.isHexString(tx.maxFeePerGas)
+        ? ethers.toBigInt(tx.maxFeePerGas).toString()
+        : tx.maxFeePerGas,
+      maxPriorityFeePerGas: ethers.isHexString(tx.maxPriorityFeePerGas)
+        ? ethers.toBigInt(tx.maxPriorityFeePerGas).toString()
+        : tx.maxPriorityFeePerGas,
+      gasLimit: ethers.isHexString(tx.gas)
+        ? ethers.toBigInt(tx.gas).toString()
+        : tx.gas,
     },
   }),
 


### PR DESCRIPTION
- Make sure vulticonnect can handle diffrent standard for gas setting   (hex and decimal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the processing of gas settings in MetaMask transactions, ensuring accurate handling of hexadecimal values for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->