### PR TITLE
Fix current EVM ChainId in extension

### DIFF
--- a/clients/extension/src/storage/currentEvmChainId.ts
+++ b/clients/extension/src/storage/currentEvmChainId.ts
@@ -1,0 +1,22 @@
+import { Chain } from '@core/chain/Chain'
+import { getEvmChainId } from '@core/chain/chains/evm/chainInfo'
+
+import { getPersistentState } from '../state/persistent/getPersistentState'
+import { setPersistentState } from '../state/persistent/setPersistentState'
+
+type GetCurrentEVMChainIdFunction = () => Promise<string>
+
+type SetCurrentEVMChainIdFunction = (chainId: string) => Promise<void>
+
+const initialEVMChainID = getEvmChainId(Chain.Ethereum)
+
+const currentEVMChainIdStorageKey = 'currentEVMChainId'
+
+export const getCurrentEVMChainId: GetCurrentEVMChainIdFunction = () =>
+  getPersistentState(currentEVMChainIdStorageKey, initialEVMChainID)
+
+export const setCurrentEVMChainId: SetCurrentEVMChainIdFunction = async (
+  chainId: string
+) => {
+  await setPersistentState(currentEVMChainIdStorageKey, chainId)
+}


### PR DESCRIPTION
## Description

Some dApps like BSC Explorer need to switch wallets ethereum chain even before connection to extension. this PR ensures that we have a general EVM ChainId in the extension.

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced persistent storage for the current EVM (Ethereum) chain selection, ensuring your preferred chain is remembered across sessions.

- **Bug Fixes**
  - Improved chain switching logic to handle cases where no previous session exists, providing a more reliable experience when adding or switching Ethereum chains.

- **Chores**
  - Enhanced debug logging for chain switching actions to aid in troubleshooting and transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->