### PR TITLE
feat: TRON resource management data layer (1/3)

### DIFF
--- a/core/chain/chains/tron/resources/formatTronResource.test.ts
+++ b/core/chain/chains/tron/resources/formatTronResource.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  formatTronResourceValue,
+  formatTronWithdrawalTime,
+  sunToTrx,
+  trxToSun,
+} from './formatTronResource'
+
+describe('formatTronResourceValue', () => {
+  it('formats values below 1000 without K notation', () => {
+    expect(
+      formatTronResourceValue({ available: 500, total: 800, unit: '' })
+    ).toBe('500/800')
+  })
+
+  it('formats values >= 1000 with K notation when no unit', () => {
+    expect(
+      formatTronResourceValue({ available: 1500, total: 2000, unit: '' })
+    ).toBe('1.50K/2.00K')
+  })
+
+  it('formats values >= 1000 with unit suffix', () => {
+    expect(
+      formatTronResourceValue({ available: 1500, total: 2000, unit: 'KB' })
+    ).toBe('1.50/2.00KB')
+  })
+
+  it('handles zero values', () => {
+    expect(formatTronResourceValue({ available: 0, total: 0, unit: '' })).toBe(
+      '0/0'
+    )
+  })
+
+  it('handles available greater than total', () => {
+    expect(
+      formatTronResourceValue({ available: 1200, total: 1000, unit: '' })
+    ).toBe('1.20K/1.00K')
+  })
+})
+
+describe('formatTronWithdrawalTime', () => {
+  it('returns ready_to_claim when time has passed', () => {
+    const pastTime = Date.now() - 1000
+    expect(formatTronWithdrawalTime(pastTime)).toBe('ready_to_claim')
+  })
+
+  it('returns ready_to_claim when time is exactly now', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1000000)
+    expect(formatTronWithdrawalTime(1000000)).toBe('ready_to_claim')
+    vi.useRealTimers()
+  })
+
+  it('formats days and hours when more than 1 day remaining', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    const twoDaysThreeHours = 2 * 86_400_000 + 3 * 3_600_000
+    expect(formatTronWithdrawalTime(twoDaysThreeHours)).toBe('2d 3h')
+    vi.useRealTimers()
+  })
+
+  it('formats hours and minutes when less than 1 day remaining', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    const fiveHoursTenMinutes = 5 * 3_600_000 + 10 * 60_000
+    expect(formatTronWithdrawalTime(fiveHoursTenMinutes)).toBe('5h 10m')
+    vi.useRealTimers()
+  })
+
+  it('formats 0h Xm for less than 1 hour', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    const thirtyMinutes = 30 * 60_000
+    expect(formatTronWithdrawalTime(thirtyMinutes)).toBe('0h 30m')
+    vi.useRealTimers()
+  })
+})
+
+describe('sunToTrx', () => {
+  it('converts SUN to TRX', () => {
+    expect(sunToTrx(BigInt(1_000_000))).toBe(1)
+  })
+
+  it('converts zero', () => {
+    expect(sunToTrx(BigInt(0))).toBe(0)
+  })
+
+  it('converts fractional amounts', () => {
+    expect(sunToTrx(BigInt(500_000))).toBe(0.5)
+  })
+
+  it('converts large amounts', () => {
+    expect(sunToTrx(BigInt(100_000_000_000))).toBe(100_000)
+  })
+})
+
+describe('trxToSun', () => {
+  it('converts TRX to SUN', () => {
+    expect(trxToSun(1)).toBe(BigInt(1_000_000))
+  })
+
+  it('converts zero', () => {
+    expect(trxToSun(0)).toBe(BigInt(0))
+  })
+
+  it('converts fractional TRX', () => {
+    expect(trxToSun(0.5)).toBe(BigInt(500_000))
+  })
+
+  it('rounds to nearest SUN', () => {
+    expect(trxToSun(1.0000005)).toBe(BigInt(1_000_001))
+  })
+})

