### PR TITLE
fix(keygen): initialize ECDSA WASM before prepareKeygenSetup in batching path

### DIFF
--- a/core/ui/mpc/keygen/create/CreateVaultKeygenActionProvider.tsx
+++ b/core/ui/mpc/keygen/create/CreateVaultKeygenActionProvider.tsx
@@ -14,6 +14,7 @@ import {
   setKeygenComplete,
   waitForKeygenComplete,
 } from '@vultisig/core-mpc/keygenComplete'
+import { initializeMpcLib } from '@vultisig/core-mpc/lib/initialize'
 import { MldsaKeygen } from '@vultisig/core-mpc/mldsa/mldsaKeygen'
 import { MpcLib } from '@vultisig/core-mpc/mpcLib'
 import { Schnorr } from '@vultisig/core-mpc/schnorr/schnorrKeygen'
@@ -71,6 +72,7 @@ export const CreateVaultKeygenActionProvider = ({ children }: ChildrenProp) => {
         encryptionKeyHex
       )
 
+      await initializeMpcLib('ecdsa')
       await dklsKeygen.prepareKeygenSetup()
 
       const schnorrKeygen = new Schnorr(


### PR DESCRIPTION
## Summary
- Fixes #3666
- The `@vultisig/core-mpc` migration (PR #3647) removed `initializeMpcLib('ecdsa')` from `DKLS.prepareKeygenSetup()`. The batching path in `CreateVaultKeygenActionProvider` calls `prepareKeygenSetup()` directly before `startKeygenWithRetry()`, so the ECDSA WASM module is never initialized in time, causing vault creation to fail when TSS Batching is enabled.
- Adds `await initializeMpcLib('ecdsa')` before `prepareKeygenSetup()` in the batching path, restoring the pre-migration behavior.

## Test plan
- [ ] Enable "Enable TSS Batching" in Developer Options
- [ ] Create a new vault — should succeed
- [ ] Disable TSS Batching and create a vault — should still succeed (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of vault key generation operations when using TSS batching mode by ensuring proper initialization of cryptographic components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->