### PR TITLE
fix(keysign): show signing coin logo in Rive animation (#3751)

### DIFF
--- a/core/ui/mpc/keysign/flow/KeysignLoadingAnimation.tsx
+++ b/core/ui/mpc/keysign/flow/KeysignLoadingAnimation.tsx
@@ -13,7 +13,7 @@ const AnimationContainer = styled.div`
 type KeysignLoadingAnimationProps = {
   isConnected: boolean
   progress?: number
-  chainLogoSrc?: string
+  logoSrc?: string
 }
 
 /**
@@ -21,15 +21,15 @@ type KeysignLoadingAnimationProps = {
  *
  * The `.riv` file defaults to the Connecting state (`Connected=false`).
  * When `isConnected` is true, the animation transitions to the Signing
- * state with progress tracking and chain logo display.
+ * state with progress tracking and token/chain logo display.
  */
 export const KeysignLoadingAnimation = ({
   isConnected,
   progress = 0,
-  chainLogoSrc,
+  logoSrc,
 }: KeysignLoadingAnimationProps) => {
   const { RiveComponent, containerRef, setConnected, setProgress } =
-    useKeysignLoadingAnimation({ chainLogoSrc })
+    useKeysignLoadingAnimation({ logoSrc })
 
   useEffect(() => {
     setConnected(isConnected)

--- a/core/ui/mpc/keysign/flow/KeysignSigningState.tsx
+++ b/core/ui/mpc/keysign/flow/KeysignSigningState.tsx
@@ -2,19 +2,20 @@ import styled from 'styled-components'
 
 import { useKeysignMessagePayload } from '../state/keysignMessagePayload'
 import { KeysignLoadingAnimation } from './KeysignLoadingAnimation'
-import { getKeysignPayloadChainLogoSrc } from './utils/getKeysignPayloadChainLogoSrc'
+import { getKeysignPayloadLogoSrc } from './utils/getKeysignPayloadLogoSrc'
 
 /**
  * Full-screen signing state shown while an MPC keysign is in progress.
- * Renders the chain-aware Rive animation with chain icon.
+ * Renders the Rive animation with the signing coin's logo (falling back to
+ * the chain logo when no coin logo is available).
  */
 export const KeysignSigningState = () => {
   const payload = useKeysignMessagePayload()
-  const chainLogoSrc = getKeysignPayloadChainLogoSrc(payload)
+  const logoSrc = getKeysignPayloadLogoSrc(payload)
 
   return (
     <Container>
-      <KeysignLoadingAnimation isConnected chainLogoSrc={chainLogoSrc} />
+      <KeysignLoadingAnimation isConnected logoSrc={logoSrc} />
     </Container>
   )
 }

--- a/core/ui/mpc/keysign/flow/hooks/useKeysignLoadingAnimation.ts
+++ b/core/ui/mpc/keysign/flow/hooks/useKeysignLoadingAnimation.ts
@@ -6,37 +6,37 @@ import { useRiveLoadingAnimation } from '../../../../animations/useRiveLoadingAn
 import { rasterizeImage } from '../../../../animations/utils/rasterizeImage'
 
 type UseKeysignLoadingAnimationInput = {
-  chainLogoSrc?: string
+  logoSrc?: string
 }
 
 /**
  * Hook for the Rive loading animation shown during MPC keysign signing.
  *
- * @param chainLogoSrc - Optional URL of the chain logo to display inside
- *   the Rive animation via the `fromLogo` ViewModel image input.
+ * @param logoSrc - Optional URL of the logo (coin or chain) to display inside
+ *   the Rive animation via the `toToken` ViewModel image input.
  * @returns The result of {@link useRiveLoadingAnimation} configured with the
  *   keysign animation source, including `RiveComponent`, `containerRef`,
  *   `setConnected`, and `setProgress`.
  */
 export const useKeysignLoadingAnimation = ({
-  chainLogoSrc,
+  logoSrc,
 }: UseKeysignLoadingAnimationInput = {}) => {
   const animation = useRiveLoadingAnimation({
     src: '/core/animations/keysign-animation-v2.riv',
   })
 
-  const fromLogo = useViewModelInstanceImage(
-    'fromLogo',
+  const toToken = useViewModelInstanceImage(
+    'toToken',
     animation.viewModelInstance
   )
 
   useEffect(() => {
-    if (!chainLogoSrc || !fromLogo) return
+    if (!logoSrc || !toToken) return
 
     let cancelled = false
     const load = async () => {
       const result = await attempt(async () => {
-        const bytes = await rasterizeImage(chainLogoSrc)
+        const bytes = await rasterizeImage(logoSrc)
         if (cancelled) return null
         const riveImage = await decodeImage(bytes)
         if (cancelled) return null
@@ -44,7 +44,7 @@ export const useKeysignLoadingAnimation = ({
       })
 
       if ('data' in result && result.data) {
-        fromLogo.setValue(result.data)
+        toToken.setValue(result.data)
       }
     }
     void load()
@@ -52,7 +52,7 @@ export const useKeysignLoadingAnimation = ({
     return () => {
       cancelled = true
     }
-  }, [chainLogoSrc, fromLogo])
+  }, [logoSrc, toToken])
 
   return animation
 }

--- a/core/ui/mpc/keysign/flow/utils/getKeysignPayloadLogoSrc.test.ts
+++ b/core/ui/mpc/keysign/flow/utils/getKeysignPayloadLogoSrc.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getCoinLogoSrc } from '../../../../chain/coin/icon/utils/getCoinLogoSrc'
+import { getChainLogoSrc } from '../../../../chain/metadata/getChainLogoSrc'
+import { customMessageDefaultChain } from '../../customMessage/chains'
+import { getKeysignPayloadLogoSrc } from './getKeysignPayloadLogoSrc'
+
+const getKeysignChainMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@vultisig/core-mpc/keysign/utils/getKeysignChain', () => ({
+  getKeysignChain: getKeysignChainMock,
+}))
+
+vi.mock('../../../../chain/metadata/getChainLogoSrc', () => ({
+  getChainLogoSrc: vi.fn((chain: string) => `/core/chains/${chain}.svg`),
+}))
+
+vi.mock('../../../../chain/coin/icon/utils/getCoinLogoSrc', () => ({
+  getCoinLogoSrc: vi.fn((logo: string) => `/core/coins/${logo}.svg`),
+}))
+
+const testChain = 'Ethereum'
+
+type AnyPayload = Parameters<typeof getKeysignPayloadLogoSrc>[0]
+
+const keysignPayload = (logo: string | undefined): AnyPayload =>
+  ({
+    keysign: {
+      coin: logo === undefined ? undefined : { logo, chain: testChain },
+    },
+  }) as unknown as AnyPayload
+
+const customMessagePayload = (chain?: string): AnyPayload =>
+  ({
+    custom: { chain },
+  }) as unknown as AnyPayload
+
+describe('getKeysignPayloadLogoSrc', () => {
+  beforeEach(() => {
+    vi.mocked(getCoinLogoSrc).mockClear()
+    vi.mocked(getChainLogoSrc).mockClear()
+    getKeysignChainMock.mockReset()
+    getKeysignChainMock.mockReturnValue(testChain)
+  })
+
+  it('uses the coin logo for a standard keysign payload with a logo', () => {
+    const result = getKeysignPayloadLogoSrc(keysignPayload('eth'))
+
+    expect(getCoinLogoSrc).toHaveBeenCalledWith('eth')
+    expect(getChainLogoSrc).not.toHaveBeenCalled()
+    expect(result).toBe('/core/coins/eth.svg')
+  })
+
+  it('falls back to the chain logo when the standard keysign coin logo is empty', () => {
+    const result = getKeysignPayloadLogoSrc(keysignPayload(''))
+
+    expect(getCoinLogoSrc).not.toHaveBeenCalled()
+    expect(getChainLogoSrc).toHaveBeenCalledWith(testChain)
+    expect(result).toBe(`/core/chains/${testChain}.svg`)
+  })
+
+  it('falls back to the chain logo when the standard keysign coin is missing', () => {
+    const result = getKeysignPayloadLogoSrc(keysignPayload(undefined))
+
+    expect(getCoinLogoSrc).not.toHaveBeenCalled()
+    expect(getChainLogoSrc).toHaveBeenCalledWith(testChain)
+    expect(result).toBe(`/core/chains/${testChain}.svg`)
+  })
+
+  it('uses the specified chain logo for a custom message payload', () => {
+    const result = getKeysignPayloadLogoSrc(customMessagePayload('Solana'))
+
+    expect(getChainLogoSrc).toHaveBeenCalledWith('Solana')
+    expect(getCoinLogoSrc).not.toHaveBeenCalled()
+    expect(result).toBe('/core/chains/Solana.svg')
+  })
+
+  it('uses the default custom-message chain logo when no chain is specified', () => {
+    const result = getKeysignPayloadLogoSrc(customMessagePayload(undefined))
+
+    expect(getChainLogoSrc).toHaveBeenCalledWith(customMessageDefaultChain)
+    expect(getCoinLogoSrc).not.toHaveBeenCalled()
+    expect(result).toBe(`/core/chains/${customMessageDefaultChain}.svg`)
+  })
+})

--- a/core/ui/mpc/keysign/flow/utils/getKeysignPayloadLogoSrc.ts
+++ b/core/ui/mpc/keysign/flow/utils/getKeysignPayloadLogoSrc.ts
@@ -2,18 +2,26 @@ import { Chain } from '@vultisig/core-chain/Chain'
 import { KeysignMessagePayload } from '@vultisig/core-mpc/keysign/keysignPayload/KeysignMessagePayload'
 import { getKeysignChain } from '@vultisig/core-mpc/keysign/utils/getKeysignChain'
 
+import { getCoinLogoSrc } from '../../../../chain/coin/icon/utils/getCoinLogoSrc'
 import { getChainLogoSrc } from '../../../../chain/metadata/getChainLogoSrc'
 import { customMessageDefaultChain } from '../../customMessage/chains'
 
 /**
- * Extracts the chain logo source URL from a keysign message payload.
- * For standard keysign payloads, uses the transaction coin's chain.
- * For custom message payloads, uses the specified chain or the default.
+ * Resolves the logo source URL shown inside the keysign Rive animation.
+ *
+ * Standard keysign payloads prefer the signing coin's own logo; if the coin
+ * or its logo is missing, the chain logo is used as a safe fallback.
+ * Custom message payloads always use the specified chain logo (or the
+ * default custom-message chain).
  */
-export const getKeysignPayloadChainLogoSrc = (
+export const getKeysignPayloadLogoSrc = (
   payload: KeysignMessagePayload
 ): string => {
   if ('keysign' in payload) {
+    const coinLogo = payload.keysign.coin?.logo
+    if (coinLogo) {
+      return getCoinLogoSrc(coinLogo)
+    }
     return getChainLogoSrc(getKeysignChain(payload.keysign))
   }
 


### PR DESCRIPTION
Fixes #3751. Alternative implementation to #3757 incorporating review feedback.

## Changes

- **`useKeysignLoadingAnimation`** — binds to the correct Rive `toToken` ViewModel image input (was `fromLogo`, which isn't the Signing-state image). Renames `chainLogoSrc` → `logoSrc`.
- **`getKeysignPayloadLogoSrc`** (renamed from `getKeysignPayloadChainLogoSrc`) — prefers the signing coin's own logo for standard keysign payloads (`payload.keysign.coin.logo`) and falls back to the chain logo when the coin logo is missing. Custom message payloads still use the chain logo. File renamed to match the function name; name is variant-agnostic since both branches no longer share the same logo kind.
- **`KeysignLoadingAnimation` / `KeysignSigningState`** — updated the prop to `logoSrc` to match.
- **Unit tests** — added `getKeysignPayloadLogoSrc.test.ts` covering:
  - standard keysign with coin logo
  - standard keysign with empty coin logo (chain-logo fallback)
  - standard keysign with missing coin (chain-logo fallback)
  - custom message with explicit chain
  - custom message with no chain (default chain)

## Differences from #3757

- No `?? ''` fallback to `getCoinLogoSrc` (which would produce a broken `/core/coins/.svg` path) — falls back to the chain logo instead.
- File renamed to match the function.
- Variant-agnostic naming (`logoSrc`, `getKeysignPayloadLogoSrc`) since the function can return either coin or chain logo.
- No unrelated changes to `clients/desktop/wailsjs/runtime/package.json` (that file is auto-generated by Wails).
- Adds unit test coverage.

## Test plan

- [x] Unit tests pass (`yarn test core/ui/mpc/keysign/flow/utils/getKeysignPayloadLogoSrc.test.ts`)
- [x] Lint clean on touched files
- [x] No new typecheck errors in touched files
- [ ] Manual verification on a keysign signing screen — signing coin's logo is displayed in the Rive animation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the keysign loading animation to display coin logos when available, falling back to chain logos when necessary, providing more precise visual representation during the signing process.

* **Tests**
  * Added comprehensive test coverage for logo resolution logic to ensure correct coin and chain logo handling across different payload types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->