### PR TITLE
Extension Internal APIs: Part 17: Make the Popup determine whether the window should close after the flow is completed.

### DIFF
--- a/clients/desktop/src/App.tsx
+++ b/clients/desktop/src/App.tsx
@@ -6,6 +6,7 @@ import { initialCoreView } from '@core/ui/navigation/CoreView'
 import { QueryClientProvider } from '@core/ui/query/QueryClientProvider'
 import { CoreState } from '@core/ui/state/core'
 import { ActiveView } from '@lib/ui/navigation/ActiveView'
+import { useNavigate } from '@lib/ui/navigation/hooks/useNavigate'
 import { useNavigateBack } from '@lib/ui/navigation/hooks/useNavigateBack'
 import { NavigationProvider } from '@lib/ui/navigation/state'
 import { BrowserOpenURL, ClipboardGetText } from '@wailsapp/runtime'
@@ -20,7 +21,10 @@ import { OnboardingResetter } from './onboarding/OnboardingResetter'
 import { storage } from './storage'
 import { queriesPersister } from './storage/queriesPersister'
 
-const baseCoreState: Omit<CoreState, 'vaultCreationMpcLib' | 'goBack'> = {
+const baseCoreState: Omit<
+  CoreState,
+  'vaultCreationMpcLib' | 'goBack' | 'goHome'
+> = {
   ...storage,
   client: 'desktop',
   openUrl: BrowserOpenURL,
@@ -51,6 +55,7 @@ const AppContent = () => {
   const [vaultCreationMpcLib] = useVaultCreationMpcLib()
   const processError = useProcessAppError()
   const goBack = useNavigateBack()
+  const navigate = useNavigate()
 
   const coreState = useMemo(
     () => ({
@@ -58,8 +63,9 @@ const AppContent = () => {
       vaultCreationMpcLib,
       processError,
       goBack,
+      goHome: () => navigate(initialCoreView),
     }),
-    [vaultCreationMpcLib, processError, goBack]
+    [vaultCreationMpcLib, processError, goBack, navigate]
   )
 
   return (

--- a/clients/extension/src/inpage/providers/core/sharedHandlers.ts
+++ b/clients/extension/src/inpage/providers/core/sharedHandlers.ts
@@ -42,7 +42,6 @@ export const getSharedHandlers = (chain: Chain) => {
         },
         {
           account: tx.from,
-          closeOnFinish: false,
         }
       )
 

--- a/clients/extension/src/inpage/providers/ethereum.ts
+++ b/clients/extension/src/inpage/providers/ethereum.ts
@@ -298,7 +298,6 @@ export class Ethereum extends EventEmitter {
           },
           {
             account,
-            closeOnFinish: false,
           }
         )
 
@@ -323,7 +322,6 @@ export class Ethereum extends EventEmitter {
           },
           {
             account,
-            closeOnFinish: false,
           }
         )
 
@@ -372,7 +370,6 @@ export class Ethereum extends EventEmitter {
           },
           {
             account: from,
-            closeOnFinish: false,
           }
         )
 

--- a/clients/extension/src/inpage/providers/providerFactory.ts
+++ b/clients/extension/src/inpage/providers/providerFactory.ts
@@ -31,12 +31,9 @@ export const createProviders = () => {
     plugin: {
       request: async ({ params }: { params: [{ id: string }] }) => {
         const [{ id }] = params
-        const { joinUrl } = await callPopup(
-          {
-            pluginReshare: { pluginId: id },
-          },
-          { closeOnFinish: false }
-        )
+        const { joinUrl } = await callPopup({
+          pluginReshare: { pluginId: id },
+        })
 
         return joinUrl
       },

--- a/clients/extension/src/inpage/providers/solana.ts
+++ b/clients/extension/src/inpage/providers/solana.ts
@@ -258,19 +258,14 @@ export class Solana implements Wallet {
     const messageBuffer = Buffer.from(message)
     const decodedString = new TextDecoder().decode(messageBuffer)
 
-    const signature = await callPopup(
-      {
-        signMessage: {
-          sign_message: {
-            message: decodedString,
-            chain: Chain.Solana,
-          },
+    const signature = await callPopup({
+      signMessage: {
+        sign_message: {
+          message: decodedString,
+          chain: Chain.Solana,
         },
       },
-      {
-        closeOnFinish: false,
-      }
-    )
+    })
 
     return {
       signature: Uint8Array.from(Buffer.from(String(signature), 'hex')),
@@ -290,19 +285,14 @@ export class Solana implements Wallet {
       address: account.address,
     })
 
-    const signature = await callPopup(
-      {
-        signMessage: {
-          sign_message: {
-            message,
-            chain: Chain.Solana,
-          },
+    const signature = await callPopup({
+      signMessage: {
+        sign_message: {
+          message,
+          chain: Chain.Solana,
         },
       },
-      {
-        closeOnFinish: false,
-      }
-    )
+    })
 
     return {
       account: account,
@@ -332,7 +322,6 @@ export class Solana implements Wallet {
           },
         },
         {
-          closeOnFinish: false,
           account: getTransactionAuthority(serializedTransaction),
         }
       )

--- a/clients/extension/src/inpage/providers/thorchain.ts
+++ b/clients/extension/src/inpage/providers/thorchain.ts
@@ -40,7 +40,6 @@ export class THORChain extends BaseCosmosChain {
             },
             {
               account: tx.from,
-              closeOnFinish: false,
             }
           )
 

--- a/clients/extension/src/inpage/providers/xdefiKeplr.ts
+++ b/clients/extension/src/inpage/providers/xdefiKeplr.ts
@@ -528,7 +528,7 @@ export class XDEFIKeplrProvider extends Keplr {
             },
           },
         },
-        { account: transactionDetails.from, closeOnFinish: false }
+        { account: transactionDetails.from }
       )
 
       const { serialized } = deserializeSigningOutput(chain, data)
@@ -629,7 +629,7 @@ export class XDEFIKeplrProvider extends Keplr {
             },
           },
         },
-        { account: transactionDetails.from, closeOnFinish: false }
+        { account: transactionDetails.from }
       )
 
       const { serialized } = deserializeSigningOutput(chain, data)

