### PR TITLE
Potential fix for the crash related to send fees.

### DIFF
--- a/core/ui/mpc/keysign/KeysignActionFees.ts
+++ b/core/ui/mpc/keysign/KeysignActionFees.ts
@@ -1,5 +1,0 @@
-type KeysignActionFees =
-  | { type: 'send'; networkFeesFormatted: string; totalFeesFormatted?: string }
-  | { type: 'swap'; totalFeesFormatted: string }
-
-export type SendFees = Extract<KeysignActionFees, { type: 'send' }>

--- a/core/ui/vault/send/SendPage.tsx
+++ b/core/ui/vault/send/SendPage.tsx
@@ -9,7 +9,6 @@ import { SendAmountProvider } from './state/amount'
 import { SendFormFieldsStateProvider } from './state/formFields'
 import { SendMemoProvider } from './state/memo'
 import { SendReceiverProvider } from './state/receiver'
-import { SendFeesProvider } from './state/sendFees'
 import { SendVerify } from './verify/SendVerify'
 
 const sendSteps = ['form', 'verify'] as const
@@ -24,21 +23,19 @@ export const SendPage = () => {
 
   return (
     <SendFormFieldsStateProvider>
-      <SendFeesProvider initialValue={null}>
-        <FeeSettingsProvider>
-          <SendAmountProvider initialValue={null}>
-            <SendReceiverProvider initialValue={address ?? ''}>
-              <SendMemoProvider initialValue="">
-                <Match
-                  value={step}
-                  form={() => <SendForm onFinish={toNextStep} />}
-                  verify={() => <SendVerify onBack={toPreviousStep} />}
-                />
-              </SendMemoProvider>
-            </SendReceiverProvider>
-          </SendAmountProvider>
-        </FeeSettingsProvider>
-      </SendFeesProvider>
+      <FeeSettingsProvider>
+        <SendAmountProvider initialValue={null}>
+          <SendReceiverProvider initialValue={address ?? ''}>
+            <SendMemoProvider initialValue="">
+              <Match
+                value={step}
+                form={() => <SendForm onFinish={toNextStep} />}
+                verify={() => <SendVerify onBack={toPreviousStep} />}
+              />
+            </SendMemoProvider>
+          </SendReceiverProvider>
+        </SendAmountProvider>
+      </FeeSettingsProvider>
     </SendFormFieldsStateProvider>
   )
 }

