### PR TITLE
Fix the extension's expanded view so that it opens to the last view you were using, rather than always redirecting to the vaults page.

### DIFF
--- a/clients/extension/src/components/expand-view/index.tsx
+++ b/clients/extension/src/components/expand-view/index.tsx
@@ -1,21 +1,22 @@
 import { isPopupView } from '@clients/extension/src/utils/functions'
-import { useCore } from '@core/ui/state/core'
+import { initialCoreView } from '@core/ui/navigation/CoreView'
 import { ExpandIcon } from '@lib/ui/icons/ExpandIcon'
 import { ListItem } from '@lib/ui/list/item'
 import { useTranslation } from 'react-i18next'
 
+import { useOpenInExpandedViewMutation } from '../../expanded-view/mutations/openInExpandedView'
+
 export const ExpandView = () => {
   const { t } = useTranslation()
-  const { openUrl } = useCore()
   const visible = isPopupView()
+
+  const { mutate: openInExpandedView } = useOpenInExpandedViewMutation()
 
   return (
     visible && (
       <ListItem
         icon={<ExpandIcon fontSize={20} />}
-        onClick={() =>
-          openUrl(`chrome-extension://${chrome.runtime.id}/index.html`)
-        }
+        onClick={() => openInExpandedView(initialCoreView)}
         title={t('expand_view')}
         hoverable
         showArrow

--- a/clients/extension/src/expanded-view/mutations/openInExpandedView.ts
+++ b/clients/extension/src/expanded-view/mutations/openInExpandedView.ts
@@ -1,0 +1,16 @@
+import { useCore } from '@core/ui/state/core'
+import { useMutation } from '@tanstack/react-query'
+
+import { AppView } from '../../navigation/AppView'
+import { setInitialView } from '../../storage/initialView'
+
+export const useOpenInExpandedViewMutation = () => {
+  const { openUrl } = useCore()
+
+  return useMutation({
+    mutationFn: async (view: AppView) => {
+      await setInitialView(view)
+      openUrl(`chrome-extension://${chrome.runtime.id}/index.html`)
+    },
+  })
+}

--- a/clients/extension/src/storage/initialView.ts
+++ b/clients/extension/src/storage/initialView.ts
@@ -1,10 +1,14 @@
 import { AppView } from '@clients/extension/src/navigation/AppView'
 import { getStorageValue } from '@lib/extension/storage/get'
 import { removeStorageValue } from '@lib/extension/storage/remove'
+import { setStorageValue } from '@lib/extension/storage/set'
 
 const initialViewKey = 'initialView'
 
 export const getInitialView = async () =>
   getStorageValue<AppView | null>(initialViewKey, null)
+
+export const setInitialView = async (view: AppView) =>
+  setStorageValue(initialViewKey, view)
 
 export const removeInitialView = async () => removeStorageValue(initialViewKey)


### PR DESCRIPTION
- Updated `ExpandView` and `ExpandViewGuard` components to use `useOpenInExpandedViewMutation` for handling navigation to the expanded view, improving code clarity and maintainability.
- Introduced `setInitialView` function in storage to manage the initial view state.
- Enhanced the logic for determining when to redirect to the expanded view based on the operating system and popup state.

## Description

Please include a summary of the change and which issue is fixed. 

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context