### PR TITLE
Refactor DownloadKeygenQrCode to include vault name in filename generation and update TxSuccess to copy block explorer URL to clipboard.

### DIFF
--- a/core/ui/mpc/keygen/qr/DownloadKeygenQrCode.tsx
+++ b/core/ui/mpc/keygen/qr/DownloadKeygenQrCode.tsx
@@ -1,5 +1,8 @@
 import { SaveAsImage } from '@core/ui/file/SaveAsImage'
-import { useKeygenVault } from '@core/ui/mpc/keygen/state/keygenVault'
+import {
+  useKeygenVault,
+  useKeygenVaultName,
+} from '@core/ui/mpc/keygen/state/keygenVault'
 import { PrintableQrCode } from '@core/ui/qr/PrintableQrCode'
 import { IconButton } from '@lib/ui/buttons/IconButton'
 import { ShareIcon } from '@lib/ui/icons/ShareIcon'
@@ -14,15 +17,15 @@ const prefix = 'VaultKeygenQR'
 export const DownloadKeygenQrCode = ({ value }: ValueProp<string>) => {
   const { t } = useTranslation()
   const keygenVault = useKeygenVault()
-
+  const vaultName = useKeygenVaultName()
   const fileName = useMemo(() => {
     if ('existingVault' in keygenVault) {
       const uid = getVaultExportUid(keygenVault.existingVault)
       return [prefix, keygenVault.existingVault.name, uid.slice(-3)].join('-')
     }
 
-    return prefix
-  }, [keygenVault])
+    return [prefix, vaultName].join('-')
+  }, [keygenVault, vaultName])
 
   return (
     <SaveAsImage

--- a/core/ui/mpc/keysign/tx/TxSuccess.tsx
+++ b/core/ui/mpc/keysign/tx/TxSuccess.tsx
@@ -70,7 +70,9 @@ export const TxSuccess = ({
                     <MiddleTruncate width={85} text={txHash} />
                   </Text>
                 </TruncatedTextWrapper>
-                <TxRowIconButton onClick={() => copyToClipboard(txHash)}>
+                <TxRowIconButton
+                  onClick={() => copyToClipboard(blockExplorerUrl)}
+                >
                   <ClipboardCopyIcon />
                 </TxRowIconButton>
                 <TxRowIconButton onClick={() => openUrl(blockExplorerUrl)}>


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #2395 
Fixes #2357 

<img width="1382" height="996" alt="CleanShot 2025-09-23 at 21 40 43@2x" src="https://github.com/user-attachments/assets/9b9203f5-4c71-4964-93b3-816e04521719" />


## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Downloaded keygen QR code files now include the vault name when no existing vault is present, improving clarity and organization.
  * On the transaction success screen, the copy-to-clipboard action now copies the full block explorer URL instead of only the transaction hash, making sharing and referencing easier. Opening the URL remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->