### PR TITLE
[WIP] Add: persist state flow for send and swap on extension

### DIFF
--- a/core/ui/utils/isExtensionEnv.ts
+++ b/core/ui/utils/isExtensionEnv.ts
@@ -1,0 +1,7 @@
+export function isExtensionEnv(): boolean {
+  return !!(
+    typeof chrome !== 'undefined' &&
+    chrome.runtime &&
+    chrome.runtime.id
+  )
+}

--- a/core/ui/vault/persistent/getPersistentStateProviderSetup.tsx
+++ b/core/ui/vault/persistent/getPersistentStateProviderSetup.tsx
@@ -1,0 +1,63 @@
+import React, {
+  createContext,
+  Dispatch,
+  SetStateAction,
+  useContext,
+  useEffect,
+  useRef,
+} from 'react'
+
+import { usePersistentState } from './usePersistentState'
+
+type GetPersistentStateProviderSetup = <T>(
+  name: string,
+  getStorageKey: (vaultId?: string) => string
+) => {
+  provider: React.FC<ProviderProps<T>>
+  useState: () => [T, Dispatch<SetStateAction<T>>]
+}
+
+type ProviderProps<T> = {
+  initialValue: T
+  vaultId?: string
+  children: React.ReactNode
+}
+
+export const getPersistentStateProviderSetup: GetPersistentStateProviderSetup =
+  <T,>(name: string, getStorageKey: (vaultId?: string) => string) => {
+    type ContextState = { value: T; setValue: Dispatch<SetStateAction<T>> }
+    const Context = createContext<ContextState | undefined>(undefined)
+
+    const Provider: React.FC<ProviderProps<T>> = ({
+      children,
+      initialValue,
+      vaultId,
+    }) => {
+      const key = getStorageKey(vaultId)
+      const [value, setValue] = usePersistentState({ key, initialValue })
+      const previousVaultId = useRef<string | undefined>(vaultId)
+      useEffect(() => {
+        if (previousVaultId.current && previousVaultId.current !== vaultId) {
+          setValue(initialValue)
+        }
+        previousVaultId.current = vaultId
+      }, [vaultId, setValue, initialValue])
+
+      return (
+        <Context.Provider value={{ value, setValue }}>
+          {children}
+        </Context.Provider>
+      )
+    }
+
+    return {
+      provider: Provider,
+      useState: () => {
+        const context = useContext(Context)
+        if (!context) {
+          throw new Error(`${name} is not provided`)
+        }
+        return [context.value, context.setValue]
+      },
+    }
+  }

--- a/core/ui/vault/persistent/usePersistentState.ts
+++ b/core/ui/vault/persistent/usePersistentState.ts
@@ -1,0 +1,69 @@
+import { attempt } from '@lib/utils/attempt'
+import { useEffect, useState } from 'react'
+
+type UsePersistentStateOptions<T> = {
+  key: string
+  initialValue: T
+  onValueChange?: (value: T) => void
+}
+
+export function usePersistentState<T>({
+  key,
+  initialValue,
+  onValueChange,
+}: UsePersistentStateOptions<T>) {
+  const [localValue, setLocalValue] = useState<T>(initialValue)
+
+  useEffect(() => {
+    let isMounted = true
+    const initializeValue = async () => {
+      const result = await attempt(() => chrome.storage.local.get(key))
+      if (result.data) {
+        const value = result.data[key]
+        if (isMounted) {
+          setLocalValue(value ?? initialValue)
+        }
+      } else {
+        if (isMounted) setLocalValue(initialValue)
+      }
+    }
+    initializeValue()
+    return () => {
+      isMounted = false
+    }
+  }, [key, initialValue])
+
+  useEffect(() => {
+    const handleStorageChange = (changes: {
+      [key: string]: chrome.storage.StorageChange
+    }) => {
+      if (key in changes) {
+        const newValue = changes[key].newValue
+        if (newValue !== undefined) {
+          setLocalValue(newValue)
+          onValueChange?.(newValue)
+        }
+      }
+    }
+    chrome.storage.onChanged.addListener(handleStorageChange)
+    return () => chrome.storage.onChanged.removeListener(handleStorageChange)
+  }, [key, onValueChange])
+
+  const setValue = async (newValue: T | ((prev: T) => T)) => {
+    const finalValue =
+      typeof newValue === 'function'
+        ? (newValue as (prev: T) => T)(localValue)
+        : newValue
+    await chrome.storage.local.set({ [key]: finalValue })
+    setLocalValue(finalValue)
+    onValueChange?.(finalValue)
+  }
+
+  const clearValue = async () => {
+    await chrome.storage.local.remove(key)
+    setLocalValue(initialValue)
+    onValueChange?.(initialValue)
+  }
+
+  return [localValue, setValue, clearValue] as const
+}

