### PR TITLE
fix(extension): fix personal_sign timeout on non-mainnet EVM chains for key-import vaults

### DIFF
--- a/core/inpage-provider/popup/view/resolvers/signMessage/overview/index.tsx
+++ b/core/inpage-provider/popup/view/resolvers/signMessage/overview/index.tsx
@@ -21,6 +21,7 @@ import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
 import { StrictText } from '@lib/ui/text'
 import { useQuery } from '@tanstack/react-query'
 import { Chain } from '@vultisig/core-chain/Chain'
+import { getChainKind } from '@vultisig/core-chain/ChainKind'
 import { CustomMessagePayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/custom_message_payload_pb'
 import { getVaultId } from '@vultisig/core-mpc/vault/Vault'
 import { shouldBeDefined } from '@vultisig/lib-utils/assert/shouldBeDefined'
@@ -118,16 +119,18 @@ export const Overview = () => {
     queryFn: getDeveloperOptions,
   })
 
+  const keysignChain = getChainKind(chain) === 'evm' ? Chain.Ethereum : chain
+
   const keysignMessagePayload = useMemo(
     () => ({
       custom: create(CustomMessagePayloadSchema, {
         method,
         message,
-        chain,
+        chain: keysignChain,
         vaultPublicKeyEcdsa: getVaultId(vault),
       }),
     }),
-    [method, message, chain, vault]
+    [method, message, keysignChain, vault]
   )
 
   return (


### PR DESCRIPTION
## Summary
- Normalized EVM chains to `Ethereum` in the custom message keysign payload
- When `personal_sign` was called on a non-mainnet EVM chain (e.g. Base), the chain-specific coin type produced a wrong derivation path for the server
- For key-import (seed phrase) vaults, the server couldn't find the key share at that path, causing MPC timeout after 1 minute
- Non-EVM chains (Solana, TON, Tron) are unaffected — they keep their original chain



## Test plan
- [ ] Import a seed phrase vault as a fast vault
- [ ] Switch to a non-mainnet EVM chain (e.g. Base, chain ID `0x2105`)
- [ ] Call `personal_sign` from a dApp — should sign successfully
- [ ] Verify signing still works on Ethereum mainnet
- [ ] Verify the built-in "Sign message" page still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal chain handling for message signing operations to better map blockchain types during the signing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->