### PR TITLE
fix(mpc): bootstrap MPC engine singleton per chunk

### DIFF
--- a/clients/desktop/src/main.tsx
+++ b/clients/desktop/src/main.tsx
@@ -1,3 +1,5 @@
+import '@core/ui/mpc/bootstrapMpcEngine'
+
 import { Buffer } from 'buffer'
 import { createRoot } from 'react-dom/client'
 

--- a/clients/extension/src/pages/index.tsx
+++ b/clients/extension/src/pages/index.tsx
@@ -1,3 +1,5 @@
+import '@core/ui/mpc/bootstrapMpcEngine'
+
 import { NavigationProvider } from '@clients/extension/src/navigation/NavigationProvider'
 import { views } from '@clients/extension/src/navigation/views'
 import { ExtensionNotificationManager } from '@clients/extension/src/notifications/ExtensionNotificationManager'

--- a/clients/extension/src/pages/popup.tsx
+++ b/clients/extension/src/pages/popup.tsx
@@ -1,3 +1,5 @@
+import '@core/ui/mpc/bootstrapMpcEngine'
+
 import { PopupApp } from '@core/inpage-provider/popup/app'
 
 import { renderExtensionPage } from './core/render'

--- a/core/ui/mpc/bootstrapMpcEngine.ts
+++ b/core/ui/mpc/bootstrapMpcEngine.ts
@@ -1,0 +1,9 @@
+// Registers the MPC engine on the @vultisig/mpc-types module singleton.
+// @vultisig/core-mpc calls getMpcEngine() lazily and throws if this never runs,
+// so each chunk entry that may touch MPC must import this module first — before
+// any other @vultisig/* import. Each bundle is a separate module graph, so the
+// registration must happen once per chunk.
+import { configureMpc } from '@vultisig/mpc-types'
+import { WasmMpcEngine } from '@vultisig/mpc-wasm'
+
+configureMpc(new WasmMpcEngine())

--- a/core/ui/package.json
+++ b/core/ui/package.json
@@ -30,6 +30,8 @@
     "@vultisig/core-config": "0.9.1",
     "@vultisig/core-mpc": "1.0.0",
     "@vultisig/lib-utils": "0.9.1",
+    "@vultisig/mpc-types": "^0.1.0",
+    "@vultisig/mpc-wasm": "^0.1.0",
     "@vultisig/sdk": "0.11.0",
     "bs58": "^6.0.0",
     "cosmjs-types": "^0.11.0",

