### PR TITLE
Fix extension width in expand mode

### DIFF
--- a/clients/extension/src/providers/AppProviders.tsx
+++ b/clients/extension/src/providers/AppProviders.tsx
@@ -24,9 +24,11 @@ import { createGlobalStyle } from 'styled-components'
 const ExtensionGlobalStyle = createGlobalStyle`
   body {
     margin: 0 auto;
+    max-width: 1024px;
     min-height: 600px;
+    min-width: 400px;
     overflow: hidden;
-    width: 400px;
+    width: 100%;
   }
 `
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated layout styling to make the extension window responsive, with a flexible width between 400px and 1024px.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->