--- a/clients/extension/src/pages/index.tsx
+++ b/clients/extension/src/pages/index.tsx
@@ -4,7 +4,9 @@ import { renderExtensionPage } from '@clients/extension/src/pages/core/render'
 import { isPopupView } from '@clients/extension/src/utils/functions'
 import { ExtensionCoreApp } from '@core/extension/ExtensionCoreApp'
 import { useProcessAppError } from '@core/ui/errors/hooks/useProcessAppError'
+import { initialCoreView } from '@core/ui/navigation/CoreView'
 import { ActiveView } from '@lib/ui/navigation/ActiveView'
+import { useNavigate } from '@lib/ui/navigation/hooks/useNavigate'
 import { useNavigateBack } from '@lib/ui/navigation/hooks/useNavigateBack'
 import { createGlobalStyle, css } from 'styled-components'
 
@@ -30,9 +32,14 @@ const ExtensionGlobalStyle = createGlobalStyle`
 const App = () => {
   const processError = useProcessAppError()
   const goBack = useNavigateBack()
+  const navigate = useNavigate()
 
   return (
-    <ExtensionCoreApp processError={processError} goBack={goBack}>
+    <ExtensionCoreApp
+      processError={processError}
+      goBack={goBack}
+      goHome={() => navigate(initialCoreView)}
+    >
       <ActiveView views={views} />
     </ExtensionCoreApp>
   )

--- a/core/extension/ExtensionCoreApp.tsx
+++ b/core/extension/ExtensionCoreApp.tsx
@@ -9,7 +9,7 @@ import { useMemo } from 'react'
 import { storage } from './storage'
 import { StorageMigrationsManager } from './storage/migrations/StorageMigrationManager'
 
-const baseCoreState: Omit<CoreState, 'goBack'> = {
+const baseCoreState: Omit<CoreState, 'goBack' | 'goHome'> = {
   ...storage,
   client: 'extension',
   openUrl: url => window.open(url, '_blank', 'noopener,noreferrer'),
@@ -33,6 +33,7 @@ const baseCoreState: Omit<CoreState, 'goBack'> = {
 type ExtensionCoreAppProps = ChildrenProp & {
   processError?: ErrorBoundaryProcessError
   goBack: () => void
+  goHome: () => void
   targetVaultId?: string
 }
 
@@ -41,6 +42,7 @@ export const ExtensionCoreApp = ({
   processError,
   goBack,
   targetVaultId,
+  goHome,
 }: ExtensionCoreAppProps) => {
   const coreState = useMemo(
     () => ({
@@ -48,8 +50,9 @@ export const ExtensionCoreApp = ({
       processError,
       targetVaultId,
       goBack,
+      goHome,
     }),
-    [processError, targetVaultId, goBack]
+    [processError, targetVaultId, goBack, goHome]
   )
 
   return (

--- a/core/inpage-provider/popup/app.tsx
+++ b/core/inpage-provider/popup/app.tsx
@@ -57,6 +57,7 @@ export const PopupApp = () => {
         return (
           <ExtensionCoreApp
             goBack={cancelPopupCall}
+            goHome={cancelPopupCall}
             targetVaultId={context?.appSession?.vaultId}
           >
             <VaultsOnly>

--- a/core/inpage-provider/popup/index.ts
+++ b/core/inpage-provider/popup/index.ts
@@ -2,7 +2,7 @@ import {
   PopupInterface,
   PopupMethod,
 } from '@core/inpage-provider/popup/interface'
-import { PopupCall, PopupOptions } from '@core/inpage-provider/popup/resolver'
+import { PopupCall } from '@core/inpage-provider/popup/resolver'
 
 import { callInpageProviderBridgeBackgroundAgent } from '../bridge'
 
@@ -10,7 +10,7 @@ import { callInpageProviderBridgeBackgroundAgent } from '../bridge'
 // For background context, use `callPopupFromBackground` and provide the appropriate `context`.
 export const callPopup = async <M extends PopupMethod>(
   call: PopupCall<M>,
-  options: PopupOptions & { account?: string } = { closeOnFinish: true }
+  options: { account?: string } = {}
 ): Promise<PopupInterface[M]['output']> =>
   callInpageProviderBridgeBackgroundAgent({
     popup: { call, options },

--- a/core/inpage-provider/popup/resolver.ts
+++ b/core/inpage-provider/popup/resolver.ts
@@ -27,6 +27,7 @@ export type PopupCall<M extends PopupMethod> = {
 
 export type PopupResponse<M extends PopupMethod> = PopupMessageKey & {
   result: Result<PopupInterface[M]['output']>
+  shouldClosePopup: boolean
 }
 
 export const isPopupMessage = <T extends PopupMessageKey>(
@@ -44,7 +45,6 @@ export type PopupMessage<M extends PopupMethod = PopupMethod> = {
 }
 
 export type PopupOptions = {
-  closeOnFinish?: boolean
   account?: string
 }
 

--- a/core/inpage-provider/popup/view/core/call.ts
+++ b/core/inpage-provider/popup/view/core/call.ts
@@ -1,11 +1,10 @@
 import { shouldBePresent } from '@lib/utils/assert/shouldBePresent'
-import { Result } from '@lib/utils/types/Result'
-import { useCallback } from 'react'
+import { useMutation } from '@tanstack/react-query'
 
 import { callIdQueryParam } from '../../config'
-import { PopupError } from '../../error'
-import { PopupInterface, PopupMethod } from '../../interface'
-import { getPopupMessageSourceId } from '../../resolver'
+import { PopupMethod } from '../../interface'
+import { getPopupMessageSourceId, PopupResponse } from '../../resolver'
+import { ResolvePopupInput } from '../resolver'
 
 export const usePopupCallId = () => {
   const url = new URL(window.location.href)
@@ -16,26 +15,20 @@ export const usePopupCallId = () => {
   )
 }
 
-export const useResolvePopupCall = () => {
+export const useResolvePopupCallMutation = () => {
   const callId = usePopupCallId()
 
-  return useCallback(
-    (result: Result<PopupInterface[PopupMethod]['output']>) => {
-      chrome.runtime.sendMessage({
+  return useMutation({
+    mutationFn: async (input: ResolvePopupInput<PopupMethod>) => {
+      const message: PopupResponse<PopupMethod> = {
+        ...input,
         sourceId: getPopupMessageSourceId('popup'),
         callId,
-        result,
-      })
+      }
+
+      await chrome.runtime.sendMessage(message)
+
+      return true
     },
-    [callId]
-  )
-}
-
-export const useCancelPopupCall = () => {
-  const resolvePopupCall = useResolvePopupCall()
-
-  return useCallback(() => {
-    resolvePopupCall({ error: PopupError.RejectedByUser })
-    window.close()
-  }, [resolvePopupCall])
+  })
 }

--- a/core/inpage-provider/popup/view/resolver.ts
+++ b/core/inpage-provider/popup/view/resolver.ts
@@ -5,18 +5,23 @@ import {
 } from '@core/inpage-provider/popup/interface'
 import { OnFinishProp } from '@lib/ui/props'
 import { Resolver } from '@lib/utils/types/Resolver'
-import { Result } from '@lib/utils/types/Result'
 import { ReactNode } from 'react'
 
 import {
   AuthorizedCallContext,
   UnauthorizedCallContext,
 } from '../../call/context'
+import { PopupResponse } from '../resolver'
+
+export type ResolvePopupInput<M extends PopupMethod> = Pick<
+  PopupResponse<M>,
+  'result' | 'shouldClosePopup'
+>
 
 export type PopupResolver<M extends PopupMethod> = Resolver<
   {
     input: PopupInterface[M]['input']
-  } & OnFinishProp<Result<PopupInterface[M]['output']>> & {
+  } & OnFinishProp<ResolvePopupInput<M>> & {
       context: M extends AuthorizedPopupMethod
         ? AuthorizedCallContext
         : UnauthorizedCallContext

--- a/core/inpage-provider/popup/view/resolvers/exportVaults/index.tsx
+++ b/core/inpage-provider/popup/view/resolvers/exportVaults/index.tsx
@@ -23,13 +23,16 @@ export const ExportVaults: PopupResolver<'exportVaults'> = ({ onFinish }) => {
 
   const onSubmit = useCallback(() => {
     onFinish({
-      data: vaultIds.map(vaultId => {
-        const vault = shouldBePresent(
-          vaults.find(vault => getVaultId(vault) === vaultId)
-        )
+      result: {
+        data: vaultIds.map(vaultId => {
+          const vault = shouldBePresent(
+            vaults.find(vault => getVaultId(vault) === vaultId)
+          )
 
-        return toVaultExport(vault)
-      }),
+          return toVaultExport(vault)
+        }),
+      },
+      shouldClosePopup: true,
     })
   }, [onFinish, vaultIds, vaults])
 

--- a/core/inpage-provider/popup/view/resolvers/grantVaultAccess/index.tsx
+++ b/core/inpage-provider/popup/view/resolvers/grantVaultAccess/index.tsx
@@ -44,7 +44,7 @@ export const GrantVaultAccess: PopupResolver<'grantVaultAccess'> = ({
       return appSession
     },
     onSuccess: appSession => {
-      onFinish({ data: { appSession } })
+      onFinish({ result: { data: { appSession } }, shouldClosePopup: true })
     },
   })
   const { requestOrigin } = shouldBePresent(context)

--- a/core/inpage-provider/popup/view/resolvers/pluginReshare/index.tsx
+++ b/core/inpage-provider/popup/view/resolvers/pluginReshare/index.tsx
@@ -34,7 +34,7 @@ export const PluginReshare: PopupResolver<'pluginReshare'> = ({
                     onFinish={joinUrl => {
                       onFinish({
                         result: { data: { joinUrl } },
-                        shouldClosePopup: true,
+                        shouldClosePopup: false,
                       })
                       onNextStep()
                     }}

--- a/core/inpage-provider/popup/view/resolvers/pluginReshare/index.tsx
+++ b/core/inpage-provider/popup/view/resolvers/pluginReshare/index.tsx
@@ -32,7 +32,10 @@ export const PluginReshare: PopupResolver<'pluginReshare'> = ({
                 from={({ onFinish: onNextStep }) => (
                   <PluginJoinKeygenUrl
                     onFinish={joinUrl => {
-                      onFinish({ data: { joinUrl } })
+                      onFinish({
+                        result: { data: { joinUrl } },
+                        shouldClosePopup: true,
+                      })
                       onNextStep()
                     }}
                   />

--- a/core/inpage-provider/popup/view/resolvers/sendTx/SendTxOverview.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/SendTxOverview.tsx
@@ -461,7 +461,6 @@ export const SendTxOverview = () => {
                     keysignPayload={{
                       keysign: keysignPayload,
                     }}
-                    isDAppSigning={true}
                   />
                 </PageFooter>
               </>

--- a/core/inpage-provider/popup/view/resolvers/sendTx/index.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/index.tsx
@@ -30,10 +30,13 @@ export const SendTx: PopupResolver<'sendTx'> = ({ onFinish }) => {
       onSuccess: result => {
         const [{ hash, data }] = getRecordUnionValue(result, 'txs')
         onFinish({
-          data: {
-            hash,
-            data: data.toJSON(),
+          result: {
+            data: {
+              hash,
+              data: data.toJSON(),
+            },
           },
+          shouldClosePopup: true,
         })
       },
     }),

--- a/core/inpage-provider/popup/view/resolvers/sendTx/index.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/index.tsx
@@ -36,7 +36,7 @@ export const SendTx: PopupResolver<'sendTx'> = ({ onFinish }) => {
               data: data.toJSON(),
             },
           },
-          shouldClosePopup: true,
+          shouldClosePopup: false,
         })
       },
     }),

--- a/core/inpage-provider/popup/view/resolvers/signMessage/Overview.tsx
+++ b/core/inpage-provider/popup/view/resolvers/signMessage/Overview.tsx
@@ -71,10 +71,7 @@ export const Overview = () => {
         </List>
       </PageContent>
       <PageFooter>
-        <StartKeysignPrompt
-          keysignPayload={keysignMessagePayload}
-          isDAppSigning={true}
-        />
+        <StartKeysignPrompt keysignPayload={keysignMessagePayload} />
       </PageFooter>
     </VStack>
   )

--- a/core/inpage-provider/popup/view/resolvers/signMessage/index.tsx
+++ b/core/inpage-provider/popup/view/resolvers/signMessage/index.tsx
@@ -29,7 +29,10 @@ export const SignMessage: PopupResolver<'signMessage'> = ({ onFinish }) => {
     () => ({
       onSuccess: result => {
         onFinish({
-          data: getRecordUnionValue(result, 'signature'),
+          result: {
+            data: { signature: getRecordUnionValue(result, 'signature') },
+          },
+          shouldClosePopup: true,
         })
       },
     }),

--- a/core/inpage-provider/popup/view/resolvers/signMessage/index.tsx
+++ b/core/inpage-provider/popup/view/resolvers/signMessage/index.tsx
@@ -32,7 +32,7 @@ export const SignMessage: PopupResolver<'signMessage'> = ({ onFinish }) => {
           result: {
             data: getRecordUnionValue(result, 'signature'),
           },
-          shouldClosePopup: true,
+          shouldClosePopup: false,
         })
       },
     }),

--- a/core/inpage-provider/popup/view/resolvers/signMessage/index.tsx
+++ b/core/inpage-provider/popup/view/resolvers/signMessage/index.tsx
@@ -30,7 +30,7 @@ export const SignMessage: PopupResolver<'signMessage'> = ({ onFinish }) => {
       onSuccess: result => {
         onFinish({
           result: {
-            data: { signature: getRecordUnionValue(result, 'signature') },
+            data: getRecordUnionValue(result, 'signature'),
           },
           shouldClosePopup: true,
         })

--- a/core/ui/mpc/keysign/KeysignSigningStep.tsx
+++ b/core/ui/mpc/keysign/KeysignSigningStep.tsx
@@ -8,7 +8,6 @@ import { KeysignSigningState } from '@core/ui/mpc/keysign/flow/KeysignSigningSta
 import { KeysignTxOverview } from '@core/ui/mpc/keysign/tx/KeysignTxOverview'
 import { SwapKeysignTxOverview } from '@core/ui/mpc/keysign/tx/swap/SwapKeysignTxOverview'
 import { TxSuccess } from '@core/ui/mpc/keysign/tx/TxSuccess'
-import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { useCore } from '@core/ui/state/core'
 import { MatchRecordUnion } from '@lib/ui/base/MatchRecordUnion'
 import { StepTransition } from '@lib/ui/base/StepTransition'
@@ -26,17 +25,14 @@ import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { TxHashProvider } from '../../chain/state/txHash'
-import { useCoreViewState } from '../../navigation/hooks/useCoreViewState'
 import { useKeysignMessagePayload } from './state/keysignMessagePayload'
 
 type KeysignSigningStepProps = Partial<OnBackProp>
 
 export const KeysignSigningStep = ({ onBack }: KeysignSigningStepProps) => {
   const { t } = useTranslation()
-  const { version } = useCore()
-  const navigate = useCoreNavigate()
+  const { version, goHome } = useCore()
   const payload = useKeysignMessagePayload()
-  const [{ isDAppSigning }] = useCoreViewState<'keysign'>()
   const { mutate: startKeysign, ...mutationStatus } =
     useKeysignMutation(payload)
 
@@ -45,95 +41,86 @@ export const KeysignSigningStep = ({ onBack }: KeysignSigningStepProps) => {
   return (
     <MatchQuery
       value={mutationStatus}
-      success={result => {
-        const handleFinish = () =>
-          isDAppSigning ? window.close() : navigate({ id: 'vault' })
+      success={result => (
+        <>
+          <PageHeader title={t('overview')} hasBorder />
+          <MatchRecordUnion
+            value={payload}
+            handlers={{
+              keysign: payload => {
+                const { swapPayload } = payload
+                const isSwapTx = swapPayload && swapPayload.value
+                const txs = getRecordUnionValue(result, 'txs')
 
-        return (
-          <>
-            <PageHeader title={t('overview')} hasBorder />
-            <MatchRecordUnion
-              value={payload}
-              handlers={{
-                keysign: payload => {
-                  const { swapPayload } = payload
-                  const isSwapTx = swapPayload && swapPayload.value
-                  const txs = getRecordUnionValue(result, 'txs')
-
-                  return (
-                    <TxHashProvider value={getLastItem(txs).hash}>
-                      {isSwapTx ? (
-                        <PageContent alignItems="center" scrollable>
-                          <SwapKeysignTxOverview
-                            txHashes={txs.map(tx => tx.hash)}
-                            value={payload}
-                          />
-                        </PageContent>
-                      ) : (
-                        <StepTransition
-                          from={({ onFinish: onSeeTxDetails }) => (
-                            <>
-                              <PageContent alignItems="center" scrollable>
-                                <VStack gap={16} maxWidth={576} fullWidth>
-                                  <TxSuccess
-                                    value={payload}
-                                    onSeeTxDetails={onSeeTxDetails}
-                                  />
-                                </VStack>
-                              </PageContent>
-                              <PageFooter alignItems="center">
-                                <VStack maxWidth={576} fullWidth>
-                                  <Button onClick={handleFinish}>
-                                    {t('done')}
-                                  </Button>
-                                </VStack>
-                              </PageFooter>
-                            </>
-                          )}
-                          to={() => (
-                            <>
-                              <PageContent alignItems="center" scrollable>
-                                <VStack gap={16} maxWidth={576} fullWidth>
-                                  <KeysignTxOverview />
-                                </VStack>
-                              </PageContent>
-                              <PageFooter alignItems="center">
-                                <VStack maxWidth={576} fullWidth>
-                                  <Button onClick={handleFinish}>
-                                    {t('complete')}
-                                  </Button>
-                                </VStack>
-                              </PageFooter>
-                            </>
-                          )}
+                return (
+                  <TxHashProvider value={getLastItem(txs).hash}>
+                    {isSwapTx ? (
+                      <PageContent alignItems="center" scrollable>
+                        <SwapKeysignTxOverview
+                          txHashes={txs.map(tx => tx.hash)}
+                          value={payload}
                         />
-                      )}
-                    </TxHashProvider>
-                  )
-                },
-                custom: payload => (
-                  <>
-                    <PageContent scrollable>
-                      <TxOverviewPanel>
-                        <KeysignCustomMessageInfo value={payload} />
-                        <TxOverviewChainDataRow>
-                          <span>{t('signature')}</span>
-                          <span>
-                            {getRecordUnionValue(result, 'signature')}
-                          </span>
-                        </TxOverviewChainDataRow>
-                      </TxOverviewPanel>
-                    </PageContent>
-                    <PageFooter>
-                      <Button onClick={handleFinish}>{t('complete')}</Button>
-                    </PageFooter>
-                  </>
-                ),
-              }}
-            />
-          </>
-        )
-      }}
+                      </PageContent>
+                    ) : (
+                      <StepTransition
+                        from={({ onFinish: onSeeTxDetails }) => (
+                          <>
+                            <PageContent alignItems="center" scrollable>
+                              <VStack gap={16} maxWidth={576} fullWidth>
+                                <TxSuccess
+                                  value={payload}
+                                  onSeeTxDetails={onSeeTxDetails}
+                                />
+                              </VStack>
+                            </PageContent>
+                            <PageFooter alignItems="center">
+                              <VStack maxWidth={576} fullWidth>
+                                <Button onClick={goHome}>{t('done')}</Button>
+                              </VStack>
+                            </PageFooter>
+                          </>
+                        )}
+                        to={() => (
+                          <>
+                            <PageContent alignItems="center" scrollable>
+                              <VStack gap={16} maxWidth={576} fullWidth>
+                                <KeysignTxOverview />
+                              </VStack>
+                            </PageContent>
+                            <PageFooter alignItems="center">
+                              <VStack maxWidth={576} fullWidth>
+                                <Button onClick={goHome}>
+                                  {t('complete')}
+                                </Button>
+                              </VStack>
+                            </PageFooter>
+                          </>
+                        )}
+                      />
+                    )}
+                  </TxHashProvider>
+                )
+              },
+              custom: payload => (
+                <>
+                  <PageContent scrollable>
+                    <TxOverviewPanel>
+                      <KeysignCustomMessageInfo value={payload} />
+                      <TxOverviewChainDataRow>
+                        <span>{t('signature')}</span>
+                        <span>{getRecordUnionValue(result, 'signature')}</span>
+                      </TxOverviewChainDataRow>
+                    </TxOverviewPanel>
+                  </PageContent>
+                  <PageFooter>
+                    <Button onClick={goHome}>{t('complete')}</Button>
+                  </PageFooter>
+                </>
+              ),
+            }}
+          />
+        </>
+      )}
       error={error => (
         <FullPageFlowErrorState error={error} title={t('signing_error')} />
       )}

--- a/core/ui/navigation/CoreView.ts
+++ b/core/ui/navigation/CoreView.ts
@@ -37,7 +37,6 @@ export type CoreView =
       state: {
         securityType: VaultSecurityType
         keysignPayload: KeysignMessagePayload
-        isDAppSigning?: boolean
       }
     }
   | { id: 'languageSettings' }

--- a/core/ui/state/core.tsx
+++ b/core/ui/state/core.tsx
@@ -33,6 +33,7 @@ export type CoreState = CoreStorage & {
   processError?: ErrorBoundaryProcessError
   targetVaultId?: string
   goBack: () => void
+  goHome: () => void
 }
 
 export const { useValue: useCore, provider: CoreProvider } =


### PR DESCRIPTION
## Automatically close the popup when the wallet is connected
<img width="1728" height="1080" alt="image" src="https://github.com/user-attachments/assets/c40781b9-26cd-4e94-8ffa-473ce4d11075" />

## Keep the popup open after a successful keysign
<img width="1728" height="1080" alt="image" src="https://github.com/user-attachments/assets/69f9df5b-947a-4b49-b935-bb52e4fab079" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Home action in desktop and extension apps for quick return to the start screen.

- UX Improvements
  - Popups now close based on the action outcome for more consistent behavior across networks (Ethereum, Solana, THORChain, etc.).
  - Signing and transaction flows finish by returning you to Home, reducing extra steps.
  - Simplified signing screens by removing unnecessary indicators.

- Public API
  - Core app components now accept a Home callback, enabling navigation back to the initial view from various flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->