--- a/core/ui/vite/sdkResolvePlugin.ts
+++ b/core/ui/vite/sdkResolvePlugin.ts
@@ -129,6 +129,13 @@ export function sdkResolvePlugin(): Plugin {
             '@vultisig/lib-dkls',
             '@vultisig/lib-schnorr',
             '@vultisig/lib-mldsa',
+            // MPC engine singleton lives in @vultisig/mpc-types. If Vite pre-bundles
+            // these, @vultisig/core-mpc ends up with its own inlined copy of mpc-types
+            // while the SDK platform entry writes to a different copy, and
+            // getMpcEngine() throws "MPC engine not configured" at runtime.
+            '@vultisig/mpc-types',
+            '@vultisig/mpc-wasm',
+            '@vultisig/core-mpc',
           ],
           esbuildOptions: {
             plugins: [sdkResolveEsbuildPlugin()],

--- a/yarn.lock
+++ b/yarn.lock
@@ -776,6 +776,8 @@ __metadata:
     "@vultisig/core-config": "npm:0.9.1"
     "@vultisig/core-mpc": "npm:1.0.0"
     "@vultisig/lib-utils": "npm:0.9.1"
+    "@vultisig/mpc-types": "npm:^0.1.0"
+    "@vultisig/mpc-wasm": "npm:^0.1.0"
     "@vultisig/sdk": "npm:0.11.0"
     bs58: "npm:^6.0.0"
     cosmjs-types: "npm:^0.11.0"
@@ -5840,6 +5842,22 @@ __metadata:
     long: "npm:^5.3.2"
     viem: "npm:^2.47.4"
   checksum: 10c0/8527b4af9b05a62dd9d5e214a038dd26047db3a7440c9acf4d47f34b5654c33a870f003c7a3109178a1f6fac35aafb0fa76027490a41917318303339fdb66ad7
+  languageName: node
+  linkType: hard
+
+"@vultisig/mpc-types@npm:0.1.2, @vultisig/mpc-types@npm:^0.1.0":
+  version: 0.1.2
+  resolution: "@vultisig/mpc-types@npm:0.1.2"
+  checksum: 10c0/65e7c8e712ff0e8143fe41c43b830bc0efbe85051668a5fc4a1a849fd1fd72844afd7f71c6638f14eab7301ffb45591c74ce4115ae031310383ee6a611898251
+  languageName: node
+  linkType: hard
+
+"@vultisig/mpc-wasm@npm:^0.1.0":
+  version: 0.1.1
+  resolution: "@vultisig/mpc-wasm@npm:0.1.1"
+  dependencies:
+    "@vultisig/mpc-types": "npm:0.1.2"
+  checksum: 10c0/85307a580a6d8d80065e7f901415a8378809272d0919e2b14d7d26f5e79df1dddfcb6417a4e7b21113e321158e52745dab90a97d84db628da8866e53a365f443
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- `@vultisig/core-mpc` throws `"MPC engine not configured. Import from a platform entry point…"` when the SDK's platform-entry side-effect gets tree-shaken or when a consumer chunk never loads the platform entry at all
- Add a tiny `@core/ui/mpc/bootstrapMpcEngine` module that calls `configureMpc(new WasmMpcEngine())` and wire it into the three chunk entries that actually touch MPC (popup, options, desktop)
- Exclude the MPC singleton packages from Vite's `optimizeDeps` so the SDK and `@vultisig/core-mpc` share one `@vultisig/mpc-types` module instance

## Root cause

Two compounding issues, both on SDK main:

1. `@vultisig/sdk`'s `package.json` has `"sideEffects": false`, which permits bundlers to drop the top-level `configureMpc(new WasmMpcEngine())` call in each platform entry.
2. The extension is split into independent chunks (`popup`, `options/index`, `background`, `inpage`, `content`). Each chunk is its own module graph, so a `configureMpc` that runs in one chunk does not reach `@vultisig/core-mpc` in any other chunk. `popup` and `options` never import a SDK platform entry directly — they reach `@vultisig/core-mpc` through `@core/ui` and `@core/inpage-provider`.
3. Vite's `optimizeDeps` can inline `@vultisig/mpc-types` inside a pre-bundled `@vultisig/core-mpc`, producing a second singleton instance distinct from the one the SDK writes to — even when everything else is wired correctly.

SDK-side fix tracked in vultisig/vultisig-sdk#287 (proposes making platform entries side-effectful in `package.json`, plus an explicit `bootstrap()` export). This PR is the consumer-side unblock for vultisig-windows.

## Changes

| File | Change |
|------|--------|
| `core/ui/mpc/bootstrapMpcEngine.ts` | New. Calls `configureMpc(new WasmMpcEngine())` with a comment explaining why it must be imported first. |
| `core/ui/vite/sdkResolvePlugin.ts` | Adds `@vultisig/mpc-types`, `@vultisig/mpc-wasm`, `@vultisig/core-mpc` to `optimizeDeps.exclude`. Prevents Vite from inlining the singleton across pre-bundled chunks. |
| `core/ui/package.json` | Declares `@vultisig/mpc-types` and `@vultisig/mpc-wasm` as explicit deps so the bootstrap resolves cleanly on fresh installs (both are published on npm). |
| `clients/extension/src/pages/index.tsx` | Imports `@core/ui/mpc/bootstrapMpcEngine` as first module. |
| `clients/extension/src/pages/popup.tsx` | Imports `@core/ui/mpc/bootstrapMpcEngine` as first module. |
| `clients/desktop/src/main.tsx` | Imports `@core/ui/mpc/bootstrapMpcEngine` as first module. Same design hazard as extension; desktop doesn't currently trip it (single bundle, single module graph) but this makes it immune to future bundler tree-shaking changes. |
| `yarn.lock` | Adds entries for the two new deps. No other changes. |

`background/index.ts` and `inpage/index.ts` intentionally do **not** bootstrap: neither chunk ever calls `getMpcEngine()`. `background` only imports `Vault` types from `@vultisig/core-mpc`; `inpage` imports a single protobuf type. Adding the bootstrap there would pull `@vultisig/mpc-wasm` + DKLS/Schnorr JS into bundles that never use them.

## Verification

- `yarn lint` — clean
- `yarn typecheck` — clean (with SDK main override; CI applies its own override)
- `yarn build` in `clients/extension` — produces loadable extension; confirmed `configureMpc(new WasmMpcEngine())` call is live in `dist/assets/ActiveView.js` (the shared chunk pulled in by both `popup.js` and `index.js`)

## Test plan

- [x] Lint clean
- [x] Full repo typecheck clean
- [x] Extension `yarn build` produces valid `dist/` with `manifest.json` and all HTML/JS/WASM assets
- [x] Bundle grep confirms `configureMpc(new WasmMpcEngine())` is preserved by terser
- [ ] Load unpacked extension in Chrome, open popup/options, confirm no `"MPC engine not configured"` in DevTools console
- [ ] Trigger a vault read or keygen flow to exercise `getMpcEngine()` and confirm it returns the configured `WasmMpcEngine`
- [ ] Desktop `yarn wails:dev` smoke pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Initialized MPC engine support across desktop and extension applications to enable multi-party computation functionality.

* **Chores**
  * Added required dependencies for MPC engine support.
  * Updated build configuration to optimize module loading and pre-bundling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->