### PR TITLE
Override polkadot-js wallet in injectedWeb3

### DIFF
--- a/clients/extension/src/inpage/utils/windowInjector.ts
+++ b/clients/extension/src/inpage/utils/windowInjector.ts
@@ -141,6 +141,10 @@ async function setupContentScriptMessenger(
             vultisig: {
               enable: (origin?: string) => providers.polkadot.enable(origin),
             },
+            'polkadot-js': {
+              enable: (origin?: string) => providers.polkadot.enable(origin),
+              version: '0.46.9',
+            },
           },
           configurable: false,
           writable: false,


### PR DESCRIPTION
## Description

Summary
- Registers Vultisig as `polkadot-js` in `window.injectedWeb3` when wallet is prioritized
- dApps that check for the official `Polkadot.js` extension will now route to Vultisig
- Follows the same override pattern used for MetaMask, Phantom, Keplr, and TronLink
- Tested on https://portal.astar.network and  https://app.hydration.net/
## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):
https://github.com/user-attachments/assets/96f96f1b-fc70-44f5-afaa-cc83195aa7a1


## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Polkadot-JS provider integration, enabling compatibility with additional Web3 applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->