### PR TITLE
Fix RUNE -> CACAO swap

### DIFF
--- a/core/mpc/keysign/txInputData/resolvers/cosmos/index.ts
+++ b/core/mpc/keysign/txInputData/resolvers/cosmos/index.ts
@@ -2,6 +2,7 @@ import { Chain, CosmosChain, VaultBasedCosmosChain } from '@core/chain/Chain'
 import { cosmosFeeCoinDenom } from '@core/chain/chains/cosmos/cosmosFeeCoinDenom'
 import { getCosmosGasLimit } from '@core/chain/chains/cosmos/cosmosGasLimitRecord'
 import { getCosmosChainKind } from '@core/chain/chains/cosmos/utils/getCosmosChainKind'
+import { chainFeeCoin } from '@core/chain/coin/chainFeeCoin'
 import { areEqualCoins } from '@core/chain/coin/Coin'
 import { nativeSwapChainIds } from '@core/chain/swap/native/NativeSwapChain'
 import { TransactionType } from '@core/mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
@@ -165,8 +166,33 @@ export const getCosmosTxInputData: TxInputDataResolver<'cosmos'> = ({
         }
       }
 
-      const swapPayload = getKeysignSwapPayload(keysignPayload)
-      if (isDeposit || swapPayload) {
+      const getSwapPayload = () => {
+        const swapPayload = getKeysignSwapPayload(keysignPayload)
+        if (!swapPayload) {
+          return null
+        }
+
+        return getRecordUnionValue(swapPayload, 'native')
+      }
+
+      const swapPayload = getSwapPayload()
+
+      const getDepositAmount = () => {
+        if (isDeposit) {
+          return shouldBePresent(keysignPayload.toAmount)
+        }
+
+        if (
+          swapPayload &&
+          areEqualCoins(coin, chainFeeCoin[swapPayload.chain])
+        ) {
+          return swapPayload.fromAmount
+        }
+      }
+
+      const depositAmount = getDepositAmount()
+
+      if (depositAmount) {
         const depositCoin = TW.Cosmos.Proto.THORChainCoin.create({
           asset: TW.Cosmos.Proto.THORChainAsset.create({
             chain: nativeSwapChainIds[chain as VaultBasedCosmosChain],
@@ -174,32 +200,9 @@ export const getCosmosTxInputData: TxInputDataResolver<'cosmos'> = ({
             ticker: coin.ticker,
             synth: false,
           }),
+          amount: depositAmount,
+          decimals: new Long(coin.decimals),
         })
-        const swapFromAmount =
-          swapPayload && 'native' in swapPayload
-            ? swapPayload.native.fromAmount
-            : undefined
-        const depositAmount = swapFromAmount ?? keysignPayload.toAmount
-
-        if (Number(depositAmount) > 0) {
-          depositCoin.amount = depositAmount!
-          depositCoin.decimals = new Long(coin.decimals)
-        }
-
-        const getTxMemo = () => {
-          if (isDeposit) {
-            return memo
-          }
-
-          const swapChain =
-            swapPayload && 'native' in swapPayload
-              ? swapPayload.native.chain
-              : chain
-
-          return swapChain === Chain.MayaChain ? memo : ''
-        }
-
-        const txMemo = getTxMemo()
 
         return {
           messages: [
@@ -212,7 +215,8 @@ export const getCosmosTxInputData: TxInputDataResolver<'cosmos'> = ({
                 }),
             }),
           ],
-          txMemo,
+          // That doesn't make sense, but iOS and Android have this logic.
+          txMemo: chain === Chain.MayaChain ? memo : swapPayload ? '' : memo,
         }
       }
 

--- a/core/mpc/keysign/txInputData/resolvers/cosmos/index.ts
+++ b/core/mpc/keysign/txInputData/resolvers/cosmos/index.ts
@@ -181,10 +181,25 @@ export const getCosmosTxInputData: TxInputDataResolver<'cosmos'> = ({
             : undefined
         const depositAmount = swapFromAmount ?? keysignPayload.toAmount
 
-        if (Number(depositAmount || '0') > 0) {
+        if (Number(depositAmount) > 0) {
           depositCoin.amount = depositAmount!
           depositCoin.decimals = new Long(coin.decimals)
         }
+
+        const getTxMemo = () => {
+          if (isDeposit) {
+            return memo
+          }
+
+          const swapChain =
+            swapPayload && 'native' in swapPayload
+              ? swapPayload.native.chain
+              : chain
+
+          return swapChain === Chain.MayaChain ? memo : ''
+        }
+
+        const txMemo = getTxMemo()
 
         return {
           messages: [
@@ -197,8 +212,7 @@ export const getCosmosTxInputData: TxInputDataResolver<'cosmos'> = ({
                 }),
             }),
           ],
-          // That doesn't make sense, but iOS and Android have this logic.
-          txMemo: chain === Chain.MayaChain ? memo : swapPayload ? '' : memo,
+          txMemo,
         }
       }
 


### PR DESCRIPTION
RUNE -> CACAO
<img width="402" height="708" alt="image" src="https://github.com/user-attachments/assets/ba7f3c8a-f610-4901-929a-d5ede4b40f55" />

CACAO -> RUNE
<img width="401" height="717" alt="image" src="https://github.com/user-attachments/assets/cf10aeb1-c4f1-40e4-ab0b-2781cc283905" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrects deposit amount calculation for Cosmos-related deposits, ensuring accurate amounts for native swaps and direct deposits.
  * Prevents creating deposit messages when required payload data is missing, reducing failed or unintended transactions.
  * Improves handling of chain-specific fee coins during swap-related deposits.

* **Refactor**
  * Streamlines deposit message construction by deriving the deposit amount in a single step.
  * Simplifies conditional logic for when to create deposit messages, improving reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->