### PR TITLE
fix: restore all chain keyshares on seed phrase vault backup import

### DIFF
--- a/core/mpc/types/utils/commVault.ts
+++ b/core/mpc/types/utils/commVault.ts
@@ -90,13 +90,15 @@ export const fromCommVault = (vault: CommVault): Vault => {
     eddsa: vault.publicKeyEddsa,
   }
 
-  const chainPublicKeys: Partial<Record<Chain, string>> = {}
-  const chainByPublicKey = new Map<string, Chain>()
+  const allChainPublicKeys: Partial<Record<Chain, string>> = {}
+  const chainsByPublicKey = new Map<string, Chain[]>()
 
   vault.chainPublicKeys.forEach(cp => {
     const chain = cp.chain as Chain
-    chainPublicKeys[chain] = cp.publicKey
-    chainByPublicKey.set(cp.publicKey, chain)
+    allChainPublicKeys[chain] = cp.publicKey
+    const existing = chainsByPublicKey.get(cp.publicKey) ?? []
+    existing.push(chain)
+    chainsByPublicKey.set(cp.publicKey, existing)
   })
 
   const keyShares = recordFromKeys(
@@ -117,11 +119,20 @@ export const fromCommVault = (vault: CommVault): Vault => {
 
   const chainKeyShares: Partial<Record<Chain, string>> = {}
   vault.keyShares.forEach(keyShare => {
-    const chain = chainByPublicKey.get(keyShare.publicKey)
-    if (chain) {
-      chainKeyShares[chain] = keyShare.keyshare
+    const chains = chainsByPublicKey.get(keyShare.publicKey)
+    if (chains) {
+      chains.forEach(chain => {
+        chainKeyShares[chain] = keyShare.keyshare
+      })
     }
   })
+
+  const chainPublicKeysWithKeyShare = toEntries(allChainPublicKeys).filter(
+    ({ key }) => key in chainKeyShares
+  )
+  const chainPublicKeys = Object.fromEntries(
+    chainPublicKeysWithKeyShare.map(({ key, value }) => [key, value])
+  ) as Partial<Record<Chain, string>>
 
   return {
     ...pick(vault, [

--- a/core/ui/vault/mutations/useCreateVaultMutation.ts
+++ b/core/ui/vault/mutations/useCreateVaultMutation.ts
@@ -89,6 +89,7 @@ export const useCreateVaultMutation = (
       ])
 
       await refetchQueries([StorageKey.vaults])
+      await refetchQueries([StorageKey.currentVaultId])
 
       return vault
     },


### PR DESCRIPTION
Closes #3561

## Summary

- **`fromCommVault`**: changed `chainByPublicKey` from `Map<string, Chain>` to `Map<string, Chain[]>` — EVM chains sharing the same public key (e.g. Ethereum + Base) now all receive their keyshare on import. Added filtering so `chainPublicKeys` only contains chains that have a keyshare, ensuring consistency.
- **`useCreateVaultMutation`**: added `refetchQueries([StorageKey.currentVaultId])` after the vault list refetch — imported vault now becomes the active vault automatically without requiring manual selection.

## Test plan

- [ ] Create a seed phrase (key import) vault with Ethereum and Base chains
- [ ] Generate a backup file
- [ ] Import the backup file
- [ ] Verify the imported vault is automatically set as the active vault
- [ ] Verify transactions can be signed on both Ethereum and Base

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vault ID not being properly refreshed after vault creation, ensuring the current vault information is consistently updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->