### PR TITLE
Fix the crash that occurs when sending a verification if the fee quote has not been loaded.

### DIFF
--- a/core/ui/vault/send/state/useSendTxKeysignPayloadQuery.ts
+++ b/core/ui/vault/send/state/useSendTxKeysignPayloadQuery.ts
@@ -9,7 +9,7 @@ import { useTransformQueriesData } from '@lib/ui/query/hooks/useTransformQueries
 import { useCallback } from 'react'
 
 import { useSendCappedAmountQuery } from '../queries/useSendCappedAmountQuery'
-import { useSendFeeQuote } from '../queries/useSendFeeQuoteQuery'
+import { useSendFeeQuoteQuery } from '../queries/useSendFeeQuoteQuery'
 import { useSendKeysignTxDataQuery } from '../queries/useSendKeysignTxDataQuery'
 import { useSendMemo } from './memo'
 import { useSendReceiver } from './receiver'
@@ -23,7 +23,7 @@ export const useSendTxKeysignPayloadQuery = () => {
   const vault = useCurrentVault()
 
   const txData = useSendKeysignTxDataQuery()
-  const feeQuote = useSendFeeQuote()
+  const feeQuote = useSendFeeQuoteQuery()
 
   const cappedAmount = useSendCappedAmountQuery()
 
@@ -33,9 +33,10 @@ export const useSendTxKeysignPayloadQuery = () => {
     {
       txData,
       cappedAmount,
+      feeQuote,
     },
     useCallback(
-      ({ txData, cappedAmount }) => {
+      ({ txData, cappedAmount, feeQuote }) => {
         const publicKey = getPublicKey({
           chain: coin.chain,
           walletCore,
@@ -67,7 +68,6 @@ export const useSendTxKeysignPayloadQuery = () => {
       [
         coin,
         memo,
-        feeQuote,
         receiver,
         vault.hexChainCode,
         vault.libType,


### PR DESCRIPTION
<img width="1092" height="864" alt="image" src="https://github.com/user-attachments/assets/22d54cc8-114e-4a0a-8b32-26090a36bb20" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved transaction fee quote handling in the transaction signing process for enhanced accuracy and consistency in fee calculations during transaction creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->