### PR TITLE
fix(ci): pack lib/dkls, lib/mldsa, lib/schnorr from SDK main

### DIFF
--- a/.github/actions/prepare-vultisig-sdk-from-main/action.yml
+++ b/.github/actions/prepare-vultisig-sdk-from-main/action.yml
@@ -36,7 +36,7 @@ runs:
         SDK_CLONE_DIR="${RUNNER_TEMP:-/tmp}/vultisig-sdk"
         PACK_DIR="${RUNNER_TEMP:-/tmp}/sdk-packs"
         mkdir -p "$PACK_DIR"
-        for dir in packages/sdk packages/core/chain packages/core/config packages/core/mpc packages/lib/utils packages/mpc-types packages/mpc-wasm; do
+        for dir in packages/sdk packages/core/chain packages/core/config packages/core/mpc packages/lib/utils packages/lib/dkls packages/lib/mldsa packages/lib/schnorr packages/mpc-types packages/mpc-wasm; do
           cd "$SDK_CLONE_DIR/$dir" && npm pack --pack-destination "$PACK_DIR"
         done
         cd "$GITHUB_WORKSPACE"


### PR DESCRIPTION
## Summary
vultisig-sdk [#290](https://github.com/vultisig/vultisig-sdk/pull/290) made `@vultisig/lib-dkls`, `@vultisig/lib-mldsa`, and `@vultisig/lib-schnorr` direct `workspace:*` deps of `@vultisig/sdk`. Since `npm pack` copies `workspace:*` references verbatim, the packed `@vultisig/sdk` tarball landed here with three unresolvable refs — every PR built after that SDK change has been failing `yarn install` with:

```
YN0001: Error: @vultisig/lib-dkls@workspace:*: Workspace not found
```

Extend the pack loop in [.github/actions/prepare-vultisig-sdk-from-main/action.yml](.github/actions/prepare-vultisig-sdk-from-main/action.yml) to also pack those three workspaces. The existing node patcher at lines 52–68 picks up every tarball in `PACK_DIR` and writes `file:`-tarball resolutions automatically, so no other changes are needed.

## Test plan
- [ ] CI `Run yarn install` completes the resolution step successfully
- [ ] Lint, typecheck, and test jobs all reach completion (not blocked by resolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved SDK packaging workflow to ensure additional cryptographic library components are properly included in distribution builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->