### PR TITLE
fix: use correct API endpoint for fast key import based on TSS batching setting

### DIFF
--- a/core/ui/mpc/keygen/keyimport/fast/KeyImportFastKeygenServerActionProvider.tsx
+++ b/core/ui/mpc/keygen/keyimport/fast/KeyImportFastKeygenServerActionProvider.tsx
@@ -1,12 +1,14 @@
 import { useVaultCreationInput } from '@core/ui/mpc/keygen/create/state/vaultCreationInput'
+import { useCurrentHexChainCode } from '@core/ui/mpc/state/currentHexChainCode'
 import { useCurrentHexEncryptionKey } from '@core/ui/mpc/state/currentHexEncryptionKey'
 import { useMpcSessionId } from '@core/ui/mpc/state/mpcSession'
+import { useIsTssBatchingEnabled } from '@core/ui/storage/tssBatchingEnabled'
 import { ChildrenProp } from '@lib/ui/props'
 import { generateLocalPartyId } from '@vultisig/core-mpc/devices/localPartyId'
 import { keyImportWithServer } from '@vultisig/core-mpc/fast/api/keyImportWithServer'
+import { sequentialKeyImportWithServer } from '@vultisig/core-mpc/fast/api/sequentialKeyImportWithServer'
 import { toLibType } from '@vultisig/core-mpc/types/utils/libType'
 import { getRecordUnionValue } from '@vultisig/lib-utils/record/union/getRecordUnionValue'
-import { useCallback } from 'react'
 
 import { FastKeygenServerActionProvider } from '../../fast/state/fastKeygenServerAction'
 import { useKeyImportInput } from '../state/keyImportInput'
@@ -19,27 +21,43 @@ export const KeyImportFastKeygenServerActionProvider = ({
 
   const { name, email, password } = getRecordUnionValue(input, 'fast')
   const sessionId = useMpcSessionId()
+  const hexChainCode = useCurrentHexChainCode()
   const hexEncryptionKey = useCurrentHexEncryptionKey()
   const { chains } = useKeyImportInput()
+  const isTssBatchingEnabled = useIsTssBatchingEnabled()
 
-  const action = useCallback(async () => {
+  const action = async () => {
     const derivationGroups = getKeyImportDerivationGroups(chains)
     const representativeChains = derivationGroups.map(
       group => group.representativeChain
     )
 
-    await keyImportWithServer({
-      name,
-      encryption_password: password,
-      session_id: sessionId,
-      local_party_id: generateLocalPartyId('server'),
-      email,
-      hex_encryption_key: hexEncryptionKey,
-      lib_type: toLibType({ libType: 'DKLS', isKeyImport: true }),
-      protocols: ['ecdsa', 'eddsa'],
-      chains: representativeChains,
-    })
-  }, [email, hexEncryptionKey, name, password, sessionId, chains])
+    if (isTssBatchingEnabled) {
+      await keyImportWithServer({
+        name,
+        encryption_password: password,
+        session_id: sessionId,
+        local_party_id: generateLocalPartyId('server'),
+        email,
+        hex_encryption_key: hexEncryptionKey,
+        lib_type: toLibType({ libType: 'DKLS', isKeyImport: true }),
+        protocols: ['ecdsa', 'eddsa'],
+        chains: representativeChains,
+      })
+    } else {
+      await sequentialKeyImportWithServer({
+        name,
+        encryption_password: password,
+        session_id: sessionId,
+        local_party_id: generateLocalPartyId('server'),
+        email,
+        hex_encryption_key: hexEncryptionKey,
+        hex_chain_code: hexChainCode,
+        lib_type: toLibType({ libType: 'DKLS', isKeyImport: true }),
+        chains: representativeChains,
+      })
+    }
+  }
 
   return (
     <FastKeygenServerActionProvider value={action}>


### PR DESCRIPTION
Closes #3674

## Summary
- `KeyImportFastKeygenServerActionProvider` always called `keyImportWithServer` (`/batch/import`) regardless of the **Enable TSS Batching** developer option
- Now checks `isTssBatchingEnabled` and routes to the correct endpoint:
  - **ON**: `keyImportWithServer` → `/batch/import`
  - **OFF**: `sequentialKeyImportWithServer` → `/import`
- Removes legacy `useCallback` wrapper (React Compiler handles memoization)
- Adds missing `hex_chain_code` parameter for the sequential import path
- Aligns with the pattern already used by `CreateFastKeygenServerActionProvider` and `ReshareFastKeygenServerActionProvider`

## Test plan
- [ ] Enable TSS Batching → fast key import should call `/batch/import`
- [ ] Disable TSS Batching → fast key import should call `/import`
- [ ] Verify fast key import completes successfully in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced key import flow to support both batch and sequential processing modes, with selection determined by system configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->