--- a/core/chain/chains/tron/resources/formatTronResource.ts
+++ b/core/chain/chains/tron/resources/formatTronResource.ts
@@ -1,0 +1,52 @@
+const msPerMinute = 60_000
+const msPerHour = 3_600_000
+const msPerDay = 86_400_000
+
+type FormatTronResourceValueInput = {
+  available: number
+  total: number
+  unit: string
+}
+
+export const formatTronResourceValue = ({
+  available,
+  total,
+  unit,
+}: FormatTronResourceValueInput): string => {
+  if (total >= 1000 && unit) {
+    const availableK = (available / 1000).toFixed(2)
+    const totalK = (total / 1000).toFixed(2)
+    return `${availableK}/${totalK}${unit}`
+  }
+
+  if (total >= 1000) {
+    const availableK = (available / 1000).toFixed(2)
+    const totalK = (total / 1000).toFixed(2)
+    return `${availableK}K/${totalK}K`
+  }
+
+  return `${available}/${total}`
+}
+
+export const formatTronWithdrawalTime = (expireTimeMs: number): string => {
+  const remaining = expireTimeMs - Date.now()
+
+  if (remaining <= 0) {
+    return 'ready_to_claim'
+  }
+
+  const days = Math.floor(remaining / msPerDay)
+  const hours = Math.floor((remaining % msPerDay) / msPerHour)
+
+  if (days > 0) {
+    return `${days}d ${hours}h`
+  }
+
+  const minutes = Math.floor((remaining % msPerHour) / msPerMinute)
+  return `${hours}h ${minutes}m`
+}
+
+export const sunToTrx = (sun: bigint): number => Number(sun) / 1_000_000
+
+export const trxToSun = (trx: number): bigint =>
+  BigInt(Math.round(trx * 1_000_000))

--- a/core/chain/chains/tron/resources/getTronAccountResources.ts
+++ b/core/chain/chains/tron/resources/getTronAccountResources.ts
@@ -1,0 +1,101 @@
+import { tronRpcUrl } from '@core/chain/chains/tron/config'
+import { queryUrl } from '@lib/utils/query/queryUrl'
+
+import { TronAccountResources, TronUnfreezingEntry } from './types'
+
+type TronFrozenV2Entry = {
+  type?: string | null
+  amount?: number | null
+}
+
+type TronUnfrozenV2Entry = {
+  unfreeze_amount?: number | null
+  unfreeze_expire_time?: number | null
+}
+
+type TronGetAccountResponse = {
+  frozenV2?: TronFrozenV2Entry[]
+  unfrozenV2?: TronUnfrozenV2Entry[]
+}
+
+type TronGetAccountResourceResponse = {
+  freeNetUsed?: number
+  freeNetLimit?: number
+  NetUsed?: number
+  NetLimit?: number
+  EnergyUsed?: number
+  EnergyLimit?: number
+}
+
+export const getTronAccountResources = async (
+  address: string
+): Promise<TronAccountResources> => {
+  const [account, resource] = await Promise.all([
+    queryUrl<TronGetAccountResponse>(`${tronRpcUrl}/wallet/getaccount`, {
+      body: { address, visible: true },
+    }),
+    queryUrl<TronGetAccountResourceResponse>(
+      `${tronRpcUrl}/wallet/getaccountresource`,
+      {
+        body: { address, visible: true },
+      }
+    ),
+  ])
+
+  const frozenV2 = account.frozenV2 ?? []
+
+  const frozenForBandwidthSun = BigInt(
+    frozenV2
+      .filter(entry => entry.type == null || entry.type === 'BANDWIDTH')
+      .reduce((sum, entry) => sum + (entry.amount ?? 0), 0)
+  )
+
+  const frozenForEnergySun = BigInt(
+    frozenV2
+      .filter(entry => entry.type === 'ENERGY')
+      .reduce((sum, entry) => sum + (entry.amount ?? 0), 0)
+  )
+
+  const unfreezingEntries: TronUnfreezingEntry[] = (account.unfrozenV2 ?? [])
+    .flatMap(entry => {
+      if (entry.unfreeze_amount == null || entry.unfreeze_expire_time == null) {
+        return []
+      }
+      return [
+        {
+          unfreezeAmountSun: BigInt(entry.unfreeze_amount),
+          expireTimeMs: entry.unfreeze_expire_time,
+        },
+      ]
+    })
+    .sort((a, b) => a.expireTimeMs - b.expireTimeMs)
+
+  const freeNetUsed = resource.freeNetUsed ?? 0
+  const freeNetLimit = resource.freeNetLimit ?? 0
+  const netUsed = resource.NetUsed ?? 0
+  const netLimit = resource.NetLimit ?? 0
+  const energyUsed = resource.EnergyUsed ?? 0
+  const energyLimit = resource.EnergyLimit ?? 0
+
+  const totalBandwidth = freeNetLimit + netLimit
+  const availableBandwidth = freeNetLimit - freeNetUsed + (netLimit - netUsed)
+
+  const totalEnergy = energyLimit
+  const availableEnergy = energyLimit - energyUsed
+
+  return {
+    bandwidth: {
+      available: Math.max(availableBandwidth, 0),
+      total: totalBandwidth,
+      used: freeNetUsed + netUsed,
+    },
+    energy: {
+      available: Math.max(availableEnergy, 0),
+      total: totalEnergy,
+      used: energyUsed,
+    },
+    frozenForBandwidthSun,
+    frozenForEnergySun,
+    unfreezingEntries,
+  }
+}

