### PR TITLE
Fix: currentVaultId remains null

### DIFF
--- a/core/ui/storage/currentVaultId.tsx
+++ b/core/ui/storage/currentVaultId.tsx
@@ -61,7 +61,7 @@ export const CurrentVaultIdProvider = ({
   useEffect(() => {
     if (isPending || guardedValue === value) return
 
-    mutate(value)
+    mutate(guardedValue)
   }, [guardedValue, value, isPending, mutate])
 
   return (


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

This fixes currentVaultId being null when a vault is first imported. 

Fixes #1551 (Replaces #1562)

## Which feature is affected?
- [x] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation when updating the current vault ID to ensure a valid and existing vault is always selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->