### PR TITLE
fix(extension): Polkadot signRaw support for dApp raw messages

### DIFF
--- a/clients/extension/src/inpage/providers/polkadot/index.ts
+++ b/clients/extension/src/inpage/providers/polkadot/index.ts
@@ -108,7 +108,7 @@ export class Polkadot extends EventEmitter {
   async signRaw(
     payload: PolkadotSignerPayloadRaw
   ): Promise<PolkadotSignerResult> {
-    const signature = await callPopup(
+    const signatureHex = await callPopup(
       {
         signMessage: {
           sign_message: {
@@ -122,7 +122,7 @@ export class Polkadot extends EventEmitter {
 
     return {
       id: ++signingId,
-      signature,
+      signature: ed25519SignaturePrefix + signatureHex,
     }
   }
 }

--- a/core/ui/mpc/keysign/customMessage/chains.ts
+++ b/core/ui/mpc/keysign/customMessage/chains.ts
@@ -5,6 +5,7 @@ export const customMessageSupportedChains = [
   Chain.Solana,
   Chain.Ton,
   Chain.Tron,
+  Chain.Polkadot,
 ] as const
 
 export type CustomMessageSupportedChain =

--- a/core/ui/mpc/keysign/customMessage/getCustomMessageHex.ts
+++ b/core/ui/mpc/keysign/customMessage/getCustomMessageHex.ts
@@ -34,5 +34,6 @@ export const getCustomMessageHex = ({
     solana: () => Buffer.from(bytes).toString('hex'),
     ton: () => Buffer.from(bytes).toString('hex'),
     tron: () => stripHexPrefix(keccak256(bytes)),
+    polkadot: () => Buffer.from(bytes).toString('hex'),
   })
 }


### PR DESCRIPTION
## Summary
- Adds `Chain.Polkadot` to `customMessageSupportedChains` so `signer.signRaw()` no longer throws "Unsupported chain Polkadot"
- Teaches `getCustomMessageHex` to encode raw Polkadot bytes for ed25519 signing (hex of message bytes, no keccak)
- Prefixes the returned signature with the ed25519 MultiSignature byte (`0x00`) so dApps can decode the result via `MultiSignature`

Fixes #3675

## Why this works without further changes
- `signatureAlgorithms.polkadot = 'eddsa'` and `signatureFormats.polkadot = 'raw'` were already in the SDK
- `SignMessageInput['sign_message'].chain` already permits `OtherChain.Polkadot`
- The existing `custom` branch in `useKeysignMutation` and `FastKeysignServerStep` handles the MPC flow for both secure and fast vaults

No SDK changes required.

## Test plan
- [x] `yarn check` (typecheck + lint:fix + knip)
- [ ] Reproduce the original failure on `main`: `signer.signRaw({ address, data: '0x48656c6c6f', type: 'bytes' })` shows "Unsupported chain Polkadot"
- [ ] On this branch, the popup opens, signing completes, and result is `{ id, signature: '0x00<128 hex chars>' }`
- [ ] Signature validates as a 64-byte ed25519 signature against the account public key
- [ ] EVM / Solana / Tron signMessage flows still work (regression check)
- [ ] Polkadot `signPayload` (extrinsic signing) still works (regression check)

## Out of scope
- `<Bytes>...</Bytes>` wrapping used by some Substrate wallets (see issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now sign custom messages on the Polkadot blockchain.

* **Bug Fixes**
  * Fixed signature formatting for Polkadot to apply consistent prefixes across all signing operations, ensuring proper signature validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->