--- a/core/ui/vault/send/fee/SendFiatFeeValue.tsx
+++ b/core/ui/vault/send/fee/SendFiatFeeValue.tsx
@@ -14,19 +14,19 @@ import { useCurrentSendCoin } from '../state/sendCoin'
 import { useSendChainSpecific } from './SendChainSpecificProvider'
 
 export const SendFiatFeeValue = () => {
-  const coin = useCurrentSendCoin()
+  const { chain } = useCurrentSendCoin()
   const fiatCurrency = useFiatCurrency()
   const chainSpecific = useSendChainSpecific()
   const fee = getFeeAmount(chainSpecific)
 
-  const feeCoin = chainFeeCoin[coin.chain]
+  const coin = chainFeeCoin[chain]
   const feeCoinPriceQuery = useCoinPriceQuery({
-    coin: feeCoin,
+    coin,
   })
 
-  const { decimals: feeCoinDecimals, ticker: feeCoinTicker } = feeCoin
+  const { decimals, ticker } = coin
 
-  const humanReadableFeeValue = fromChainAmount(fee, feeCoinDecimals)
+  const humanReadableFeeValue = fromChainAmount(fee, decimals)
 
   return (
     <MatchQuery
@@ -40,7 +40,7 @@ export const SendFiatFeeValue = () => {
       success={price => (
         <VStack alignItems="flex-end">
           <Text size={14}>
-            {formatTokenAmount(humanReadableFeeValue, feeCoinTicker)}
+            {formatTokenAmount(humanReadableFeeValue, ticker)}
           </Text>
           <Text size={14} color="shy">
             {formatAmount(humanReadableFeeValue * price, fiatCurrency)}

--- a/core/ui/vault/send/fee/SendFiatFeeValue.tsx
+++ b/core/ui/vault/send/fee/SendFiatFeeValue.tsx
@@ -5,24 +5,22 @@ import { useCoinPriceQuery } from '@core/ui/chain/coin/price/queries/useCoinPric
 import { useFiatCurrency } from '@core/ui/storage/fiatCurrency'
 import { VStack } from '@lib/ui/layout/Stack'
 import { Skeleton } from '@lib/ui/loaders/Skeleton'
+import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
 import { Text } from '@lib/ui/text'
 import { formatAmount } from '@lib/utils/formatAmount'
 import { formatTokenAmount } from '@lib/utils/formatTokenAmount'
-import { useEffect } from 'react'
 
 import { useCurrentSendCoin } from '../state/sendCoin'
-import { useSendFees } from '../state/sendFees'
 import { useSendChainSpecific } from './SendChainSpecificProvider'
 
 export const SendFiatFeeValue = () => {
   const coin = useCurrentSendCoin()
-  const [, setFees] = useSendFees()
   const fiatCurrency = useFiatCurrency()
   const chainSpecific = useSendChainSpecific()
   const fee = getFeeAmount(chainSpecific)
 
   const feeCoin = chainFeeCoin[coin.chain]
-  const { isPending, data: price } = useCoinPriceQuery({
+  const feeCoinPriceQuery = useCoinPriceQuery({
     coin: feeCoin,
   })
 
@@ -30,36 +28,25 @@ export const SendFiatFeeValue = () => {
 
   const humanReadableFeeValue = fromChainAmount(fee, feeCoinDecimals)
 
-  let formattedAmount: string | null = null
-
-  useEffect(() => {
-    if (!formattedAmount) return
-
-    setFees({
-      type: 'send',
-      networkFeesFormatted: formattedAmount,
-    })
-  }, [formattedAmount, setFees])
-
-  if (isPending)
-    return (
-      <VStack>
-        <Skeleton width="88" height="12" />
-        <Skeleton width="48" height="12" />
-      </VStack>
-    )
-
-  if (!price || !humanReadableFeeValue) return null
-
-  formattedAmount = formatAmount(humanReadableFeeValue * price, fiatCurrency)
   return (
-    <VStack alignItems="flex-end">
-      <Text size={14}>
-        {formatTokenAmount(humanReadableFeeValue, feeCoinTicker)}
-      </Text>
-      <Text size={14} color="shy">
-        {formattedAmount}
-      </Text>
-    </VStack>
+    <MatchQuery
+      value={feeCoinPriceQuery}
+      pending={() => (
+        <VStack>
+          <Skeleton width="88" height="12" />
+          <Skeleton width="48" height="12" />
+        </VStack>
+      )}
+      success={price => (
+        <VStack alignItems="flex-end">
+          <Text size={14}>
+            {formatTokenAmount(humanReadableFeeValue, feeCoinTicker)}
+          </Text>
+          <Text size={14} color="shy">
+            {formatAmount(humanReadableFeeValue * price, fiatCurrency)}
+          </Text>
+        </VStack>
+      )}
+    />
   )
 }

--- a/core/ui/vault/send/state/sendFees.ts
+++ b/core/ui/vault/send/state/sendFees.ts
@@ -1,6 +1,0 @@
-import { getStateProviderSetup } from '@lib/ui/state/getStateProviderSetup'
-
-import { SendFees } from '../../../mpc/keysign/KeysignActionFees'
-
-export const { useState: useSendFees, provider: SendFeesProvider } =
-  getStateProviderSetup<null | SendFees>('SendFees')


### PR DESCRIPTION
<img width="1130" height="990" alt="image" src="https://github.com/user-attachments/assets/59709700-42b1-4d5c-8a98-c1e9ea498b5c" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a loading state for fee prices, showing a skeleton until data is available.
  - Improved fiat fee display with clearer, human-readable formatting.

- Bug Fixes
  - Ensured more accurate and consistent fiat conversion for network fees during send.

- Refactor
  - Simplified the Send page by removing a redundant fees provider to streamline state management.
  - Unified fee price retrieval via a single query-driven flow, reducing local state and effects for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->