### PR TITLE
chore(claude): add create-issue skill with project templates

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: create-issue
+description: Create a GitHub issue for vultisig-windows using the official bug/feature templates.
+---
+
+# Create Issue
+
+## Usage
+`/create-issue` — infer everything from conversation context.
+
+## Templates
+
+### Bug Report → label: `bug`, title prefix: `[Fix]`
+
+```
+<!-- AGENT
+type: "bugfix"
+priority: "critical|high|medium|low"
+size: "tiny|small|medium"
+platform: [windows, extension]
+files:
+  read: []
+  write: []
+verify: ["yarn check:all"]
+-->
+
+# [Fix] <what's broken> [<screen/area>]
+
+## Problem
+<!-- 2-3 sentences. What's broken? Who's affected? -->
+
+## Expected Behavior
+<!-- What should happen instead? -->
+
+## Steps to Reproduce
+1.
+2.
+3.
+
+## Solution
+<!-- 1 paragraph. WHAT to do and WHY this approach. Leave blank if unsure. -->
+
+## Scope
+
+### Must Do
+- [ ] <!-- Specific fix 1 -->
+- [ ] <!-- Specific fix 2 -->
+
+### Must NOT Do
+- Don't change unrelated code
+- Don't refactor surrounding logic
+
+## Acceptance Criteria
+- [ ] `yarn check:all` succeeds
+- [ ] <!-- Specific behavior check 1 -->
+- [ ] <!-- Specific behavior check 2 -->
+```
+
+### Feature Request → label: `enhancement`, title prefix: `[Add]`
+
+```
+<!-- AGENT
+type: "feature"
+priority: "critical|high|medium|low"
+size: "tiny|small|medium"
+platform: [windows, extension]
+files:
+  read: []
+  write: []
+verify: ["yarn check:all"]
+-->
+
+# [Add] <what to build> [<screen/area>]
+
+## Problem
+<!-- 2-3 sentences. What's missing or suboptimal? -->
+
+## Solution
+<!-- 1 paragraph. WHAT to do and WHY this approach. -->
+
+## Scope
+
+### Must Do
+- [ ] <!-- Specific deliverable 1 -->
+- [ ] <!-- Specific deliverable 2 -->
+
+### Must NOT Do
+- Don't change existing behavior
+- Don't add extra dependencies without approval
+
+### Out of Scope
+- <!-- Related but separate work — future issue -->
+
+## Acceptance Criteria
+- [ ] `yarn check:all` succeeds
+- [ ] <!-- Specific behavior check 1 -->
+- [ ] <!-- Specific behavior check 2 -->
+```
+
+## Size Guide
+
+| Size | Files | Lines | Example |
+|------|-------|-------|---------|
+| `tiny` | 1 | <50 | Fix typo, update constant |
+| `small` | 1–3 | 50–200 | Fix a bug, add a function |
+| `medium` | 3–8 | 200–500 | New feature with tests |
+| `large` | 8+ | 500+ | **SPLIT THIS** |
+
+## Key Repo Rules (from ISSUE_GUIDE.md)
+- Never edit `lib/` — upstream mirrors
+- Never modify `core/mpc/` or `tss/` without explicit review approval
+- Use resolver pattern for chain-specific logic
+- Only edit `en.ts` for translations
+
+## Workflow
+
+```bash
+gh issue create \
+  --title "[Fix|Add] Short description [Area]" \
+  --label "bug|enhancement" \
+  --body "$(cat <<'EOF'
+<full body from template above>
+EOF
+)"
+```
+
+Print the issue URL when done.


### PR DESCRIPTION
## Description
Adds a `/create-issue` Claude skill that generates GitHub issues using the project's official bug and feature templates. The skill reads from `.github/ISSUE_TEMPLATE/` and enforces the AGENT metadata block, size guide, and repo rules from `ISSUE_GUIDE.md`.

## Which feature is affected
Claude tooling / developer experience

## Checklist
- [x] Follows project issue template structure
- [x] Includes AGENT metadata block
- [x] Size guide matches `ISSUE_GUIDE.md`
- [x] Repo rules (no `lib/`, `core/mpc/`, etc.) included

## Agent Metadata
<!-- AGENT
type: "feature"
priority: "low"
size: "small"
platform: [extension]
files:
  read: [".github/ISSUE_TEMPLATE/bug_report.md", ".github/ISSUE_TEMPLATE/feature_request.md", ".github/ISSUE_GUIDE.md"]
  write: [".claude/skills/create-issue/SKILL.md"]
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the create-issue GitHub skill, including usage instructions, issue templates (Bug Report and Feature Request), and workflow configuration guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->