### PR TITLE
Simplify agent health check to auth-only validation

### DIFF
--- a/core/ui/agent/orchestrator/AgentHealthService.ts
+++ b/core/ui/agent/orchestrator/AgentHealthService.ts
@@ -1,44 +1,18 @@
-import { verifierUrl } from '../config'
 import type { ServiceStatus } from '../types'
 import type { AgentAuthService } from './AgentAuthService'
-import type { AgentBackendClient } from './AgentBackendClient'
 
 export class AgentHealthService {
   private auth: AgentAuthService
-  private backendClient: AgentBackendClient
 
-  constructor(auth: AgentAuthService, backendClient: AgentBackendClient) {
+  constructor(auth: AgentAuthService) {
     this.auth = auth
-    this.backendClient = backendClient
   }
 
   async checkServices(vaultPubKey: string): Promise<ServiceStatus> {
-    const checks = await Promise.allSettled([
-      fetch('https://api.vultisig.com/ping', {
-        signal: AbortSignal.timeout(5000),
-      }),
-      fetch(verifierUrl + '/ping', {
-        signal: AbortSignal.timeout(5000),
-      }),
-      fetch(this.backendClient.getBaseUrl() + '/ping', {
-        signal: AbortSignal.timeout(5000),
-      }),
-    ])
+    const authenticated = vaultPubKey
+      ? await this.auth.validate(vaultPubKey)
+      : false
 
-    const isOk = (r: PromiseSettledResult<Response>): boolean =>
-      r.status === 'fulfilled' && r.value.status < 500
-
-    const status: ServiceStatus = {
-      fastVaultServer: isOk(checks[0]),
-      verifier: isOk(checks[1]),
-      agentBackend: isOk(checks[2]),
-      authenticated: false,
-    }
-
-    if (vaultPubKey) {
-      status.authenticated = await this.auth.validate(vaultPubKey)
-    }
-
-    return status
+    return { authenticated }
   }
 }

--- a/core/ui/agent/orchestrator/AgentOrchestrator.ts
+++ b/core/ui/agent/orchestrator/AgentOrchestrator.ts
@@ -73,7 +73,7 @@ export class AgentOrchestrator {
       getVaultCoins: deps.getVaultCoins,
       getAddressBookItems: deps.getAddressBookItems,
     })
-    this.healthService = new AgentHealthService(this.auth, this.backendClient)
+    this.healthService = new AgentHealthService(this.auth)
     this.promptService = new AgentPromptService(this.events)
     this.toolExecutor = new AgentToolExecutor(
       toolHandlers,

--- a/core/ui/agent/types.ts
+++ b/core/ui/agent/types.ts
@@ -115,9 +115,6 @@ export type TextDeltaEvent = {
 }
 
 export type ServiceStatus = {
-  fastVaultServer: boolean
-  verifier: boolean
-  agentBackend: boolean
   authenticated: boolean
 }
 


### PR DESCRIPTION
## Summary
- Remove unused ping checks to relay, verifier, and agent-backend (were hitting wrong endpoints anyway — `/ping` instead of `/healthz`)
- Simplify `AgentHealthService` to only validate auth token via verifier `/auth/me`
- Clean up `ServiceStatus` type — only `authenticated` field was ever used

## Test plan
- [ ] Open agent page, verify connection status works after sign-in
- [ ] Verify no more `/ping` 404 errors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined health service architecture by removing external service dependency checks.
  * Simplified health status monitoring to focus exclusively on authentication verification, reducing system complexity and improving performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->