### PR TITLE
feat: add THORChain and MayaChain name service resolution in send flow

### DIFF
--- a/core/ui/chain/nameService/NameServiceName.ts
+++ b/core/ui/chain/nameService/NameServiceName.ts
@@ -1,0 +1,15 @@
+/** Supported name service suffixes. */
+export const nameServiceSuffixes = ['.thor', '.maya'] as const
+
+export type NameServiceSuffix = (typeof nameServiceSuffixes)[number]
+
+/**
+ * Detects whether a user-typed value is a name service name (`.thor` or `.maya`).
+ * Returns the matching suffix or `null` if the value is not a name service name.
+ */
+export const detectNameServiceSuffix = (
+  value: string
+): NameServiceSuffix | null => {
+  const trimmed = value.trim().toLowerCase()
+  return nameServiceSuffixes.find(s => trimmed.endsWith(s)) ?? null
+}

--- a/core/ui/chain/nameService/chainToThornameAlias.ts
+++ b/core/ui/chain/nameService/chainToThornameAlias.ts
@@ -1,0 +1,28 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+
+/**
+ * Maps internal Chain identifiers to the uppercase chain codes used in
+ * THORChain / MayaChain thorname alias records (e.g. `"ETH"`, `"BTC"`).
+ *
+ * Only chains that THORChain or MayaChain can register aliases for are
+ * included — the mapping is intentionally partial.
+ */
+export const chainToThornameAlias: Partial<Record<Chain, string>> = {
+  [Chain.Avalanche]: 'AVAX',
+  [Chain.Arbitrum]: 'ARB',
+  [Chain.Base]: 'BASE',
+  [Chain.Bitcoin]: 'BTC',
+  [Chain.BitcoinCash]: 'BCH',
+  [Chain.BSC]: 'BSC',
+  [Chain.Cosmos]: 'GAIA',
+  [Chain.Dash]: 'DASH',
+  [Chain.Dogecoin]: 'DOGE',
+  [Chain.Ethereum]: 'ETH',
+  [Chain.Kujira]: 'KUJI',
+  [Chain.Litecoin]: 'LTC',
+  [Chain.MayaChain]: 'MAYA',
+  [Chain.Ripple]: 'XRP',
+  [Chain.THORChain]: 'THOR',
+  [Chain.Tron]: 'TRON',
+  [Chain.Zcash]: 'ZEC',
+}

