### PR TITLE
feat(extension): warning indicator for unlimited ERC20 approvals

### DIFF
--- a/core/inpage-provider/popup/view/resolvers/sendTx/blockaid/BlockaidSimulationContent.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/blockaid/BlockaidSimulationContent.tsx
@@ -8,7 +8,8 @@ import { Collapse } from '@core/inpage-provider/popup/view/resolvers/signMessage
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { extractTokenAndAmount } from '@core/ui/chain/tx/utils/extractTokenAndAmount'
 import { formatTokenAmount } from '@core/ui/chain/tx/utils/formatTokenAmount'
-import { VStack } from '@lib/ui/layout/Stack'
+import { TriangleAlertIcon } from '@lib/ui/icons/TriangleAlertIcon'
+import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { List } from '@lib/ui/list'
 import { ListItem } from '@lib/ui/list/item'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
@@ -331,20 +332,38 @@ const EvmCalldataFallback = ({
           <ListItem description={keysignPayload.toAddress} title={t('to')} />
         )}
         {tokenQuery.data && tokenPair ? (
-          <ListItem
-            icon={<CoinIcon coin={tokenQuery.data} />}
-            title={functionName || t('contract_execution')}
-            description={(() => {
-              const fmt = formatTokenAmount({
-                rawAmount: BigInt(tokenPair.rawAmount),
-                decimals: tokenQuery.data.decimals,
-                functionName: rawFunctionName,
-              })
-              return fmt.display
-                ? `${fmt.display} ${tokenQuery.data.ticker}`
-                : tokenQuery.data.ticker
-            })()}
-          />
+          (() => {
+            const fmt = formatTokenAmount({
+              rawAmount: BigInt(tokenPair.rawAmount),
+              decimals: tokenQuery.data.decimals,
+              functionName: rawFunctionName,
+            })
+            const ticker = tokenQuery.data.ticker
+            const isUnlimited = fmt.isSentinel && !!fmt.display
+            return (
+              <ListItem
+                icon={
+                  <CoinIcon coin={tokenQuery.data} style={{ fontSize: 24 }} />
+                }
+                title={functionName || t('contract_execution')}
+                status={isUnlimited ? 'warning' : 'default'}
+                description={
+                  isUnlimited ? (
+                    <HStack alignItems="center" gap={6}>
+                      <Text as={TriangleAlertIcon} color="warning" size={14} />
+                      <Text color="warning" size={12} weight={500}>
+                        {`${fmt.display} ${ticker}`}
+                      </Text>
+                    </HStack>
+                  ) : fmt.display ? (
+                    `${fmt.display} ${ticker}`
+                  ) : (
+                    ticker
+                  )
+                }
+              />
+            )
+          })()
         ) : contractCallQuery.data ? (
           <ListItem
             title={functionName || t('contract_execution')}

--- a/core/ui/mpc/keysign/tx/TxOverviewAmount.tsx
+++ b/core/ui/mpc/keysign/tx/TxOverviewAmount.tsx
@@ -1,6 +1,7 @@
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { useCoinPriceQuery } from '@core/ui/chain/coin/price/queries/useCoinPriceQuery'
-import { VStack } from '@lib/ui/layout/Stack'
+import { TriangleAlertIcon } from '@lib/ui/icons/TriangleAlertIcon'
+import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Panel } from '@lib/ui/panel/Panel'
 import { ValueProp } from '@lib/ui/props'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
@@ -46,7 +47,6 @@ export const TxOverviewAmount = ({
   // actual token being moved (e.g. Uniswap V4 execute, multicalls). The
   // function label alone is more informative than a misleading zero amount.
   const showAmount = !!amountOverride || amount > 0 || !resolvedLabel
-  const amountContent = amountOverride ?? `${amount} ${value.ticker}`
   const showFiat = !amountOverride && amount > 0
 
   return (
@@ -56,7 +56,17 @@ export const TxOverviewAmount = ({
           {topLabel}
         </Text>
         {value && <CoinIcon coin={value} style={{ fontSize: 32 }} />}
-        {showAmount && <Text size={18}>{amountContent}</Text>}
+        {showAmount &&
+          (amountOverride ? (
+            <HStack alignItems="center" gap={6}>
+              <Text as={TriangleAlertIcon} color="warning" size={18} />
+              <Text size={18} color="warning">
+                {amountOverride}
+              </Text>
+            </HStack>
+          ) : (
+            <Text size={18}>{`${amount} ${value.ticker}`}</Text>
+          ))}
         {showFiat && (
           <MatchQuery
             value={priceQuery}


### PR DESCRIPTION
## Summary
- Verify screen's calldata-fallback row now tints `status="warning"` and prepends a ⚠️ icon to "Unlimited {TICKER}" so users can't miss a `MAX_UINT256` approval — a common phishing vector
- Done-screen hero mirrors the same treatment for the `amountOverride` path in `TxOverviewAmount`
- Also bumped the fallback `CoinIcon` to `fontSize: 24` to match the `BlockaidTransferDisplay` pattern — it was rendering too small without an explicit size

Closes #3735. Phase 1's approval-only sentinel policy is preserved (`increaseAllowance` still renders as a delta, not "Unlimited"). Ported to extension only — companion iOS/Android work tracked separately per the issue.

## Test plan
- [x] `yarn check` — typecheck + lint pass
- [x] `yarn test --run` — 78/78 pass
- [x] Manual: dApp triggers `approve(spender, MAX_UINT256)` on USDC/ETH mainnet → verify screen shows ⚠️ "Unlimited USDC" with yellow tint (screenshot confirmed by reviewer)
- [x] Manual: same flow through to done screen → hero shows ⚠️ "Unlimited USDC"
- [x] Manual: regular approval with finite amount → no warning icon, row renders as before
- [x] Manual: `increaseAllowance(MAX_UINT256)` → renders delta, no "Unlimited" label (Phase 1 policy unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  - Improved visual warnings for unlimited token amounts with alert icons
  - Enhanced warning displays for transaction amount overrides with icons and highlighted styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->