### PR TITLE
Potential solution for the stale queries issue (displaying the QR code for a previous transaction when joining the keysign).

### DIFF
--- a/clients/extension/src/utils/pendingRequests.ts
+++ b/clients/extension/src/utils/pendingRequests.ts
@@ -1,4 +1,7 @@
-import { fixedDataQueryOptions } from '@lib/ui/query/utils/options'
+import {
+  noPersistQueryOptions,
+  noRefetchQueryOptions,
+} from '@lib/ui/query/utils/options'
 import { useQuery } from '@tanstack/react-query'
 
 import { getPersistentState } from '../state/persistent/getPersistentState'
@@ -51,5 +54,6 @@ export const useStoredPendingRequestQuery = <K extends StoredRequestKey>(
   useQuery({
     queryKey: ['storedRequest', key],
     queryFn: () => getStoredPendingRequest(key),
-    ...fixedDataQueryOptions,
+    ...noRefetchQueryOptions,
+    ...noPersistQueryOptions,
   })

--- a/core/ui/chain/providers/WalletCoreProvider.tsx
+++ b/core/ui/chain/providers/WalletCoreProvider.tsx
@@ -1,7 +1,10 @@
 import { FlowErrorPageContent } from '@lib/ui/flow/FlowErrorPageContent'
 import { ChildrenProp } from '@lib/ui/props'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
-import { fixedDataQueryOptions } from '@lib/ui/query/utils/options'
+import {
+  noPersistQueryOptions,
+  noRefetchQueryOptions,
+} from '@lib/ui/query/utils/options'
 import { shouldBePresent } from '@lib/utils/assert/shouldBePresent'
 import { extractErrorMsg } from '@lib/utils/error/extractErrorMsg'
 import { useQuery } from '@tanstack/react-query'
@@ -15,7 +18,8 @@ const WalletCoreContext = createContext<WalletCore | null>(null)
 export const WalletCoreProvider = ({ children }: ChildrenProp) => {
   const query = useQuery({
     queryKey: ['walletCore'],
-    ...fixedDataQueryOptions,
+    ...noPersistQueryOptions,
+    ...noRefetchQueryOptions,
     queryFn: async () => {
       const wasm = await initWasm()
       return wasm

--- a/core/ui/compression/queries/useSevenZipQuery.ts
+++ b/core/ui/compression/queries/useSevenZipQuery.ts
@@ -1,11 +1,15 @@
 import { getSevenZip } from '@core/mpc/compression/getSevenZip'
-import { fixedDataQueryOptions } from '@lib/ui/query/utils/options'
+import {
+  noPersistQueryOptions,
+  noRefetchQueryOptions,
+} from '@lib/ui/query/utils/options'
 import { useQuery } from '@tanstack/react-query'
 
 export const useSevenZipQuery = () => {
   return useQuery({
     queryKey: ['seven-zip'],
     queryFn: getSevenZip,
-    ...fixedDataQueryOptions,
+    ...noRefetchQueryOptions,
+    ...noPersistQueryOptions,
   })
 }

--- a/core/ui/mpc/devices/queries/queries/useMpcSignersQuery.ts
+++ b/core/ui/mpc/devices/queries/queries/useMpcSignersQuery.ts
@@ -1,6 +1,9 @@
 import { useMpcServerUrl } from '@core/ui/mpc/state/mpcServerUrl'
 import { useMpcSessionId } from '@core/ui/mpc/state/mpcSession'
-import { fixedDataQueryOptions } from '@lib/ui/query/utils/options'
+import {
+  noPersistQueryOptions,
+  noRefetchQueryOptions,
+} from '@lib/ui/query/utils/options'
 import { isEmpty } from '@lib/utils/array/isEmpty'
 import { withoutDuplicates } from '@lib/utils/array/withoutDuplicates'
 import { queryUrl } from '@lib/utils/query/queryUrl'
@@ -27,6 +30,7 @@ export const useMpcSignersQuery = () => {
     },
     retry: true,
     retryDelay: 1000,
-    ...fixedDataQueryOptions,
+    ...noRefetchQueryOptions,
+    ...noPersistQueryOptions,
   })
 }

--- a/core/ui/mpc/keysign/queries/useJoinKeysignUrlQuery.tsx
+++ b/core/ui/mpc/keysign/queries/useJoinKeysignUrlQuery.tsx
@@ -9,7 +9,10 @@ import { useMpcServiceName } from '@core/ui/mpc/state/mpcServiceName'
 import { useMpcSessionId } from '@core/ui/mpc/state/mpcSession'
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { getVaultId } from '@core/ui/vault/Vault'
-import { fixedDataQueryOptions } from '@lib/ui/query/utils/options'
+import {
+  noPersistQueryOptions,
+  noRefetchQueryOptions,
+} from '@lib/ui/query/utils/options'
 import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 
@@ -45,6 +48,7 @@ export const useJoinKeysignUrlQuery = (
   return useQuery({
     queryKey: ['joinKeysignUrl', input],
     queryFn: async () => getJoinKeysignUrl(input),
-    ...fixedDataQueryOptions,
+    ...noRefetchQueryOptions,
+    ...noPersistQueryOptions,
   })
 }

--- a/core/ui/storage/addressBook.tsx
+++ b/core/ui/storage/addressBook.tsx
@@ -2,7 +2,10 @@ import { AddressBookItem } from '@core/ui/address-book/model'
 import { useCore } from '@core/ui/state/core'
 import { StorageKey } from '@core/ui/storage/StorageKey'
 import { useInvalidateQueries } from '@lib/ui/query/hooks/useInvalidateQueries'
-import { fixedDataQueryOptions } from '@lib/ui/query/utils/options'
+import {
+  noPersistQueryOptions,
+  noRefetchQueryOptions,
+} from '@lib/ui/query/utils/options'
 import { shouldBePresent } from '@lib/utils/assert/shouldBePresent'
 import { sortEntitiesWithOrder } from '@lib/utils/entities/EntityWithOrder'
 import { useMutation, useQuery } from '@tanstack/react-query'
@@ -46,7 +49,8 @@ export const useAddressBookItemsQuery = () => {
 
       return sortEntitiesWithOrder(addresses)
     },
-    ...fixedDataQueryOptions,
+    ...noRefetchQueryOptions,
+    ...noPersistQueryOptions,
   })
 }
 

