### PR TITLE
fix(extension): address book crash with key-import vault missing target chain

### DIFF
--- a/core/ui/vault/send/addresses/components/AddressBookModal/index.tsx
+++ b/core/ui/vault/send/addresses/components/AddressBookModal/index.tsx
@@ -16,6 +16,7 @@ import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
 import { deriveAddress } from '@vultisig/core-chain/publicKey/address/deriveAddress'
 import { getPublicKey } from '@vultisig/core-chain/publicKey/getPublicKey'
+import { isKeyImportVault } from '@vultisig/core-mpc/vault/Vault'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -54,6 +55,10 @@ export const AddressBookModal = ({ onSelect, onClose }: Props) => {
       if (match?.address) {
         acc.push({ name: vault.name, address: match.address })
       } else {
+        if (isKeyImportVault(vault) && !vault.chainPublicKeys?.[coin.chain]) {
+          return acc
+        }
+
         const publicKey = getPublicKey({
           chain: coin.chain,
           walletCore,


### PR DESCRIPTION
## Summary
- Skip phrase-imported (key-import) vaults that don't have the target chain in `chainPublicKeys` when building the address book list
- Follows the existing `isKeyImportVault()` + `chainPublicKeys[chain]` guard pattern used in `getAccount.ts` and `coins.tsx`
- Prevents "Chain public key not found" crash when a phrase-imported vault (e.g. Ethereum-only) is present and the user opens the address book for a different chain (e.g. Bitcoin)

## Test plan
- [ ] Import a vault using a seed phrase, selecting **only Ethereum** during setup
- [ ] Import a second vault (regular 2of2) with all chains
- [ ] Switch to the second vault, go to Send for a non-Ethereum coin (e.g. Bitcoin)
- [ ] Click the address book icon — should open without crash
- [ ] The phrase-imported vault should be omitted from the vault list for Bitcoin
- [ ] Switch to Send for Ethereum — the phrase-imported vault's address should appear in the address book

Closes #3742

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved handling for certain vault types when required cryptographic keys are unavailable, preventing unnecessary processing and potential issues in address management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->