### PR TITLE
Add ehancement to TX overview

### DIFF
--- a/core/ui/mpc/keysign/tx/swap/SwapKeysignTxOverview.tsx
+++ b/core/ui/mpc/keysign/tx/swap/SwapKeysignTxOverview.tsx
@@ -78,22 +78,27 @@ export const SwapKeysignTxOverview = ({
     <>
       <TransactionSuccessAnimation />
       <VStack alignItems="center" gap={8}>
-        <HStack gap={8} style={{ position: 'relative' }}>
-          {fromCoin && (
-            <SwapCoinItem coin={fromCoin} tokenAmount={formattedFromAmount} />
-          )}
-          {toCoin && (
-            <SwapCoinItem
-              coin={toCoin}
-              tokenAmount={parseFloat(toAmountDecimal)}
-            />
-          )}
-          <IconWrapper alignItems="center" justifyContent="center">
-            <IconInternalWrapper>
-              <ChevronRightIcon />
-            </IconInternalWrapper>
-          </IconWrapper>
-        </HStack>
+        <VStack gap={8}>
+          <Text centerHorizontally color="shy" size={10} height="large">
+            {t('swap')}
+          </Text>
+          <HStack gap={8} style={{ position: 'relative' }}>
+            {fromCoin && (
+              <SwapCoinItem coin={fromCoin} tokenAmount={formattedFromAmount} />
+            )}
+            {toCoin && (
+              <SwapCoinItem
+                coin={toCoin}
+                tokenAmount={parseFloat(toAmountDecimal)}
+              />
+            )}
+            <IconWrapper alignItems="center" justifyContent="center">
+              <IconInternalWrapper>
+                <ChevronRightIcon />
+              </IconInternalWrapper>
+            </IconWrapper>
+          </HStack>
+        </VStack>
         <SwapInfoWrapper gap={16} fullWidth>
           <TrackTxPrompt
             title={t('transaction')}


### PR DESCRIPTION
Fixes: https://github.com/orgs/vultisig/projects/12/views/1?pane=issue&itemId=121259553&issue=vultisig%7Cvultisig-windows%7C2118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added a centered “Swap” header above the coin row in the swap transaction overview for clearer context.
  * Improved vertical spacing and alignment to create a more readable, structured layout.
  * Preserved existing coin display and chevron/icon behavior; visual changes only.
  * Enhances clarity when reviewing swap details without altering interaction or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->