### PR TITLE
fix: add merge_group trigger to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: ['main']
   pull_request:
     branches: ['main']
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Fixes #3650

## Summary
- The merge queue fires `merge_group` events, but `build.yml` only listens for `push` and `pull_request`. This causes merge queue entries to get stuck in `AWAITING_CHECKS` forever since CI never triggers on the temporary merge commit.
- Adds `merge_group:` to the workflow triggers so checks run correctly for queued PRs.

## Test plan
- [ ] After merging, dequeue and re-enqueue PR #3640 — CI should now trigger on the merge queue commit
- [ ] Verify merge queue entries progress past `AWAITING_CHECKS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)