--- a/core/ui/vault/send/SendPage.tsx
+++ b/core/ui/vault/send/SendPage.tsx
@@ -3,6 +3,7 @@ import { useStepNavigation } from '@lib/ui/hooks/useStepNavigation'
 import { useNavigateBack } from '@lib/ui/navigation/hooks/useNavigateBack'
 
 import { useCoreViewState } from '../../navigation/hooks/useCoreViewState'
+import { useAssertCurrentVaultId } from '../../storage/currentVaultId'
 import { FeeSettingsProvider } from './fee/settings/state/feeSettings'
 import { SendForm } from './form/SendForm'
 import { SendAmountProvider } from './state/amount'
@@ -20,14 +21,18 @@ export const SendPage = () => {
     onExit: useNavigateBack(),
   })
   const [{ address }] = useCoreViewState<'send'>()
+  const currentVaultId = useAssertCurrentVaultId()
 
   return (
     <SendFormFieldsStateProvider>
-      <SendFeesProvider initialValue={null}>
+      <SendFeesProvider initialValue={null} vaultId={currentVaultId}>
         <FeeSettingsProvider>
-          <SendAmountProvider initialValue={null}>
-            <SendReceiverProvider initialValue={address ?? ''}>
-              <SendMemoProvider initialValue="">
+          <SendAmountProvider initialValue={null} vaultId={currentVaultId}>
+            <SendReceiverProvider
+              initialValue={address ?? ''}
+              vaultId={currentVaultId}
+            >
+              <SendMemoProvider initialValue="" vaultId={currentVaultId}>
                 <Match
                   value={step}
                   form={() => <SendForm onFinish={toNextStep} />}

--- a/core/ui/vault/send/state/amount.ts
+++ b/core/ui/vault/send/state/amount.ts
@@ -1,4 +1,13 @@
+import { isExtensionEnv } from '@core/ui/utils/isExtensionEnv'
+import { getPersistentStateProviderSetup } from '@core/ui/vault/persistent/getPersistentStateProviderSetup'
 import { getStateProviderSetup } from '@lib/ui/state/getStateProviderSetup'
 
+const providerSetup = isExtensionEnv()
+  ? getPersistentStateProviderSetup<number | null>(
+      'SendAmount',
+      (vaultId?: string) => `send_amount_${vaultId}`
+    )
+  : getStateProviderSetup<number | null>('SendAmount')
+
 export const { useState: useSendAmount, provider: SendAmountProvider } =
-  getStateProviderSetup<number | null>('SendAmount')
+  providerSetup

--- a/core/ui/vault/send/state/formFields.tsx
+++ b/core/ui/vault/send/state/formFields.tsx
@@ -1,3 +1,5 @@
+import { isExtensionEnv } from '@core/ui/utils/isExtensionEnv'
+import { getPersistentStateProviderSetup } from '@core/ui/vault/persistent/getPersistentStateProviderSetup'
 import { ChildrenProp } from '@lib/ui/props'
 import { getStateProviderSetup } from '@lib/ui/state/getStateProviderSetup'
 
@@ -11,17 +13,23 @@ type FocusedSendFieldContext = {
   errors: ValidationResult<SendFormShape>
 }
 
+const providerSetup = isExtensionEnv()
+  ? getPersistentStateProviderSetup<FocusedSendFieldContext>(
+      'SendFormFieldStateProvider',
+      (vaultId?: string) => `send_form_fields_${vaultId}`
+    )
+  : getStateProviderSetup<FocusedSendFieldContext>('SendFormFieldStateProvider')
+
 export const {
   useState: useSendFormFieldState,
   provider: InternalSendFormFieldsStateProvider,
-} = getStateProviderSetup<FocusedSendFieldContext>('SendFormFieldStateProvider')
+} = providerSetup
 
 export const SendFormFieldsStateProvider = ({ children }: ChildrenProp) => {
   const [state] = useCoreViewState<'send'>()
 
   const initialSendFormFieldState: FocusedSendFieldContext = {
     field: 'coin' in state ? 'address' : 'coin',
-
     errors: {},
   }
 

--- a/core/ui/vault/send/state/memo.ts
+++ b/core/ui/vault/send/state/memo.ts
@@ -1,4 +1,13 @@
+import { isExtensionEnv } from '@core/ui/utils/isExtensionEnv'
+import { getPersistentStateProviderSetup } from '@core/ui/vault/persistent/getPersistentStateProviderSetup'
 import { getStateProviderSetup } from '@lib/ui/state/getStateProviderSetup'
 
+const providerSetup = isExtensionEnv()
+  ? getPersistentStateProviderSetup<string>(
+      'SendMemo',
+      (vaultId?: string) => `send_memo_${vaultId}`
+    )
+  : getStateProviderSetup<string>('SendMemo')
+
 export const { useState: useSendMemo, provider: SendMemoProvider } =
-  getStateProviderSetup<string>('SendMemo')
+  providerSetup

--- a/core/ui/vault/send/state/receiver.ts
+++ b/core/ui/vault/send/state/receiver.ts
@@ -1,4 +1,13 @@
+import { isExtensionEnv } from '@core/ui/utils/isExtensionEnv'
+import { getPersistentStateProviderSetup } from '@core/ui/vault/persistent/getPersistentStateProviderSetup'
 import { getStateProviderSetup } from '@lib/ui/state/getStateProviderSetup'
 
+const providerSetup = isExtensionEnv()
+  ? getPersistentStateProviderSetup<string>(
+      'SendReceiver',
+      (vaultId?: string) => `send_receiver_${vaultId}`
+    )
+  : getStateProviderSetup<string>('SendReceiver')
+
 export const { useState: useSendReceiver, provider: SendReceiverProvider } =
-  getStateProviderSetup<string>('SendReceiver')
+  providerSetup

--- a/core/ui/vault/send/state/sendFees.ts
+++ b/core/ui/vault/send/state/sendFees.ts
@@ -1,6 +1,15 @@
+import { isExtensionEnv } from '@core/ui/utils/isExtensionEnv'
+import { getPersistentStateProviderSetup } from '@core/ui/vault/persistent/getPersistentStateProviderSetup'
 import { getStateProviderSetup } from '@lib/ui/state/getStateProviderSetup'
 
 import { SendFees } from '../../../mpc/keysign/KeysignActionFees'
 
+const providerSetup = isExtensionEnv()
+  ? getPersistentStateProviderSetup<null | SendFees>(
+      'SendFees',
+      (vaultId?: string) => `send_fees_${vaultId}`
+    )
+  : getStateProviderSetup<null | SendFees>('SendFees')
+
 export const { useState: useSendFees, provider: SendFeesProvider } =
-  getStateProviderSetup<null | SendFees>('SendFees')
+  providerSetup

--- a/core/ui/vault/swap/components/SwapPage.tsx
+++ b/core/ui/vault/swap/components/SwapPage.tsx
@@ -6,6 +6,7 @@ import { PageHeaderBackButton } from '@lib/ui/page/PageHeaderBackButton'
 import { match } from '@lib/utils/match'
 import { useTranslation } from 'react-i18next'
 
+import { useAssertCurrentVaultId } from '../../../storage/currentVaultId'
 import { SwapForm } from '../form/SwapForm'
 import { FromAmountProvider } from '../state/fromAmount'
 import { ToCoinProvider } from '../state/toCoin'
@@ -20,6 +21,7 @@ export const SwapPage = () => {
     steps: sendSteps,
     onExit: useNavigateBack(),
   })
