### PR TITLE
fix: folder vault toggles show disabled state (#3506)

### DIFF
--- a/core/ui/vaultsOrganisation/folder/update/index.tsx
+++ b/core/ui/vaultsOrganisation/folder/update/index.tsx
@@ -253,7 +253,7 @@ const ManageFolderVaults = ({
                   <Switch checked onChange={handleRemove} />
                 </SwitchWrapper>
               }
-              disabled
+              disabled={status === 'dragging'}
             />
             {status === 'overlay' && <DnDItemHighlight />}
           </DnDItemContainer>


### PR DESCRIPTION
## Summary
- Vault row toggles in the folder update page were permanently dimmed (opacity: 0.4) because `VaultListRow` received a hardcoded `disabled` prop
- `disabled` is now only applied when the DnD item `status === 'dragging'`, so the toggle appears active at rest and only dims during an active drag (to prevent accidental removals while reordering)

Fixes #3506

## Test plan
- [ ] Open Vault selection → open a Folder → observe vaults already in the folder show active (checked) toggles, not dimmed
- [ ] Drag to reorder vaults in the folder — row dims during drag, returns to normal after drop
- [ ] Tapping the toggle on a folder vault removes it from the folder correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the folder management interface where a switch control remained unnecessarily disabled during non-drag operations. The control now properly responds to user interactions during normal workflows while maintaining appropriate disablement only during active drag sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->