### PR TITLE
Fix thorchain fee edge case

### DIFF
--- a/core/chain/tx/fee/getFeeAmount.ts
+++ b/core/chain/tx/fee/getFeeAmount.ts
@@ -7,6 +7,8 @@ import { rippleTxFee } from '@core/chain/tx/fee/ripple'
 import { KeysignChainSpecific } from '@core/mpc/keysign/chainSpecific/KeysignChainSpecific'
 import { matchDiscriminatedUnion } from '@lib/utils/matchDiscriminatedUnion'
 
+import { nativeTxFeeRune } from './thorchain/config'
+
 export const getFeeAmount = (chainSpecific: KeysignChainSpecific): bigint =>
   matchDiscriminatedUnion(chainSpecific, 'case', 'value', {
     utxoSpecific: ({ byteFee }) => BigInt(byteFee) * BigInt(250), // assume the average size of an UTXO transaction is 250 vbytes
@@ -17,7 +19,7 @@ export const getFeeAmount = (chainSpecific: KeysignChainSpecific): bigint =>
       BigInt(priorityFee) == BigInt(0)
         ? BigInt(solanaConfig.priorityFeeLimit)
         : BigInt(priorityFee), // currently we hardcode the priority fee to 100_000 lamports
-    thorchainSpecific: ({ fee }) => BigInt(fee ?? 0),
+    thorchainSpecific: ({ fee }) => BigInt(fee ?? nativeTxFeeRune),
     mayaSpecific: () => BigInt(cosmosGasLimitRecord[Chain.MayaChain]),
     cosmosSpecific: ({ gas }) => BigInt(gas),
     polkadotSpecific: () => polkadotConfig.fee,

--- a/core/chain/tx/fee/thorchain/config.ts
+++ b/core/chain/tx/fee/thorchain/config.ts
@@ -1,0 +1,1 @@
+export const nativeTxFeeRune = 2_000_000


### PR DESCRIPTION
Occasionally the chainSpecific returns undefined for THORchain fee insteaed of a valid number. This PR adds a falllack to avoid throwing an error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fee calculation reliability by handling missing or undefined fee values, preventing potential errors during transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->