--- a/core/ui/storage/balanceVisibility.tsx
+++ b/core/ui/storage/balanceVisibility.tsx
@@ -1,5 +1,8 @@
 import { useInvalidateQueries } from '@lib/ui/query/hooks/useInvalidateQueries'
-import { fixedDataQueryOptions } from '@lib/ui/query/utils/options'
+import {
+  noPersistQueryOptions,
+  noRefetchQueryOptions,
+} from '@lib/ui/query/utils/options'
 import { shouldBeDefined } from '@lib/utils/assert/shouldBeDefined'
 import { useMutation, useQuery } from '@tanstack/react-query'
 
@@ -23,7 +26,8 @@ export const useIsBalanceVisibleQuery = () => {
   return useQuery({
     queryKey: [StorageKey.isBalanceVisible],
     queryFn: getIsBalanceVisible,
-    ...fixedDataQueryOptions,
+    ...noRefetchQueryOptions,
+    ...noPersistQueryOptions,
   })
 }
 

--- a/core/ui/storage/coinFinderIgnore.tsx
+++ b/core/ui/storage/coinFinderIgnore.tsx
@@ -1,6 +1,9 @@
 import { CoinKey } from '@core/chain/coin/Coin'
 import { useInvalidateQueries } from '@lib/ui/query/hooks/useInvalidateQueries'
-import { fixedDataQueryOptions } from '@lib/ui/query/utils/options'
+import {
+  noPersistQueryOptions,
+  noRefetchQueryOptions,
+} from '@lib/ui/query/utils/options'
 import { shouldBePresent } from '@lib/utils/assert/shouldBePresent'
 import { useMutation, useQuery } from '@tanstack/react-query'
 
