### PR TITLE
fix: edge case for utxo

### DIFF
--- a/core/mpc/keysign/chainSpecific/utxo.ts
+++ b/core/mpc/keysign/chainSpecific/utxo.ts
@@ -12,6 +12,8 @@ import {
 
 import { ChainSpecificResolver } from './ChainSpecificResolver'
 
+const dustStats = 600n
+
 const getByteFee = async (chain: UtxoChain) => {
   if (chain === UtxoChain.Zcash) {
     return 1000
@@ -38,8 +40,8 @@ export const getUtxoSpecific: ChainSpecificResolver<
 
   if (amount) {
     const balance = await getCoinBalance(coin)
-
-    result.sendMaxAmount = toChainAmount(amount, coin.decimals) === balance
+    const requested = toChainAmount(amount, coin.decimals)
+    result.sendMaxAmount = balance - requested <= dustStats
   }
 
   return result


### PR DESCRIPTION
Fix for tiny-change occasional failure:
When you send > 75% of a UTXO and the leftover (“change”) is ≤ 600 sat, creating that tiny dust output causes the signature step to fail. Now, if leftover ≤ 600 sat we treat the transaction as “send-all” instead:

- Drop the change output

- Recalculate the fee for the full-value send



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of small remaining balances ("dust") when sending maximum amounts in UTXO-based transactions, allowing minor remainders to be considered as "send max".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->