### PR TITLE
fix: Playwright fixture compatibility with v1.58

### DIFF
--- a/clients/extension/tests/e2e/fixtures/dapp-page.fixture.ts
+++ b/clients/extension/tests/e2e/fixtures/dapp-page.fixture.ts
@@ -342,7 +342,7 @@ export interface DAppFixtures {
 export const dappFixture = base.extend<DAppFixtures>({
   // Test DApp server URL
   // eslint-disable-next-line no-empty-pattern
-  testDappUrl: async (_fixtures, use) => {
+  testDappUrl: async ({}, use) => {
     // Create HTTP server
     const server = http.createServer((req, res) => {
       res.writeHead(200, { 'Content-Type': 'text/html' })

--- a/clients/extension/tests/e2e/fixtures/extension-loader.ts
+++ b/clients/extension/tests/e2e/fixtures/extension-loader.ts
@@ -50,7 +50,7 @@ export const test = base.extend<{
   extensionId: string
   testDappUrl: string
 }>({
-  context: async (_fixtures, use) => {
+  context: async ({}, use) => {
     const context = await chromium.launchPersistentContext('', {
       headless: false,
       args: [
@@ -80,7 +80,7 @@ export const test = base.extend<{
   },
 
   // Serve the test DApp over HTTP so the content script can inject
-  testDappUrl: async (_fixtures, use) => {
+  testDappUrl: async ({}, use) => {
     const html = fs.readFileSync(testDappPath, 'utf-8')
 
     const server = http.createServer((req, res) => {


### PR DESCRIPTION
## Summary
- Fix `_fixtures` parameter in `extension-loader.ts` and `dapp-page.fixture.ts` to use `{}` destructuring
- Playwright 1.58 changed `test.extend()` to require destructured first argument, breaking all E2E tests

## What broke
```
First argument must use the object destructuring pattern: _fixtures
```
All extension E2E tests fail with this error on Playwright ≥1.58.

## Fix
```diff
- context: async (_fixtures, use) => {
+ context: async ({}, use) => {
```

Two files affected:
- `clients/extension/tests/e2e/fixtures/extension-loader.ts` (2 instances)
- `clients/extension/tests/e2e/fixtures/dapp-page.fixture.ts` (1 instance)

## Test plan
- [x] Onboarding tests pass (3/3) after fix
- [x] No other fixture files use `_fixtures` pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal test fixtures to improve code quality and reduce unused parameters in test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->