### PR TITLE
fix(mpc): defensive layer + lint for SW/inpage chunks (#3777)

### DIFF
--- a/clients/extension/src/background/index.ts
+++ b/clients/extension/src/background/index.ts
@@ -2,6 +2,14 @@
 // listeners during initial synchronous service worker evaluation.
 import '../notifications/pushServiceWorkerBindings'
 
+// MPC note — see vultisig/vultisig-windows#3777.
+// This service-worker chunk intentionally does NOT import @core/ui/mpc/bootstrapMpcEngine.
+// The background worker does not call getMpcEngine() today; bootstrapping here
+// would pull DKLS/Schnorr JS + WASM into the SW bundle for no reason. If you
+// add MPC code paths to this chunk (e.g. a signing helper), import
+// '@core/ui/mpc/bootstrapMpcEngine' at the top of this file BEFORE any other
+// @vultisig/* import. The SW is a separate JS realm from the popup, so the
+// shim must run once per realm.
 import { runBackgroundEventsAgent } from '@core/inpage-provider/background/events/background'
 import { runInpageProviderBridgeBackgroundAgent } from '@core/inpage-provider/bridge/background'
 

--- a/clients/extension/src/inpage/index.ts
+++ b/clients/extension/src/inpage/index.ts
@@ -1,3 +1,10 @@
+// MPC note — see vultisig/vultisig-windows#3777.
+// This inpage (dapp page) chunk intentionally does NOT import
+// @core/ui/mpc/bootstrapMpcEngine. The inpage script runs in a dapp's realm
+// and only proxies requests to the extension; it must not bundle DKLS/Schnorr
+// WASM. If you add MPC code paths here, add the bootstrap import at the top
+// and confirm the bundle-size impact. Types-only imports from
+// @vultisig/core-mpc/types/** are safe (protobuf messages, no engine calls).
 import { runBackgroundEventsInpageAgent } from '@core/inpage-provider/background/events/inpage'
 import { runBridgeInpageAgent } from '@lib/extension/bridge/inpage'
 

--- a/core/ui/mpc/bootstrapMpcEngine.ts
+++ b/core/ui/mpc/bootstrapMpcEngine.ts
@@ -1,8 +1,26 @@
-// Registers the MPC engine on the @vultisig/mpc-types module singleton.
-// @vultisig/core-mpc calls getMpcEngine() lazily and throws if this never runs,
-// so each chunk entry that may touch MPC must import this module first — before
-// any other @vultisig/* import. Each bundle is a separate module graph, so the
-// registration must happen once per chunk.
+// MPC engine bootstrap shim — see vultisig/vultisig-windows#3777 postmortem.
+//
+// @vultisig/core-mpc lazily calls getMpcEngine() on @vultisig/mpc-types and
+// throws "MPC engine not configured" if nothing registered one. The SDK now
+// anchors this singleton on globalThis (runtimeStore pattern), which fixes the
+// cross-chunk duplication bug on its own. We still keep this shim because:
+//
+// 1. MV3 realms. The extension service worker, popup, and inpage script each
+//    run in a separate JS realm with their own globalThis. Every realm that
+//    can reach MPC code must import this file once at its entrypoint.
+// 2. Tree-shaking. Even with `sideEffects` declared in the SDK package, a
+//    consumer that only imports types from @vultisig/core-mpc can still have
+//    the platform entry's top-level configure call dropped. Importing this
+//    shim as a side-effect is the explicit, unshakeable anchor.
+// 3. Defence in depth. A future bundler or chunking change could regress the
+//    SDK-side fix; this shim catches it before it ships.
+//
+// Rules:
+// - Import this file FIRST in every realm entrypoint that may touch MPC.
+// - Do NOT import it from background or inpage chunks that never call
+//   getMpcEngine() — it drags DKLS/Schnorr WASM into their bundles. See the
+//   no-restricted-imports rule in eslint.config.mjs and the headers of
+//   clients/extension/src/{background,inpage}/index.ts.
 import { configureMpc } from '@vultisig/mpc-types'
 import { WasmMpcEngine } from '@vultisig/mpc-wasm'
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,8 +10,8 @@ import tsParser from '@typescript-eslint/parser'
 import importPlugin from 'eslint-plugin-import'
 import jsxA11Y from 'eslint-plugin-jsx-a11y'
 import react from 'eslint-plugin-react'
-import reactHooks from 'eslint-plugin-react-hooks'
 import reactCompiler from 'eslint-plugin-react-compiler'
+import reactHooks from 'eslint-plugin-react-hooks'
 import simpleImportSort from 'eslint-plugin-simple-import-sort'
 import storybook from 'eslint-plugin-storybook'
 import unusedImportsPlugin from 'eslint-plugin-unused-imports'
@@ -126,6 +126,45 @@ export default [
     files: ['**/*.d.ts'],
     rules: {
       '@typescript-eslint/consistent-type-definitions': 'off',
+    },
+  },
+  // MPC engine chunk isolation — see vultisig/vultisig-windows#3777.
+  // The extension service worker and inpage chunks must not pull @vultisig/core-mpc
+  // (or related MPC packages) into their bundles unless they also import
+  // '@core/ui/mpc/bootstrapMpcEngine' at the entrypoint. Today neither chunk calls
+  // getMpcEngine(); this rule prevents a future refactor from silently shipping
+  // "MPC engine not configured" at runtime or bloating the SW/inpage bundle with
+  // DKLS/Schnorr WASM. Protobuf types under @vultisig/core-mpc/types/** are allowed
+  // (no engine calls, used by the inpage cosmos provider).
+  {
+    files: [
+      'clients/extension/src/background/**/*.{ts,tsx}',
+      'clients/extension/src/inpage/**/*.{ts,tsx}',
+    ],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              regex: '^@vultisig/core-mpc(?!/types($|/)).*$',
+              message:
+                'This chunk must not import runtime code from @vultisig/core-mpc (only @vultisig/core-mpc/types/** is allowed). If MPC is truly needed here, import "@core/ui/mpc/bootstrapMpcEngine" at the top of the entry file and update the eslint override plus the chunk header comment. See vultisig/vultisig-windows#3777.',
+            },
+            {
+              group: [
+                '@vultisig/mpc-types',
+                '@vultisig/mpc-wasm',
+                '@vultisig/lib-dkls',
+                '@vultisig/lib-schnorr',
+                '@vultisig/lib-mldsa',
+              ],
+              message:
+                'This chunk must not import MPC engine packages. If MPC is truly needed here, import "@core/ui/mpc/bootstrapMpcEngine" at the top of the entry file and update the eslint override plus the chunk header comment. See vultisig/vultisig-windows#3777.',
+            },
+          ],
+        },
+      ],
     },
   },
   ...storybook.configs['flat/recommended'],

