### PR TITLE
ci: use SDK main branch for all CI checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,45 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
+      - name: Clone and build SDK main
+        run: |
+          git clone --depth 1 https://github.com/vultisig/vultisig-sdk.git /tmp/vultisig-sdk
+          cd /tmp/vultisig-sdk
+          corepack enable
+          corepack prepare yarn@${{ env.YARN_VERSION }} --activate
+          yarn install
+          yarn build:shared
+          yarn build:all
+
+      - name: Override SDK packages with main branch
+        run: |
+          mkdir -p /tmp/sdk-packs
+          for dir in packages/sdk packages/core/chain packages/core/config packages/core/mpc packages/lib/utils; do
+            cd /tmp/vultisig-sdk/$dir && npm pack --pack-destination /tmp/sdk-packs
+          done
+          cd $GITHUB_WORKSPACE
+          PACK_DIR=/tmp/sdk-packs node - <<'NODE'
+            const fs = require('fs');
+            const path = require('path');
+            const { execFileSync } = require('child_process');
+            const packDir = process.env.PACK_DIR;
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            const packs = fs.readdirSync(packDir).filter(f => f.endsWith('.tgz'));
+            const resolutions = pkg.resolutions || {};
+            for (const tgz of packs) {
+              const manifest = execFileSync(
+                'tar',
+                ['-xzf', path.join(packDir, tgz), '-O', 'package/package.json'],
+                { encoding: 'utf8' }
+              );
+              const name = JSON.parse(manifest).name;
+              resolutions[name] = path.join(packDir, tgz);
+            }
+            pkg.resolutions = resolutions;
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          NODE
+          YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
+
       - name: Validate public files
         run: yarn workspace @core/ui validate-public
 
@@ -106,87 +145,6 @@ jobs:
         with:
           name: extension-dist-${{ github.sha }}
           path: clients/extension/dist
-
-  sdk-compat:
-    needs: lint
-    runs-on: ubuntu-22.04
-    continue-on-error: true
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 1
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Prepare Yarn
-        run: corepack prepare yarn@${{ env.YARN_VERSION }} --activate
-
-      - name: Cache node_modules
-        uses: actions/cache@v4
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-sdk-compat-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-sdk-compat-
-
-      - name: Install dependencies
-        run: yarn install
-
-      - name: Clone and build SDK main
-        run: |
-          git clone --depth 1 https://github.com/vultisig/vultisig-sdk.git /tmp/vultisig-sdk
-          cd /tmp/vultisig-sdk
-          corepack enable
-          corepack prepare yarn@${{ env.YARN_VERSION }} --activate
-          yarn install
-          yarn build:shared
-          yarn build:all
-
-      - name: Pack and override SDK packages
-        run: |
-          mkdir -p /tmp/sdk-packs
-          for dir in packages/sdk packages/core/chain packages/core/config packages/core/mpc packages/lib/utils; do
-            cd /tmp/vultisig-sdk/$dir && npm pack --pack-destination /tmp/sdk-packs
-          done
-          cd $GITHUB_WORKSPACE
-          PACK_DIR=/tmp/sdk-packs node - <<'NODE'
-            const fs = require('fs');
-            const path = require('path');
-            const { execFileSync } = require('child_process');
-            const packDir = process.env.PACK_DIR;
-            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-            const packs = fs.readdirSync(packDir).filter(f => f.endsWith('.tgz'));
-            const resolutions = pkg.resolutions || {};
-            for (const tgz of packs) {
-              const manifest = execFileSync(
-                'tar',
-                ['-xzf', path.join(packDir, tgz), '-O', 'package/package.json'],
-                { encoding: 'utf8' }
-              );
-              const name = JSON.parse(manifest).name;
-              resolutions[name] = path.join(packDir, tgz);
-            }
-            pkg.resolutions = resolutions;
-            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
-          NODE
-          YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
-
-      - name: Typecheck
-        run: yarn typecheck
-
-      - name: Test
-        run: yarn test
-
-      - name: Test (extension)
-        run: cd clients/extension && npx vitest run --config tests/unit/vitest.config.ts
 
   build:
     needs: lint


### PR DESCRIPTION
## Summary

- Move SDK main branch override into the `lint` job so all checks (typecheck, tests, knip) run against the latest SDK
- Remove the separate `sdk-compat` job since `lint` now covers it

## Motivation

PRs that depend on unreleased SDK features (e.g. #3532 with TON types) were failing typecheck in `lint` because it used the npm-published SDK. The separate `sdk-compat` job had the override but ran after `lint`, so it never got a chance to prove compatibility.

Now all CI checks use SDK `main` — matching how we develop.

## Test plan

- [ ] Verify `lint` job passes with SDK main override
- [ ] Verify PR #3532 passes typecheck after merging main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline for improved SDK integration testing and dependency resolution during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->