### PR TITLE
fix: hide QBTC from seed-phrase import chain list

### DIFF
--- a/core/ui/vault/import/seedphrase/config.ts
+++ b/core/ui/vault/import/seedphrase/config.ts
@@ -3,5 +3,5 @@ import { Chain } from '@vultisig/core-chain/Chain'
 export const seedphraseWordCounts = [12, 24] as const
 
 export const seedphraseImportSupportedChains = Object.values(Chain).filter(
-  chain => chain !== Chain.Cardano
+  chain => chain !== Chain.Cardano && chain !== Chain.QBTC
 )


### PR DESCRIPTION
## Summary
- QBTC uses MLDSA (ML-DSA-44), which has no BIP32/BIP39 HD derivation, so a mnemonic cannot deterministically produce a QBTC key.
- In the seed-import flow, ticking QBTC either generates a fresh MLDSA key unrelated to the seed (batch + `featureFlags.mldsaKeygen && isMLDSAEnabled`) or is silently skipped by `getKeyImportDerivationGroups`. Both are misleading.
- Filter `Chain.QBTC` out of `seedphraseImportSupportedChains` alongside `Chain.Cardano`, which is excluded for the same category of derivation incompatibility.

Closes #3755

## Test plan
- [ ] `yarn check:all` succeeds
- [ ] Start a new vault via "Import from seed phrase" and confirm QBTC is not in the chain selector
- [ ] Confirm Cardano remains hidden (regression check)
- [ ] Confirm other chains (EVMs, UTXO, Cosmos, Solana, etc.) are still selectable and import correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated supported blockchain networks for seedphrase imports to refine compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->