### PR TITLE
Separate appCustomViews to prevent accidentally providing an unnecessary app view when one already exists in the core.

### DIFF
--- a/clients/desktop/src/navigation/views.tsx
+++ b/clients/desktop/src/navigation/views.tsx
@@ -1,4 +1,4 @@
-import { sharedViews } from '@core/ui/navigation/sharedViews'
+import { SharedViewId, sharedViews } from '@core/ui/navigation/sharedViews'
 import { IncompleteOnboardingOnly } from '@core/ui/onboarding/IncompleteOnboardingOnly'
 import { VaultsPage } from '@core/ui/vaultsOrganisation/components/VaultsPage'
 import { ManageVaultsPage } from '@core/ui/vaultsOrganisation/manage/ManageVaultsPage'
@@ -33,8 +33,7 @@ import { SetupVaultPageController } from '../vault/setup/SetupVaultPageControlle
 import { ShareVaultPage } from '../vault/share/ShareVaultPage'
 import { AppViewId } from './AppView'
 
-export const views: Views<AppViewId> = {
-  ...sharedViews,
+const appCustomViews: Views<Exclude<AppViewId, SharedViewId>> = {
   vault: VaultPage,
   joinKeygen: JoinKeygenPage,
   setupFastVault: SetupFastVaultPage,
@@ -69,4 +68,9 @@ export const views: Views<AppViewId> = {
   signCustomMessage: SignCustomMessagePage,
   dkls: ManageDklsPage,
   faq: FaqVaultPage,
+}
+
+export const views: Views<AppViewId> = {
+  ...sharedViews,
+  ...appCustomViews,
 }

--- a/clients/extension/src/navigation/views.tsx
+++ b/clients/extension/src/navigation/views.tsx
@@ -14,7 +14,7 @@ import { SetupVaultPageController } from '@clients/extension/src/pages/setup-vau
 import { TransactionPage } from '@clients/extension/src/pages/transaction'
 import { VaultPage } from '@clients/extension/src/pages/vault'
 import { VaultSettingsPage } from '@clients/extension/src/pages/vault-settings'
-import { sharedViews } from '@core/ui/navigation/sharedViews'
+import { SharedViewId, sharedViews } from '@core/ui/navigation/sharedViews'
 import { IncompleteOnboardingOnly } from '@core/ui/onboarding/IncompleteOnboardingOnly'
 import { VaultsPage } from '@core/ui/vaultsOrganisation/components/VaultsPage'
 import { ManageVaultsPage } from '@core/ui/vaultsOrganisation/manage/ManageVaultsPage'
@@ -22,8 +22,7 @@ import { Views } from '@lib/ui/navigation/Views'
 
 import { AppViewId } from './AppView'
 
-export const views: Views<AppViewId> = {
-  ...sharedViews,
+const appCustomViews: Views<Exclude<AppViewId, SharedViewId>> = {
   vault: VaultPage,
   joinKeygen: () => <>TODO: Implement join keygen page</>,
   setupFastVault: SetupFastVaultPage,
@@ -50,4 +49,9 @@ export const views: Views<AppViewId> = {
   vaultsTab: GetVaultsPage,
   transactionTab: TransactionPage,
   manageVaults: ManageVaultsPage,
+}
+
+export const views: Views<AppViewId> = {
+  ...sharedViews,
+  ...appCustomViews,
 }

--- a/core/ui/navigation/sharedViews.tsx
+++ b/core/ui/navigation/sharedViews.tsx
@@ -20,7 +20,7 @@ import { ManageVaultFolderPage } from '../vaultsOrganisation/folder/manage/Manag
 import { VaultFolderPage } from '../vaultsOrganisation/folder/VaultFolderPage'
 import { CoreViewId } from './CoreView'
 
-type SharedViewId = Extract<
+export type SharedViewId = Extract<
   CoreViewId,
   | 'currencySettings'
   | 'defaultChains'


### PR DESCRIPTION
- Updated the views definition in both desktop and extension navigation to include the SharedViewId type, enhancing type safety.
- Introduced appCustomViews to separate custom views from shared views, improving code organization and clarity.
- Merged appCustomViews with sharedViews in the final views export for a streamlined navigation structure.

## Description

Please include a summary of the change and which issue is fixed. 

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved modularity by separating shared and app-specific views before combining them for export in navigation components.
- **Chores**
	- Made the SharedViewId type publicly accessible for broader use across modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->