### PR TITLE
 Fix Wrong addresses displayed for Vault selection on send screen 

### DIFF
--- a/core/ui/vault/send/addresses/components/AddressBookModal/index.tsx
+++ b/core/ui/vault/send/addresses/components/AddressBookModal/index.tsx
@@ -33,13 +33,16 @@ export const AddressBookModal = ({ onSelect, onClose }: Props) => {
 
   const vaultsAndAddressForSelectedCoin = useMemo(() => {
     return vaults.reduce<VaultAddressBookItem[]>((acc, vault) => {
-      const coinAddress = vault.coins.find(c => c.id === coin.id)?.address
-      if (coinAddress) {
-        acc.push({ name: vault.name, address: coinAddress })
+      const match = vault.coins.find(
+        c => c.chain === coin.chain && (coin.id ? c.id === coin.id : !c.id)
+      )
+
+      if (match?.address) {
+        acc.push({ name: vault.name, address: match.address })
       }
       return acc
     }, [])
-  }, [coin.id, vaults])
+  }, [coin.chain, coin.id, vaults])
 
   return (
     <Modal onClose={onClose} title={t('address_book')}>

--- a/lib/ui/list/item/index.tsx
+++ b/lib/ui/list/item/index.tsx
@@ -22,6 +22,7 @@ const StyledMeta = styled.span`
   flex-direction: column;
   gap: 4px;
   max-width: 100%;
+  overflow: auto;
 `
 
 const StyledTitle = styled.span`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy when displaying vault coin addresses by matching both coin ID and blockchain chain, ensuring correct addresses are shown for the selected coin.

* **Style**
  * Enabled automatic scrollbars for list item metadata to enhance display of overflowing content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->