### PR TITLE
fix: correct AZTEC token decimals from 8 to 4

### DIFF
--- a/core/chain/coin/knownTokens/cosmos.ts
+++ b/core/chain/coin/knownTokens/cosmos.ts
@@ -17,7 +17,7 @@ export const knownCosmosTokens: Record<
     aztec: {
       ticker: 'AZTEC',
       logo: 'aztec.png',
-      decimals: 8,
+      decimals: 4,
     },
   },
   [Chain.TerraClassic]: {


### PR DESCRIPTION
## Summary
Fix incorrect AZTEC token decimals on MayaChain - should be 4, not 8.

## Problem
AZTEC token was configured with 8 decimals but the actual on-chain token uses 4 decimals. This caused incorrect amount calculations in transactions:
- Input: 100 AZTEC
- Expected: 1,000,000 base units (100 × 10^4)
- Actual: 10,000,000,000 base units (100 × 10^8)

## Change
`core/chain/coin/knownTokens/cosmos.ts`: Changed `decimals: 8` to `decimals: 4` for AZTEC token under MayaChain.

## Related
This fix is needed for vultisig/vultisig-sdk#101 to sync correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected AZTEC token decimal precision on MayaChain from 8 to 4 decimals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->