--- a/knip.json
+++ b/knip.json
@@ -9,7 +9,9 @@
     "wails"
   ],
   "ignoreDependencies": [
-    "babel-plugin-react-compiler"
+    "babel-plugin-react-compiler",
+    "@vultisig/mpc-types",
+    "@vultisig/mpc-wasm"
   ],
   "workspaces": {
     "clients/desktop": {
@@ -59,8 +61,7 @@
     "core/ui": {
       "entry": [
         "vite/plugins.ts",
-        "vite/staticCopy.ts",
-        "mpc/bootstrapMpcEngine.ts"
+        "vite/staticCopy.ts"
       ],
       "project": [
         "**/*.{ts,tsx}"

--- a/knip.json
+++ b/knip.json
@@ -12,12 +12,6 @@
     "babel-plugin-react-compiler"
   ],
   "workspaces": {
-    ".": {
-      "ignoreDependencies": [
-        "@vultisig/mpc-types",
-        "@vultisig/mpc-wasm"
-      ]
-    },
     "clients/desktop": {
       "project": [
         "**/*.{ts,tsx}"

--- a/knip.json
+++ b/knip.json
@@ -59,7 +59,8 @@
     "core/ui": {
       "entry": [
         "vite/plugins.ts",
-        "vite/staticCopy.ts"
+        "vite/staticCopy.ts",
+        "mpc/bootstrapMpcEngine.ts"
       ],
       "project": [
         "**/*.{ts,tsx}"


### PR DESCRIPTION
Closes #3777

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded internal guidance clarifying MPC bundling constraints and the SDK’s singleton anchoring across extension chunks.

* **Chores**
  * Enforced import restrictions for MPC-related packages in extension chunks via linting rules.
  * Updated dependency analysis configuration so MPC-related packages are now considered (no longer ignored).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->