### PR TITLE
Add a missing back button when failing to start the key sign session.

### DIFF
--- a/core/ui/mpc/session/StartMpcSessionStep.tsx
+++ b/core/ui/mpc/session/StartMpcSessionStep.tsx
@@ -8,11 +8,11 @@ import { PageContent } from '@lib/ui/page/PageContent'
 import { PageHeader } from '@lib/ui/page/PageHeader'
 import { OnFinishProp, ValueProp } from '@lib/ui/props'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
-import { Text } from '@lib/ui/text'
-import { extractErrorMsg } from '@lib/utils/error/extractErrorMsg'
 import { useMutation } from '@tanstack/react-query'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
+
+import { FlowErrorPageContent } from '../../flow/FlowErrorPageContent'
 
 export const StartMpcSessionStep = ({
   onFinish,
@@ -42,7 +42,12 @@ export const StartMpcSessionStep = ({
         <MatchQuery
           value={status}
           pending={() => <Spinner size="3em" />}
-          error={error => <Text>{extractErrorMsg(error)}</Text>}
+          error={error => (
+            <FlowErrorPageContent
+              title={t('session_init_failed')}
+              error={error}
+            />
+          )}
         />
       </PageContent>
     </>


### PR DESCRIPTION
- Replaced the error display logic in the MatchQuery component to utilize FlowErrorPageContent for improved user feedback during session initialization failures.
- Updated imports to include the new FlowErrorPageContent component, enhancing the clarity and maintainability of the error handling process.

## Description

Please include a summary of the change and which issue is fixed. 

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context