### PR TITLE
fix(extension): fix Bittensor dApp wallet discovery

### DIFF
--- a/clients/extension/src/inpage/utils/windowInjector.ts
+++ b/clients/extension/src/inpage/utils/windowInjector.ts
@@ -160,22 +160,17 @@ async function setupContentScriptMessenger(
         injectedWeb3: {
           value: {
             ...(window.injectedWeb3 || {}),
-            vultisig: {
-              enable: (origin?: string) => providers.polkadot.enable(origin),
-            },
             'polkadot-js': {
               enable: (origin?: string) => providers.polkadot.enable(origin),
               version: '0.46.9',
             },
-            'vultisig-bittensor': {
-              enable: (origin?: string) => providers.bittensor.enable(origin),
-            },
             bittensor: {
               enable: (origin?: string) => providers.bittensor.enable(origin),
+              version: '0.46.9',
             },
           },
-          configurable: false,
-          writable: false,
+          configurable: true,
+          writable: true,
         },
       })
     )


### PR DESCRIPTION
## Summary
- Bittensor/Polkadot dApps (taostats.io) couldn't discover Vultisig wallet due to missing `version` property on `injectedWeb3` entries — `@polkadot/extension-dapp` requires `typeof version === 'string'` to accept a provider
- Removed duplicate branded entries (`vultisig`, `vultisig-bittensor`) that caused the same address to appear 4x in dApp account selectors
- Changed `injectedWeb3` to `writable: true` — taostats crashes with `TypeError: Cannot assign to read only property 'injectedWeb3'` when trying to register its own adapter

## Test plan
- [ ] Build extension, load on taostats.io → Connect Wallet should discover Vultisig
- [ ] Account selector shows 2 entries (polkadot-js + bittensor) instead of 4
- [ ] No console errors on taostats.io related to injectedWeb3
- [ ] Polkadot dApps (polkadot.js.org/apps) still discover Vultisig via polkadot-js entry
- [ ] Staking page (/pro/stake) loads balance correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed support for Vultisig and Vultisig-Bittensor wallet integrations
  * Updated Bittensor network configuration with version details
  * Enhanced Web3 injection flexibility for improved extensibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->