### PR TITLE
Keep the discount tier card collapsed initially unless it is currently active.

### DIFF
--- a/core/ui/vult/discount/tier/index.tsx
+++ b/core/ui/vult/discount/tier/index.tsx
@@ -35,9 +35,7 @@ export const VultDiscountTier = ({
     return activeDiscountTierIndex < vultDiscountTiers.indexOf(value)
   }, [activeDiscountTier, value])
 
-  const [isExpanded, setIsExpanded] = useState(
-    () => isActive || !activeDiscountTier
-  )
+  const [isExpanded, setIsExpanded] = useState(isActive)
 
   return (
     <DiscountTierContainer value={value}>


### PR DESCRIPTION
<img width="1136" height="908" alt="image" src="https://github.com/user-attachments/assets/f0b2aee1-9da4-4fd4-aa75-482cc98ea93b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated discount tier expansion behavior to align only with the tier's active state, improving consistency in UI interactions and state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->