### PR TITLE
Display the average send fee for a Sui send instead of showing the referenceGasPrice.

### DIFF
--- a/core/chain/chains/sui/config.ts
+++ b/core/chain/chains/sui/config.ts
@@ -1,0 +1,2 @@
+export const suiGasBudget = 3000_000n
+export const suiAverageSendGas = 5_000n

--- a/core/chain/tx/fee/getFeeAmount.ts
+++ b/core/chain/tx/fee/getFeeAmount.ts
@@ -7,6 +7,7 @@ import { rippleTxFee } from '@core/chain/tx/fee/ripple'
 import { KeysignChainSpecific } from '@core/mpc/keysign/chainSpecific/KeysignChainSpecific'
 import { matchDiscriminatedUnion } from '@lib/utils/matchDiscriminatedUnion'
 
+import { suiAverageSendGas } from '../../chains/sui/config'
 import { nativeTxFeeRune } from './thorchain/config'
 
 export const getFeeAmount = (chainSpecific: KeysignChainSpecific): bigint =>
@@ -14,7 +15,8 @@ export const getFeeAmount = (chainSpecific: KeysignChainSpecific): bigint =>
     utxoSpecific: ({ byteFee }) => BigInt(byteFee) * BigInt(250), // assume the average size of an UTXO transaction is 250 vbytes
     ethereumSpecific: ({ maxFeePerGasWei, gasLimit }) =>
       BigInt(maxFeePerGasWei) * BigInt(gasLimit),
-    suicheSpecific: ({ referenceGasPrice }) => BigInt(referenceGasPrice),
+    suicheSpecific: ({ referenceGasPrice }) =>
+      BigInt(referenceGasPrice) * suiAverageSendGas,
     solanaSpecific: ({ priorityFee }) =>
       BigInt(priorityFee) == BigInt(0)
         ? BigInt(solanaConfig.priorityFeeLimit)

--- a/core/mpc/keysign/txInputData/resolvers/sui.ts
+++ b/core/mpc/keysign/txInputData/resolvers/sui.ts
@@ -1,3 +1,4 @@
+import { suiGasBudget } from '@core/chain/chains/sui/config'
 import { SuiCoin } from '@core/mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
 import { TW } from '@trustwallet/wallet-core'
 import Long from 'long'
@@ -16,7 +17,7 @@ export const getSuiTxInputData: TxInputDataResolver<'sui'> = ({
   const inputData = TW.Sui.Proto.SigningInput.create({
     referenceGasPrice: Long.fromString(referenceGasPrice),
     signer: keysignPayload.coin?.address,
-    gasBudget: Long.fromString('3000000'),
+    gasBudget: Long.fromBigInt(suiGasBudget),
 
     paySui: TW.Sui.Proto.PaySui.create({
       inputCoins: coins.map((coin: SuiCoin) => {


### PR DESCRIPTION
<img width="1755" height="1085" alt="image" src="https://github.com/user-attachments/assets/b355e89c-23b2-4e9d-9c41-622ce35ee357" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Sui transactions now use a dynamic gas budget aligned with network norms, improving reliability and reducing underfunded sends.
  - Fee estimation for Sui incorporates average gas usage, providing more accurate upfront fee previews.
  - Users may notice slightly higher displayed fees for Sui to better reflect real network costs; no action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->