+  const currentVaultId = useAssertCurrentVaultId()
 
   const { primaryControls, title } = match(step, {
     form: () => ({
@@ -33,7 +35,7 @@ export const SwapPage = () => {
   })
 
   return (
-    <FromAmountProvider initialValue={null}>
+    <FromAmountProvider initialValue={null} vaultId={currentVaultId}>
       <ToCoinProvider>
         <PageHeader
           primaryControls={primaryControls}

--- a/core/ui/vault/swap/state/fromAmount.ts
+++ b/core/ui/vault/swap/state/fromAmount.ts
@@ -1,4 +1,13 @@
+import { isExtensionEnv } from '@core/ui/utils/isExtensionEnv'
+import { getPersistentStateProviderSetup } from '@core/ui/vault/persistent/getPersistentStateProviderSetup'
 import { getStateProviderSetup } from '@lib/ui/state/getStateProviderSetup'
 
+const providerSetup = isExtensionEnv()
+  ? getPersistentStateProviderSetup<number | null>(
+      'FromAmount',
+      (vaultId?: string) => `swap_from_amount_${vaultId}`
+    )
+  : getStateProviderSetup<number | null>('FromAmount')
+
 export const { useState: useFromAmount, provider: FromAmountProvider } =
-  getStateProviderSetup<number | null>('FromAmount')
+  providerSetup

--- a/core/ui/vault/swap/state/toCoin.tsx
+++ b/core/ui/vault/swap/state/toCoin.tsx
@@ -1,18 +1,28 @@
 import { areEqualCoins, CoinKey } from '@core/chain/coin/Coin'
+import { isExtensionEnv } from '@core/ui/utils/isExtensionEnv'
+import { getPersistentStateProviderSetup } from '@core/ui/vault/persistent/getPersistentStateProviderSetup'
 import { useCurrentVaultNativeCoins } from '@core/ui/vault/state/currentVaultCoins'
 import { ChildrenProp } from '@lib/ui/props'
 import { getStateProviderSetup } from '@lib/ui/state/getStateProviderSetup'
 import { useMemo } from 'react'
 
 import { useCoreViewState } from '../../../navigation/hooks/useCoreViewState'
+import { useAssertCurrentVaultId } from '../../../storage/currentVaultId'
 
-const { useState: useToCoin, provider: ToCoinInternalProvider } =
-  getStateProviderSetup<CoinKey>('ToCoin')
+const providerSetup = isExtensionEnv()
+  ? getPersistentStateProviderSetup<CoinKey>(
+      'ToCoin',
+      (vaultId?: string) => `swap_to_coin_${vaultId}`
+    )
+  : getStateProviderSetup<CoinKey>('ToCoin')
+
+const { useState: useToCoin, provider: ToCoinInternalProvider } = providerSetup
 
 export { useToCoin }
 
 export const ToCoinProvider: React.FC<ChildrenProp> = ({ children }) => {
   const [{ coin: fromCoin }] = useCoreViewState<'swap'>()
+  const currentVaultId = useAssertCurrentVaultId()
 
   const nativeCoins = useCurrentVaultNativeCoins()
 
@@ -23,7 +33,10 @@ export const ToCoinProvider: React.FC<ChildrenProp> = ({ children }) => {
   }, [fromCoin, nativeCoins])
 
   return (
-    <ToCoinInternalProvider initialValue={initialValue}>
+    <ToCoinInternalProvider
+      initialValue={initialValue}
+      vaultId={currentVaultId}
+    >
       {children}
     </ToCoinInternalProvider>
   )


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #1782 

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * State for send and swap forms now persists across sessions when using the browser extension.
  * State is scoped to the current vault, ensuring separation between different vaults.
* **Improvements**
  * Enhanced reliability of form state management in browser extension environments.
  * Automatic reset of form state when switching between vaults.
* **Bug Fixes**
  * Prevents unintended sharing or loss of form data when switching vaults or reloading the extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->