### PR TITLE
fix: uneven assets size on swap screen

### DIFF
--- a/core/ui/vault/swap/components/SwapCoinInputField/index.tsx
+++ b/core/ui/vault/swap/components/SwapCoinInputField/index.tsx
@@ -61,7 +61,7 @@ export const SwapCoinInputField = ({
         </HStack>
         <CoinBalance value={value} />
       </HStack>
-      <HStack flexGrow justifyContent="space-between" alignItems="center">
+      <HStack flexGrow justifyContent="space-between" alignItems="flex-start">
         <CoinWrapper
           role="button"
           tabIndex={0}

--- a/core/ui/vault/swap/form/amount/ManageFromAmount.tsx
+++ b/core/ui/vault/swap/form/amount/ManageFromAmount.tsx
@@ -2,7 +2,7 @@ import { fromChainAmount } from '@core/chain/amount/fromChainAmount'
 import { AmountSuggestion } from '@core/ui/vault/send/amount/AmountSuggestion'
 import { useCurrentVaultCoin } from '@core/ui/vault/state/currentVaultCoins'
 import { AmountTextInput } from '@lib/ui/inputs/AmountTextInput'
-import { HStack } from '@lib/ui/layout/Stack'
+import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { useCallback, useState } from 'react'
 import styled from 'styled-components'
 
@@ -47,47 +47,45 @@ export const ManageFromAmount = () => {
   )
 
   return (
-    <AmountContainer gap={6} alignItems="flex-end">
-      <PositionedAmountInput
-        type="number"
-        placeholder={'0'}
-        onWheel={event => event.currentTarget.blur()}
-        value={value}
-        onChange={e => handleInputValueChange(e.target.value)}
-        suggestion={
-          <SwapCoinBalanceDependant
-            coin={swapCoin}
-            pending={() => null}
-            error={() => null}
-            success={amount => (
-              <HStack alignItems="center" gap={4}>
-                {suggestions.map(suggestion => (
-                  <AmountSuggestion
-                    onClick={() =>
-                      handleInputValueChange(
-                        String(fromChainAmount(amount, decimals) * suggestion)
-                      )
-                    }
-                    key={suggestion}
-                    value={suggestion}
-                  />
-                ))}
-              </HStack>
-            )}
-          />
-        }
+    <VStack gap={4} alignItems="flex-end">
+      <AmountContainer gap={6} alignItems="flex-end">
+        <PositionedAmountInput
+          type="number"
+          placeholder={'0'}
+          onWheel={event => event.currentTarget.blur()}
+          value={value}
+          onChange={e => handleInputValueChange(e.target.value)}
+        />
+        {value !== null && (
+          <SwapFiatAmount value={{ amount: value, ...fromCoinKey }} />
+        )}
+      </AmountContainer>
+      <SwapCoinBalanceDependant
+        coin={swapCoin}
+        pending={() => null}
+        error={() => null}
+        success={amount => (
+          <HStack alignItems="center" gap={4}>
+            {suggestions.map(suggestion => (
+              <AmountSuggestion
+                onClick={() =>
+                  handleInputValueChange(
+                    String(fromChainAmount(amount, decimals) * suggestion)
+                  )
+                }
+                key={suggestion}
+                value={suggestion}
+              />
+            ))}
+          </HStack>
+        )}
       />
-
-      {value !== null && (
-        <SwapFiatAmount value={{ amount: value, ...fromCoinKey }} />
-      )}
-    </AmountContainer>
+    </VStack>
   )
 }
 
 const PositionedAmountInput = styled(AmountTextInput)`
   text-align: right;
-
   border: none;
   font-family: inherit;
   &:hover {


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #1748 

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved vertical alignment of elements in the swap coin input field for a more consistent appearance.
	- Updated the layout of the amount input section to better separate the input, fiat value, and suggestion buttons, enhancing visual clarity and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->