### PR TITLE
Use the maximum fee for swaps and update the swap test to match Android.

### DIFF
--- a/core/mpc/keysign/signingInputs/resolvers/evm/index.ts
+++ b/core/mpc/keysign/signingInputs/resolvers/evm/index.ts
@@ -10,6 +10,7 @@ import { toEvmTwAmount } from '@core/chain/chains/evm/tx/tw/toEvmTwAmount'
 import { toEvmTxData } from '@core/chain/chains/evm/tx/tw/toEvmTxData'
 import { shouldBePresent } from '@lib/utils/assert/shouldBePresent'
 import { matchRecordUnion } from '@lib/utils/matchRecordUnion'
+import { maxBigInt } from '@lib/utils/math/maxBigInt'
 import { assertField } from '@lib/utils/record/assertField'
 import { TW } from '@trustwallet/wallet-core'
 
@@ -172,7 +173,7 @@ export const getEvmSigningInputs: SigningInputsResolver<'evm'> = ({
     }
     if (swapPayload && 'general' in swapPayload) {
       const { gasPrice, gas } = shouldBePresent(swapPayload.general.quote?.tx)
-      input.maxFeePerGasWei = BigInt(gasPrice)
+      input.maxFeePerGasWei = maxBigInt(BigInt(gasPrice), input.maxFeePerGasWei)
       if (BigInt(gas) > input.gasLimit) {
         input.gasLimit = BigInt(gas)
       }

--- a/core/mpc/keysign/tests/fixtures/lifiswap.json
+++ b/core/mpc/keysign/tests/fixtures/lifiswap.json
@@ -140,7 +140,7 @@
       "lib_type": "DKLS"
     },
     "expected_image_hash": [
-      "4324862d2c76549bdf6578d070258f1c6c8bcbad27ab7b3dc8ca8af8452fb125"
+      "63fbeb1e3fd2e6d5c806bb1b2e9c8b4f56c79f70257de3c7e799553d0fb99f97"
     ]
   }
 ]


### PR DESCRIPTION
<img width="978" height="297" alt="image" src="https://github.com/user-attachments/assets/6d8d18e5-2539-4f46-8440-b97a87762b12" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gas fee calculation for EVM transactions to ensure maximum fees are not incorrectly lowered when swap payloads are present.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->