### PR TITLE
Fix filter devices and plugin reshare

### DIFF
--- a/clients/extension/src/pages/plugin/index.tsx
+++ b/clients/extension/src/pages/plugin/index.tsx
@@ -1,5 +1,6 @@
 import { FastVaultReshareFlow } from '@core/ui/mpc/keygen/reshare/fast/FastVaultReshareFlow'
 import { ReshareVaultFlowProviders } from '@core/ui/mpc/keygen/reshare/ReshareVaultFlowProviders'
+import { ReshareVaultKeygenActionProvider } from '@core/ui/mpc/keygen/reshare/ReshareVaultKeygenActionProvider'
 import { KeygenOperationProvider } from '@core/ui/mpc/keygen/state/currentKeygenOperationType'
 import { EmailProvider } from '@core/ui/state/email'
 import { PasswordProvider } from '@core/ui/state/password'
@@ -13,12 +14,14 @@ export const PluginPage = () => {
       <EmailProvider initialValue="">
         <PasswordProvider initialValue="">
           <KeygenOperationProvider value={{ reshare: 'plugin' }}>
-            <StepTransition
-              from={({ onFinish }) => (
-                <PluginJoinKeygenUrl onFinish={onFinish} />
-              )}
-              to={() => <FastVaultReshareFlow />}
-            />
+            <ReshareVaultKeygenActionProvider>
+              <StepTransition
+                from={({ onFinish }) => (
+                  <PluginJoinKeygenUrl onFinish={onFinish} />
+                )}
+                to={() => <FastVaultReshareFlow />}
+              />
+            </ReshareVaultKeygenActionProvider>
           </KeygenOperationProvider>
         </PasswordProvider>
       </EmailProvider>

--- a/core/ui/mpc/fast/config.ts
+++ b/core/ui/mpc/fast/config.ts
@@ -1,3 +1,3 @@
 export const pluginPeersConfig = {
-  minimumJoinedParties: 4,
+  minimumJoinedParties: 3,
 }

--- a/core/ui/mpc/session/StartMpcSessionFlow.tsx
+++ b/core/ui/mpc/session/StartMpcSessionFlow.tsx
@@ -7,11 +7,18 @@ import { StartMpcSessionStep } from './StartMpcSessionStep'
 export const StartMpcSessionFlow = ({
   render,
   value,
-}: RenderProp & ValueProp<MpcSession>) => {
+  isPluginReshare,
+}: RenderProp &
+  ValueProp<MpcSession> &
+  Partial<{ isPluginReshare: boolean }>) => {
   return (
     <StepTransition
       from={({ onFinish }) => (
-        <StartMpcSessionStep onFinish={onFinish} value={value} />
+        <StartMpcSessionStep
+          onFinish={onFinish}
+          value={value}
+          isPluginReshare={isPluginReshare}
+        />
       )}
       to={() => render()}
     />

--- a/core/ui/mpc/session/StartMpcSessionStep.tsx
+++ b/core/ui/mpc/session/StartMpcSessionStep.tsx
@@ -1,3 +1,4 @@
+import { isServer } from '@core/mpc/devices/localPartyId'
 import { startMpcSession } from '@core/ui/mpc/session/utils/startMpcSession'
 import { useMpcDevices } from '@core/ui/mpc/state/mpcDevices'
 import { useMpcServerUrl } from '@core/ui/mpc/state/mpcServerUrl'
@@ -19,14 +20,24 @@ export const StartMpcSessionStep = ({
   onBack,
   onFinish,
   value,
-}: Partial<OnBackProp> & OnFinishProp & ValueProp<MpcSession>) => {
+  isPluginReshare,
+}: Partial<OnBackProp> &
+  OnFinishProp &
+  ValueProp<MpcSession> &
+  Partial<{ isPluginReshare: boolean }>) => {
   const { t } = useTranslation()
   const sessionId = useMpcSessionId()
   const serverUrl = useMpcServerUrl()
   const devices = useMpcDevices()
   const { mutate: start, ...status } = useMutation({
     mutationFn: () => {
-      return startMpcSession({ serverUrl, sessionId, devices })
+      return startMpcSession({
+        serverUrl,
+        sessionId,
+        devices: isPluginReshare
+          ? devices.filter(device => !isServer(device))
+          : devices,
+      })
     },
     onSuccess: () => onFinish(),
   })


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved plugin reshare support in the key generation flow, allowing for more flexible session initialization.
- **Improvements**
  - Minimum number of required parties for plugin operations has been reduced from 4 to 3, making it easier to start sessions with fewer participants.
- **Bug Fixes**
  - Enhanced device selection logic for plugin reshare sessions to exclude server devices when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->