### PR TITLE
Update PYTH token decimals and price provider ID in knownTokens

### DIFF
--- a/core/chain/coin/knownTokens/index.ts
+++ b/core/chain/coin/knownTokens/index.ts
@@ -276,8 +276,8 @@ const leanTokens: Partial<LeanChainTokensRecord> = {
     '0x4c5d8A75F3762c1561D96f177694f67378705E98': {
       ticker: 'PYTH',
       logo: 'pyth',
-      decimals: 18,
-      priceProviderId: 'pyth',
+      decimals: 6,
+      priceProviderId: 'pyth-network',
     },
     '0xB0fFa8000886e57F86dd5264b9582b2Ad87b2b91': {
       ticker: 'W',
@@ -381,7 +381,7 @@ const leanTokens: Partial<LeanChainTokensRecord> = {
       ticker: 'PYTH',
       logo: 'pyth',
       decimals: 6,
-      priceProviderId: 'PYTH',
+      priceProviderId: 'pyth-network',
     },
     '0x13Ad51ed4F1B7e9Dc168d8a00cB3f4dDD85EfA60': {
       ticker: 'LDO',
@@ -440,6 +440,7 @@ const leanTokens: Partial<LeanChainTokensRecord> = {
       ticker: 'PYTH',
       logo: 'pyth',
       decimals: 6,
+      priceProviderId: 'pyth-network',
     },
     '0xFdb794692724153d1488CcdBE0C56c252596735F': {
       ticker: 'LDO',


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected PYTH token decimals on Base to 6 for accurate balance display.
  * Standardized PYTH price source to pyth-network across Base, Arbitrum, and Optimism for consistent pricing.

* **Chores**
  * Updated token metadata for PYTH to align with provider expectations across supported networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->