--- a/core/ui/chain/nameService/resolveNameService.ts
+++ b/core/ui/chain/nameService/resolveNameService.ts
@@ -1,0 +1,64 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { cosmosRpcUrl } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
+import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+
+import { chainToThornameAlias } from './chainToThornameAlias'
+import { NameServiceSuffix } from './NameServiceName'
+
+type NameServiceAliases = {
+  aliases: { chain: string; address: string }[]
+}
+
+const nameServiceBaseUrl: Record<NameServiceSuffix, string> = {
+  '.thor': `${cosmosRpcUrl.THORChain}/thorchain`,
+  '.maya': `${cosmosRpcUrl.MayaChain}/mayachain`,
+}
+
+const nameServiceEndpoint: Record<NameServiceSuffix, string> = {
+  '.thor': 'thorname',
+  '.maya': 'mayaname',
+}
+
+type ResolveNameServiceInput = {
+  name: string
+  suffix: NameServiceSuffix
+  chain: Chain
+}
+
+/**
+ * Resolves a `.thor` or `.maya` name to the registered address for the given chain.
+ * Returns the address string or throws if the name doesn't exist or has no
+ * alias registered for the target chain.
+ */
+export const resolveNameService = async ({
+  name,
+  suffix,
+  chain,
+}: ResolveNameServiceInput): Promise<string> => {
+  const baseUrl = nameServiceBaseUrl[suffix]
+  const endpoint = nameServiceEndpoint[suffix]
+
+  const trimmedName = name.trim().toLowerCase()
+  const baseName = trimmedName.slice(0, -suffix.length)
+
+  const data = await queryUrl<NameServiceAliases>(
+    `${baseUrl}/${endpoint}/${baseName}`
+  )
+
+  const thornameAlias = chainToThornameAlias[chain]
+  if (!thornameAlias) {
+    throw new Error(`Chain "${chain}" is not supported by ${suffix} names`)
+  }
+
+  const match = data.aliases.find(
+    a => a.chain.toUpperCase() === thornameAlias.toUpperCase()
+  )
+
+  if (!match?.address) {
+    throw new Error(
+      `Name "${trimmedName}" has no address registered for ${chain}`
+    )
+  }
+
+  return match.address
+}

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -655,6 +655,12 @@ export const en = {
   more: 'more',
   moreInfo: 'More Info',
   name: 'Name',
+  name_service_no_address_for_chain:
+    'Name "{{name}}" has no address for {{chain}}',
+  name_service_not_found: 'Name "{{name}}" not found',
+  name_service_resolving: 'Resolving {{name}}...',
+  name_service_unsupported_chain:
+    '{{chain}} is not supported by {{suffix}} names',
   name_your_vault: 'Name your vault',
   network: 'Network',
   network_fee: 'Network Fee',

--- a/core/ui/vault/send/addresses/components/ManageAddressesInputField.tsx
+++ b/core/ui/vault/send/addresses/components/ManageAddressesInputField.tsx
@@ -1,3 +1,6 @@
+import { chainToThornameAlias } from '@core/ui/chain/nameService/chainToThornameAlias'
+import { detectNameServiceSuffix } from '@core/ui/chain/nameService/NameServiceName'
+import { resolveNameService } from '@core/ui/chain/nameService/resolveNameService'
 import { useAssertWalletCore } from '@core/ui/chain/providers/WalletCoreProvider'
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { ScanQrView } from '@core/ui/qr/components/ScanQrView'
@@ -38,6 +41,8 @@ import styled from 'styled-components'
 import { getAddress } from 'viem'
 import { getEnsAddress, normalize } from 'viem/ens'
 
+const isEnsName = (value: string) => /^.+\.eth$/i.test(value.trim())
+
 type MangeReceiverViewState = 'default' | 'addressBook' | 'scanner'
 
 export const ManageReceiverAddressInputField = () => {
@@ -47,7 +52,7 @@ export const ManageReceiverAddressInputField = () => {
   const { getClipboardText } = useCore()
   const { name } = useCurrentVault()
   const [value, setValue] = useSendReceiver()
-  const [, setReceiverLabel] = useSendReceiverLabel()
+  const [receiverLabel, setReceiverLabel] = useSendReceiverLabel()
   const [viewState, setViewState] = useState<MangeReceiverViewState>('default')
   const [qrView, setQrView] = useState<'scan' | 'upload'>('scan')
   const [touched, setTouched] = useState(false)
@@ -64,8 +69,8 @@ export const ManageReceiverAddressInputField = () => {
       setTouched(true)
       setValue(value)
       // Clear the receiver label whenever the user provides a raw address directly
-      // (label is set asynchronously by the name resolution effect below when applicable)
-      if (!/^.+\.eth$/i.test(value.trim())) {
+      // (label is set asynchronously by the name resolution effects below when applicable)
+      if (!isEnsName(value) && !detectNameServiceSuffix(value)) {
         setReceiverLabel('')
       }
       const receiverError = validateSendReceiver({
@@ -109,6 +114,11 @@ export const ManageReceiverAddressInputField = () => {
     latestValueRef.current = value
   }, [value])
 
+  const [nameServiceStatus, setNameServiceStatus] = useState<
+    'idle' | 'resolving' | 'error'
+  >('idle')
+  const [nameServiceError, setNameServiceError] = useState('')
+
   useEffect(() => {
     // Only attempt ENS resolution on Ethereum mainnet — two known limitations:
     // 1. Root .eth names only; ENSIP-11 multi-chain coin types not yet supported.
@@ -116,11 +126,7 @@ export const ManageReceiverAddressInputField = () => {
     //    offchain resolvers (CCIP-Read / EIP-3668) and non-.eth TLDs.
     // Loop prevention: after resolution the receiver is set to a raw address
     // which won't match the .eth regex, so this effect is skipped on the re-fire.
-    if (
-      coin.chain !== EvmChain.Ethereum ||
-      !/^.+\.eth$/i.test(debouncedValue.trim())
-    )
-      return
+    if (coin.chain !== EvmChain.Ethereum || !isEnsName(debouncedValue)) return
 
     // Clear stale label before attempting new resolution so a failed lookup
     // never leaves a ghost label from a previous successful one
@@ -166,6 +172,78 @@ export const ManageReceiverAddressInputField = () => {
     setValue,
     setReceiverLabel,
     setFocusedSendField,
+  ])
+
+  useEffect(() => {
+    const suffix = detectNameServiceSuffix(debouncedValue)
+    if (!suffix) {
+      setNameServiceStatus('idle')
+      setNameServiceError('')
+      return
+    }
+
+    const requestedName = debouncedValue.trim()
+
+    if (!chainToThornameAlias[coin.chain]) {
+      setNameServiceStatus('error')
+      setNameServiceError(
+        t('name_service_unsupported_chain', {
+          chain: coin.chain,
+          suffix,
+        })
+      )
+      return
+    }
+
+    setNameServiceStatus('resolving')
+    setNameServiceError('')
+    setReceiverLabel('')
+
+    let cancelled = false
+
+    attempt(async () =>
+      resolveNameService({
+        name: requestedName,
+        suffix,
+        chain: coin.chain,
+      })
+    ).then(result => {
+      if (cancelled) return
+      if (latestValueRef.current.trim() !== requestedName) return
+
+      if (!('error' in result) && result.data) {
+        setNameServiceStatus('idle')
+        setReceiverLabel(requestedName)
+        setValue(result.data)
+        setFocusedSendField(state => ({ ...state, field: 'amount' }))
+      } else if ('error' in result) {
+        setNameServiceStatus('error')
+        const errorMessage = String(
+          result.error instanceof Error ? result.error.message : result.error
+        )
+        const isNotFound =
+          errorMessage.includes('404') || errorMessage.includes('not found')
+        setNameServiceError(
+          isNotFound
+            ? t('name_service_not_found', { name: requestedName })
+            : t('name_service_no_address_for_chain', {
+                name: requestedName,
+                chain: coin.chain,
+              })
+        )
+      }
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [
+    coin.chain,
+    debouncedValue,
+    setValue,
+    setReceiverLabel,
+    setFocusedSendField,
+    t,
   ])
 
   return (
@@ -238,7 +316,11 @@ export const ManageReceiverAddressInputField = () => {
             <VStack gap={8}>
               <VStack gap={4}>
                 <Input
-                  validation={error ? 'warning' : undefined}
+                  validation={
+                    error || nameServiceStatus === 'error'
+                      ? 'warning'
+                      : undefined
+                  }
                   placeholder={t('enter_address_here')}
                   value={value}
                   onValueChange={newValue =>
@@ -247,6 +329,19 @@ export const ManageReceiverAddressInputField = () => {
                   onBlur={() => setTouched(true)}
                   data-testid="send-address-input"
                 />
+                {receiverLabel && nameServiceStatus === 'idle' ? (
+                  <ResolvedLabel size={12} color="primary">
+                    {receiverLabel}
+                  </ResolvedLabel>
+                ) : null}
+                {nameServiceStatus === 'resolving' ? (
+                  <Text size={12} color="shy">
+                    {t('name_service_resolving', { name: value.trim() })}
+                  </Text>
+                ) : null}
+                {nameServiceStatus === 'error' && nameServiceError ? (
+                  <AnimatedSendFormInputError error={nameServiceError} />
+                ) : null}
                 {error && <AnimatedSendFormInputError error={error} />}
               </VStack>
 
@@ -314,4 +409,8 @@ const QrModalOverlay = styled(VStack).attrs({
 const QrModalBody = styled(VStack)`
   flex: 1;
   min-height: 0;
+`
+
+const ResolvedLabel = styled(Text)`
+  padding: 0 4px;
 `


### PR DESCRIPTION
## Summary
- Adds `.thor` and `.maya` name service resolution to the send recipient address field
- Creates `core/ui/chain/nameService/` module with chain-to-thorname alias mapping and resolution logic
- Shows resolving status, resolved name label, and clear error messages for not-found names, unsupported chains, or missing chain aliases
- Follows the same debounce + race-condition protection pattern as the existing ENS resolution

Closes #3609

## Test plan
- [ ] Enter a `.thor` name (e.g. `test.thor`) in the send recipient field on a supported chain (e.g. Bitcoin, Ethereum) — verify it resolves to the correct address
- [ ] Enter a `.maya` name in the send recipient field — verify it resolves correctly
- [ ] Enter a name that doesn't exist — verify "not found" error is shown
- [ ] Enter a valid name on a chain with no registered alias — verify appropriate error message
- [ ] Enter a `.thor` name then quickly type a raw address — verify no stale resolution overwrites the input
- [ ] Verify ENS resolution still works on Ethereum
- [ ] Verify the resolved name label appears below the input after successful resolution
- [ ] Verify the resolved name label appears in the send overview/verify screen
- [ ] `yarn check:all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving supported name-service addresses ending in `.thor` and `.maya` when sending funds.
  * Recipient labels can now appear automatically after a successful name lookup.

* **Bug Fixes**
  * Improved validation and error handling for name-based recipients, including clearer messages when a name isn’t found, has no address for the selected chain, or the chain isn’t supported.
  * Added safer handling to avoid stale lookup results from updating the form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->