@@ -29,7 +32,8 @@ export const useCoinFinderIgnoreQuery = () => {
   return useQuery({
     queryKey: [StorageKey.coinFinderIgnore],
     queryFn: getCoinFinderIgnore,
-    ...fixedDataQueryOptions,
+    ...noRefetchQueryOptions,
+    ...noPersistQueryOptions,
   })
 }
 

--- a/core/ui/storage/currentVaultId.tsx
+++ b/core/ui/storage/currentVaultId.tsx
@@ -1,7 +1,10 @@
 import { useCore } from '@core/ui/state/core'
 import { ChildrenProp, ValueProp } from '@lib/ui/props'
 import { useInvalidateQueries } from '@lib/ui/query/hooks/useInvalidateQueries'
-import { fixedDataQueryOptions } from '@lib/ui/query/utils/options'
+import {
+  noPersistQueryOptions,
+  noRefetchQueryOptions,
+} from '@lib/ui/query/utils/options'
 import { getValueProviderSetup } from '@lib/ui/state/getValueProviderSetup'
 import { shouldBePresent } from '@lib/utils/assert/shouldBePresent'
 import {
@@ -47,7 +50,8 @@ export const useCurrentVaultIdQuery = () => {
   return useQuery({
     queryKey: [StorageKey.currentVaultId],
     queryFn: getCurrentVaultId,
-    ...fixedDataQueryOptions,
+    ...noRefetchQueryOptions,
+    ...noPersistQueryOptions,
   })
 }
 

--- a/core/ui/storage/defaultChains.tsx
+++ b/core/ui/storage/defaultChains.tsx
@@ -1,5 +1,8 @@
 import { Chain } from '@core/chain/Chain'
-import { fixedDataQueryOptions } from '@lib/ui/query/utils/options'
+import {
+  noPersistQueryOptions,
+  noRefetchQueryOptions,
+} from '@lib/ui/query/utils/options'
 import { useQuery } from '@tanstack/react-query'
 
 import { useCore } from '../state/core'
@@ -25,6 +28,7 @@ export const useDefaultChainsQuery = () => {
   return useQuery({
     queryKey: [StorageKey.defaultChains],
     queryFn: getDefaultChains,
-    ...fixedDataQueryOptions,
+    ...noRefetchQueryOptions,
+    ...noPersistQueryOptions,
   })
 }

--- a/core/ui/storage/fiatCurrency.tsx
+++ b/core/ui/storage/fiatCurrency.tsx
@@ -1,6 +1,9 @@
 import { FiatCurrency } from '@core/config/FiatCurrency'
 import { useInvalidateQueries } from '@lib/ui/query/hooks/useInvalidateQueries'
-import { fixedDataQueryOptions } from '@lib/ui/query/utils/options'
+import {
+  noPersistQueryOptions,
+  noRefetchQueryOptions,
+} from '@lib/ui/query/utils/options'
 import { shouldBeDefined } from '@lib/utils/assert/shouldBeDefined'
 import { useMutation, useQuery } from '@tanstack/react-query'
 
@@ -22,7 +25,8 @@ export const useFiatCurrencyQuery = () => {
   return useQuery({
     queryKey: [StorageKey.fiatCurrency],
     queryFn: getFiatCurrency,
-    ...fixedDataQueryOptions,
+    ...noRefetchQueryOptions,
+    ...noPersistQueryOptions,
   })
 }
 

--- a/core/ui/storage/initialView.tsx
+++ b/core/ui/storage/initialView.tsx
@@ -1,5 +1,8 @@
 import { View } from '@lib/ui/navigation/View'
-import { fixedDataQueryOptions } from '@lib/ui/query/utils/options'
+import {
+  noPersistQueryOptions,
+  noRefetchQueryOptions,
+} from '@lib/ui/query/utils/options'
 import { useQuery } from '@tanstack/react-query'
 
 import { useCore } from '../state/core'
@@ -17,6 +20,7 @@ export const useInitialViewQuery = () => {
   return useQuery({
     queryKey: [StorageKey.initialView],
     queryFn: getInitialView,
-    ...fixedDataQueryOptions,
+    ...noRefetchQueryOptions,
+    ...noPersistQueryOptions,
   })
 }

--- a/core/ui/storage/language.tsx
+++ b/core/ui/storage/language.tsx
@@ -1,5 +1,8 @@
 import { useInvalidateQueries } from '@lib/ui/query/hooks/useInvalidateQueries'
-import { fixedDataQueryOptions } from '@lib/ui/query/utils/options'
+import {
+  noPersistQueryOptions,
+  noRefetchQueryOptions,
+} from '@lib/ui/query/utils/options'
 import { shouldBeDefined } from '@lib/utils/assert/shouldBeDefined'
 import { useMutation, useQuery } from '@tanstack/react-query'
 
@@ -22,7 +25,8 @@ export const useLanguageQuery = () => {
   return useQuery({
     queryKey: [StorageKey.language],
     queryFn: getLanguage,
-    ...fixedDataQueryOptions,
+    ...noRefetchQueryOptions,
+    ...noPersistQueryOptions,
   })
 }
 

--- a/core/ui/storage/onboarding.tsx
+++ b/core/ui/storage/onboarding.tsx
@@ -1,5 +1,8 @@
 import { useInvalidateQueries } from '@lib/ui/query/hooks/useInvalidateQueries'
-import { fixedDataQueryOptions } from '@lib/ui/query/utils/options'
+import {
+  noPersistQueryOptions,
+  noRefetchQueryOptions,
+} from '@lib/ui/query/utils/options'
 import { shouldBeDefined } from '@lib/utils/assert/shouldBeDefined'
 import { useMutation, useQuery } from '@tanstack/react-query'
 
@@ -25,7 +28,8 @@ export const useHasFinishedOnboardingQuery = () => {
   return useQuery({
     queryKey: [StorageKey.hasFinishedOnboarding],
     queryFn: getHasFinishedOnboarding,
-    ...fixedDataQueryOptions,
+    ...noRefetchQueryOptions,
+    ...noPersistQueryOptions,
   })
 }
 

--- a/core/ui/storage/passcodeAutoLock.tsx
+++ b/core/ui/storage/passcodeAutoLock.tsx
@@ -1,4 +1,7 @@
-import { fixedDataQueryOptions } from '@lib/ui/query/utils/options'
+import {
+  noPersistQueryOptions,
+  noRefetchQueryOptions,
+} from '@lib/ui/query/utils/options'
 import { shouldBeDefined } from '@lib/utils/assert/shouldBeDefined'
 import { useQuery } from '@tanstack/react-query'
 
@@ -27,7 +30,8 @@ export const usePasscodeAutoLockQuery = () => {
   return useQuery({
     queryKey: [StorageKey.passcodeAutoLock],
     queryFn: getPasscodeAutoLock,
-    ...fixedDataQueryOptions,
+    ...noRefetchQueryOptions,
+    ...noPersistQueryOptions,
   })
 }
 

--- a/core/ui/storage/passcodeEncryption.tsx
+++ b/core/ui/storage/passcodeEncryption.tsx
@@ -1,4 +1,7 @@
-import { fixedDataQueryOptions } from '@lib/ui/query/utils/options'
+import {
+  noPersistQueryOptions,
+  noRefetchQueryOptions,
+} from '@lib/ui/query/utils/options'
 import { shouldBeDefined } from '@lib/utils/assert/shouldBeDefined'
 import { useQuery } from '@tanstack/react-query'
 
@@ -24,7 +27,8 @@ export const usePasscodeEncryptionQuery = () => {
   return useQuery({
     queryKey: [StorageKey.passcodeEncryption],
     queryFn: getPasscodeEncryption,
-    ...fixedDataQueryOptions,
+    ...noRefetchQueryOptions,
+    ...noPersistQueryOptions,
   })
 }
 

--- a/core/ui/storage/vaultFolders.tsx
+++ b/core/ui/storage/vaultFolders.tsx
@@ -1,9 +1,11 @@
 import { useCore } from '@core/ui/state/core'
 import { useInvalidateQueries } from '@lib/ui/query/hooks/useInvalidateQueries'
-import { fixedDataQueryOptions } from '@lib/ui/query/utils/options'
+import {
+  noPersistQueryOptions,
+  noRefetchQueryOptions,
+} from '@lib/ui/query/utils/options'
 import { isEmpty } from '@lib/utils/array/isEmpty'
 import { shouldBePresent } from '@lib/utils/assert/shouldBePresent'
-import { sortEntitiesWithOrder } from '@lib/utils/entities/EntityWithOrder'
 import { Entry } from '@lib/utils/entities/Entry'
 import { getLastItemOrder } from '@lib/utils/order/getLastItemOrder'
 import { useMutation, useQuery } from '@tanstack/react-query'
@@ -45,12 +47,9 @@ export const useVaultFoldersQuery = () => {
 
   return useQuery({
     queryKey: [StorageKey.vaultFolders],
-    queryFn: async () => {
-      const result = await getVaultFolders()
-
-      return sortEntitiesWithOrder(result)
-    },
-    ...fixedDataQueryOptions,
+    queryFn: getVaultFolders,
+    ...noRefetchQueryOptions,
+    ...noPersistQueryOptions,
   })
 }
 

--- a/core/ui/storage/vaults.tsx
+++ b/core/ui/storage/vaults.tsx
@@ -3,7 +3,10 @@ import { isFeeCoin } from '@core/chain/coin/utils/isFeeCoin'
 import { useCore } from '@core/ui/state/core'
 import { useInvalidateQueries } from '@lib/ui/query/hooks/useInvalidateQueries'
 import { useTransformQueriesData } from '@lib/ui/query/hooks/useTransformQueriesData'
-import { fixedDataQueryOptions } from '@lib/ui/query/utils/options'
+import {
+  noPersistQueryOptions,
+  noRefetchQueryOptions,
+} from '@lib/ui/query/utils/options'
 import { getValueProviderSetup } from '@lib/ui/state/getValueProviderSetup'
 import { withoutDuplicates } from '@lib/utils/array/withoutDuplicates'
 import { sortEntitiesWithOrder } from '@lib/utils/entities/EntityWithOrder'
@@ -66,13 +69,15 @@ export const useVaultsQuery = () => {
   const vaults = useQuery({
     queryKey: [StorageKey.vaults],
     queryFn: getVaults,
-    ...fixedDataQueryOptions,
+    ...noPersistQueryOptions,
+    ...noRefetchQueryOptions,
   })
 
   const coins = useQuery({
     queryKey: [StorageKey.vaultsCoins],
     queryFn: getCoins,
-    ...fixedDataQueryOptions,
+    ...noPersistQueryOptions,
+    ...noRefetchQueryOptions,
   })
 
   return useTransformQueriesData(

--- a/lib/ui/query/utils/options.ts
+++ b/lib/ui/query/utils/options.ts
@@ -13,15 +13,13 @@ type UseQueryGenericOptions = Partial<
   >
 >
 
-const noRefetchQueryOptions: UseQueryGenericOptions = {
+export const noRefetchQueryOptions: UseQueryGenericOptions = {
   refetchOnMount: false,
   refetchOnWindowFocus: false,
   refetchOnReconnect: false,
 }
 
-export const fixedDataQueryOptions: UseQueryGenericOptions = {
-  ...noRefetchQueryOptions,
-  staleTime: Infinity,
+export const noPersistQueryOptions: UseQueryGenericOptions = {
   meta: { disablePersist: true },
 }
 


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated query configurations throughout the app to explicitly disable automatic refetching and data persistence, replacing previous fixed data options.
  - Simplified internal query functions for improved maintainability.
- **Chores**
  - Enhanced internal utilities to offer more granular control over query behavior without affecting public interfaces or user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->