### PR TITLE
fix(extension): return { publicKey } from legacy solana.connect()

### DIFF
--- a/clients/extension/src/inpage/providers/solana.ts
+++ b/clients/extension/src/inpage/providers/solana.ts
@@ -269,8 +269,8 @@ export class Solana implements Wallet {
   }
 
   connect = async () => {
-    const result = await this.#connect()
-    return result
+    await this.#connect()
+    return { publicKey: shouldBePresent(this.publicKey) }
   }
 
   disconnect = async () => {

--- a/clients/extension/tests/unit/solana-provider.test.ts
+++ b/clients/extension/tests/unit/solana-provider.test.ts
@@ -182,8 +182,8 @@ describe('Solana Provider', () => {
       expect(mockRequestAccount).toHaveBeenCalledWith(Chain.Solana)
       expect(sol.isConnected).toBe(true)
       expect(sol.publicKey).toBeTruthy()
-      expect(result).toHaveProperty('accounts')
-      expect(result.accounts).toHaveLength(1)
+      expect(result).toHaveProperty('publicKey')
+      expect(result.publicKey.toString()).toBe('SoLaNaAddr123')
     })
 
     it('propagates errors from requestAccount', async () => {


### PR DESCRIPTION
## Summary
- Closes #3788.
- The legacy `connect()` on `window.vultisig.solana` / `window.phantom.solana` / `window.solana` now returns `{ publicKey: PublicKey }` to match Phantom's documented contract, instead of the wallet-standard `{ accounts }` shape that broke any dApp using `const { publicKey } = await window.solana.connect()`.
- The Wallet Standard `features['standard:connect'].connect` path is unchanged and still returns `{ accounts }` per spec.

## Test plan
- [ ] `yarn check:all` passes locally.
- [ ] In a fresh browser session with a vault that has a Solana account: `(await window.vultisig.solana.connect()).publicKey.toString()` returns the connected base58 address.
- [ ] `(await window.vultisig.solana.connect()).publicKey.toBytes().length === 32`.
- [ ] A `@solana/wallet-adapter`-based dApp (e.g. Jupiter) still discovers Vultisig via Wallet Standard and connects without regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Solana provider connection now returns a response containing the public key only, ensuring callers receive a consistent publicKey value.
* **Tests**
  * Unit tests updated to validate the connect response exposes the publicKey as the expected identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->