### PR TITLE
fix: restore vite-plugin-top-level-await for extension service worker

### DIFF
--- a/clients/extension/package.json
+++ b/clients/extension/package.json
@@ -92,6 +92,7 @@
     "vite": "^7.3.1",
     "vite-plugin-node-polyfills": "^0.25.0",
     "vite-plugin-static-copy": "^3.3.0",
+    "vite-plugin-top-level-await": "^1.6.0",
     "vite-plugin-wasm": "^3.6.0",
     "web-push": "^3.6.7",
     "ws": "^8.19.0"

--- a/clients/extension/vite.config.ts
+++ b/clients/extension/vite.config.ts
@@ -2,6 +2,7 @@ import path from 'path'
 import { defineConfig, loadEnv, PluginOption } from 'vite'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
+import topLevelAwait from 'vite-plugin-top-level-await'
 import wasm from 'vite-plugin-wasm'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
@@ -37,7 +38,7 @@ export default defineConfig(async ({ mode }) => {
 
     switch (chunk) {
       case 'background':
-        plugins = [nodePolyfills({ exclude: ['fs'] }), wasm()]
+        plugins = [nodePolyfills({ exclude: ['fs'] }), wasm(), topLevelAwait()]
         break
       case 'inpage':
         format = 'iife'

--- a/yarn.lock
+++ b/yarn.lock
@@ -652,6 +652,7 @@ __metadata:
     vite: "npm:^7.3.1"
     vite-plugin-node-polyfills: "npm:^0.25.0"
     vite-plugin-static-copy: "npm:^3.3.0"
+    vite-plugin-top-level-await: "npm:^1.6.0"
     vite-plugin-wasm: "npm:^3.6.0"
     web-push: "npm:^3.6.7"
     ws: "npm:^8.19.0"


### PR DESCRIPTION
## Summary
- Restores `vite-plugin-top-level-await` to the extension background chunk build, fixing the service worker remaining permanently "Inactive" in Chrome
- The background bundle statically imports `secp256k1.wasm` through `backgroundResolvers → getAccount → @vultisig/core-chain/publicKey/getPublicKey → bip32 → tiny-secp256k1`. Without the TLA plugin, this WASM init becomes a raw top-level `await` that prevents the service worker module from activating.
- Regression introduced in #3671

Closes #3692

## Test plan
- [ ] Build the extension with `yarn build:extension`
- [ ] Load the unpacked extension in Chrome
- [ ] Verify the service worker shows as "Active" (or activates when clicked)
- [ ] Verify clicking the service worker link opens DevTools console
- [ ] Verify push notifications still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tooling configuration for the extension client to enhance build process capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->