### PR TITLE
Add missing i18n translation keys

### DIFF
--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -1425,4 +1425,7 @@ export const de = {
   foreground_notification_generic: 'Transaktion vorbehaltlich der Genehmigung',
   foreground_notification_send: 'Senden Sie {{amount}}',
   foreground_notification_swap: 'Tausche {{from}} → {{to}}',
+  in_progress: 'Im Gange...',
+  route: 'Route',
+  via: 'über',
 }

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -1412,4 +1412,7 @@ export const es = {
   foreground_notification_generic: 'Transacción pendiente de aprobación',
   foreground_notification_send: 'Enviar {{amount}}',
   foreground_notification_swap: 'Intercambiar {{from}} → {{to}}',
+  in_progress: 'En curso...',
+  route: 'Ruta',
+  via: 'a través de',
 }

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -1388,4 +1388,7 @@ export const hr = {
   foreground_notification_generic: 'Transakcija čeka odobrenje',
   foreground_notification_send: 'Pošalji {{amount}}',
   foreground_notification_swap: 'Zamijeni {{from}} → {{to}}',
+  in_progress: 'U tijeku...',
+  route: 'Ruta',
+  via: 'preko',
 }

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -1416,4 +1416,7 @@ export const it = {
   foreground_notification_generic: 'Transazione in attesa di approvazione',
   foreground_notification_send: 'Invia {{amount}}',
   foreground_notification_swap: 'Scambia {{from}} → {{to}}',
+  in_progress: 'In corso...',
+  route: 'Itinerario',
+  via: 'via',
 }

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -1376,4 +1376,7 @@ export const ko = {
   foreground_notification_generic: '승인 대기 중인 거래',
   foreground_notification_send: '{{amount}}을 보내주세요',
   foreground_notification_swap: '{{from}} → {{to}}로 교환',
+  in_progress: '진행 중...',
+  route: '노선',
+  via: '~을 통해',
 }

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -1392,4 +1392,7 @@ export const nl = {
     'Transactie onder voorbehoud van goedkeuring',
   foreground_notification_send: 'Verzend {{amount}}',
   foreground_notification_swap: 'Wissel {{from}} → {{to}}',
+  in_progress: 'Bezig...',
+  route: 'Route',
+  via: 'via',
 }

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -1414,4 +1414,7 @@ export const pt = {
   foreground_notification_generic: 'Transação pendente de aprovação.',
   foreground_notification_send: 'Enviar {{amount}}',
   foreground_notification_swap: 'Trocar {{from}} → {{to}}',
+  in_progress: 'Em andamento...',
+  route: 'Rota',
+  via: 'via',
 }

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -1385,4 +1385,7 @@ export const ru = {
   foreground_notification_generic: 'Сделка ожидает одобрения.',
   foreground_notification_send: 'Отправить {{amount}}',
   foreground_notification_swap: 'Поменять местами {{from}} → {{to}}',
+  in_progress: 'В ходе выполнения...',
+  route: 'Маршрут',
+  via: 'с помощью',
 }

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -1303,4 +1303,7 @@ export const zh = {
   foreground_notification_generic: '交易待审批',
   foreground_notification_send: '发送 {{amount}}',
   foreground_notification_swap: '交换 {{from}} → {{to}}',
+  in_progress: '进行中...',
+  route: '路线',
+  via: '通过',
 }


### PR DESCRIPTION
## Summary
- Synced 3 missing translation keys (`in_progress`, `route`, `via`) to all 9 non-English locales

Closes #3699

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added translation strings for status indicators and navigation labels across all supported languages, including German, Spanish, Croatian, Italian, Korean, Dutch, Portuguese, Russian, and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->