### PR TITLE
Fix the KyberSwap route query; correct the labeling of the network fee to accurately reflect it as a network fee rather than a swap fee; utilize fee estimation data provided by swap providers instead of re-estimating it ourselves; and estimate the gas limit for all EVM chains, not just ZKSync.

### DIFF
--- a/clients/desktop/wailsjs/runtime/package.json
+++ b/clients/desktop/wailsjs/runtime/package.json
@@ -4,6 +4,8 @@
   "description": "Wails Javascript runtime library",
   "main": "runtime.js",
   "types": "runtime.d.ts",
+  "scripts": {
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/wailsapp/wails.git"

--- a/core/chain/swap/SwapFee.ts
+++ b/core/chain/swap/SwapFee.ts
@@ -4,5 +4,5 @@ export type SwapFee = CoinKey & CoinAmount
 
 export type SwapFees = {
   network: SwapFee
-  swap: SwapFee
+  swap?: SwapFee
 }

--- a/core/chain/swap/general/GeneralSwapQuote.ts
+++ b/core/chain/swap/general/GeneralSwapQuote.ts
@@ -9,8 +9,8 @@ export type GeneralSwapTx =
         to: string
         data: string
         value: string
-        gasPrice: string
-        gas: number
+        gasPrice?: bigint
+        gas?: bigint
       }
     }
   | {

--- a/core/chain/swap/general/GeneralSwapQuote.ts
+++ b/core/chain/swap/general/GeneralSwapQuote.ts
@@ -1,5 +1,6 @@
 import { SwapFee } from '@core/chain/swap/SwapFee'
 
+import { EvmFeeQuote } from '../../tx/fee/evm/EvmFeeSettings'
 import { GeneralSwapProvider } from './GeneralSwapProvider'
 
 export type GeneralSwapTx =
@@ -9,8 +10,7 @@ export type GeneralSwapTx =
         to: string
         data: string
         value: string
-        gasPrice?: bigint
-        gas?: bigint
+        feeQuote: Partial<EvmFeeQuote>
       }
     }
   | {

--- a/core/chain/swap/general/kyber/api/route.ts
+++ b/core/chain/swap/general/kyber/api/route.ts
@@ -1,5 +1,4 @@
 import { AccountCoin } from '@core/chain/coin/AccountCoin'
-import { isFeeCoin } from '@core/chain/coin/utils/isFeeCoin'
 import { addQueryParams } from '@lib/utils/query/addQueryParams'
 import { queryUrl } from '@lib/utils/query/queryUrl'
 import { TransferDirection } from '@lib/utils/TransferDirection'
@@ -43,8 +42,8 @@ export const getKyberSwapRoute = async ({
   amount,
   isAffiliate,
 }: Input): Promise<KyberSwapRoute> => {
-  const [tokenIn, tokenOut] = [from, to].map(coin =>
-    isFeeCoin(coin) ? evmNativeCoinAddress : coin.ticker
+  const [tokenIn, tokenOut] = [from, to].map(
+    ({ id }) => id || evmNativeCoinAddress
   )
 
   const routeParams: KyberSwapRouteParams = {

--- a/core/chain/swap/general/kyber/api/tx.ts
+++ b/core/chain/swap/general/kyber/api/tx.ts
@@ -5,6 +5,7 @@ import { convertDuration } from '@lib/utils/time/convertDuration'
 
 import { AccountCoin } from '../../../../coin/AccountCoin'
 import { isFeeCoin } from '../../../../coin/utils/isFeeCoin'
+import { EvmFeeQuote } from '../../../../tx/fee/evm/EvmFeeSettings'
 import { GeneralSwapQuote } from '../../GeneralSwapQuote'
 import { KyberSwapEnabledChain } from '../chains'
 import {
@@ -93,6 +94,14 @@ export const getKyberSwapTx = async ({
 
   const { amountOut, data, gas } = buildResponse.data
 
+  const feeQuote: Partial<EvmFeeQuote> = {}
+  if (routeSummary?.gasPrice) {
+    feeQuote.maxFeePerGas = BigInt(routeSummary?.gasPrice)
+  }
+  if (gas) {
+    feeQuote.gasLimit = BigInt(gas)
+  }
+
   return {
     dstAmount: amountOut,
     provider: 'kyber',
@@ -102,10 +111,7 @@ export const getKyberSwapTx = async ({
         to: routerAddress,
         data,
         value: isFeeCoin(from) ? amount.toString() : '0',
-        gasPrice: routeSummary?.gasPrice
-          ? BigInt(routeSummary?.gasPrice)
-          : undefined,
-        gas: gas ? BigInt(gas) : undefined,
+        feeQuote,
       },
     },
   }

--- a/core/chain/swap/general/kyber/api/tx.ts
+++ b/core/chain/swap/general/kyber/api/tx.ts
@@ -3,10 +3,8 @@ import { isInError } from '@lib/utils/error/isInError'
 import { queryUrl } from '@lib/utils/query/queryUrl'
 import { convertDuration } from '@lib/utils/time/convertDuration'
 
-import { EvmChain } from '../../../../Chain'
 import { AccountCoin } from '../../../../coin/AccountCoin'
 import { isFeeCoin } from '../../../../coin/utils/isFeeCoin'
-import { getEvmSwapGasLimit } from '../../../../tx/fee/evm/evmGasLimit'
 import { GeneralSwapQuote } from '../../GeneralSwapQuote'
 import { KyberSwapEnabledChain } from '../chains'
 import {
@@ -34,20 +32,6 @@ type KyberSwapBuildResponse = {
     routerAddress: string
     gasPrice?: string
   }
-}
-
-const gasMultiplier: Record<EvmChain, number> = {
-  [EvmChain.Ethereum]: 1.4,
-  [EvmChain.Arbitrum]: 2,
-  [EvmChain.Optimism]: 2,
-  [EvmChain.Base]: 2,
-  [EvmChain.Polygon]: 2,
-  [EvmChain.Avalanche]: 2,
-  [EvmChain.BSC]: 2,
-  [EvmChain.CronosChain]: 1.6,
-  [EvmChain.Zksync]: 1.6,
-  [EvmChain.Blast]: 1.6,
-  [EvmChain.Mantle]: 1.6,
 }
 
 export const getKyberSwapTx = async ({
@@ -109,8 +93,6 @@ export const getKyberSwapTx = async ({
 
   const { amountOut, data, gas } = buildResponse.data
 
-  const baseGas = parseInt(gas) || getEvmSwapGasLimit(from.chain)
-
   return {
     dstAmount: amountOut,
     provider: 'kyber',
@@ -121,7 +103,7 @@ export const getKyberSwapTx = async ({
         data,
         value: isFeeCoin(from) ? amount.toString() : '0',
         gasPrice: routeSummary?.gasPrice || '0',
-        gas: Math.round(baseGas * gasMultiplier[from.chain]),
+        gas: parseInt(gas),
       },
     },
   }

--- a/core/chain/swap/general/kyber/api/tx.ts
+++ b/core/chain/swap/general/kyber/api/tx.ts
@@ -102,8 +102,10 @@ export const getKyberSwapTx = async ({
         to: routerAddress,
         data,
         value: isFeeCoin(from) ? amount.toString() : '0',
-        gasPrice: routeSummary?.gasPrice || '0',
-        gas: parseInt(gas),
+        gasPrice: routeSummary?.gasPrice
+          ? BigInt(routeSummary?.gasPrice)
+          : undefined,
+        gas: gas ? BigInt(gas) : undefined,
       },
     },
   }

--- a/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
+++ b/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
@@ -100,8 +100,8 @@ export const getLifiSwapQuote = async ({
             to: shouldBePresent(to),
             data: shouldBePresent(data),
             value: BigInt(shouldBePresent(value)).toString(),
-            gasPrice: BigInt(shouldBePresent(gasPrice)).toString(),
-            gas: Number(shouldBePresent(gasLimit)),
+            gasPrice: BigInt(shouldBePresent(gasPrice)),
+            gas: BigInt(shouldBePresent(gasLimit)),
           },
         }),
       }

--- a/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
+++ b/core/chain/swap/general/lifi/api/getLifiSwapQuote.ts
@@ -13,6 +13,7 @@ import { TransferDirection } from '@lib/utils/TransferDirection'
 import { createConfig, getQuote } from '@lifi/sdk'
 
 import { AccountCoinKey } from '../../../../coin/AccountCoin'
+import { EvmFeeQuote } from '../../../../tx/fee/evm/EvmFeeSettings'
 import { GeneralSwapQuote } from '../../GeneralSwapQuote'
 
 type Input = Record<TransferDirection, AccountCoinKey<LifiSwapEnabledChain>> & {
@@ -94,16 +95,24 @@ export const getLifiSwapQuote = async ({
             },
           }
         },
-        evm: () => ({
-          evm: {
-            from: shouldBePresent(from),
-            to: shouldBePresent(to),
-            data: shouldBePresent(data),
-            value: BigInt(shouldBePresent(value)).toString(),
-            gasPrice: BigInt(shouldBePresent(gasPrice)),
-            gas: BigInt(shouldBePresent(gasLimit)),
-          },
-        }),
+        evm: () => {
+          const feeQuote: Partial<EvmFeeQuote> = {}
+          if (gasPrice) {
+            feeQuote.maxFeePerGas = BigInt(gasPrice)
+          }
+          if (gasLimit) {
+            feeQuote.gasLimit = BigInt(gasLimit)
+          }
+          return {
+            evm: {
+              from: shouldBePresent(from),
+              to: shouldBePresent(to),
+              data: shouldBePresent(data),
+              value: BigInt(shouldBePresent(value)).toString(),
+              feeQuote,
+            },
+          }
+        },
       }
     ),
   }

--- a/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.ts
+++ b/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.ts
@@ -12,6 +12,7 @@ import { queryUrl } from '@lib/utils/query/queryUrl'
 import { pick } from '@lib/utils/record/pick'
 
 import { evmNativeCoinAddress } from '../../../../chains/evm/config'
+import { EvmFeeQuote } from '../../../../tx/fee/evm/EvmFeeSettings'
 
 type Input = {
   account: ChainAccount
@@ -54,14 +55,21 @@ export const getOneInchSwapQuote = async ({
   const { dstAmount, tx }: OneInchSwapQuoteResponse =
     await queryUrl<OneInchSwapQuoteResponse>(url)
 
+  const feeQuote: Partial<EvmFeeQuote> = {}
+  if (tx.gasPrice) {
+    feeQuote.maxFeePerGas = BigInt(tx.gasPrice)
+  }
+  if (tx.gas) {
+    feeQuote.gasLimit = BigInt(tx.gas)
+  }
+
   return {
     dstAmount,
     provider: '1inch',
     tx: {
       evm: {
         ...tx,
-        gasPrice: BigInt(tx.gasPrice),
-        gas: BigInt(tx.gas),
+        feeQuote,
       },
     },
   }

--- a/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.ts
+++ b/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.ts
@@ -58,7 +58,11 @@ export const getOneInchSwapQuote = async ({
     dstAmount,
     provider: '1inch',
     tx: {
-      evm: tx,
+      evm: {
+        ...tx,
+        gasPrice: BigInt(tx.gasPrice),
+        gas: BigInt(tx.gas),
+      },
     },
   }
 }

--- a/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.ts
+++ b/core/chain/swap/general/oneInch/api/getOneInchSwapQuote.ts
@@ -5,7 +5,6 @@ import { isFeeCoin } from '@core/chain/coin/utils/isFeeCoin'
 import { GeneralSwapQuote } from '@core/chain/swap/general/GeneralSwapQuote'
 import { OneInchSwapQuoteResponse } from '@core/chain/swap/general/oneInch/api/OneInchSwapQuoteResponse'
 import { oneInchAffiliateConfig } from '@core/chain/swap/general/oneInch/oneInchAffiliateConfig'
-import { getEvmSwapGasLimit } from '@core/chain/tx/fee/evm/evmGasLimit'
 import { rootApiUrl } from '@core/config'
 import { hexToNumber } from '@lib/utils/hex/hexToNumber'
 import { addQueryParams } from '@lib/utils/query/addQueryParams'
@@ -59,10 +58,7 @@ export const getOneInchSwapQuote = async ({
     dstAmount,
     provider: '1inch',
     tx: {
-      evm: {
-        ...tx,
-        gas: tx.gas || getEvmSwapGasLimit(chain),
-      },
+      evm: tx,
     },
   }
 }

--- a/core/chain/swap/keysign/getSwapKeysignPayloadFields.ts
+++ b/core/chain/swap/keysign/getSwapKeysignPayloadFields.ts
@@ -47,7 +47,11 @@ export const getSwapKeysignPayloadFields = ({
         GeneralSwapTx,
         Omit<OneInchTransaction, '$typeName' | 'swapFee'>
       >(quote.tx, {
-        evm: ({ gas, ...tx }) => ({ ...tx, gas: BigInt(gas) }),
+        evm: ({ gasPrice, gas, ...tx }) => ({
+          ...tx,
+          gasPrice: gasPrice?.toString() ?? '0',
+          gas: gas ?? BigInt(0),
+        }),
         solana: ({ data }) => ({
           from: '',
           to: '',

--- a/core/chain/swap/keysign/getSwapKeysignPayloadFields.ts
+++ b/core/chain/swap/keysign/getSwapKeysignPayloadFields.ts
@@ -47,10 +47,10 @@ export const getSwapKeysignPayloadFields = ({
         GeneralSwapTx,
         Omit<OneInchTransaction, '$typeName' | 'swapFee'>
       >(quote.tx, {
-        evm: ({ gasPrice, gas, ...tx }) => ({
+        evm: ({ feeQuote, ...tx }) => ({
           ...tx,
-          gasPrice: gasPrice?.toString() ?? '0',
-          gas: gas ?? BigInt(0),
+          gasPrice: feeQuote.maxFeePerGas?.toString() ?? '0',
+          gas: feeQuote.gasLimit ?? BigInt(0),
         }),
         solana: ({ data }) => ({
           from: '',

--- a/core/chain/tx/fee/evm/EvmFeeSettings.ts
+++ b/core/chain/tx/fee/evm/EvmFeeSettings.ts
@@ -1,4 +1,7 @@
-export type EvmFeeSettings = {
+export type EvmFeeQuote = {
   maxPriorityFeePerGas: bigint
   gasLimit: bigint
+  maxFeePerGas: bigint
 }
+
+export type EvmFeeSettings = Omit<EvmFeeQuote, 'maxFeePerGas'>

--- a/core/chain/tx/fee/evm/evmGasLimit.ts
+++ b/core/chain/tx/fee/evm/evmGasLimit.ts
@@ -45,7 +45,7 @@ type DeriveEvmGasLimitInput = {
 export const deriveEvmGasLimit = ({ coin, data }: DeriveEvmGasLimitInput) => {
   const { id, chain } = coin
   if (data && isHex(data)) {
-    return chain === EvmChain.Mantle ? 1_500_000_000 : 600_000
+    return chain === EvmChain.Mantle ? 1_500_000_000n : 600_000n
   }
 
   return (id ? erc20TransferGasLimit : feeCoinTransferGasLimit)[chain]

--- a/core/chain/tx/fee/evm/evmGasLimit.ts
+++ b/core/chain/tx/fee/evm/evmGasLimit.ts
@@ -1,6 +1,12 @@
 import { EvmChain } from '@core/chain/Chain'
+import { isHex } from 'viem'
 
-export const evmNativeTokenGasLimit: Record<EvmChain, bigint> = {
+import { CoinKey } from '../../../coin/Coin'
+
+const zkSyncTransferGasLimit = 200000n
+const mantleTransferGasLimit = 90_000_000n
+
+const feeCoinTransferGasLimit: Record<EvmChain, bigint> = {
   [EvmChain.Ethereum]: 23000n,
   [EvmChain.Base]: 40000n,
   [EvmChain.Arbitrum]: 120000n,
@@ -10,23 +16,36 @@ export const evmNativeTokenGasLimit: Record<EvmChain, bigint> = {
   [EvmChain.Blast]: 40000n,
   [EvmChain.BSC]: 40000n,
   [EvmChain.Avalanche]: 23000n,
-  [EvmChain.Zksync]: 200000n,
-  [EvmChain.Mantle]: 90_000_000n,
+  [EvmChain.Zksync]: zkSyncTransferGasLimit,
+  [EvmChain.Mantle]: mantleTransferGasLimit,
 }
 
-export const evmTokenGasLimit: Record<EvmChain, bigint> = {
-  [EvmChain.Ethereum]: 120000n,
-  [EvmChain.Base]: 120000n,
-  [EvmChain.Arbitrum]: 120000n,
-  [EvmChain.Polygon]: 120000n,
-  [EvmChain.Optimism]: 120000n,
-  [EvmChain.CronosChain]: 120000n,
-  [EvmChain.Blast]: 120000n,
-  [EvmChain.BSC]: 120000n,
-  [EvmChain.Avalanche]: 120000n,
-  [EvmChain.Zksync]: 200000n,
-  [EvmChain.Mantle]: 90_000_000n,
+const defaultErc20TransferGasLimit = 120000n
+
+const erc20TransferGasLimit: Record<EvmChain, bigint> = {
+  [EvmChain.Ethereum]: defaultErc20TransferGasLimit,
+  [EvmChain.Base]: defaultErc20TransferGasLimit,
+  [EvmChain.Arbitrum]: defaultErc20TransferGasLimit,
+  [EvmChain.Polygon]: defaultErc20TransferGasLimit,
+  [EvmChain.Optimism]: defaultErc20TransferGasLimit,
+  [EvmChain.CronosChain]: defaultErc20TransferGasLimit,
+  [EvmChain.Blast]: defaultErc20TransferGasLimit,
+  [EvmChain.BSC]: defaultErc20TransferGasLimit,
+  [EvmChain.Avalanche]: defaultErc20TransferGasLimit,
+  [EvmChain.Zksync]: zkSyncTransferGasLimit,
+  [EvmChain.Mantle]: mantleTransferGasLimit,
 }
 
-export const getEvmSwapGasLimit = (chain: EvmChain): number =>
-  chain === EvmChain.Mantle ? 1_500_000_000 : 600_000
+type DeriveEvmGasLimitInput = {
+  coin: CoinKey<EvmChain>
+  data?: string
+}
+
+export const deriveEvmGasLimit = ({ coin, data }: DeriveEvmGasLimitInput) => {
+  const { id, chain } = coin
+  if (data && isHex(data)) {
+    return chain === EvmChain.Mantle ? 1_500_000_000 : 600_000
+  }
+
+  return (id ? erc20TransferGasLimit : feeCoinTransferGasLimit)[chain]
+}

--- a/core/chain/tx/fee/evm/evmGasLimit.ts
+++ b/core/chain/tx/fee/evm/evmGasLimit.ts
@@ -41,6 +41,7 @@ type DeriveEvmGasLimitInput = {
   data?: string
 }
 
+// If data is a hex string, we treat it as a contract call; otherwise, it's considered a simple memo
 export const deriveEvmGasLimit = ({ coin, data }: DeriveEvmGasLimitInput) => {
   const { id, chain } = coin
   if (data && isHex(data)) {

--- a/core/chain/tx/fee/evm/getEvmGasLimit.ts
+++ b/core/chain/tx/fee/evm/getEvmGasLimit.ts
@@ -1,9 +1,0 @@
-import { EvmChain } from '@core/chain/Chain'
-
-import { CoinKey } from '../../../coin/Coin'
-import { evmNativeTokenGasLimit, evmTokenGasLimit } from './evmGasLimit'
-
-export const getEvmGasLimit = ({ chain, id }: CoinKey<EvmChain>) => {
-  const record = id ? evmTokenGasLimit : evmNativeTokenGasLimit
-  return record[chain]
-}

--- a/core/chain/tx/fee/utxo/adjustByteFee.ts
+++ b/core/chain/tx/fee/utxo/adjustByteFee.ts
@@ -1,14 +1,3 @@
-import { byteFeeMultiplier, UtxoFeeSettings } from './UtxoFeeSettings'
-
-export const adjustByteFee = (
-  byteFee: number,
-  { priority }: UtxoFeeSettings
-) => {
-  if (typeof priority === 'number') {
-    return priority
-  }
-
-  const multiplier = byteFeeMultiplier[priority]
-
+export const adjustByteFee = (byteFee: number, multiplier: number) => {
   return Math.ceil(byteFee * multiplier)
 }

--- a/core/inpage-provider/popup/view/resolvers/sendTx/queries/parsedTx.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/queries/parsedTx.ts
@@ -44,13 +44,6 @@ export const useParsedTxQuery = (): Query<ParsedTx> => {
     retry: false,
   })
 
-  const feeSettingsQuery = useQuery({
-    queryKey: ['fee-settings', transactionPayload],
-    queryFn: () => getFeeSettings(transactionPayload),
-    ...noRefetchQueryOptions,
-    retry: false,
-  })
-
   const skipBroadcast = useMemo(
     () =>
       matchRecordUnion<ITransactionPayload, boolean | undefined>(
@@ -65,11 +58,10 @@ export const useParsedTxQuery = (): Query<ParsedTx> => {
 
   return useTransformQueriesData(
     {
-      feeSettings: feeSettingsQuery,
       customTxData: customTxDataQuery,
     },
     useCallback(
-      ({ feeSettings, customTxData }) => {
+      ({ customTxData }) => {
         const coin = matchRecordUnion<CustomTxData, Coin>(customTxData, {
           regular: ({ coin }) => coin,
           solana: tx => {
@@ -96,7 +88,7 @@ export const useParsedTxQuery = (): Query<ParsedTx> => {
         })
 
         return {
-          feeSettings,
+          feeSettings: getFeeSettings(transactionPayload),
           customTxData,
           skipBroadcast,
           coin: {
@@ -105,7 +97,13 @@ export const useParsedTxQuery = (): Query<ParsedTx> => {
           },
         }
       },
-      [vault.hexChainCode, vault.publicKeys, walletCore, skipBroadcast]
+      [
+        vault.hexChainCode,
+        vault.publicKeys,
+        walletCore,
+        skipBroadcast,
+        transactionPayload,
+      ]
     )
   )
 }

--- a/core/mpc/keysign/chainSpecific/resolver.ts
+++ b/core/mpc/keysign/chainSpecific/resolver.ts
@@ -1,7 +1,9 @@
 import { AccountCoin } from '@core/chain/coin/AccountCoin'
+import { EvmFeeQuote } from '@core/chain/tx/fee/evm/EvmFeeSettings'
 import {
   CosmosSpecific,
   EthereumSpecific,
+  UTXOSpecific,
 } from '@core/mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
 import { TransactionType } from '@core/mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
 import type { KeysignPayload } from '@core/mpc/types/vultisig/keysign/v1/keysign_message_pb'
@@ -18,21 +20,21 @@ type SpecificKeyByValue<R> = Extract<
   { value: R }
 >['case']
 
-export type ChainSpecificResolverInput<
-  T = any,
-  R = KeysignChainSpecificValue,
-> = {
+export type ChainSpecificResolverInput<R = KeysignChainSpecificValue> = {
   coin: AccountCoin<ChainsBySpecific<SpecificKeyByValue<R>>>
   receiver?: string
-  feeSettings?: T
   isDeposit?: boolean
   amount?: bigint
   transactionType?: TransactionType
-  psbt?: Psbt
-} & (R extends EthereumSpecific ? { data?: string } : {}) &
-  (R extends CosmosSpecific ? { timeoutTimestamp?: string } : {})
+} & (R extends EthereumSpecific
+  ? { data?: string; feeQuote?: Partial<EvmFeeQuote> }
+  : R extends UTXOSpecific
+    ? { byteFeeMultiplier?: number; psbt?: Psbt }
+    : R extends CosmosSpecific
+      ? { timeoutTimestamp?: string }
+      : {})
 
-export type ChainSpecificResolver<
-  R = KeysignChainSpecificValue,
-  T = any,
-> = Resolver<ChainSpecificResolverInput<T, R>, Promise<R>>
+export type ChainSpecificResolver<R = KeysignChainSpecificValue> = Resolver<
+  ChainSpecificResolverInput<R>,
+  Promise<R>
+>

--- a/core/mpc/keysign/chainSpecific/resolvers/evm.ts
+++ b/core/mpc/keysign/chainSpecific/resolvers/evm.ts
@@ -43,6 +43,7 @@ export const getEthereumSpecific: ChainSpecificResolver<
       address: coin.address as `0x${string}`,
     })
   )
+
   const data = stringData ? formatData(stringData) : undefined
 
   const estimatedFee = await asyncFallbackChain(

--- a/core/mpc/keysign/chainSpecific/resolvers/evm.ts
+++ b/core/mpc/keysign/chainSpecific/resolvers/evm.ts
@@ -3,7 +3,6 @@ import { Chain } from '@core/chain/Chain'
 import { evmChainInfo } from '@core/chain/chains/evm/chainInfo'
 import { getEvmClient } from '@core/chain/chains/evm/client'
 import { getEvmBaseFee } from '@core/chain/tx/fee/evm/baseFee'
-import { EvmFeeSettings } from '@core/chain/tx/fee/evm/EvmFeeSettings'
 import { deriveEvmGasLimit } from '@core/chain/tx/fee/evm/evmGasLimit'
 import { getEvmMaxPriorityFeePerGas } from '@core/chain/tx/fee/evm/maxPriorityFeePerGas'
 import {
@@ -31,9 +30,8 @@ const formatData = (data: string): `0x${string}` => {
 }
 
 export const getEthereumSpecific: ChainSpecificResolver<
-  EthereumSpecific,
-  EvmFeeSettings
-> = async ({ coin, feeSettings = {}, amount, receiver, data }) => {
+  EthereumSpecific
+> = async ({ coin, feeQuote = {}, amount, receiver, data }) => {
   const { chain } = coin
 
   const client = getEvmClient(chain)
@@ -77,7 +75,7 @@ export const getEthereumSpecific: ChainSpecificResolver<
 
   const { maxFeePerGas, maxPriorityFeePerGas, gasLimit } = {
     ...estimatedFee,
-    ...feeSettings,
+    ...feeQuote,
   }
 
   return create(EthereumSpecificSchema, {

--- a/core/mpc/keysign/chainSpecific/resolvers/evm.ts
+++ b/core/mpc/keysign/chainSpecific/resolvers/evm.ts
@@ -4,7 +4,7 @@ import { evmChainInfo } from '@core/chain/chains/evm/chainInfo'
 import { getEvmClient } from '@core/chain/chains/evm/client'
 import { getEvmBaseFee } from '@core/chain/tx/fee/evm/baseFee'
 import { EvmFeeSettings } from '@core/chain/tx/fee/evm/EvmFeeSettings'
-import { getEvmGasLimit } from '@core/chain/tx/fee/evm/getEvmGasLimit'
+import { deriveEvmGasLimit } from '@core/chain/tx/fee/evm/evmGasLimit'
 import { getEvmMaxPriorityFeePerGas } from '@core/chain/tx/fee/evm/maxPriorityFeePerGas'
 import {
   EthereumSpecific,
@@ -33,7 +33,7 @@ const formatData = (data: string): `0x${string}` => {
 export const getEthereumSpecific: ChainSpecificResolver<
   EthereumSpecific,
   EvmFeeSettings
-> = async ({ coin, feeSettings = {}, amount, receiver, data: stringData }) => {
+> = async ({ coin, feeSettings = {}, amount, receiver, data }) => {
   const { chain } = coin
 
   const client = getEvmClient(chain)
@@ -44,8 +44,6 @@ export const getEthereumSpecific: ChainSpecificResolver<
     })
   )
 
-  const data = stringData ? formatData(stringData) : undefined
-
   const estimatedFee = await asyncFallbackChain(
     () => {
       if (chain === Chain.Zksync) {
@@ -54,7 +52,7 @@ export const getEthereumSpecific: ChainSpecificResolver<
           account: coin.address as `0x${string}`,
           to: shouldBePresent(receiver) as `0x${string}`,
           value: amount,
-          data: data as `0x${string}` | undefined,
+          data: data ? formatData(data) : undefined,
         })
       }
 
@@ -72,7 +70,7 @@ export const getEthereumSpecific: ChainSpecificResolver<
       return {
         maxFeePerGas,
         maxPriorityFeePerGas,
-        gasLimit: getEvmGasLimit(coin),
+        gasLimit: deriveEvmGasLimit({ coin, data }),
       }
     }
   )

--- a/core/mpc/keysign/chainSpecific/resolvers/utxo.ts
+++ b/core/mpc/keysign/chainSpecific/resolvers/utxo.ts
@@ -3,7 +3,6 @@ import { UtxoChain } from '@core/chain/Chain'
 import { getUtxoStats } from '@core/chain/chains/utxo/client/getUtxoStats'
 import { getCoinBalance } from '@core/chain/coin/balance'
 import { adjustByteFee } from '@core/chain/tx/fee/utxo/adjustByteFee'
-import { UtxoFeeSettings } from '@core/chain/tx/fee/utxo/UtxoFeeSettings'
 import {
   UTXOSpecific,
   UTXOSpecificSchema,
@@ -22,16 +21,15 @@ const getByteFee = async (chain: UtxoChain) => {
   return data.suggested_transaction_fee_per_byte_sat
 }
 
-export const getUtxoSpecific: ChainSpecificResolver<
-  UTXOSpecific,
-  UtxoFeeSettings
-> = async ({ coin, feeSettings, amount, psbt }) => {
+export const getUtxoSpecific: ChainSpecificResolver<UTXOSpecific> = async ({
+  coin,
+  byteFeeMultiplier = 1,
+  amount,
+  psbt,
+}) => {
   const chain = coin.chain as UtxoChain
 
-  let byteFee = await getByteFee(chain)
-  if (feeSettings) {
-    byteFee = adjustByteFee(byteFee, feeSettings)
-  }
+  const byteFee = adjustByteFee(await getByteFee(chain), byteFeeMultiplier)
 
   const result = create(UTXOSpecificSchema, {
     byteFee: byteFee.toString(),

--- a/core/ui/vault/send/fee/settings/state/feeSettings.tsx
+++ b/core/ui/vault/send/fee/settings/state/feeSettings.tsx
@@ -1,4 +1,5 @@
 import { Chain } from '@core/chain/Chain'
+import { ChainKind } from '@core/chain/ChainKind'
 import { isFeeCoin } from '@core/chain/coin/utils/isFeeCoin'
 import { EvmFeeSettings } from '@core/chain/tx/fee/evm/EvmFeeSettings'
 import { UtxoFeeSettings } from '@core/chain/tx/fee/utxo/UtxoFeeSettings'
@@ -7,8 +8,17 @@ import { getStateProviderSetup } from '@lib/ui/state/getStateProviderSetup'
 import { omit } from '@lib/utils/record/omit'
 import { useCallback, useMemo } from 'react'
 
-export type FeeSettings = EvmFeeSettings | UtxoFeeSettings
 import { useCurrentSendCoin } from '../../../state/sendCoin'
+
+export const feeSettingsChainKinds = [
+  'evm',
+  'utxo',
+] as const satisfies ChainKind[]
+
+type FeeSettingsChainKind = (typeof feeSettingsChainKinds)[number]
+
+export type FeeSettings<T extends FeeSettingsChainKind = FeeSettingsChainKind> =
+  T extends 'evm' ? EvmFeeSettings : UtxoFeeSettings
 
 type FeeSettingsRecord = Record<string, FeeSettings>
 

--- a/core/ui/vault/send/fee/settings/utxo/ManageUtxoFeeSettings.tsx
+++ b/core/ui/vault/send/fee/settings/utxo/ManageUtxoFeeSettings.tsx
@@ -4,7 +4,10 @@ import {
   FeePriority,
 } from '@core/chain/tx/fee/FeePriority'
 import { adjustByteFee } from '@core/chain/tx/fee/utxo/adjustByteFee'
-import { UtxoFeeSettings } from '@core/chain/tx/fee/utxo/UtxoFeeSettings'
+import {
+  byteFeeMultiplier,
+  UtxoFeeSettings,
+} from '@core/chain/tx/fee/utxo/UtxoFeeSettings'
 import { HorizontalLine } from '@core/ui/vault/send/components/HorizontalLine'
 import { useSendChainSpecific } from '@core/ui/vault/send/fee/SendChainSpecificProvider'
 import { useFeeSettings } from '@core/ui/vault/send/fee/settings/state/feeSettings'
@@ -17,6 +20,7 @@ import { VStack } from '@lib/ui/layout/Stack'
 import { Modal } from '@lib/ui/modal'
 import { OnCloseProp } from '@lib/ui/props'
 import { Text } from '@lib/ui/text'
+import { isOneOf } from '@lib/utils/array/isOneOf'
 import { shouldBePresent } from '@lib/utils/assert/shouldBePresent'
 import { getDiscriminatedUnionValue } from '@lib/utils/getDiscriminatedUnionValue'
 import { useMemo, useState } from 'react'
@@ -100,7 +104,12 @@ export const ManageUtxoFeeSettings: React.FC<OnCloseProp> = ({ onClose }) => {
           }
           value={
             value.priority
-              ? adjustByteFee(Number(byteFee), { priority: value.priority })
+              ? adjustByteFee(
+                  Number(byteFee),
+                  isOneOf(value.priority, feePriorities)
+                    ? byteFeeMultiplier[value.priority]
+                    : value.priority
+                )
               : null
           }
           onValueChange={priority => setValue({ ...value, priority })}

--- a/core/ui/vault/send/queries/useSendChainSpecificQuery.ts
+++ b/core/ui/vault/send/queries/useSendChainSpecificQuery.ts
@@ -1,5 +1,18 @@
+import { getChainKind } from '@core/chain/ChainKind'
+import { feePriorities } from '@core/chain/tx/fee/FeePriority'
+import { byteFeeMultiplier } from '@core/chain/tx/fee/utxo/UtxoFeeSettings'
+import { ChainSpecificResolverInput } from '@core/mpc/keysign/chainSpecific/resolver'
+import { UTXOSpecific } from '@core/mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
+import { isOneOf } from '@lib/utils/array/isOneOf'
+import { match } from '@lib/utils/match'
+import { useMemo } from 'react'
+
 import { useChainSpecificQuery } from '../../../chain/coin/queries/useChainSpecificQuery'
-import { useFeeSettings } from '../fee/settings/state/feeSettings'
+import {
+  FeeSettings,
+  feeSettingsChainKinds,
+  useFeeSettings,
+} from '../fee/settings/state/feeSettings'
 import { useSendAmount } from '../state/amount'
 import { useSendMemo } from '../state/memo'
 import { useSendReceiver } from '../state/receiver'
@@ -12,11 +25,37 @@ export const useSendChainSpecificQuery = () => {
   const [amount] = useSendAmount()
   const [memo] = useSendMemo()
 
-  return useChainSpecificQuery({
-    coin,
-    receiver,
-    feeSettings,
-    amount: amount ?? 0n,
-    data: memo,
-  })
+  const input: ChainSpecificResolverInput = useMemo(() => {
+    const result: ChainSpecificResolverInput = {
+      coin,
+      receiver,
+      amount: amount ?? 0n,
+      data: memo,
+    }
+
+    if (feeSettings) {
+      const chainKind = getChainKind(coin.chain)
+      if (!isOneOf(chainKind, feeSettingsChainKinds)) {
+        return result
+      }
+
+      match(chainKind, {
+        evm: () => {
+          result.feeQuote = feeSettings as FeeSettings<'evm'>
+        },
+        utxo: () => {
+          const { priority } = feeSettings as FeeSettings<'utxo'>
+          ;(
+            result as ChainSpecificResolverInput<UTXOSpecific>
+          ).byteFeeMultiplier = isOneOf(priority, feePriorities)
+            ? byteFeeMultiplier[priority]
+            : priority
+        },
+      })
+    }
+
+    return result
+  }, [amount, coin, feeSettings, memo, receiver])
+
+  return useChainSpecificQuery(input)
 }

--- a/core/ui/vault/swap/form/info/SwapFees.tsx
+++ b/core/ui/vault/swap/form/info/SwapFees.tsx
@@ -63,32 +63,38 @@ export const SwapFees: FC<SwapFeesProps> = ({ RowComponent }) => {
             style={{ overflow: 'hidden' }}
           >
             <FeesWrapper gap={10}>
-              <RowComponent>
-                <Text>{t('swap_fee')}</Text>
-                <MatchQuery
-                  value={query}
-                  pending={() => <Skeleton width="48px" height="12px" />}
-                  error={() => (
-                    <Text color="danger">{t('failed_to_load')}</Text>
-                  )}
-                  success={({ swap }) => (
-                    <Text color="shy">
-                      <SwapFeeFiatValue value={[swap]} />
-                    </Text>
-                  )}
-                />
-              </RowComponent>
-
               <MatchQuery
                 value={query}
-                success={({ network }) => (
+                pending={() => (
                   <RowComponent>
-                    <span>{t('network_fee')}</span>
-                    <Text color="shy">
-                      {formatFee(network)} (~
-                      <SwapFeeFiatValue value={[network]} />)
-                    </Text>
+                    <Text>{t('swap_fee')}</Text>
+                    <Skeleton width="48px" height="12px" />
                   </RowComponent>
+                )}
+                error={() => (
+                  <RowComponent>
+                    <Text>{t('swap_fee')}</Text>
+                    <Text color="danger">{t('failed_to_load')}</Text>
+                  </RowComponent>
+                )}
+                success={({ network, swap }) => (
+                  <>
+                    {swap && (
+                      <RowComponent>
+                        <Text>{t('swap_fee')}</Text>
+                        <Text color="shy">
+                          <SwapFeeFiatValue value={[swap]} />
+                        </Text>
+                      </RowComponent>
+                    )}
+                    <RowComponent>
+                      <span>{t('network_fee')}</span>
+                      <Text color="shy">
+                        {formatFee(network)} (~
+                        <SwapFeeFiatValue value={[network]} />)
+                      </Text>
+                    </RowComponent>
+                  </>
                 )}
               />
             </FeesWrapper>

--- a/core/ui/vault/swap/form/info/VerifySwapFees.tsx
+++ b/core/ui/vault/swap/form/info/VerifySwapFees.tsx
@@ -20,29 +20,38 @@ export const VerifySwapFees: FC<VerifySwapFeesProps> = ({ RowComponent }) => {
     <>
       <MatchQuery
         value={query}
-        success={({ network }) => (
+        pending={() => (
           <RowComponent>
-            <span>{t('network_fee')}</span>
-            <Text color="supporting">
-              {formatFee(network)} (~
-              <SwapFeeFiatValue value={[network]} />)
-            </Text>
+            <Text>{t('swap_fee')}</Text>
+            <Skeleton width="48px" height="12px" />
           </RowComponent>
         )}
+        error={() => (
+          <RowComponent>
+            <Text>{t('swap_fee')}</Text>
+            <Text color="danger">{t('failed_to_load')}</Text>
+          </RowComponent>
+        )}
+        success={({ network, swap }) => (
+          <>
+            {swap && (
+              <RowComponent>
+                <Text>{t('swap_fee')}</Text>
+                <Text color="shy">
+                  <SwapFeeFiatValue value={[swap]} />
+                </Text>
+              </RowComponent>
+            )}
+            <RowComponent>
+              <span>{t('network_fee')}</span>
+              <Text color="shy">
+                {formatFee(network)} (~
+                <SwapFeeFiatValue value={[network]} />)
+              </Text>
+            </RowComponent>
+          </>
+        )}
       />
-      <RowComponent>
-        <Text>{t('swap_fee')}</Text>
-        <MatchQuery
-          value={query}
-          pending={() => <Skeleton width="48px" height="12px" />}
-          error={() => <Text color="danger">{t('failed_to_load')}</Text>}
-          success={({ swap }) => (
-            <Text color="supporting">
-              <SwapFeeFiatValue value={[swap]} />
-            </Text>
-          )}
-        />
-      </RowComponent>
       <RowComponent>
         <span>{t('max_total_fees')}</span>
         <MatchQuery

--- a/core/ui/vault/swap/queries/useSwapChainSpecificQuery.ts
+++ b/core/ui/vault/swap/queries/useSwapChainSpecificQuery.ts
@@ -1,16 +1,16 @@
 import { toChainAmount } from '@core/chain/amount/toChainAmount'
-import { UtxoChain } from '@core/chain/Chain'
+import { isChainOfKind } from '@core/chain/ChainKind'
 import { chainFeeCoin } from '@core/chain/coin/chainFeeCoin'
 import { areEqualCoins } from '@core/chain/coin/Coin'
 import { getPublicKey } from '@core/chain/publicKey/getPublicKey'
 import { getSwapKeysignPayloadFields } from '@core/chain/swap/keysign/getSwapKeysignPayloadFields'
 import { SwapQuote } from '@core/chain/swap/quote/SwapQuote'
+import { byteFeeMultiplier } from '@core/chain/tx/fee/utxo/UtxoFeeSettings'
 import { ChainSpecificResolverInput } from '@core/mpc/keysign/chainSpecific/resolver'
 import { useAssertWalletCore } from '@core/ui/chain/providers/WalletCoreProvider'
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { useCurrentVaultCoin } from '@core/ui/vault/state/currentVaultCoins'
 import { usePotentialQuery } from '@lib/ui/query/hooks/usePotentialQuery'
-import { isOneOf } from '@lib/utils/array/isOneOf'
 import { matchRecordUnion } from '@lib/utils/matchRecordUnion'
 import { getRecordUnionValue } from '@lib/utils/record/union/getRecordUnionValue'
 import { useMemo } from 'react'
@@ -87,12 +87,9 @@ export const useSwapChainSpecificQuery = () => {
           areEqualCoins(fromCoinKey, chainFeeCoin[swapChain]),
         general: () => false,
       }),
-    }
-
-    if (isOneOf(fromCoin.chain, Object.values(UtxoChain))) {
-      input.feeSettings = {
-        priority: 'fast',
-      }
+      byteFeeMultiplier: isChainOfKind(fromCoin.chain, 'utxo')
+        ? byteFeeMultiplier.fast
+        : undefined,
     }
 
     return input

--- a/core/ui/vault/swap/queries/useSwapChainSpecificQuery.ts
+++ b/core/ui/vault/swap/queries/useSwapChainSpecificQuery.ts
@@ -5,6 +5,7 @@ import { areEqualCoins } from '@core/chain/coin/Coin'
 import { getPublicKey } from '@core/chain/publicKey/getPublicKey'
 import { getSwapKeysignPayloadFields } from '@core/chain/swap/keysign/getSwapKeysignPayloadFields'
 import { SwapQuote } from '@core/chain/swap/quote/SwapQuote'
+import { EvmFeeQuote } from '@core/chain/tx/fee/evm/EvmFeeSettings'
 import { byteFeeMultiplier } from '@core/chain/tx/fee/utxo/UtxoFeeSettings'
 import { ChainSpecificResolverInput } from '@core/mpc/keysign/chainSpecific/resolver'
 import { useAssertWalletCore } from '@core/ui/chain/providers/WalletCoreProvider'
@@ -90,6 +91,17 @@ export const useSwapChainSpecificQuery = () => {
       byteFeeMultiplier: isChainOfKind(fromCoin.chain, 'utxo')
         ? byteFeeMultiplier.fast
         : undefined,
+      feeQuote: matchRecordUnion<SwapQuote, Partial<EvmFeeQuote> | undefined>(
+        swapQuote,
+        {
+          native: () => undefined,
+          general: ({ tx }) =>
+            matchRecordUnion(tx, {
+              evm: ({ feeQuote }) => feeQuote,
+              solana: () => undefined,
+            }),
+        }
+      ),
     }
 
     return input

--- a/core/ui/vault/swap/queries/useSwapChainSpecificQuery.ts
+++ b/core/ui/vault/swap/queries/useSwapChainSpecificQuery.ts
@@ -1,16 +1,18 @@
 import { toChainAmount } from '@core/chain/amount/toChainAmount'
-import { EvmChain, UtxoChain } from '@core/chain/Chain'
+import { UtxoChain } from '@core/chain/Chain'
 import { chainFeeCoin } from '@core/chain/coin/chainFeeCoin'
 import { areEqualCoins } from '@core/chain/coin/Coin'
 import { getPublicKey } from '@core/chain/publicKey/getPublicKey'
 import { getSwapKeysignPayloadFields } from '@core/chain/swap/keysign/getSwapKeysignPayloadFields'
-import { getEvmSwapGasLimit } from '@core/chain/tx/fee/evm/evmGasLimit'
+import { SwapQuote } from '@core/chain/swap/quote/SwapQuote'
 import { ChainSpecificResolverInput } from '@core/mpc/keysign/chainSpecific/resolver'
 import { useAssertWalletCore } from '@core/ui/chain/providers/WalletCoreProvider'
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { useCurrentVaultCoin } from '@core/ui/vault/state/currentVaultCoins'
 import { usePotentialQuery } from '@lib/ui/query/hooks/usePotentialQuery'
 import { isOneOf } from '@lib/utils/array/isOneOf'
+import { matchRecordUnion } from '@lib/utils/matchRecordUnion'
+import { getRecordUnionValue } from '@lib/utils/record/union/getRecordUnionValue'
 import { useMemo } from 'react'
 
 import { getChainSpecificQuery } from '../../../chain/coin/queries/useChainSpecificQuery'
@@ -76,24 +78,20 @@ export const useSwapChainSpecificQuery = () => {
       coin: fromCoin,
       amount: toChainAmount(fromAmount, fromCoin.decimals),
       receiver: toAddress,
-    }
-
-    if ('native' in swapQuote) {
-      const { swapChain } = swapQuote.native
-      const nativeFeeCoin = chainFeeCoin[swapChain]
-
-      input.isDeposit = areEqualCoins(fromCoinKey, nativeFeeCoin)
+      data: matchRecordUnion<SwapQuote, string | undefined>(swapQuote, {
+        native: () => undefined,
+        general: ({ tx }) => getRecordUnionValue(tx).data,
+      }),
+      isDeposit: matchRecordUnion<SwapQuote, boolean>(swapQuote, {
+        native: ({ swapChain }) =>
+          areEqualCoins(fromCoinKey, chainFeeCoin[swapChain]),
+        general: () => false,
+      }),
     }
 
     if (isOneOf(fromCoin.chain, Object.values(UtxoChain))) {
       input.feeSettings = {
         priority: 'fast',
-      }
-    }
-
-    if (isOneOf(fromCoin.chain, Object.values(EvmChain))) {
-      input.feeSettings = {
-        gasLimit: getEvmSwapGasLimit(fromCoin.chain),
       }
     }
 

--- a/core/ui/vault/swap/queries/useSwapFeesQuery.ts
+++ b/core/ui/vault/swap/queries/useSwapFeesQuery.ts
@@ -45,13 +45,7 @@ export const useSwapFeesQuery = () => {
         },
         general: ({ tx }) => {
           return matchRecordUnion(tx, {
-            evm: ({ gasPrice, gas }) => ({
-              swap: {
-                chain: fromCoinKey.chain,
-                id: fromCoinKey.id,
-                amount: BigInt(gasPrice) * BigInt(gas),
-                decimals: fromFeeCoin.decimals,
-              },
+            evm: () => ({
               network,
             }),
             solana: ({ networkFee, swapFee }) => ({


### PR DESCRIPTION
## Swap initiated on Desktop
<img width="1688" height="1066" alt="image" src="https://github.com/user-attachments/assets/06bec874-d32f-40ff-bcde-83588eefe866" />

## Swap initiated on Extension
<img width="1345" height="926" alt="image" src="https://github.com/user-attachments/assets/5ef1d753-d96d-4754-9322-d0d6d299f1a6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unified fee handling with feeQuote across EVM swaps (Kyber, 1inch, Li.Fi).
  - Automatic EVM gas/fee derivation with resilient fallbacks.
  - UTXO byte-fee multiplier support for finer control.
  - Fees UI now separates swap and network fees with clear pending/error states.
  - Swap fee is now optional where unavailable.

- Bug Fixes
  - More reliable gas limit/price estimation, reducing failed transactions.
  - More accurate token address resolution in swap routes.

- Refactor
  - Simplified fee APIs and removed legacy gas-limit logic.
  - Streamlined fee settings and chain-specific query inputs.

- Chores
  - Added empty scripts field to desktop runtime package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->