### PR TITLE
Fix RUJI Positions Placement 

### DIFF
--- a/core/ui/vault/chain/positions/VaultChainPositionsSection.tsx
+++ b/core/ui/vault/chain/positions/VaultChainPositionsSection.tsx
@@ -24,7 +24,7 @@ export const VaultChainPositionsSection = () => {
       <Text size={20} weight={600}>
         {t('positions')}
       </Text>
-      {rujiCoin && <WithdrawablePositions value={rujiCoin} />}
+      <WithdrawablePositions value={rujiCoin} />
     </Panel>
   )
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vault Chain Positions section now appears only when the active vault chain is THORChain.
  * The section is hidden for non-THORChain vaults.
  * Withdrawable positions are shown only when THORChain is active and the required native token is present.
  * Existing THORChain behavior for viewing withdrawable positions remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->