### PR TITLE
WIP Import vault padding

### DIFF
--- a/core/ui/vault/import/components/BackupFileDropzone.tsx
+++ b/core/ui/vault/import/components/BackupFileDropzone.tsx
@@ -39,7 +39,7 @@ export const BackupFileDropzone = ({ onFinish }: BackupFileDropzoneProps) => {
         </DropZoneContent>
         <input {...getInputProps()} />
       </InteractiveDropZoneContainer>
-      <Text color="shy">Supported file types: .bak & .vult</Text>
+      <Text color="shy">{t('supported_file_types')}</Text>
     </>
   )
 }

--- a/core/ui/vault/import/components/UploadBackupFileStep.tsx
+++ b/core/ui/vault/import/components/UploadBackupFileStep.tsx
@@ -32,6 +32,8 @@ export const UploadBackupFileStep = ({
     <>
       <FlowPageHeader title={t('import_vault')} />
       <PageContent
+        style={{ height: '90%', paddingTop: '0px' }}
+        justifyContent="center"
         as="form"
         {...getFormProps({
           onSubmit: () => {
@@ -40,7 +42,7 @@ export const UploadBackupFileStep = ({
           isDisabled,
         })}
       >
-        <VStack gap={20} flexGrow>
+        <VStack gap={20} flexGrow justifyContent="center">
           {file ? (
             <UploadedBackupFile value={file} />
           ) : (
@@ -52,7 +54,12 @@ export const UploadBackupFileStep = ({
             </Text>
           )}
         </VStack>
-        <Button isLoading={isPending} isDisabled={isDisabled} type="submit">
+        <Button
+          isLoading={isPending}
+          isDisabled={isDisabled}
+          type="submit"
+          style={{ marginTop: '16px' }}
+        >
           {t('continue')}
         </Button>
       </PageContent>

--- a/core/ui/vault/import/components/UploadBackupFileStep.tsx
+++ b/core/ui/vault/import/components/UploadBackupFileStep.tsx
@@ -29,10 +29,9 @@ export const UploadBackupFileStep = ({
   const isDisabled = !file
 
   return (
-    <>
+    <VStack fullHeight>
       <FlowPageHeader title={t('import_vault')} />
       <PageContent
-        style={{ height: '90%', paddingTop: '0px' }}
         justifyContent="center"
         as="form"
         {...getFormProps({
@@ -58,11 +57,10 @@ export const UploadBackupFileStep = ({
           isLoading={isPending}
           isDisabled={isDisabled}
           type="submit"
-          style={{ marginTop: '16px' }}
         >
           {t('continue')}
         </Button>
       </PageContent>
-    </>
+    </VStack>
   )
 }

--- a/core/ui/vault/import/components/UploadBackupFileStep.tsx
+++ b/core/ui/vault/import/components/UploadBackupFileStep.tsx
@@ -53,11 +53,7 @@ export const UploadBackupFileStep = ({
             </Text>
           )}
         </VStack>
-        <Button
-          isLoading={isPending}
-          isDisabled={isDisabled}
-          type="submit"
-        >
+        <Button isLoading={isPending} isDisabled={isDisabled} type="submit">
           {t('continue')}
         </Button>
       </PageContent>

--- a/lib/ui/inputs/upload/DropZoneContainer.tsx
+++ b/lib/ui/inputs/upload/DropZoneContainer.tsx
@@ -6,9 +6,9 @@ import styled from 'styled-components'
 
 export const DropZoneContainer = styled.div`
   flex: 1;
-  height: 400px;
+  height: 300px;
   width: 100%;
-  max-height: 400px;
+  max-height: 300px;
   ${centerContent};
   ${borderRadius.m};
   padding: 20px;


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 
Fix padding on import Vault Page, currently blocked by https://github.com/vultisig/vultisig-windows/pull/1628
Fixes #1618 

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):
<img width="402" alt="Screenshot 2025-05-19 at 16 51 40" src="https://github.com/user-attachments/assets/a2b442b7-e834-47c8-b381-62485f014a33" />


## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved layout and vertical centering of the backup file upload form and its elements.
  - Reduced the height of the file dropzone for a more compact appearance.

- **New Features**
  - Updated supported file types text to support localization, making the interface more internationalization-friendly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->