### PR TITLE
fix: add batch keygen support to key import initiator

### DIFF
--- a/core/ui/mpc/keygen/keyimport/KeyImportKeygenActionProvider.tsx
+++ b/core/ui/mpc/keygen/keyimport/KeyImportKeygenActionProvider.tsx
@@ -284,7 +284,7 @@ export const KeyImportKeygenActionProvider = ({ children }: ChildrenProp) => {
         hexChainCode: rootEcdsaResult.chaincode,
         keyShares,
         localPartyId,
-        libType: 'DKLS' as MpcLib,
+        libType: 'DKLS' satisfies MpcLib,
         isBackedUp: false,
         order: getLastItemOrder(vaultOrders),
         lastPasswordVerificationTime: hasServer(signers)
@@ -744,7 +744,7 @@ async function runBatchKeyImport({
     hexChainCode: rootEcdsaResult.chaincode,
     keyShares,
     localPartyId,
-    libType: 'KeyImport' as MpcLib,
+    libType: 'KeyImport' satisfies MpcLib,
     isBackedUp: false,
     order: getLastItemOrder(vaultOrders),
     lastPasswordVerificationTime: hasServer(signers) ? Date.now() : undefined,

--- a/core/ui/mpc/keygen/keyimport/KeyImportKeygenActionProvider.tsx
+++ b/core/ui/mpc/keygen/keyimport/KeyImportKeygenActionProvider.tsx
@@ -356,6 +356,22 @@ type ChainKeygenResult = {
   result: KeyShareResult
 }
 
+type DklsProtocolSpec = {
+  instance: DKLS
+  privateKeyHex: string
+  setupMessageId: string | undefined
+  protocolMessageId: string
+  chains?: Chain[]
+}
+
+type SchnorrProtocolSpec = {
+  instance: Schnorr
+  privateKeyHex: string
+  setupMessageId: string
+  protocolMessageId: string
+  chains?: Chain[]
+}
+
 type RunDklsTrackInput = {
   sharedDklsParams: SharedDklsParams
   hexChainCode: string
@@ -369,10 +385,21 @@ type RunDklsTrackInput = {
 }
 
 /**
- * Runs root ECDSA keygen then each per-chain ECDSA keygen sequentially
- * on the single shared DKLS WASM engine. vs_wasm is not safe for
- * concurrent use within the same curve — running DKLS sessions in
- * parallel causes "memory access out of bounds" errors.
+ * Phase 1 (setup upload): sequentially calls prepareKeyImportSetup for the
+ * root and every per-chain ECDSA keygen. All setup messages are uploaded to
+ * the relay upfront because the server's initImportProtocols fetches them
+ * serially before launching any keygen goroutine — if we upload per-chain
+ * setups after root keygen completes, the server times out waiting.
+ *
+ * Phase 2 (message exchange): sequentially runs startKeyImportWithRetry for
+ * each protocol, which reuses the pending session created in Phase 1. vs_wasm
+ * is not safe for concurrent use within the same curve, so exchanges must
+ * also run one-at-a-time on the shared DKLS engine.
+ *
+ * Per-chain keygens use hexChainCode directly rather than
+ * rootEcdsaResult.chaincode because the root hasn't run yet at Phase 1 time.
+ * For key import the initiator defines the chain code, so these are the same
+ * bytes that keyShare.rootChainCode() returns.
  */
 async function runDklsTrack({
   sharedDklsParams,
@@ -388,39 +415,8 @@ async function runDklsTrack({
   rootResult: KeyShareResult
   chainResults: ChainKeygenResult[]
 }> {
-  const dklsKeygen = new DKLS(
-    { keyimport: true },
-    sharedDklsParams.isInitiateDevice,
-    sharedDklsParams.serverUrl,
-    sharedDklsParams.sessionId,
-    sharedDklsParams.localPartyId,
-    sharedDklsParams.signers,
-    sharedDklsParams.oldKeygenCommittee,
-    sharedDklsParams.hexEncryptionKey
-  )
-
-  const rootResult = await dklsKeygen.startKeyImportWithRetry(
-    rootEcdsaPrivateKeyHex,
-    hexChainCode,
-    undefined,
-    'p-ecdsa'
-  )
-  onStepComplete('ecdsa')
-
-  const chainResults: ChainKeygenResult[] = []
-  for (const { representativeChain, chains: groupChains } of ecdsaGroups) {
-    let chainPrivateKeyHex = ''
-    if (isInitiatingDevice && hdWallet) {
-      chainPrivateKeyHex = deriveChainPrivateKey({
-        representativeChain,
-        hdWallet,
-        walletCore,
-        usePhantomSolanaPath,
-        algorithm: 'ecdsa',
-      })
-    }
-
-    const chainDkls = new DKLS(
+  const makeDkls = () =>
+    new DKLS(
       { keyimport: true },
       sharedDklsParams.isInitiateDevice,
       sharedDklsParams.serverUrl,
@@ -431,14 +427,68 @@ async function runDklsTrack({
       sharedDklsParams.hexEncryptionKey
     )
 
-    const result = await chainDkls.startKeyImportWithRetry(
-      chainPrivateKeyHex,
-      hexChainCode,
-      representativeChain,
-      `p-${representativeChain}`
-    )
+  const protocols: DklsProtocolSpec[] = [
+    {
+      instance: makeDkls(),
+      privateKeyHex: rootEcdsaPrivateKeyHex,
+      setupMessageId: undefined,
+      protocolMessageId: 'p-ecdsa',
+    },
+    ...ecdsaGroups.map(({ representativeChain, chains: groupChains }) => {
+      const privateKeyHex =
+        isInitiatingDevice && hdWallet
+          ? deriveChainPrivateKey({
+              representativeChain,
+              hdWallet,
+              walletCore,
+              usePhantomSolanaPath,
+              algorithm: 'ecdsa',
+            })
+          : ''
 
-    chainResults.push({ chains: groupChains, result })
+      return {
+        instance: makeDkls(),
+        privateKeyHex,
+        setupMessageId: representativeChain,
+        protocolMessageId: `p-${representativeChain}`,
+        chains: groupChains,
+      }
+    }),
+  ]
+
+  for (const { instance, privateKeyHex, setupMessageId } of protocols) {
+    await instance.prepareKeyImportSetup(
+      privateKeyHex,
+      hexChainCode,
+      setupMessageId
+    )
+  }
+
+  const [rootSpec, ...chainSpecs] = protocols
+
+  const rootResult = await rootSpec.instance.startKeyImportWithRetry(
+    rootSpec.privateKeyHex,
+    hexChainCode,
+    rootSpec.setupMessageId,
+    rootSpec.protocolMessageId
+  )
+  onStepComplete('ecdsa')
+
+  const chainResults: ChainKeygenResult[] = []
+  for (const {
+    instance,
+    privateKeyHex,
+    setupMessageId,
+    protocolMessageId,
+    chains: groupChains,
+  } of chainSpecs) {
+    const result = await instance.startKeyImportWithRetry(
+      privateKeyHex,
+      hexChainCode,
+      setupMessageId,
+      protocolMessageId
+    )
+    chainResults.push({ chains: groupChains!, result })
   }
 
   return { rootResult, chainResults }
@@ -457,8 +507,8 @@ type RunSchnorrTrackInput = {
 }
 
 /**
- * Runs root EdDSA keygen then each per-chain EdDSA keygen sequentially
- * on the single shared Schnorr WASM engine.
+ * Same two-phase pattern as runDklsTrack, on the shared Schnorr WASM engine.
+ * See runDklsTrack for the setup-upfront rationale.
  */
 async function runSchnorrTrack({
   sharedDklsParams,
@@ -474,40 +524,8 @@ async function runSchnorrTrack({
   rootResult: KeyShareResult
   chainResults: ChainKeygenResult[]
 }> {
-  const schnorrKeygen = new Schnorr(
-    { keyimport: true },
-    sharedDklsParams.isInitiateDevice,
-    sharedDklsParams.serverUrl,
-    sharedDklsParams.sessionId,
-    sharedDklsParams.localPartyId,
-    sharedDklsParams.signers,
-    sharedDklsParams.oldKeygenCommittee,
-    sharedDklsParams.hexEncryptionKey,
-    new Uint8Array()
-  )
-
-  const rootResult = await schnorrKeygen.startKeyImportWithRetry(
-    rootEddsaPrivateKeyHex,
-    hexChainCode,
-    'eddsa_key_import',
-    'p-eddsa'
-  )
-  onStepComplete('eddsa')
-
-  const chainResults: ChainKeygenResult[] = []
-  for (const { representativeChain, chains: groupChains } of eddsaGroups) {
-    let chainPrivateKeyHex = ''
-    if (isInitiatingDevice && hdWallet) {
-      chainPrivateKeyHex = deriveChainPrivateKey({
-        representativeChain,
-        hdWallet,
-        walletCore,
-        usePhantomSolanaPath,
-        algorithm: 'eddsa',
-      })
-    }
-
-    const chainSchnorr = new Schnorr(
+  const makeSchnorr = () =>
+    new Schnorr(
       { keyimport: true },
       sharedDklsParams.isInitiateDevice,
       sharedDklsParams.serverUrl,
@@ -519,14 +537,68 @@ async function runSchnorrTrack({
       new Uint8Array()
     )
 
-    const result = await chainSchnorr.startKeyImportWithRetry(
-      chainPrivateKeyHex,
-      hexChainCode,
-      representativeChain,
-      `p-${representativeChain}`
-    )
+  const protocols: SchnorrProtocolSpec[] = [
+    {
+      instance: makeSchnorr(),
+      privateKeyHex: rootEddsaPrivateKeyHex,
+      setupMessageId: 'eddsa_key_import',
+      protocolMessageId: 'p-eddsa',
+    },
+    ...eddsaGroups.map(({ representativeChain, chains: groupChains }) => {
+      const privateKeyHex =
+        isInitiatingDevice && hdWallet
+          ? deriveChainPrivateKey({
+              representativeChain,
+              hdWallet,
+              walletCore,
+              usePhantomSolanaPath,
+              algorithm: 'eddsa',
+            })
+          : ''
 
-    chainResults.push({ chains: groupChains, result })
+      return {
+        instance: makeSchnorr(),
+        privateKeyHex,
+        setupMessageId: representativeChain,
+        protocolMessageId: `p-${representativeChain}`,
+        chains: groupChains,
+      }
+    }),
+  ]
+
+  for (const { instance, privateKeyHex, setupMessageId } of protocols) {
+    await instance.prepareKeyImportSetup(
+      privateKeyHex,
+      hexChainCode,
+      setupMessageId
+    )
+  }
+
+  const [rootSpec, ...chainSpecs] = protocols
+
+  const rootResult = await rootSpec.instance.startKeyImportWithRetry(
+    rootSpec.privateKeyHex,
+    hexChainCode,
+    rootSpec.setupMessageId,
+    rootSpec.protocolMessageId
+  )
+  onStepComplete('eddsa')
+
+  const chainResults: ChainKeygenResult[] = []
+  for (const {
+    instance,
+    privateKeyHex,
+    setupMessageId,
+    protocolMessageId,
+    chains: groupChains,
+  } of chainSpecs) {
+    const result = await instance.startKeyImportWithRetry(
+      privateKeyHex,
+      hexChainCode,
+      setupMessageId,
+      protocolMessageId
+    )
+    chainResults.push({ chains: groupChains!, result })
   }
 
   return { rootResult, chainResults }

--- a/core/ui/mpc/keygen/keyimport/KeyImportKeygenActionProvider.tsx
+++ b/core/ui/mpc/keygen/keyimport/KeyImportKeygenActionProvider.tsx
@@ -350,10 +350,193 @@ type BatchKeyImportInput = {
   onStepComplete: (step: KeygenStep) => void
 }
 
+type ChainKeygenResult = {
+  chains: Chain[]
+  result: KeyShareResult
+}
+
+type RunDklsTrackInput = {
+  sharedDklsParams: SharedDklsParams
+  hexChainCode: string
+  rootEcdsaPrivateKeyHex: string
+  ecdsaGroups: ReturnType<typeof getKeyImportDerivationGroups>
+  hdWallet: any
+  walletCore: any
+  isInitiatingDevice: boolean
+  usePhantomSolanaPath?: boolean
+  onStepComplete: (step: KeygenStep) => void
+}
+
 /**
- * Runs all key import protocols in parallel using batch message IDs
- * (p-ecdsa, p-eddsa, p-mldsa, p-{chain}) that match the server's
- * /batch/import handler expectations.
+ * Runs root ECDSA keygen then each per-chain ECDSA keygen sequentially
+ * on the single shared DKLS WASM engine. vs_wasm is not safe for
+ * concurrent use within the same curve — running DKLS sessions in
+ * parallel causes "memory access out of bounds" errors.
+ */
+async function runDklsTrack({
+  sharedDklsParams,
+  hexChainCode,
+  rootEcdsaPrivateKeyHex,
+  ecdsaGroups,
+  hdWallet,
+  walletCore,
+  isInitiatingDevice,
+  usePhantomSolanaPath,
+  onStepComplete,
+}: RunDklsTrackInput): Promise<{
+  rootResult: KeyShareResult
+  chainResults: ChainKeygenResult[]
+}> {
+  const dklsKeygen = new DKLS(
+    { keyimport: true },
+    sharedDklsParams.isInitiateDevice,
+    sharedDklsParams.serverUrl,
+    sharedDklsParams.sessionId,
+    sharedDklsParams.localPartyId,
+    sharedDklsParams.signers,
+    sharedDklsParams.oldKeygenCommittee,
+    sharedDklsParams.hexEncryptionKey
+  )
+
+  const rootResult = await dklsKeygen.startKeyImportWithRetry(
+    rootEcdsaPrivateKeyHex,
+    hexChainCode,
+    undefined,
+    'p-ecdsa'
+  )
+  onStepComplete('ecdsa')
+
+  const chainResults: ChainKeygenResult[] = []
+  for (const { representativeChain, chains: groupChains } of ecdsaGroups) {
+    let chainPrivateKeyHex = ''
+    if (isInitiatingDevice && hdWallet) {
+      chainPrivateKeyHex = deriveChainPrivateKey({
+        representativeChain,
+        hdWallet,
+        walletCore,
+        usePhantomSolanaPath,
+        algorithm: 'ecdsa',
+      })
+    }
+
+    const chainDkls = new DKLS(
+      { keyimport: true },
+      sharedDklsParams.isInitiateDevice,
+      sharedDklsParams.serverUrl,
+      sharedDklsParams.sessionId,
+      sharedDklsParams.localPartyId,
+      sharedDklsParams.signers,
+      sharedDklsParams.oldKeygenCommittee,
+      sharedDklsParams.hexEncryptionKey
+    )
+
+    const result = await chainDkls.startKeyImportWithRetry(
+      chainPrivateKeyHex,
+      hexChainCode,
+      representativeChain,
+      `p-${representativeChain}`
+    )
+
+    chainResults.push({ chains: groupChains, result })
+  }
+
+  return { rootResult, chainResults }
+}
+
+type RunSchnorrTrackInput = {
+  sharedDklsParams: SharedDklsParams
+  hexChainCode: string
+  rootEddsaPrivateKeyHex: string
+  eddsaGroups: ReturnType<typeof getKeyImportDerivationGroups>
+  hdWallet: any
+  walletCore: any
+  isInitiatingDevice: boolean
+  usePhantomSolanaPath?: boolean
+  onStepComplete: (step: KeygenStep) => void
+}
+
+/**
+ * Runs root EdDSA keygen then each per-chain EdDSA keygen sequentially
+ * on the single shared Schnorr WASM engine.
+ */
+async function runSchnorrTrack({
+  sharedDklsParams,
+  hexChainCode,
+  rootEddsaPrivateKeyHex,
+  eddsaGroups,
+  hdWallet,
+  walletCore,
+  isInitiatingDevice,
+  usePhantomSolanaPath,
+  onStepComplete,
+}: RunSchnorrTrackInput): Promise<{
+  rootResult: KeyShareResult
+  chainResults: ChainKeygenResult[]
+}> {
+  const schnorrKeygen = new Schnorr(
+    { keyimport: true },
+    sharedDklsParams.isInitiateDevice,
+    sharedDklsParams.serverUrl,
+    sharedDklsParams.sessionId,
+    sharedDklsParams.localPartyId,
+    sharedDklsParams.signers,
+    sharedDklsParams.oldKeygenCommittee,
+    sharedDklsParams.hexEncryptionKey,
+    new Uint8Array()
+  )
+
+  const rootResult = await schnorrKeygen.startKeyImportWithRetry(
+    rootEddsaPrivateKeyHex,
+    hexChainCode,
+    'eddsa_key_import',
+    'p-eddsa'
+  )
+  onStepComplete('eddsa')
+
+  const chainResults: ChainKeygenResult[] = []
+  for (const { representativeChain, chains: groupChains } of eddsaGroups) {
+    let chainPrivateKeyHex = ''
+    if (isInitiatingDevice && hdWallet) {
+      chainPrivateKeyHex = deriveChainPrivateKey({
+        representativeChain,
+        hdWallet,
+        walletCore,
+        usePhantomSolanaPath,
+        algorithm: 'eddsa',
+      })
+    }
+
+    const chainSchnorr = new Schnorr(
+      { keyimport: true },
+      sharedDklsParams.isInitiateDevice,
+      sharedDklsParams.serverUrl,
+      sharedDklsParams.sessionId,
+      sharedDklsParams.localPartyId,
+      sharedDklsParams.signers,
+      sharedDklsParams.oldKeygenCommittee,
+      sharedDklsParams.hexEncryptionKey,
+      new Uint8Array()
+    )
+
+    const result = await chainSchnorr.startKeyImportWithRetry(
+      chainPrivateKeyHex,
+      hexChainCode,
+      representativeChain,
+      `p-${representativeChain}`
+    )
+
+    chainResults.push({ chains: groupChains, result })
+  }
+
+  return { rootResult, chainResults }
+}
+
+/**
+ * Runs key import protocols in parallel across curves (DKLS, Schnorr, MLDSA)
+ * but serially within each curve. vs_wasm engines are per-curve singletons
+ * and not reentrant, so running multiple DKLS sessions concurrently corrupts
+ * WASM memory. Message IDs (p-ecdsa, p-eddsa, p-mldsa, p-{chain}) match the
+ * server's /batch/import handler.
  */
 async function runBatchKeyImport({
   sharedDklsParams,
@@ -378,27 +561,13 @@ async function runBatchKeyImport({
 }: BatchKeyImportInput): Promise<Vault> {
   onStepStart('prepareVault')
 
-  const dklsKeygen = new DKLS(
-    { keyimport: true },
-    sharedDklsParams.isInitiateDevice,
-    sharedDklsParams.serverUrl,
-    sharedDklsParams.sessionId,
-    sharedDklsParams.localPartyId,
-    sharedDklsParams.signers,
-    sharedDklsParams.oldKeygenCommittee,
-    sharedDklsParams.hexEncryptionKey
+  const ecdsaGroups = derivationGroups.filter(
+    ({ representativeChain }) =>
+      signatureAlgorithms[getChainKind(representativeChain)] === 'ecdsa'
   )
-
-  const schnorrKeygen = new Schnorr(
-    { keyimport: true },
-    sharedDklsParams.isInitiateDevice,
-    sharedDklsParams.serverUrl,
-    sharedDklsParams.sessionId,
-    sharedDklsParams.localPartyId,
-    sharedDklsParams.signers,
-    sharedDklsParams.oldKeygenCommittee,
-    sharedDklsParams.hexEncryptionKey,
-    new Uint8Array()
+  const eddsaGroups = derivationGroups.filter(
+    ({ representativeChain }) =>
+      signatureAlgorithms[getChainKind(representativeChain)] === 'eddsa'
   )
 
   const includeMldsa = featureFlags.mldsaKeygen && isMLDSAEnabled
@@ -412,6 +581,30 @@ async function runBatchKeyImport({
   if (includeMldsa) {
     onStepStart('mldsa')
   }
+
+  const dklsTrackPromise = runDklsTrack({
+    sharedDklsParams,
+    hexChainCode,
+    rootEcdsaPrivateKeyHex,
+    ecdsaGroups,
+    hdWallet,
+    walletCore,
+    isInitiatingDevice,
+    usePhantomSolanaPath: keyImportInput.usePhantomSolanaPath,
+    onStepComplete,
+  })
+
+  const schnorrTrackPromise = runSchnorrTrack({
+    sharedDklsParams,
+    hexChainCode,
+    rootEddsaPrivateKeyHex,
+    eddsaGroups,
+    hdWallet,
+    walletCore,
+    isInitiatingDevice,
+    usePhantomSolanaPath: keyImportInput.usePhantomSolanaPath,
+    onStepComplete,
+  })
 
   const mldsaPromise = includeMldsa
     ? new MldsaKeygen(
@@ -430,99 +623,18 @@ async function runBatchKeyImport({
         })
     : Promise.resolve(undefined)
 
-  const chainPromises = derivationGroups.map(
-    async ({ representativeChain, chains: groupChains }) => {
-      const chainKind = getChainKind(representativeChain)
-      const algorithm = signatureAlgorithms[chainKind]
+  const [dklsTrack, schnorrTrack, mldsaResult] = await Promise.all([
+    dklsTrackPromise,
+    schnorrTrackPromise,
+    mldsaPromise,
+  ])
 
-      let chainPrivateKeyHex = ''
-      if (isInitiatingDevice && hdWallet) {
-        chainPrivateKeyHex = deriveChainPrivateKey({
-          representativeChain,
-          hdWallet,
-          walletCore,
-          usePhantomSolanaPath: keyImportInput.usePhantomSolanaPath,
-          algorithm,
-        })
-      }
+  if (derivationGroups.length > 0) {
+    onStepComplete('chainKeys')
+  }
 
-      let result: KeyShareResult
-      if (algorithm === 'ecdsa') {
-        const chainDkls = new DKLS(
-          { keyimport: true },
-          sharedDklsParams.isInitiateDevice,
-          sharedDklsParams.serverUrl,
-          sharedDklsParams.sessionId,
-          sharedDklsParams.localPartyId,
-          sharedDklsParams.signers,
-          sharedDklsParams.oldKeygenCommittee,
-          sharedDklsParams.hexEncryptionKey
-        )
-        result = await chainDkls.startKeyImportWithRetry(
-          chainPrivateKeyHex,
-          hexChainCode,
-          representativeChain,
-          `p-${representativeChain}`
-        )
-      } else {
-        const chainSchnorr = new Schnorr(
-          { keyimport: true },
-          sharedDklsParams.isInitiateDevice,
-          sharedDklsParams.serverUrl,
-          sharedDklsParams.sessionId,
-          sharedDklsParams.localPartyId,
-          sharedDklsParams.signers,
-          sharedDklsParams.oldKeygenCommittee,
-          sharedDklsParams.hexEncryptionKey,
-          new Uint8Array()
-        )
-        result = await chainSchnorr.startKeyImportWithRetry(
-          chainPrivateKeyHex,
-          hexChainCode,
-          representativeChain,
-          `p-${representativeChain}`
-        )
-      }
-
-      return { chains: groupChains, result }
-    }
-  )
-
-  const chainKeysPromise =
-    chainPromises.length > 0
-      ? Promise.all(chainPromises).then(results => {
-          onStepComplete('chainKeys')
-          return results
-        })
-      : Promise.resolve([])
-
-  const [rootEcdsaResult, rootEddsaResult, mldsaResult, chainResults] =
-    await Promise.all([
-      dklsKeygen
-        .startKeyImportWithRetry(
-          rootEcdsaPrivateKeyHex,
-          hexChainCode,
-          undefined,
-          'p-ecdsa'
-        )
-        .then(r => {
-          onStepComplete('ecdsa')
-          return r
-        }),
-      schnorrKeygen
-        .startKeyImportWithRetry(
-          rootEddsaPrivateKeyHex,
-          hexChainCode,
-          'eddsa_key_import',
-          'p-eddsa'
-        )
-        .then(r => {
-          onStepComplete('eddsa')
-          return r
-        }),
-      mldsaPromise,
-      chainKeysPromise,
-    ])
+  const rootEcdsaResult = dklsTrack.rootResult
+  const rootEddsaResult = schnorrTrack.rootResult
 
   const chainPublicKeys: Partial<Record<Chain, string>> = {}
   const chainKeyShares: Partial<Record<Chain, string>> = {}
@@ -531,7 +643,10 @@ async function runBatchKeyImport({
     eddsa: rootEddsaResult.keyshare,
   }
 
-  for (const { chains: groupChains, result } of chainResults) {
+  for (const { chains: groupChains, result } of [
+    ...dklsTrack.chainResults,
+    ...schnorrTrack.chainResults,
+  ]) {
     for (const chain of groupChains) {
       chainPublicKeys[chain] = result.publicKey
       chainKeyShares[chain] = result.keyshare

--- a/core/ui/mpc/keygen/keyimport/KeyImportKeygenActionProvider.tsx
+++ b/core/ui/mpc/keygen/keyimport/KeyImportKeygenActionProvider.tsx
@@ -22,6 +22,7 @@ import {
   setKeygenComplete,
   waitForKeygenComplete,
 } from '@vultisig/core-mpc/keygenComplete'
+import { initializeMpcLib } from '@vultisig/core-mpc/lib/initialize'
 import { MldsaKeygen } from '@vultisig/core-mpc/mldsa/mldsaKeygen'
 import { MpcLib } from '@vultisig/core-mpc/mpcLib'
 import { Schnorr } from '@vultisig/core-mpc/schnorr/schnorrKeygen'
@@ -560,6 +561,13 @@ async function runBatchKeyImport({
   onStepComplete,
 }: BatchKeyImportInput): Promise<Vault> {
   onStepStart('prepareVault')
+
+  // Warm up the WASM engine BEFORE starting parallel tracks. `initializeMpcLib`
+  // uses `memoizeAsync` which only caches on completion — concurrent calls before
+  // the first one finishes will double-instantiate the WASM modules and corrupt
+  // pointers inside Rust sessions ("memory access out of bounds" on outputMessage).
+  await initializeMpcLib('ecdsa')
+  await initializeMpcLib('eddsa')
 
   const ecdsaGroups = derivationGroups.filter(
     ({ representativeChain }) =>

--- a/core/ui/mpc/keygen/keyimport/KeyImportKeygenActionProvider.tsx
+++ b/core/ui/mpc/keygen/keyimport/KeyImportKeygenActionProvider.tsx
@@ -1,10 +1,13 @@
 import { useAssertWalletCore } from '@core/ui/chain/providers/WalletCoreProvider'
+import { featureFlags } from '@core/ui/featureFlags'
 import { useCurrentHexChainCode } from '@core/ui/mpc/state/currentHexChainCode'
 import { useCurrentHexEncryptionKey } from '@core/ui/mpc/state/currentHexEncryptionKey'
 import { useIsInitiatingDevice } from '@core/ui/mpc/state/isInitiatingDevice'
 import { useMpcLocalPartyId } from '@core/ui/mpc/state/mpcLocalPartyId'
 import { useMpcServerUrl } from '@core/ui/mpc/state/mpcServerUrl'
 import { useMpcSessionId } from '@core/ui/mpc/state/mpcSession'
+import { useIsMLDSAEnabled } from '@core/ui/storage/mldsaEnabled'
+import { useIsTssBatchingEnabled } from '@core/ui/storage/tssBatchingEnabled'
 import { useVaultOrders } from '@core/ui/storage/vaults'
 import { ChildrenProp } from '@lib/ui/props'
 import { Chain } from '@vultisig/core-chain/Chain'
@@ -14,10 +17,12 @@ import { phantomSolanaPath } from '@vultisig/core-chain/publicKey/address/derive
 import { signatureAlgorithms } from '@vultisig/core-chain/signing/SignatureAlgorithm'
 import { hasServer } from '@vultisig/core-mpc/devices/localPartyId'
 import { DKLS } from '@vultisig/core-mpc/dkls/dkls'
+import { KeygenStep } from '@vultisig/core-mpc/keygen/KeygenStep'
 import {
   setKeygenComplete,
   waitForKeygenComplete,
 } from '@vultisig/core-mpc/keygenComplete'
+import { MldsaKeygen } from '@vultisig/core-mpc/mldsa/mldsaKeygen'
 import { MpcLib } from '@vultisig/core-mpc/mpcLib'
 import { Schnorr } from '@vultisig/core-mpc/schnorr/schnorrKeygen'
 import { clampThenUniformScalar } from '@vultisig/core-mpc/utils/ed25519ScalarClamp'
@@ -37,6 +42,47 @@ type KeyShareResult = {
   chaincode: string
 }
 
+type SharedDklsParams = {
+  isInitiateDevice: boolean
+  serverUrl: string
+  sessionId: string
+  localPartyId: string
+  signers: string[]
+  oldKeygenCommittee: string[]
+  hexEncryptionKey: string
+}
+
+type DeriveChainKeyInput = {
+  representativeChain: Chain
+  hdWallet: any
+  walletCore: any
+  usePhantomSolanaPath?: boolean
+  algorithm: string
+}
+
+/** Derives the hex-encoded private key for a specific chain from the HD wallet. */
+const deriveChainPrivateKey = ({
+  representativeChain,
+  hdWallet,
+  walletCore,
+  usePhantomSolanaPath,
+  algorithm,
+}: DeriveChainKeyInput): string => {
+  const coinType = getCoinType({ chain: representativeChain, walletCore })
+  const chainKey =
+    representativeChain === Chain.Solana && usePhantomSolanaPath
+      ? hdWallet.getKey(coinType, phantomSolanaPath)
+      : hdWallet.getKeyForCoin(coinType)
+
+  const chainKeyData = new Uint8Array(chainKey.data())
+
+  if (algorithm === 'ecdsa') {
+    return Buffer.from(chainKeyData).toString('hex')
+  }
+
+  return Buffer.from(clampThenUniformScalar(chainKeyData)).toString('hex')
+}
+
 export const KeyImportKeygenActionProvider = ({ children }: ChildrenProp) => {
   const serverUrl = useMpcServerUrl()
   const encryptionKeyHex = useCurrentHexEncryptionKey()
@@ -48,9 +94,11 @@ export const KeyImportKeygenActionProvider = ({ children }: ChildrenProp) => {
   const vaultOrders = useVaultOrders()
   const walletCore = useAssertWalletCore()
   const keyImportInput = useKeyImportInput()
+  const isTssBatchingEnabled = useIsTssBatchingEnabled()
+  const isMLDSAEnabled = useIsMLDSAEnabled()
 
   const keygenAction: KeygenAction = useCallback(
-    async ({ onStepChange, signers }) => {
+    async ({ onStepChange, onStepStart, onStepComplete, signers }) => {
       const { mnemonic, chains } = keyImportInput
 
       let hdWallet: ReturnType<
@@ -60,7 +108,7 @@ export const KeyImportKeygenActionProvider = ({ children }: ChildrenProp) => {
         hdWallet = walletCore.HDWallet.createWithMnemonic(mnemonic, '')
       }
 
-      const sharedDklsParams = {
+      const sharedDklsParams: SharedDklsParams = {
         isInitiateDevice: isInitiatingDevice,
         serverUrl,
         sessionId,
@@ -70,13 +118,53 @@ export const KeyImportKeygenActionProvider = ({ children }: ChildrenProp) => {
         hexEncryptionKey: encryptionKeyHex,
       }
 
-      onStepChange('ecdsa')
-
       let rootEcdsaPrivateKeyHex: string | undefined
       if (isInitiatingDevice && hdWallet) {
         const masterKey = hdWallet.getMasterKey(walletCore.Curve.secp256k1)
         rootEcdsaPrivateKeyHex = Buffer.from(masterKey.data()).toString('hex')
       }
+
+      let rootEddsaPrivateKeyHex: string | undefined
+      if (isInitiatingDevice && hdWallet) {
+        const masterKey = hdWallet.getMasterKey(walletCore.Curve.ed25519)
+        const masterKeyData = new Uint8Array(masterKey.data())
+        const clampedKey = clampThenUniformScalar(masterKeyData)
+        rootEddsaPrivateKeyHex = Buffer.from(clampedKey).toString('hex')
+      }
+
+      const derivationGroups = getKeyImportDerivationGroups(chains)
+
+      if (isTssBatchingEnabled) {
+        const vault = await runBatchKeyImport({
+          sharedDklsParams,
+          hexChainCode,
+          rootEcdsaPrivateKeyHex: rootEcdsaPrivateKeyHex ?? '',
+          rootEddsaPrivateKeyHex: rootEddsaPrivateKeyHex ?? '',
+          derivationGroups,
+          hdWallet,
+          walletCore,
+          keyImportInput,
+          isInitiatingDevice,
+          encryptionKeyHex,
+          isMLDSAEnabled,
+          vaultName,
+          localPartyId,
+          signers,
+          vaultOrders,
+          serverUrl,
+          sessionId,
+          onStepStart,
+          onStepComplete,
+        })
+
+        if (hdWallet) {
+          hdWallet.delete()
+        }
+
+        return vault
+      }
+
+      onStepChange('ecdsa')
 
       const dklsKeygen = new DKLS(
         { keyimport: true },
@@ -95,14 +183,6 @@ export const KeyImportKeygenActionProvider = ({ children }: ChildrenProp) => {
       )
 
       onStepChange('eddsa')
-
-      let rootEddsaPrivateKeyHex: string | undefined
-      if (isInitiatingDevice && hdWallet) {
-        const masterKey = hdWallet.getMasterKey(walletCore.Curve.ed25519)
-        const masterKeyData = new Uint8Array(masterKey.data())
-        const clampedKey = clampThenUniformScalar(masterKeyData)
-        rootEddsaPrivateKeyHex = Buffer.from(clampedKey).toString('hex')
-      }
 
       const schnorrKeygen = new Schnorr(
         { keyimport: true },
@@ -128,32 +208,22 @@ export const KeyImportKeygenActionProvider = ({ children }: ChildrenProp) => {
         eddsa: rootEddsaResult.keyshare,
       }
 
-      const derivationGroups = getKeyImportDerivationGroups(chains)
-
       for (const {
         representativeChain,
         chains: groupChains,
       } of derivationGroups) {
         const chainKind = getChainKind(representativeChain)
         const algorithm = signatureAlgorithms[chainKind]
-        const coinType = getCoinType({ chain: representativeChain, walletCore })
 
         let chainPrivateKeyHex: string | undefined
         if (isInitiatingDevice && hdWallet) {
-          const chainKey =
-            representativeChain === Chain.Solana &&
-            keyImportInput.usePhantomSolanaPath
-              ? hdWallet.getKey(coinType, phantomSolanaPath)
-              : hdWallet.getKeyForCoin(coinType)
-
-          const chainKeyData = new Uint8Array(chainKey.data())
-
-          if (algorithm === 'ecdsa') {
-            chainPrivateKeyHex = Buffer.from(chainKeyData).toString('hex')
-          } else {
-            const clampedKey = clampThenUniformScalar(chainKeyData)
-            chainPrivateKeyHex = Buffer.from(clampedKey).toString('hex')
-          }
+          chainPrivateKeyHex = deriveChainPrivateKey({
+            representativeChain,
+            hdWallet,
+            walletCore,
+            usePhantomSolanaPath: keyImportInput.usePhantomSolanaPath,
+            algorithm,
+          })
         }
 
         let chainResult: KeyShareResult
@@ -241,6 +311,8 @@ export const KeyImportKeygenActionProvider = ({ children }: ChildrenProp) => {
       encryptionKeyHex,
       hexChainCode,
       isInitiatingDevice,
+      isMLDSAEnabled,
+      isTssBatchingEnabled,
       keyImportInput,
       localPartyId,
       serverUrl,
@@ -254,4 +326,250 @@ export const KeyImportKeygenActionProvider = ({ children }: ChildrenProp) => {
   return (
     <KeygenActionProvider value={keygenAction}>{children}</KeygenActionProvider>
   )
+}
+
+type BatchKeyImportInput = {
+  sharedDklsParams: SharedDklsParams
+  hexChainCode: string
+  rootEcdsaPrivateKeyHex: string
+  rootEddsaPrivateKeyHex: string
+  derivationGroups: ReturnType<typeof getKeyImportDerivationGroups>
+  hdWallet: any
+  walletCore: any
+  keyImportInput: { usePhantomSolanaPath?: boolean }
+  isInitiatingDevice: boolean
+  encryptionKeyHex: string
+  isMLDSAEnabled: boolean
+  vaultName: string
+  localPartyId: string
+  signers: string[]
+  vaultOrders: number[]
+  serverUrl: string
+  sessionId: string
+  onStepStart: (step: KeygenStep) => void
+  onStepComplete: (step: KeygenStep) => void
+}
+
+/**
+ * Runs all key import protocols in parallel using batch message IDs
+ * (p-ecdsa, p-eddsa, p-mldsa, p-{chain}) that match the server's
+ * /batch/import handler expectations.
+ */
+async function runBatchKeyImport({
+  sharedDklsParams,
+  hexChainCode,
+  rootEcdsaPrivateKeyHex,
+  rootEddsaPrivateKeyHex,
+  derivationGroups,
+  hdWallet,
+  walletCore,
+  keyImportInput,
+  isInitiatingDevice,
+  encryptionKeyHex,
+  isMLDSAEnabled,
+  vaultName,
+  localPartyId,
+  signers,
+  vaultOrders,
+  serverUrl,
+  sessionId,
+  onStepStart,
+  onStepComplete,
+}: BatchKeyImportInput): Promise<Vault> {
+  onStepStart('prepareVault')
+
+  const dklsKeygen = new DKLS(
+    { keyimport: true },
+    sharedDklsParams.isInitiateDevice,
+    sharedDklsParams.serverUrl,
+    sharedDklsParams.sessionId,
+    sharedDklsParams.localPartyId,
+    sharedDklsParams.signers,
+    sharedDklsParams.oldKeygenCommittee,
+    sharedDklsParams.hexEncryptionKey
+  )
+
+  const schnorrKeygen = new Schnorr(
+    { keyimport: true },
+    sharedDklsParams.isInitiateDevice,
+    sharedDklsParams.serverUrl,
+    sharedDklsParams.sessionId,
+    sharedDklsParams.localPartyId,
+    sharedDklsParams.signers,
+    sharedDklsParams.oldKeygenCommittee,
+    sharedDklsParams.hexEncryptionKey,
+    new Uint8Array()
+  )
+
+  const includeMldsa = featureFlags.mldsaKeygen && isMLDSAEnabled
+
+  onStepComplete('prepareVault')
+  onStepStart('ecdsa')
+  onStepStart('eddsa')
+  if (derivationGroups.length > 0) {
+    onStepStart('chainKeys')
+  }
+  if (includeMldsa) {
+    onStepStart('mldsa')
+  }
+
+  const mldsaPromise = includeMldsa
+    ? new MldsaKeygen(
+        isInitiatingDevice,
+        serverUrl,
+        sessionId,
+        localPartyId,
+        signers,
+        encryptionKeyHex,
+        { messageId: 'p-mldsa', setupMessageId: 'p-mldsa-setup' }
+      )
+        .startKeygenWithRetry()
+        .then(r => {
+          onStepComplete('mldsa')
+          return r
+        })
+    : Promise.resolve(undefined)
+
+  const chainPromises = derivationGroups.map(
+    async ({ representativeChain, chains: groupChains }) => {
+      const chainKind = getChainKind(representativeChain)
+      const algorithm = signatureAlgorithms[chainKind]
+
+      let chainPrivateKeyHex = ''
+      if (isInitiatingDevice && hdWallet) {
+        chainPrivateKeyHex = deriveChainPrivateKey({
+          representativeChain,
+          hdWallet,
+          walletCore,
+          usePhantomSolanaPath: keyImportInput.usePhantomSolanaPath,
+          algorithm,
+        })
+      }
+
+      let result: KeyShareResult
+      if (algorithm === 'ecdsa') {
+        const chainDkls = new DKLS(
+          { keyimport: true },
+          sharedDklsParams.isInitiateDevice,
+          sharedDklsParams.serverUrl,
+          sharedDklsParams.sessionId,
+          sharedDklsParams.localPartyId,
+          sharedDklsParams.signers,
+          sharedDklsParams.oldKeygenCommittee,
+          sharedDklsParams.hexEncryptionKey
+        )
+        result = await chainDkls.startKeyImportWithRetry(
+          chainPrivateKeyHex,
+          hexChainCode,
+          representativeChain,
+          `p-${representativeChain}`
+        )
+      } else {
+        const chainSchnorr = new Schnorr(
+          { keyimport: true },
+          sharedDklsParams.isInitiateDevice,
+          sharedDklsParams.serverUrl,
+          sharedDklsParams.sessionId,
+          sharedDklsParams.localPartyId,
+          sharedDklsParams.signers,
+          sharedDklsParams.oldKeygenCommittee,
+          sharedDklsParams.hexEncryptionKey,
+          new Uint8Array()
+        )
+        result = await chainSchnorr.startKeyImportWithRetry(
+          chainPrivateKeyHex,
+          hexChainCode,
+          representativeChain,
+          `p-${representativeChain}`
+        )
+      }
+
+      return { chains: groupChains, result }
+    }
+  )
+
+  const chainKeysPromise =
+    chainPromises.length > 0
+      ? Promise.all(chainPromises).then(results => {
+          onStepComplete('chainKeys')
+          return results
+        })
+      : Promise.resolve([])
+
+  const [rootEcdsaResult, rootEddsaResult, mldsaResult, chainResults] =
+    await Promise.all([
+      dklsKeygen
+        .startKeyImportWithRetry(
+          rootEcdsaPrivateKeyHex,
+          hexChainCode,
+          undefined,
+          'p-ecdsa'
+        )
+        .then(r => {
+          onStepComplete('ecdsa')
+          return r
+        }),
+      schnorrKeygen
+        .startKeyImportWithRetry(
+          rootEddsaPrivateKeyHex,
+          hexChainCode,
+          'eddsa_key_import',
+          'p-eddsa'
+        )
+        .then(r => {
+          onStepComplete('eddsa')
+          return r
+        }),
+      mldsaPromise,
+      chainKeysPromise,
+    ])
+
+  const chainPublicKeys: Partial<Record<Chain, string>> = {}
+  const chainKeyShares: Partial<Record<Chain, string>> = {}
+  const keyShares: VaultKeyShares = {
+    ecdsa: rootEcdsaResult.keyshare,
+    eddsa: rootEddsaResult.keyshare,
+  }
+
+  for (const { chains: groupChains, result } of chainResults) {
+    for (const chain of groupChains) {
+      chainPublicKeys[chain] = result.publicKey
+      chainKeyShares[chain] = result.keyshare
+    }
+  }
+
+  const vault: Vault = {
+    name: vaultName,
+    publicKeys: {
+      ecdsa: rootEcdsaResult.publicKey,
+      eddsa: rootEddsaResult.publicKey,
+    },
+    signers,
+    createdAt: Date.now(),
+    hexChainCode: rootEcdsaResult.chaincode,
+    keyShares,
+    localPartyId,
+    libType: 'KeyImport' as MpcLib,
+    isBackedUp: false,
+    order: getLastItemOrder(vaultOrders),
+    lastPasswordVerificationTime: hasServer(signers) ? Date.now() : undefined,
+    chainPublicKeys,
+    chainKeyShares,
+    publicKeyMldsa: mldsaResult?.publicKey,
+    keyShareMldsa: mldsaResult?.keyshare,
+  }
+
+  await setKeygenComplete({
+    serverURL: serverUrl,
+    sessionId,
+    localPartyId,
+  })
+
+  await waitForKeygenComplete({
+    serverURL: serverUrl,
+    sessionId,
+    peers: without(signers, localPartyId),
+  })
+
+  return vault
 }


### PR DESCRIPTION
## Summary
- Fast vault seed import hung indefinitely when TSS batching was enabled because the server used `/batch/import` with prefixed message IDs (`p-ecdsa`, `p-eddsa`, `p-{chain}`) while the initiator's `KeyImportKeygenActionProvider` always ran sequentially with default (untagged) message IDs — the two sides polled different relay channels
- Added a batch path to `KeyImportKeygenActionProvider` that runs ECDSA, EdDSA, MLDSA, and per-chain keygens with matching batch message IDs, still passing actual private keys derived from the mnemonic
- Extracted `deriveChainPrivateKey` helper to share derivation logic between sequential and batch paths

## Architecture of the batch path

After several iterations against real failures, the batch path is now:

1. **Warm up WASM once** before any parallel work (`initializeMpcLib` memoizes on completion, not on the in-flight promise, so concurrent calls would double-instantiate the WASM modules and corrupt pointers — observed as "memory access out of bounds" on the first `outputMessage`).
2. **Two-phase execution per curve:**
   - Phase 1: sequentially call `prepareKeyImportSetup` for the root plus each per-chain protocol → uploads **all** setup messages to the relay upfront. Required because the server's `initImportProtocols` fetches setup messages serially with a 1-minute timeout before launching any keygen goroutine — uploading per-chain setups after root completes deadlocks.
   - Phase 2: sequentially call `startKeyImportWithRetry` on each protocol, reusing the pending session from Phase 1.
3. **Parallel across curves, serial within:** DKLS track and Schnorr track (and MLDSA if enabled) run concurrently via `Promise.all` since they use independent WASM engines. Within each curve, protocols run serially because `vs_wasm` is a single shared instance per curve and is not safe for concurrent use.

Speedup vs old sequential: for N ECDSA + M EdDSA chains, wall-clock goes from `(N+M+2)T` to `max(N+1, M+1) × T`.

## TODO / Follow-up
- **#3754** — Move each MPC session into its own Web Worker (with its own WASM instance) to unlock true N-way parallelism. The current fix is constrained to serial-within-curve because `vs_wasm` instances are single-threaded and non-reentrant; workers give us real per-protocol isolation. iOS/Android already have this via native bindings.

Closes #3752

## Test plan
- [ ] Fast vault seed import with TSS batching **enabled** + single ECDSA chain (e.g. ETH or BTC)
- [ ] Fast vault seed import with TSS batching **enabled** + mixed ECDSA + EdDSA chains (e.g. ETH + Solana)
- [ ] Fast vault seed import with TSS batching **enabled** + many chains (stress the serial-within-curve path)
- [ ] Fast vault seed import with TSS batching **disabled** still works (sequential path unchanged)
- [ ] `yarn check:all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)