### PR TITLE
Fix injection conflict with MetaMask

### DIFF
--- a/clients/extension/src/messengers/detectScriptType.ts
+++ b/clients/extension/src/messengers/detectScriptType.ts
@@ -2,18 +2,26 @@
  * Detects and returns what context the script is in.
  */
 export function detectScriptType() {
-  const hasChromeRuntime = typeof chrome !== 'undefined' && chrome.runtime
+  const hasChromeRuntime = typeof chrome !== 'undefined' && !!chrome.runtime
   const hasWindow = typeof window !== 'undefined'
+  // If window is defined but chrome.runtime.id is not the current extension ID,
+  // it's an inpage script, not a content script
+  const isInjectedInpageScript =
+    hasWindow && (!hasChromeRuntime || !chrome.runtime.id)
+
+  if (isInjectedInpageScript) return 'inpage'
+
+  if (hasChromeRuntime && !hasWindow) return 'background'
 
   if (hasChromeRuntime && hasWindow) {
-    if (window.location.pathname.includes('background')) return 'background'
-    if (window.location.pathname.includes('contentscript'))
-      return 'contentScript'
-    if (window.location.pathname.includes('index')) return 'popup'
-    return 'contentScript'
+    const path = window.location.pathname
+
+    if (path.includes('background')) return 'background'
+    if (path.includes('contentscript')) return 'contentScript'
+    if (path.includes('index')) return 'popup'
+    return 'contentScript' // fallback if not explicitly known
   }
-  if (hasChromeRuntime && !hasWindow) return 'background'
-  if (!hasChromeRuntime && hasWindow) return 'inpage'
+
   throw new Error('Undetected script.')
 }
 


### PR DESCRIPTION
## Description

When MetaMask is enabled, it injects chrome.runtime into every page, causing Vultisig's inpage script to mistakenly identify as a content script. This prevents the provider from being injected correctly.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved accuracy in detecting script context for browser extensions, leading to more reliable identification of inpage, content, and background scripts.

- **Refactor**
	- Enhanced and clarified the logic for determining script types, resulting in more predictable behavior and clearer error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->