### PR TITLE
feat(ui): display vault name in password verification popup

### DIFF
--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -1210,8 +1210,9 @@ export const en = {
   vaults: 'Vaults',
   verify: 'Verify',
   verify_password: 'Verify Password',
+  verify_password_for: 'Verify your password for:',
   verify_password_periodic_message_description:
-    'We will periodically ask you to verify your fast sign password so you will always remember it',
+    "We periodically ask for a verification so you don't forget your password.",
   version: 'Version',
   via: 'via',
   view_on_explorer: 'View on Explorer',

--- a/core/ui/mpc/fast/FastVaultPasswordModal.tsx
+++ b/core/ui/mpc/fast/FastVaultPasswordModal.tsx
@@ -47,6 +47,7 @@ export type FastVaultPasswordModalResult = {
 type FastVaultPasswordModalProps = OnBackProp &
   OnFinishProp<FastVaultPasswordModalResult> & {
     title?: string
+    subtitle?: string
     description: string
     showModal?: boolean
     withPasswordCache?: boolean
@@ -57,6 +58,7 @@ export const FastVaultPasswordModal: React.FC<FastVaultPasswordModalProps> = ({
   onFinish,
   onBack,
   title,
+  subtitle,
   description,
   withPasswordCache = false,
 }) => {
@@ -145,6 +147,11 @@ export const FastVaultPasswordModal: React.FC<FastVaultPasswordModalProps> = ({
           <Text size={17} weight={500} centerHorizontally>
             {title ?? t('enter_your_password')}
           </Text>
+          {subtitle && (
+            <Text size={22} weight={700} centerHorizontally>
+              {subtitle}
+            </Text>
+          )}
           <Text size={12} color="shy" centerHorizontally>
             {description}
           </Text>

--- a/core/ui/mpc/fast/FastVaultPasswordVerification.tsx
+++ b/core/ui/mpc/fast/FastVaultPasswordVerification.tsx
@@ -12,7 +12,7 @@ const verificationTimeoutMs = convertDuration(15, 'd', 'ms')
 
 export const FastVaultPasswordVerification = () => {
   const { t } = useTranslation()
-  const { lastPasswordVerificationTime } = useCurrentVault()
+  const { lastPasswordVerificationTime, name } = useCurrentVault()
   const now = Date.now()
 
   const shouldShowModal =
@@ -33,6 +33,8 @@ export const FastVaultPasswordVerification = () => {
 
   return (
     <FastVaultPasswordModal
+      title={t('verify_password_for')}
+      subtitle={name}
       description={t('verify_password_periodic_message_description')}
       onBack={handleBack}
       onFinish={handleFinish}

--- a/core/ui/mpc/fast/FastVaultPasswordVerification.tsx
+++ b/core/ui/mpc/fast/FastVaultPasswordVerification.tsx
@@ -8,7 +8,7 @@ import {
 } from './FastVaultPasswordModal'
 import { usePasswordVerification } from './hooks/usePasswordVerification'
 
-const verificationTimeoutMs = convertDuration(14, 'd', 'ms')
+const verificationTimeoutMs = convertDuration(15, 'd', 'ms')
 
 export const FastVaultPasswordVerification = () => {
   const { t } = useTranslation()

--- a/core/ui/mpc/fast/FastVaultPasswordVerification.tsx
+++ b/core/ui/mpc/fast/FastVaultPasswordVerification.tsx
@@ -8,7 +8,7 @@ import {
 } from './FastVaultPasswordModal'
 import { usePasswordVerification } from './hooks/usePasswordVerification'
 
-const verificationTimeoutMs = convertDuration(15, 'd', 'ms')
+const verificationTimeoutMs = convertDuration(14, 'd', 'ms')
 
 export const FastVaultPasswordVerification = () => {
   const { t } = useTranslation()


### PR DESCRIPTION
## Summary
- Display the vault name in the periodic password verification modal for fast vaults
- Update title to "Verify your password for:" with the vault name shown below
- Update description text to match Figma design

Closes #3724

## Screenshot
<img width="326" height="373" alt="pic" src="https://github.com/user-attachments/assets/5ce844c4-ada1-411a-b9c8-0ded9f10b174" />


## Test plan
- [ ] Open a fast vault and trigger the password verification modal
- [ ] Verify the vault name appears below the title
- [ ] Verify the description matches the Figma design

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced password verification modal to display the vault or account context during authentication, providing clearer guidance to users about what they're verifying their password for.
  * Updated periodic password verification messaging for improved clarity and consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->