### PR TITLE
Match memo propagation for iOS and Android in MayaSwap.

### DIFF
--- a/core/mpc/keysign/txInputData/cosmos/index.ts
+++ b/core/mpc/keysign/txInputData/cosmos/index.ts
@@ -1,4 +1,4 @@
-import { VaultBasedCosmosChain } from '@core/chain/Chain'
+import { Chain, VaultBasedCosmosChain } from '@core/chain/Chain'
 import { cosmosFeeCoinDenom } from '@core/chain/chains/cosmos/cosmosFeeCoinDenom'
 import { cosmosGasLimitRecord } from '@core/chain/chains/cosmos/cosmosGasLimitRecord'
 import { getCosmosChainKind } from '@core/chain/chains/cosmos/utils/getCosmosChainKind'
@@ -191,7 +191,8 @@ export const getCosmosTxInputData: TxInputDataResolver<'cosmos'> = ({
                 }),
             }),
           ],
-          txMemo: swapPayload ? '' : memo, // both IOS and Android specify memo in the txInputData as well when deposit
+          // That doesn't make sense, but iOS and Android have this logic.
+          txMemo: chain === Chain.MayaChain ? memo : swapPayload ? '' : memo,
         }
       }
 


### PR DESCRIPTION
<img width="422" height="711" alt="image" src="https://github.com/user-attachments/assets/04ec63d8-e4fd-4aa3-bbc3-49c9ba5ff7a5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of transaction memos for MayaChain to ensure correct display and compatibility across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->