### PR TITLE
Fix TON Max Transfer not working with co-sign

### DIFF
--- a/core/mpc/keysign/txInputData/resolvers/ton.ts
+++ b/core/mpc/keysign/txInputData/resolvers/ton.ts
@@ -11,21 +11,27 @@ export const getTonTxInputData: TxInputDataResolver<'ton'> = ({
   const { expireAt, sequenceNumber, bounceable, sendMaxAmount } =
     getBlockchainSpecificValue(keysignPayload.blockchainSpecific, 'tonSpecific')
 
-  const isMax = Boolean(sendMaxAmount)
+  const isStakeOp =
+    !!keysignPayload.memo && ['d', 'w'].includes(keysignPayload.memo.trim())
+  const shouldBounce = isStakeOp ? true : !!bounceable
+
+  const mode =
+    (sendMaxAmount
+      ? TW.TheOpenNetwork.Proto.SendMode.ATTACH_ALL_CONTRACT_BALANCE
+      : TW.TheOpenNetwork.Proto.SendMode.PAY_FEES_SEPARATELY) |
+    TW.TheOpenNetwork.Proto.SendMode.IGNORE_ACTION_PHASE_ERRORS
+
+  // For send-max, amount must be 0 (balance is attached by mode)
+  const amount = sendMaxAmount
+    ? new Long(0)
+    : new Long(Number(keysignPayload.toAmount))
+
   const tokenTransferMessage = TW.TheOpenNetwork.Proto.Transfer.create({
     dest: keysignPayload.toAddress,
-    amount: isMax ? Long.UZERO : new Long(Number(keysignPayload.toAmount)),
-    bounceable:
-      bounceable ??
-      ((keysignPayload.memo &&
-        ['d', 'w'].includes(keysignPayload.memo.trim())) ||
-        false),
+    amount,
+    bounceable: shouldBounce,
     comment: keysignPayload.memo ?? undefined,
-    mode:
-      (isMax
-        ? TW.TheOpenNetwork.Proto.SendMode.ATTACH_ALL_CONTRACT_BALANCE
-        : TW.TheOpenNetwork.Proto.SendMode.PAY_FEES_SEPARATELY) |
-      TW.TheOpenNetwork.Proto.SendMode.IGNORE_ACTION_PHASE_ERRORS,
+    mode,
   })
 
   const inputObject = {


### PR DESCRIPTION
Fixes: https://github.com/vultisig/vultisig-windows/issues/2116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * TON “send max” transfers now attach the full available balance, pay fees separately, and set the transfer amount to zero to ensure correct on-chain behavior.
  * Bounce handling improved: staking-related memos force the message to bounce; other transfers follow the user’s bounceable preference.
  * Token transfer construction made more robust while preserving destination, memo, and existing public behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->