### PR TITLE
Use initial vaults to check imported vaults (this fixes the blinking error state that occurs after vault import).

### DIFF
--- a/core/ui/vault/import/components/SaveImportedVaultStep.tsx
+++ b/core/ui/vault/import/components/SaveImportedVaultStep.tsx
@@ -6,7 +6,7 @@ import { SaveVaultStep } from '@core/ui/vault/save/SaveVaultStep'
 import { getVaultId, Vault } from '@core/ui/vault/Vault'
 import { ValueProp } from '@lib/ui/props'
 import { getLastItemOrder } from '@lib/utils/order/getLastItemOrder'
-import { useMemo } from 'react'
+import { useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { FlowErrorPageContent } from '../../../flow/FlowErrorPageContent'
@@ -17,7 +17,7 @@ export const SaveImportedVaultStep = ({ value }: ValueProp<Vault>) => {
   const navigate = useCoreNavigate()
   const override = useVaultBackupOverride()
 
-  const vaults = useVaults()
+  const initialVaults = useRef(useVaults()).current
 
   const vaultOrders = useVaultOrders()
 
@@ -30,13 +30,13 @@ export const SaveImportedVaultStep = ({ value }: ValueProp<Vault>) => {
   )
 
   const error = useMemo(() => {
-    if (vaults.find(v => getVaultId(v) === getVaultId(finalValue))) {
+    if (initialVaults.find(v => getVaultId(v) === getVaultId(finalValue))) {
       return t('vault_already_exists')
     }
     if (client === 'extension' && value.libType === 'GG20') {
       return t('extension_vault_import_restriction')
     }
-  }, [client, finalValue, t, value.libType, vaults])
+  }, [client, finalValue, t, value.libType, initialVaults])
 
   if (error) {
     return (


### PR DESCRIPTION
…oving performance and preventing unnecessary re-renders. Update error handling logic to reference initial vaults instead of current vaults.

## Description

Please include a summary of the change and which issue is fixed. 

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved reliability of the vault import step by stabilizing how existing vaults are checked during import.
  - Optimized error handling to use a consistent snapshot of vault data, reducing inconsistent validation states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->