### PR TITLE
Move the build send keysign payload to the core/mpc package.

### DIFF
--- a/core/mpc/keysign/referral/build.ts
+++ b/core/mpc/keysign/referral/build.ts
@@ -1,61 +1,52 @@
 import { create } from '@bufbuild/protobuf'
-import { isChainOfKind } from '@core/chain/ChainKind'
+import { toChainAmount } from '@core/chain/amount/toChainAmount'
 import { AccountCoin } from '@core/chain/coin/AccountCoin'
 import { getCoinBalance } from '@core/chain/coin/balance'
 import { getChainSpecific } from '@core/mpc/keysign/chainSpecific'
-import { FeeSettings } from '@core/mpc/keysign/chainSpecific/FeeSettings'
 import { refineKeysignAmount } from '@core/mpc/keysign/refine/amount'
-import { refineKeysignUtxo } from '@core/mpc/keysign/refine/utxo'
-import { getKeysignUtxoInfo } from '@core/mpc/keysign/utxo/getKeysignUtxoInfo'
 import { MpcLib } from '@core/mpc/mpcLib'
 import { toCommCoin } from '@core/mpc/types/utils/commCoin'
 import { KeysignPayloadSchema } from '@core/mpc/types/vultisig/keysign/v1/keysign_message_pb'
 import { WalletCore } from '@trustwallet/wallet-core'
 import { PublicKey } from '@trustwallet/wallet-core/dist/src/wallet-core'
 
-export type BuildSendKeysignPayloadInput = {
+export type BuildReferralKeysignPayloadInput = {
   coin: AccountCoin
-  receiver: string
-  amount: bigint
-  memo?: string
+  memo: string
+  amount: number
   vaultId: string
   localPartyId: string
   publicKey: PublicKey
   libType: MpcLib
   walletCore: WalletCore
-  feeSettings?: FeeSettings
 }
 
-export const buildSendKeysignPayload = async ({
+export const buildReferralKeysignPayload = async ({
   coin,
-  receiver,
-  amount,
   memo,
+  amount,
   vaultId,
   localPartyId,
   publicKey,
-  walletCore,
   libType,
-  feeSettings,
-}: BuildSendKeysignPayloadInput) => {
+  walletCore,
+}: BuildReferralKeysignPayloadInput) => {
   let keysignPayload = create(KeysignPayloadSchema, {
     coin: toCommCoin({
       ...coin,
       hexPublicKey: Buffer.from(publicKey.data()).toString('hex'),
     }),
-    toAddress: receiver,
-    toAmount: amount.toString(),
     memo,
+    toAmount: toChainAmount(amount, coin.decimals).toString(),
     vaultLocalPartyId: localPartyId,
     vaultPublicKeyEcdsa: vaultId,
     libType,
-    utxoInfo: await getKeysignUtxoInfo(coin),
   })
 
   keysignPayload.blockchainSpecific = await getChainSpecific({
     keysignPayload,
-    feeSettings,
     walletCore,
+    isDeposit: true,
   })
 
   const balance = await getCoinBalance(coin)
@@ -66,14 +57,6 @@ export const buildSendKeysignPayload = async ({
     publicKey,
     balance,
   })
-
-  if (isChainOfKind(coin.chain, 'utxo')) {
-    keysignPayload = refineKeysignUtxo({
-      keysignPayload,
-      walletCore,
-      publicKey,
-    })
-  }
 
   return keysignPayload
 }

--- a/core/ui/vault/send/keysignPayload/query.ts
+++ b/core/ui/vault/send/keysignPayload/query.ts
@@ -1,3 +1,7 @@
+import {
+  buildSendKeysignPayload,
+  BuildSendKeysignPayloadInput,
+} from '@core/mpc/keysign/send/build'
 import { getVaultId } from '@core/mpc/vault/Vault'
 import { useAssertWalletCore } from '@core/ui/chain/providers/WalletCoreProvider'
 import {
@@ -15,7 +19,6 @@ import { useSendAmount } from '../state/amount'
 import { useSendMemo } from '../state/memo'
 import { useSendReceiver } from '../state/receiver'
 import { useCurrentSendCoin } from '../state/sendCoin'
-import { buildSendKeysignPayload, BuildSendKeysignPayloadInput } from './build'
 
 export const useSendKeysignPayloadQuery = () => {
   const coin = useCurrentSendCoin()

--- a/core/ui/vault/settings/referral/keysignPayload/query.ts
+++ b/core/ui/vault/settings/referral/keysignPayload/query.ts
@@ -1,7 +1,7 @@
 import {
   buildReferralKeysignPayload,
   BuildReferralKeysignPayloadInput,
-} from '@core/mpc/keysign/send/build'
+} from '@core/mpc/keysign/referral/build'
 import { getVaultId } from '@core/mpc/vault/Vault'
 import { useAssertWalletCore } from '@core/ui/chain/providers/WalletCoreProvider'
 import {


### PR DESCRIPTION
…builder

- Added `buildReferralKeysignPayload` function in `core/mpc/keysign/referral/build.ts` for creating referral transaction payloads.
- Refactored `buildSendKeysignPayload` in `core/mpc/keysign/send/build.ts` to accommodate changes in input parameters and enhance UTXO handling.
- Updated UI query hooks to utilize the new referral payload builder, improving transaction processing in the referral context.

## Description

Please include a summary of the change and which issue is fixed. 

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized keysign payload construction to separate send and referral operations, improving code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->