### PR TITLE
fix: remove unnecessary query parameter from Utxo address URL

### DIFF
--- a/core/chain/chains/utxo/client/getUtxoAddressInfo.ts
+++ b/core/chain/chains/utxo/client/getUtxoAddressInfo.ts
@@ -29,7 +29,7 @@ export const getUtxoAddressInfo = ({
   address,
   chain,
 }: ChainAccount<UtxoChain>) => {
-  const url = `${getBlockchairBaseUrl(chain)}/dashboards/address/${address}?state=latest`
+  const url = `${getBlockchairBaseUrl(chain)}/dashboards/address/${address}`
 
   return queryUrl<BlockchairAddressResponse>(url)
 }


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #2482 

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context