### PR TITLE
Add expand view menu to extension

### DIFF
--- a/clients/extension/src/pages/popup/pages/main/index.tsx
+++ b/clients/extension/src/pages/popup/pages/main/index.tsx
@@ -6,7 +6,7 @@ import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { LinkTwoIcon } from '@lib/ui/icons/LinkTwoIcon'
 import { SettingsIcon } from '@lib/ui/icons/SettingsIcon'
 import { WorldIcon } from '@lib/ui/icons/WorldIcon'
-import { HStack, VStack } from '@lib/ui/layout/Stack'
+import { VStack } from '@lib/ui/layout/Stack'
 import { List } from '@lib/ui/list'
 import { ListItem } from '@lib/ui/list/item'
 import { PageContent } from '@lib/ui/page/PageContent'
@@ -55,17 +55,23 @@ export const MainPage = () => {
           </ConnectedApp>
         }
         secondaryControls={
-          <HStack alignItems="center" gap={8}>
-            <Button shape="round" size="small">
-              {t('open_desktop')}
-            </Button>
-            <Button ghost>
-              <SettingsIcon
-                fontSize={24}
-                onClick={() => appNavigate('settings')}
-              />
-            </Button>
-          </HStack>
+          <Button ghost>
+            <SettingsIcon
+              fontSize={24}
+              onClick={() => appNavigate('settings')}
+            />
+          </Button>
+        }
+        title={
+          <Text
+            color="contrast"
+            size={18}
+            style={{ maxWidth: '50%' }}
+            weight={500}
+            cropped
+          >
+            {vault.name}
+          </Text>
         }
         hasBorder
       />

--- a/clients/extension/src/pages/popup/pages/settings/index.tsx
+++ b/clients/extension/src/pages/popup/pages/settings/index.tsx
@@ -7,6 +7,7 @@ import { useFiatCurrency } from '@core/ui/state/fiatCurrency'
 import { ChevronLeftIcon } from '@lib/ui/icons/ChevronLeftIcon'
 import { CircleDollarSignIcon } from '@lib/ui/icons/CircleDollarSignIcon'
 import { CircleHelpIcon } from '@lib/ui/icons/CircleHelpIcon'
+import { ExpandIcon } from '@lib/ui/icons/ExpandIcon'
 import { LanguagesIcon } from '@lib/ui/icons/LanguagesIcon'
 import { SettingsIcon } from '@lib/ui/icons/SettingsIcon'
 import { VultisigLogoIcon } from '@lib/ui/icons/VultisigLogoIcon'
@@ -86,6 +87,18 @@ export const SettingsPage = () => {
               icon={<CircleHelpIcon fontSize={20} />}
               onClick={() => open('https://vultisig.com/faq', '_blank')}
               title={t('faq')}
+              hoverable
+              showArrow
+            />
+            <ListItem
+              icon={<ExpandIcon fontSize={20} />}
+              onClick={() =>
+                open(
+                  `chrome-extension://${chrome.runtime.id}/popup.html`,
+                  '_blank'
+                )
+              }
+              title={t('expand_view')}
               hoverable
               showArrow
             />

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -1,5 +1,6 @@
 export const en = {
   available: 'Available',
+  expand_view: 'Expand View',
   general: 'General',
   manage_chains: 'Manage Chains',
   open_desktop: 'Open Desktop',

--- a/lib/ui/icons/ExpandIcon.tsx
+++ b/lib/ui/icons/ExpandIcon.tsx
@@ -1,0 +1,28 @@
+import { FC, SVGProps } from 'react'
+
+export const ExpandIcon: FC<SVGProps<SVGSVGElement>> = ({
+  fill = 'none',
+  height = '1em',
+  stroke = '#f0f4fc',
+  strokeLinecap = 'round',
+  strokeLinejoin = 'round',
+  strokeWidth = 1.5,
+  width = '1em',
+  ...props
+}) => (
+  <svg
+    viewBox="0 0 24 24"
+    {...{
+      ...props,
+      fill,
+      height,
+      stroke,
+      strokeLinecap,
+      strokeLinejoin,
+      strokeWidth,
+      width,
+    }}
+  >
+    <path d="M21 21L15 15M21 21V16.2M21 21H16.2M3 16.2V21M3 21H7.8M3 21L9 15M21 7.8V3M21 3H16.2M21 3L15 9M3 7.8V3M3 3H7.8M3 3L9 9" />
+  </svg>
+)


### PR DESCRIPTION
Fix #1440 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an "Expand View" option in the settings, allowing users to open the extension popup in a new browser tab.
  - Introduced a new icon for the "Expand View" feature.
- **Improvements**
  - Updated the main page header to display the current vault's name with improved styling.
  - Simplified the main page header controls for easier access to settings.
- **Localization**
  - Added English translation for "Expand View."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->