### PR TITLE
Add fallback for fees on cosmos

### DIFF
--- a/core/chain/tx/fee/getFeeAmount.ts
+++ b/core/chain/tx/fee/getFeeAmount.ts
@@ -21,7 +21,8 @@ export const getFeeAmount = (chainSpecific: KeysignChainSpecific): bigint =>
         : BigInt(priorityFee), // currently we hardcode the priority fee to 100_000 lamports
     thorchainSpecific: ({ fee }) => BigInt(fee ?? nativeTxFeeRune),
     mayaSpecific: () => BigInt(cosmosGasLimitRecord[Chain.MayaChain]),
-    cosmosSpecific: ({ gas }) => BigInt(gas),
+    cosmosSpecific: ({ gas }) =>
+      BigInt(gas ?? cosmosGasLimitRecord[Chain.Cosmos]),
     polkadotSpecific: () => polkadotConfig.fee,
     tonSpecific: () => tonConfig.fee,
     tronSpecific: ({ gasEstimation }) => BigInt(gasEstimation || 0),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fee calculation for Cosmos transactions by applying a default gas limit when no gas value is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->