### PR TITLE
Update AZTEC token decimals from 4 to 8

### DIFF
--- a/core/chain/coin/knownTokens/cosmos.ts
+++ b/core/chain/coin/knownTokens/cosmos.ts
@@ -17,7 +17,7 @@ export const knownCosmosTokens: Record<
     aztec: {
       ticker: 'AZTEC',
       logo: 'aztec.png',
-      decimals: 4,
+      decimals: 8,
     },
   },
   [Chain.TerraClassic]: {


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated AZTEC token decimal precision on MayaChain from 4 to 8 decimals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->