### PR TITLE
fix: gas deduction fees

### DIFF
--- a/core/ui/vault/send/amount/ManageAmountInputField.tsx
+++ b/core/ui/vault/send/amount/ManageAmountInputField.tsx
@@ -106,8 +106,16 @@ export const ManageAmountInputField = () => {
                   gap={4}
                 >
                   {suggestions.map(suggestion => {
-                    const baseAmount = fromChainAmount(amount, decimals)
-                    const suggestionBaseValue = baseAmount * suggestion
+                    const suggestionBaseValue =
+                      suggestion === maxSuggestion
+                        ? fromChainAmount(
+                            amount -
+                              (chainSpecificQuery.data
+                                ? getFeeAmount(chainSpecificQuery.data)
+                                : BigInt(0)),
+                            decimals
+                          )
+                        : fromChainAmount(amount, decimals) * suggestion
 
                     const suggestionValue =
                       currencyInputMode === 'base'


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 
Deduct tx gas fee correctly and let user only with the correct fee deducted from the max send.

Fixes #1666 

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [x] Sending  - Please attach a tx link here https://solscan.io/tx/455wHQgxZLY3GQu5xgjgaZ18hr2sMt6yKge5T2eimd92FkQymuUt3QEMhQrREh7fju3mkKQpXzizY6KruR1GnWzQ
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - The maximum amount suggestion now dynamically accounts for transaction fees, ensuring users can send the highest possible amount without exceeding their balance.

- **Refactor**
  - Improved calculation logic for amount suggestions, providing clearer and more accurate options when selecting how much to send.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->