### PR TITLE
fix(extension): remove MPC bootstrap from SW so dApp bridge listener registers in time

### DIFF
--- a/clients/extension/src/background/index.ts
+++ b/clients/extension/src/background/index.ts
@@ -1,8 +1,11 @@
 // Must be first: Chrome requires push / notificationclick / pushsubscriptionchange
 // listeners during initial synchronous service worker evaluation.
 import '../notifications/pushServiceWorkerBindings'
-import '@core/ui/mpc/bootstrapMpcEngine'
 
+// Do NOT import '@core/ui/mpc/bootstrapMpcEngine' here. The SW never calls
+// getMpcEngine() (see #3761); importing it drags @vultisig/mpc-wasm in and
+// vite-plugin-top-level-await wraps the whole chunk in an async IIFE, so the
+// bridge onMessage listener registers too late and every dApp call hangs.
 import { runBackgroundEventsAgent } from '@core/inpage-provider/background/events/background'
 import { runInpageProviderBridgeBackgroundAgent } from '@core/inpage-provider/bridge/background'
 


### PR DESCRIPTION
## Summary
- Remove `import '@core/ui/mpc/bootstrapMpcEngine'` from the extension background service worker entry.
- Restores the invariant from #3761: background/inpage never call `getMpcEngine()` and must not statically pull `@vultisig/mpc-wasm` into their chunks.

## Context
`#3762` added `import '@core/ui/mpc/bootstrapMpcEngine'` to `clients/extension/src/background/index.ts`. That drags `@vultisig/mpc-wasm` into the SW chunk; `vite-plugin-wasm` + `vite-plugin-top-level-await` then wrap the entire bundle in a `let __tla = (async () => { … })()` IIFE. Inside the IIFE, near the end of a 141k-line body, sits `chrome.runtime.onMessage.addListener(…)`. Chrome MV3 dispatches incoming `chrome.runtime.sendMessage` calls based on listeners registered during synchronous SW evaluation, so the bridge listener ends up registered too late and every dApp RPC (`eth_chainId`, `eth_requestAccounts`, `grantVaultAccess`, …) hangs forever on `thorwallet.org`, `uniswap.org`, etc.

Reproduction on `main@5eedea9f6`:
- Page JS posts `{sourceId: 'bridge-channel-inpage', message: {background: {call: {getAppChainId: {chainKind: 'evm'}}}}}` via `window.postMessage`.
- Content script's `chrome.runtime.sendMessage` callback never fires. No `bridge-channel-background` reply ever arrives — not even the retry-exhaustion error after the 525 ms backoff window. 10 s elapsed, 0 replies.

#3761's commit message is explicit about why this bootstrap must stay out of the SW:
> *"Background and inpage aren't wired in because neither calls getMpcEngine at runtime (background only imports Vault types; inpage imports a protobuf type)."*

## Changes
| File | Change |
|------|--------|
| `clients/extension/src/background/index.ts` | Remove the `bootstrapMpcEngine` import; add a comment explaining why it must stay out of the SW chunk. |

## Test plan
- [x] `yarn lint` — clean
- [x] `yarn typecheck` — clean
- [x] `yarn workspace @clients/extension build:background` — background.js drops from 10.3 MB → 7.66 MB (`@vultisig/mpc-wasm` graph gone from the SW chunk).
- [x] Verified in Chrome against `app.thorwallet.org`: "Vulticonnect → Connect" now opens the extension popup and grants vault access. Pre-fix: same click hung forever.
- [ ] Smoke test keysign push notifications still fire (handler `await import('@vultisig/sdk')` is unaffected, but worth a QA tap).
- [ ] Regression check another EVM dApp (Uniswap, 1inch) and a non-EVM dApp (Bittensor/taostats, TonConnect).

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where dApp calls would hang due to service worker initialization timing problems

<!-- end of auto-generated comment: release notes by coderabbit.ai -->