### PR TITLE
Update fee discount labels to show percentage of base fee saved

### DIFF
--- a/core/ui/vault/swap/form/info/ReferralDiscountRow.tsx
+++ b/core/ui/vault/swap/form/info/ReferralDiscountRow.tsx
@@ -4,6 +4,7 @@ import { getColor } from '@lib/ui/theme/getters'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
+import { formatDiscountPercentOfBaseFee } from './discountPercent'
 import { DiscountRow } from './DiscountRow'
 
 const StyledMegaphoneIcon = styled(MegaphoneIcon)`
@@ -13,10 +14,11 @@ const StyledMegaphoneIcon = styled(MegaphoneIcon)`
 export const ReferralDiscountRow = () => {
   const { t } = useTranslation()
   const bps = nativeSwapAffiliateConfig.referrerFeeRateBps
+  const discountPercent = formatDiscountPercentOfBaseFee(bps)
 
   return (
     <DiscountRow icon={<StyledMegaphoneIcon />}>
-      {t('referrals_default_title')} (-{bps} bps)
+      {t('referrals_default_title')}: {discountPercent}
     </DiscountRow>
   )
 }

--- a/core/ui/vault/swap/form/info/VultDiscountRow.tsx
+++ b/core/ui/vault/swap/form/info/VultDiscountRow.tsx
@@ -7,6 +7,7 @@ import { discountTierIcons } from '@core/ui/vult/discount/tier/icons'
 import { ValueProp } from '@lib/ui/props'
 import { useTranslation } from 'react-i18next'
 
+import { formatDiscountPercentOfBaseFee } from './discountPercent'
 import { DiscountRow } from './DiscountRow'
 
 export const VultDiscountRow = ({
@@ -15,10 +16,11 @@ export const VultDiscountRow = ({
   const { t } = useTranslation()
   const Icon = discountTierIcons[tier]
   const bps = vultDiscountTierBps[tier]
+  const discountPercent = formatDiscountPercentOfBaseFee(bps)
 
   return (
     <DiscountRow icon={<Icon />}>
-      {vult.ticker} ({t(tier)} -{bps} bps)
+      {vult.ticker} {t(tier)}: {discountPercent}
     </DiscountRow>
   )
 }

--- a/core/ui/vault/swap/form/info/discountPercent.test.ts
+++ b/core/ui/vault/swap/form/info/discountPercent.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatDiscountPercentOfBaseFee } from './discountPercent'
+
+describe('formatDiscountPercentOfBaseFee', () => {
+  it('formats common tier values using base fee percentage', () => {
+    expect(formatDiscountPercentOfBaseFee(5)).toBe('10%')
+    expect(formatDiscountPercentOfBaseFee(10)).toBe('20%')
+    expect(formatDiscountPercentOfBaseFee(20)).toBe('40%')
+    expect(formatDiscountPercentOfBaseFee(50)).toBe('100%')
+  })
+
+  it('handles non-positive values safely', () => {
+    expect(formatDiscountPercentOfBaseFee(0)).toBe('0%')
+    expect(formatDiscountPercentOfBaseFee(-10)).toBe('0%')
+  })
+
+  it('rounds to max 2 decimals and trims trailing zeros', () => {
+    expect(formatDiscountPercentOfBaseFee(1)).toBe('2%')
+    expect(formatDiscountPercentOfBaseFee(3)).toBe('6%')
+    expect(formatDiscountPercentOfBaseFee(7)).toBe('14%')
+  })
+})

--- a/core/ui/vault/swap/form/info/discountPercent.ts
+++ b/core/ui/vault/swap/form/info/discountPercent.ts
@@ -1,0 +1,14 @@
+import { baseAffiliateBps } from '@core/chain/swap/affiliate/config'
+
+const maxFractionDigits = 2
+
+export const formatDiscountPercentOfBaseFee = (bps: number): string => {
+  if (!Number.isFinite(bps) || bps <= 0) {
+    return '0%'
+  }
+
+  const percent = (bps / baseAffiliateBps) * 100
+  const rounded = Number(percent.toFixed(maxFractionDigits))
+
+  return `${rounded}%`
+}


### PR DESCRIPTION
Closes #2968

<img width="540" height="860" alt="screenshot-1" src="https://github.com/user-attachments/assets/fd913ded-cca2-41ee-be7c-1d148956cb1c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discount amounts displayed in referral and vault sections now show as percentage values instead of basis points, providing clearer and more intuitive representation of savings.

* **Tests**
  * New test coverage added for discount percentage formatting, including validation of tier values, edge cases, and decimal rounding precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->