--- a/core/chain/chains/tron/resources/index.ts
+++ b/core/chain/chains/tron/resources/index.ts
@@ -1,0 +1,11 @@
+export {
+  formatTronResourceValue,
+  formatTronWithdrawalTime,
+  sunToTrx,
+} from './formatTronResource'
+export { getTronAccountResources } from './getTronAccountResources'
+export type {
+  TronAccountResources,
+  TronResourceType,
+  TronUnfreezingEntry,
+} from './types'

--- a/core/chain/chains/tron/resources/types.ts
+++ b/core/chain/chains/tron/resources/types.ts
@@ -1,0 +1,20 @@
+export type TronResourceType = 'BANDWIDTH' | 'ENERGY'
+
+export type TronResourceUsage = {
+  available: number
+  total: number
+  used: number
+}
+
+export type TronUnfreezingEntry = {
+  unfreezeAmountSun: bigint
+  expireTimeMs: number
+}
+
+export type TronAccountResources = {
+  bandwidth: TronResourceUsage
+  energy: TronResourceUsage
+  frozenForBandwidthSun: bigint
+  frozenForEnergySun: bigint
+  unfreezingEntries: TronUnfreezingEntry[]
+}


### PR DESCRIPTION
## Summary
- Add TRON Stake 2.0 resource types, API fetcher (`getTronAccountResources`), and format utilities (`formatTronResourceValue`, `sunToTrx`, `formatTronWithdrawalTime`)
- Wire freeze/unfreeze signing into `getTronSigningInputs` with memo-based dispatch (`FREEZE:BANDWIDTH`, `UNFREEZE:ENERGY`) and positive-amount validation (iOS parity)
- Unit tests for all format helpers and SUN/TRX conversions (18 tests)

## Test plan
- [x] `yarn check:all` passes (lint, typecheck, 306 tests, knip)
- [ ] Signing resolver correctness: freeze/unfreeze memos produce correct `FreezeBalanceV2Contract`/`UnfreezeBalanceV2Contract` protobuf payloads

Part 1 of 3 for #1954 — data layer only. PR2 (display UI) and PR3 (freeze/unfreeze deposit flow) will follow.