### PR TITLE
fix(extension): drop ua-parser-js to stop intermittent setupVault crash

### DIFF
--- a/clients/extension/package.json
+++ b/clients/extension/package.json
@@ -59,7 +59,6 @@
     "react-i18next": "^16.5.8",
     "styled-components": "^6.3.11",
     "tronweb": "^6.2.2",
-    "ua-parser-js": "^2.0.9",
     "uuid": "^13.0.0",
     "viem": "^2.47.4",
     "zod": "^4.3.6"

--- a/clients/extension/src/components/expand-view-guard/index.tsx
+++ b/clients/extension/src/components/expand-view-guard/index.tsx
@@ -9,10 +9,12 @@ import { getLastItem } from '@vultisig/lib-utils/array/getLastItem'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { FC, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { UAParser } from 'ua-parser-js'
 
 import { useOpenInExpandedViewMutation } from '../../expanded-view/mutations/openInExpandedView'
 import { AppView } from '../../navigation/AppView'
+
+const isWindowsOs = () =>
+  typeof navigator !== 'undefined' && /Windows/i.test(navigator.userAgent)
 
 export const ExpandViewGuard: FC<ChildrenProp> = ({ children }) => {
   const { t } = useTranslation()
@@ -29,10 +31,7 @@ export const ExpandViewGuard: FC<ChildrenProp> = ({ children }) => {
       return true
     }
 
-    const parser = new UAParser()
-    const parserResult = parser.getResult()
-
-    return parserResult.os.name !== 'Windows' && isPopup
+    return !isWindowsOs() && isPopup
   }, [currentView.id])
 
   useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -646,7 +646,6 @@ __metadata:
     styled-components: "npm:^6.3.11"
     tronweb: "npm:^6.2.2"
     typescript: "npm:^5.9.3"
-    ua-parser-js: "npm:^2.0.9"
     uuid: "npm:^13.0.0"
     viem: "npm:^2.47.4"
     vite: "npm:^7.3.1"
@@ -8125,13 +8124,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-europe-js@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "detect-europe-js@npm:0.1.2"
-  checksum: 10c0/46fccf2a9ddeec8ecb7a369be1452f84856cbd0ccdeb3c47e41fe6c9d69f63d6bd75f91b5aa1ae310e56d8fbcbff0e802b1504cdcc3a92f3327c94408e6d07a2
-  languageName: node
-  linkType: hard
-
 "detect-libc@npm:^2.0.1, detect-libc@npm:^2.0.3":
   version: 2.1.2
   resolution: "detect-libc@npm:2.1.2"
@@ -10714,13 +10706,6 @@ __metadata:
   dependencies:
     call-bound: "npm:^1.0.3"
   checksum: 10c0/65158c2feb41ff1edd6bbd6fd8403a69861cf273ff36077982b5d4d68e1d59278c71691216a4a64632bd76d4792d4d1d2553901b6666d84ade13bba5ea7bc7db
-  languageName: node
-  linkType: hard
-
-"is-standalone-pwa@npm:^0.1.1":
-  version: 0.1.1
-  resolution: "is-standalone-pwa@npm:0.1.1"
-  checksum: 10c0/af1a11edef4a8f00c24014576285070fb73eebb3583cae790c0a825e338e19f05048a26e5fd5ef10f6056032d6a4520054ff824532c15df784933c0fcc5e13fd
   languageName: node
   linkType: hard
 
@@ -15174,26 +15159,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
-  languageName: node
-  linkType: hard
-
-"ua-is-frozen@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "ua-is-frozen@npm:0.1.2"
-  checksum: 10c0/fb41929bd4924c9676391e6d7197d30580749a96697a83c8b6e77fb137e3ff8492dcd1e6f871f6a9517848651a93af37bfefb25385f16d90e19678ade22d30b7
-  languageName: node
-  linkType: hard
-
-"ua-parser-js@npm:^2.0.9":
-  version: 2.0.9
-  resolution: "ua-parser-js@npm:2.0.9"
-  dependencies:
-    detect-europe-js: "npm:^0.1.2"
-    is-standalone-pwa: "npm:^0.1.1"
-    ua-is-frozen: "npm:^0.1.2"
-  bin:
-    ua-parser-js: script/cli.js
-  checksum: 10c0/6287fb9e0d332b139bd039cbd606f909bdc3337681b7e6ec2ce9c427d1f39a040a65e03620b82bd3bc4a7d7681be70dd2fa75125fd8c72c01bd9cedb729e5683
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Selecting a chain during seedphrase import sometimes crashed the extension with **"Cannot assign to read only property 'toString' of object '#<l>'"**, bounced the user to the "Something went wrong" screen, and required a retry.

The stack traced back to [`ExpandViewGuard`](clients/extension/src/components/expand-view-guard/index.tsx) inside setupVault: `new UAParser()` → `getResult()` in `ua-parser-js@^2.0.9`. The v2 library in a Chrome extension context tries to (re)assign `toString` on an internal result object that happens to be read-only, producing the intermittent crash.

The only usage in the whole repo is a single "is the OS Windows?" check for popup-vs-expanded-view routing. Replacing that with a `/Windows/i.test(navigator.userAgent)` regex eliminates the library — and the crash — with no behavioral change.

## Why dropping the library is safe

- `ua-parser-js` is declared **only** in [clients/extension/package.json](clients/extension/package.json), not in `clients/desktop/package.json` or the root — the Wails desktop client doesn't use it at all.
- The single import site is [clients/extension/src/components/expand-view-guard/index.tsx](clients/extension/src/components/expand-view-guard/index.tsx).
- Existing redirect semantics are preserved: non-Windows popups still redirect to an expanded tab; Windows popups stay as popups.

## Changed files

- `clients/extension/src/components/expand-view-guard/index.tsx` — replace `UAParser` with a `navigator.userAgent` regex
- `clients/extension/package.json` — drop the dependency
- `yarn.lock`

Closes #3782

## Test plan

- [ ] `yarn check:all` passes
- [ ] Import seedphrase → chain-selection step → tap chains repeatedly (Ethereum, Arbitrum, Base, etc.) → never hits the "Something went wrong" error screen
- [ ] Open extension popup on a non-Windows OS → still redirects to expanded view as before
- [ ] Open extension popup on Windows → stays as popup as before
- [ ] Grep confirms `ua-parser-js` is gone from the extension's dependency tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified Windows OS detection logic to reduce extension bundle size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->