### PR TITLE
fix(keygen): QR code not readable on Android

### DIFF
--- a/core/ui/mpc/keygen/peers/SecureVaultPeerDiscoveryScreen.tsx
+++ b/core/ui/mpc/keygen/peers/SecureVaultPeerDiscoveryScreen.tsx
@@ -365,6 +365,7 @@ const QrCodeContainer = styled.div`
   border-radius: 16px;
   overflow: hidden;
   width: 100%;
+  padding: 11px;
 `
 
 const animationSize = css`


### PR DESCRIPTION
## Summary
- Added padding to `QrCodeContainer` in the secure vault keygen peer discovery screen
- The QR code SVG had no quiet zone, so the dark `QrFrameInner` background (`rgb(6, 28, 60)`) was bleeding through at the edges, preventing Android QR scanners from reading the code
- The 11px padding creates a white margin (quiet zone) around the QR code, which Android scanners need for reliable detection

## Test plan
- [ ] Open secure vault keygen flow on desktop/extension
- [ ] Scan the QR code with an Android device — verify it reads successfully
- [ ] Verify the QR code still looks visually correct (white padding within the rounded frame)
- [ ] Verify iOS scanning still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing around the QR code in the secure vault peer discovery screen for better visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->