### PR TITLE
Fix ripple cross device keysign issue

### DIFF
--- a/core/chain/signing/SignatureFormat.ts
+++ b/core/chain/signing/SignatureFormat.ts
@@ -10,6 +10,6 @@ export const signatureFormats: Record<ChainKind, SignatureFormat> = {
   polkadot: 'raw',
   ton: 'raw',
   utxo: 'der',
-  ripple: 'der',
+  ripple: 'rawWithRecoveryId',
   tron: 'rawWithRecoveryId',
 }

--- a/core/mpc/keysign/preSignedInputData/ripple.ts
+++ b/core/mpc/keysign/preSignedInputData/ripple.ts
@@ -8,24 +8,25 @@ export const getRipplePreSignedInputData: PreSignedInputDataResolver<
   'rippleSpecific'
 > = ({ keysignPayload, chainSpecific }) => {
   const coin = assertField(keysignPayload, 'coin')
-
   const pubKeyData = Buffer.from(coin.hexPublicKey, 'hex')
 
   const { gas, sequence } = chainSpecific
 
+  const payment = TW.Ripple.Proto.OperationPayment.create({
+    destination: keysignPayload.toAddress,
+    amount: Long.fromString(keysignPayload.toAmount),
+  })
+  if (keysignPayload.memo !== undefined) {
+    payment.destinationTag = Long.fromString(
+      keysignPayload.memo !== '' ? keysignPayload.memo : '0'
+    )
+  }
   const input = TW.Ripple.Proto.SigningInput.create({
     account: coin.address,
     fee: Long.fromString(gas.toString()),
     sequence: Number(sequence),
     publicKey: new Uint8Array(pubKeyData),
-    opPayment: TW.Ripple.Proto.OperationPayment.create({
-      destination: keysignPayload.toAddress,
-      amount: Long.fromString(keysignPayload.toAmount),
-      destinationTag: keysignPayload.memo
-        ? Long.fromNumber(Number(keysignPayload.memo))
-        : null,
-    }),
+    opPayment: payment,
   })
-
   return TW.Ripple.Proto.SigningInput.encode(input).finish()
 }

--- a/core/mpc/schnorr/schnorrKeysign.ts
+++ b/core/mpc/schnorr/schnorrKeysign.ts
@@ -222,7 +222,7 @@ export class SchnorrKeysign {
       return keysignSig
     }
   }
-  private async keygienWithRetry(messageToSign: string) {
+  private async keysignWithRetry(messageToSign: string) {
     for (let i = 0; i < 3; i++) {
       try {
         const result = await this.KeysignOneMessage(messageToSign, i)
@@ -238,7 +238,7 @@ export class SchnorrKeysign {
     await __wbg_init()
     let results: KeysignSignature[] = []
     for (const message of messsagesToSign) {
-      const signResult = await this.keygienWithRetry(message)
+      const signResult = await this.keysignWithRetry(message)
       if (signResult === undefined) {
         throw new Error('failed to sign message')
       }


### PR DESCRIPTION
This PR is to fix the XRP keysign issue , if initiate from windows , can't be cross sign with android and ios

The root cause: WalletCore library is newer in windows repo , while android and IOS is behind 

Secondly , windows app deal with demo slight differently