### PR TITLE
Fix the USTC send on Terra Classic.

### DIFF
--- a/core/chain/chains/cosmos/cosmosGasLimitRecord.ts
+++ b/core/chain/chains/cosmos/cosmosGasLimitRecord.ts
@@ -1,14 +1,24 @@
 import { Chain, CosmosChain } from '@core/chain/Chain'
 
-export const cosmosGasLimitRecord: Record<CosmosChain, number> = {
-  [Chain.Cosmos]: 200000,
-  [Chain.Osmosis]: 300000,
-  [Chain.Kujira]: 200000,
-  [Chain.Dydx]: 200000,
-  [Chain.Noble]: 200000,
-  [Chain.Akash]: 200000,
-  [Chain.Terra]: 300000,
-  [Chain.TerraClassic]: 300000,
-  [Chain.THORChain]: 20000000,
-  [Chain.MayaChain]: 2000000000,
+import { areEqualCoins, CoinKey } from '../../coin/Coin'
+
+export const cosmosGasLimitRecord: Record<CosmosChain, bigint> = {
+  [Chain.Cosmos]: 200000n,
+  [Chain.Osmosis]: 300000n,
+  [Chain.Kujira]: 200000n,
+  [Chain.Dydx]: 200000n,
+  [Chain.Noble]: 200000n,
+  [Chain.Akash]: 200000n,
+  [Chain.Terra]: 300000n,
+  [Chain.TerraClassic]: 300000n,
+  [Chain.THORChain]: 20000000n,
+  [Chain.MayaChain]: 2000000000n,
+}
+
+export const getCosmosGasLimit = (coin: CoinKey<CosmosChain>): bigint => {
+  if (areEqualCoins(coin, { chain: Chain.TerraClassic, id: 'uusd' })) {
+    return 1_000_000n
+  }
+
+  return cosmosGasLimitRecord[coin.chain]
 }

--- a/core/mpc/keysign/txInputData/cosmos/coinAmount.ts
+++ b/core/mpc/keysign/txInputData/cosmos/coinAmount.ts
@@ -6,7 +6,7 @@ import { KeysignPayload } from '../../../types/vultisig/keysign/v1/keysign_messa
 import { getKeysignCoin } from '../../utils/getKeysignCoin'
 
 export const getCosmosCoinAmount = (input: KeysignPayload) => {
-  const coin = getKeysignCoin(input)
+  const coin = getKeysignCoin<CosmosChain>(input)
 
   const denom = isFeeCoin(coin)
     ? cosmosFeeCoinDenom[coin.chain as CosmosChain]

--- a/core/mpc/keysign/utils/getKeysignCoin.ts
+++ b/core/mpc/keysign/utils/getKeysignCoin.ts
@@ -1,7 +1,10 @@
+import { Chain } from '@core/chain/Chain'
+import { AccountCoin } from '@core/chain/coin/AccountCoin'
 import { KeysignPayload } from '@core/mpc/types/vultisig/keysign/v1/keysign_message_pb'
 import { shouldBePresent } from '@lib/utils/assert/shouldBePresent'
 
 import { fromCommCoin } from '../../types/utils/commCoin'
 
-export const getKeysignCoin = ({ coin }: KeysignPayload) =>
-  fromCommCoin(shouldBePresent(coin))
+export const getKeysignCoin = <T extends Chain = Chain>({
+  coin,
+}: KeysignPayload): AccountCoin<T> => fromCommCoin<T>(shouldBePresent(coin))

--- a/core/mpc/types/utils/commCoin.ts
+++ b/core/mpc/types/utils/commCoin.ts
@@ -7,10 +7,12 @@ import {
   CoinSchema,
 } from '@core/mpc/types/vultisig/keysign/v1/coin_pb'
 
-export const fromCommCoin = (coin: CommCoin): AccountCoin => {
+export const fromCommCoin = <T extends Chain = Chain>(
+  coin: CommCoin
+): AccountCoin<T> => {
   return {
     id: coin.contractAddress || undefined,
-    chain: coin.chain as Chain,
+    chain: coin.chain as T,
     address: coin.address,
     ticker: coin.ticker,
     logo: coin.logo,


### PR DESCRIPTION
- Update cosmosGasLimitRecord to use bigint for gas limits, enhancing precision.
- Introduce getCosmosGasLimit function to retrieve gas limits based on coin type.
- Modify getKeysignCoin to support generics for better type handling.
- Refactor transaction fee calculation to utilize the new gas limit retrieval method, improving clarity and maintainability.

## Description

Please include a summary of the change and which issue is fixed. 

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context