### PR TITLE
Add default setting to dApp transactions

### DIFF
--- a/clients/extension/src/pages/transaction/index.tsx
+++ b/clients/extension/src/pages/transaction/index.tsx
@@ -10,6 +10,7 @@ import {
   ParsedMemoParams,
 } from '@core/chain/chains/evm/tx/getParsedMemo'
 import { chainFeeCoin } from '@core/chain/coin/chainFeeCoin'
+import { defaultEvmSwapGasLimit } from '@core/chain/tx/fee/evm/evmGasLimit'
 import { getFeeAmount } from '@core/chain/tx/fee/getFeeAmount'
 import { KeysignChainSpecific } from '@core/mpc/keysign/chainSpecific/KeysignChainSpecific'
 import { KeysignMessagePayload } from '@core/mpc/keysign/keysignPayload/KeysignMessagePayload'
@@ -18,6 +19,7 @@ import { useAssertWalletCore } from '@core/ui/chain/providers/WalletCoreProvider
 import { StartKeysignPrompt } from '@core/ui/mpc/keysign/StartKeysignPrompt'
 import { getKeysignChain } from '@core/ui/mpc/keysign/utils/getKeysignChain'
 import { ProductLogoBlock } from '@core/ui/product/ProductLogoBlock'
+import { FeeSettings } from '@core/ui/vault/send/fee/settings/state/feeSettings'
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { getVaultId } from '@core/ui/vault/Vault'
 import { MatchRecordUnion } from '@lib/ui/base/MatchRecordUnion'
@@ -58,10 +60,19 @@ export const TransactionPage = () => {
       const keysignMessagePayload: KeysignMessagePayload =
         await matchRecordUnion(transaction.transactionPayload, {
           keysign: async keysign => {
+            const chainKind = getChainKind(keysign.chain)
+            const gasSettings: FeeSettings | null =
+              chainKind === 'evm'
+                ? { priority: 'fast', gasLimit: defaultEvmSwapGasLimit }
+                : chainKind === 'utxo'
+                  ? { priority: 'fast' }
+                  : null
+
             const keysignPayload = await getKeysignPayload(
               keysign,
               vault,
-              walletCore
+              walletCore,
+              gasSettings
             )
 
             keysign.txFee = String(

--- a/clients/extension/src/utils/tx/getKeySignPayload.ts
+++ b/clients/extension/src/utils/tx/getKeySignPayload.ts
@@ -24,6 +24,7 @@ import {
   KeysignPayload,
   KeysignPayloadSchema,
 } from '@core/mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { FeeSettings } from '@core/ui/vault/send/fee/settings/state/feeSettings'
 import { Vault } from '@core/ui/vault/Vault'
 import { isOneOf } from '@lib/utils/array/isOneOf'
 import { WalletCore } from '@trustwallet/wallet-core'
@@ -32,7 +33,8 @@ import { toUtf8String } from 'ethers'
 export const getKeysignPayload = (
   transaction: IKeysignTransactionPayload,
   vault: Vault,
-  walletCore: WalletCore
+  walletCore: WalletCore,
+  feeSettings: FeeSettings | null
 ): Promise<KeysignPayload> => {
   return new Promise((resolve, reject) => {
     ;(async () => {
@@ -85,6 +87,7 @@ export const getKeysignPayload = (
           transactionType: transaction.transactionDetails.ibcTransaction
             ? TransactionType.IBC_TRANSFER
             : TransactionType.UNSPECIFIED,
+          feeSettings,
         })
         switch (chainSpecific.case) {
           case 'ethereumSpecific': {

--- a/core/mpc/keysign/chainSpecific/evm.ts
+++ b/core/mpc/keysign/chainSpecific/evm.ts
@@ -71,6 +71,12 @@ export const getEthereumSpecific: ChainSpecificResolver<
   )
 
   if (maxFeePerGasWei < 1) maxFeePerGasWei = 1
+  console.log({
+    maxFeePerGasWei: maxFeePerGasWei.toString(),
+    priorityFee: priorityFee.toString(),
+    nonce,
+    gasLimit: gasLimit.toString(),
+  })
 
   return create(EthereumSpecificSchema, {
     maxFeePerGasWei: maxFeePerGasWei.toString(),

--- a/core/ui/vault/send/fee/settings/state/feeSettings.tsx
+++ b/core/ui/vault/send/fee/settings/state/feeSettings.tsx
@@ -7,7 +7,7 @@ import { getStateProviderSetup } from '@lib/ui/state/getStateProviderSetup'
 import { omit } from '@lib/utils/record/omit'
 import { useCallback, useMemo } from 'react'
 
-type FeeSettings = EvmFeeSettings | UtxoFeeSettings
+export type FeeSettings = EvmFeeSettings | UtxoFeeSettings
 import { useCoreViewState } from '../../../../../navigation/hooks/useCoreViewState'
 
 type FeeSettingsRecord = Record<string, FeeSettings>


### PR DESCRIPTION
## Description

Since we don't have a gas setting in the dapp sign flow, to ensure compatibility with different types of swaps and DeFi functions, I used the same gas limit as the one used for swaps in the Windows app.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context