### PR TITLE
Disable saving the same vault only during import, not during reshare.

### DIFF
--- a/core/ui/vault/import/components/SaveImportedVaultStep.tsx
+++ b/core/ui/vault/import/components/SaveImportedVaultStep.tsx
@@ -1,9 +1,9 @@
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { useCore } from '@core/ui/state/core'
-import { useVaultOrders } from '@core/ui/storage/vaults'
+import { useVaultOrders, useVaults } from '@core/ui/storage/vaults'
 import { useVaultBackupOverride } from '@core/ui/vault/import/state/vaultBackupOverride'
 import { SaveVaultStep } from '@core/ui/vault/save/SaveVaultStep'
-import { Vault } from '@core/ui/vault/Vault'
+import { getVaultId, Vault } from '@core/ui/vault/Vault'
 import { Button } from '@lib/ui/buttons/Button'
 import { FlowErrorPageContent } from '@lib/ui/flow/FlowErrorPageContent'
 import { useNavigateBack } from '@lib/ui/navigation/hooks/useNavigateBack'
@@ -19,6 +19,8 @@ export const SaveImportedVaultStep = ({ value }: ValueProp<Vault>) => {
   const navigateBack = useNavigateBack()
   const override = useVaultBackupOverride()
 
+  const vaults = useVaults()
+
   const vaultOrders = useVaultOrders()
 
   const finalValue = useMemo(
@@ -29,13 +31,26 @@ export const SaveImportedVaultStep = ({ value }: ValueProp<Vault>) => {
     [override, value, vaultOrders]
   )
 
-  return client === 'extension' && value.libType === 'GG20' ? (
-    <FlowErrorPageContent
-      title={t('failed_to_save_vault')}
-      message={t('extension_vault_import_restriction')}
-      action={<Button onClick={navigateBack}>{t('back')}</Button>}
-    />
-  ) : (
+  const error = useMemo(() => {
+    if (vaults.find(v => getVaultId(v) === getVaultId(finalValue))) {
+      return t('vault_already_exists')
+    }
+    if (client === 'extension' && value.libType === 'GG20') {
+      return t('extension_vault_import_restriction')
+    }
+  }, [client, finalValue, t, value.libType, vaults])
+
+  if (error) {
+    return (
+      <FlowErrorPageContent
+        title={t('failed_to_save_vault')}
+        message={error}
+        action={<Button onClick={navigateBack}>{t('back')}</Button>}
+      />
+    )
+  }
+
+  return (
     <SaveVaultStep
       onBack={() => navigate({ id: 'vault' })}
       onFinish={() => navigate({ id: 'vault' })}

--- a/core/ui/vault/mutations/useCreateVaultMutation.ts
+++ b/core/ui/vault/mutations/useCreateVaultMutation.ts
@@ -5,19 +5,16 @@ import { useCore } from '@core/ui/state/core'
 import { getVaultId, Vault } from '@core/ui/vault/Vault'
 import { useInvalidateQueries } from '@lib/ui/query/hooks/useInvalidateQueries'
 import { useMutation, UseMutationOptions } from '@tanstack/react-query'
-import { useTranslation } from 'react-i18next'
 
 import { useAssertWalletCore } from '../../chain/providers/WalletCoreProvider'
 import { useCreateCoinsMutation } from '../../storage/coins'
 import { useSetCurrentVaultIdMutation } from '../../storage/currentVaultId'
 import { StorageKey } from '../../storage/StorageKey'
-import { useVaults } from '../../storage/vaults'
 
 export const useCreateVaultMutation = (
   options?: UseMutationOptions<any, any, Vault, unknown>
 ) => {
   const invalidateQueries = useInvalidateQueries()
-  const vaults = useVaults()
 
   const { createVault, getDefaultChains } = useCore()
 
@@ -26,14 +23,8 @@ export const useCreateVaultMutation = (
 
   const walletCore = useAssertWalletCore()
 
-  const { t } = useTranslation()
-
   return useMutation({
     mutationFn: async (input: Vault) => {
-      if (vaults.find(v => getVaultId(v) === getVaultId(input))) {
-        throw new Error(t('vault_already_exists'))
-      }
-
       const vault = await createVault(input)
 
       await invalidateQueries([StorageKey.vaults])


### PR DESCRIPTION
- Added a check to prevent saving a vault if it already exists.
- Updated error messaging for vault import restrictions based on client type.
- Refactored the SaveImportedVaultStep component to improve readability and maintainability.

## Description

Please include a summary of the change and which issue is fixed. 

Fixes #1707 

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context