### PR TITLE
reshare: fix plugin detection regex

### DIFF
--- a/core/ui/mpc/keygen/reshare/plugin/WaitForPluginAndVerifier.tsx
+++ b/core/ui/mpc/keygen/reshare/plugin/WaitForPluginAndVerifier.tsx
@@ -22,9 +22,9 @@ export const WaitForPluginAndVerifier: FC<OnFinishProp<string[]>> = ({
 
   const hasVerifier = peers.some(p => p.startsWith('verifier'))
   // Detect if there is at least one plugin in the peers list
-  // Plugin local party format is expected to be: {developer}-{plugin}-{collision prevention random number}-{random number}
+  // Plugin local party format is expected to be: {developer}-{plugin}-{collision prevention random hex}-{random number}
   // Example: vultisig-payroll-0000-1234 or raghav-personal-4567-13332
-  const pluginIdPattern = /^[^-]+-[^-]+-[0-9]{4}-[0-9]+$/ // {dev}-{plugin}-{4d}-{n}
+  const pluginIdPattern = /^[^-]+-[^-]+-[0-9a-f]{4}-[0-9]+$/ // {dev}-{plugin}-{4hex}-{n}
   const hasPlugin = peers.some(p => pluginIdPattern.test(p))
   const enoughPeers = peers.length >= pluginPeersConfig.minimumJoinedParties
 


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes detection of plugin parties in the router sessions - plugin parties can have 4 hex digits (for example, the fee plugin) vs. just numerical digits.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected validation of local party IDs to accept a 4-character hexadecimal segment, preventing valid plugin/verifier IDs from being rejected. This resolves setup failures and improves reliability without altering flows or controls.

- **Documentation**
  - Clarified inline description to indicate the segment is a random hexadecimal value, aligning the comment with actual accepted formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->