### PR TITLE
Update FAQ link to point to the support page

### DIFF
--- a/core/ui/settings/index.tsx
+++ b/core/ui/settings/index.tsx
@@ -177,7 +177,7 @@ export const SettingsPage: FC<DesktopSettings | ExtensionSettings> = props => {
           <SettingsSection title={t('support')}>
             <ListItem
               icon={<MessageCircleQuestionIcon fontSize={iconSize} />}
-              onClick={() => openUrl('https://vultisig.com/faq')}
+              onClick={() => openUrl('https://vultisig.com/support')}
               title={t('faq')}
               hoverable
               showArrow


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #2414 

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Support/FAQ link in Settings to open the current support page instead of the old FAQ address. The menu label remains “FAQ,” with no visual changes. Users are now directed to the comprehensive support portal for FAQs and assistance, improving navigation and reducing confusion when accessing help resources from within the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->