### PR TITLE
Remove the "Manage chains" button for KeyImport vaults.

### DIFF
--- a/core/ui/vault/page/components/VaultTabs/VaultTabsHeader.tsx
+++ b/core/ui/vault/page/components/VaultTabs/VaultTabsHeader.tsx
@@ -1,4 +1,6 @@
+import { isKeyImportVault } from '@core/mpc/vault/Vault'
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
+import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { IconButton } from '@lib/ui/buttons/IconButton'
 import { CryptoWalletPenIcon } from '@lib/ui/icons/CryptoWalletPenIcon'
 import { hStack } from '@lib/ui/layout/Stack'
@@ -11,6 +13,7 @@ import { SearchChain } from './controls/SearchChain'
 
 export const VaultTabsHeader = ({ children }: ChildrenProp) => {
   const { colors } = useTheme()
+  const vault = useCurrentVault()
   const navigate = useCoreNavigate()
   const [isSearchExpanded, setIsSearchExpanded] = useState(false)
 
@@ -48,7 +51,7 @@ export const VaultTabsHeader = ({ children }: ChildrenProp) => {
           />
         </SearchArea>
         <AnimatePresence initial={false}>
-          {!isSearchExpanded && (
+          {!isSearchExpanded && !isKeyImportVault(vault) && (
             <ManageButtonMotion
               key="manage-vault-chains"
               initial={{ opacity: 0, scale: 0.95 }}


### PR DESCRIPTION
<img width="1092" height="864" alt="image" src="https://github.com/user-attachments/assets/ff65fb8a-4dce-42a8-b287-adfc7bde762f" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Manage button visibility for key import vaults—button now properly hides when the vault is collapsed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->