### PR TITLE
fix(extension): EVM contract call crash — No arguments provided to bigIntMax

### DIFF
--- a/core/inpage-provider/popup/view/resolvers/sendTx/gasEstimation/estimateEvmGas.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/gasEstimation/estimateEvmGas.ts
@@ -1,5 +1,8 @@
+import { EvmChain } from '@vultisig/core-chain/Chain'
+import { deriveEvmGasLimit } from '@vultisig/core-chain/tx/fee/evm/evmGasLimit'
 import { getEvmFeeQuote } from '@vultisig/core-mpc/keysign/fee/resolvers/evm/getEvmFeeQuote'
 import { getKeysignSwapPayload } from '@vultisig/core-mpc/keysign/swap/getKeysignSwapPayload'
+import { getKeysignCoin } from '@vultisig/core-mpc/keysign/utils/getKeysignCoin'
 import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
 import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
 
@@ -10,7 +13,23 @@ type EstimateEvmGasInput = {
 export const estimateEvmGas = async ({
   keysignPayload,
 }: EstimateEvmGasInput): Promise<bigint | null> => {
+  const coin = getKeysignCoin<EvmChain>(keysignPayload)
   const swapPayload = getKeysignSwapPayload(keysignPayload)
+
+  const getData = () => {
+    if (swapPayload && 'general' in swapPayload) {
+      const value = swapPayload.general.quote?.tx?.data
+      if (value) {
+        return value
+      }
+    }
+    return keysignPayload.memo
+  }
+
+  const minimumGasLimit = deriveEvmGasLimit({
+    coin,
+    data: getData(),
+  })
 
   if (swapPayload) {
     return matchRecordUnion(swapPayload, {
@@ -18,6 +37,7 @@ export const estimateEvmGas = async ({
       general: async () => {
         const feeQuote = await getEvmFeeQuote({
           keysignPayload,
+          minimumGasLimit,
         })
         return feeQuote.gasLimit
       },
@@ -25,6 +45,7 @@ export const estimateEvmGas = async ({
   }
   const feeQuote = await getEvmFeeQuote({
     keysignPayload,
+    minimumGasLimit,
   })
   return feeQuote.gasLimit
 }

--- a/core/inpage-provider/popup/view/resolvers/sendTx/gasEstimation/estimateEvmGas.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/gasEstimation/estimateEvmGas.ts
@@ -10,6 +10,7 @@ type EstimateEvmGasInput = {
   keysignPayload: KeysignPayload
 }
 
+/** Estimates the gas limit for an EVM transaction, returning null for native swaps. */
 export const estimateEvmGas = async ({
   keysignPayload,
 }: EstimateEvmGasInput): Promise<bigint | null> => {


### PR DESCRIPTION
## Summary
- Pass `minimumGasLimit` via `deriveEvmGasLimit` when calling `getEvmFeeQuote` in the extension's gas estimation path
- Matches the pattern already used by the SDK's own EVM resolver (`getEvmChainSpecific`)
- For contract interactions with data, this provides a `600_000n` floor so `bigIntMax` always has at least one value

## Root cause
The extension's `estimateEvmGas` called `getEvmFeeQuote` without a `minimumGasLimit`. When gas estimation fails for a contract call (e.g. `pause()` reverts because the caller isn't the owner), all three gas limit values in `capGasLimit` are `undefined`, and `bigIntMax()` throws with zero arguments.

## Test plan
- [ ] Go to https://etherscan.io/token/0xbd3531da5cf5857e7cfaa92426877b022e612cf8#writeContract
- [ ] Connect Vultisig wallet
- [ ] Call `pause(true)` or any write function
- [ ] Sign Transaction screen should process the transaction without "No arguments provided to bigIntMax" error
- [ ] Normal EVM sends and swaps still work as before

Closes #3743

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EVM transaction gas estimation to better handle transaction data and calculate more accurate minimum gas limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->