### PR TITLE
feat(ui): sync Share Keygen/Keysign QR cards with Figma (#3776)

### DIFF
--- a/core/ui/chain/coin/address/index.tsx
+++ b/core/ui/chain/coin/address/index.tsx
@@ -29,7 +29,14 @@ export const AddressPage = () => {
                 <FileUpIcon />
               </IconButton>
             )}
-            value={<PrintableQrCode title={address} value={address} />}
+            value={
+              <PrintableQrCode
+                title={t('address')}
+                brandLabel={t('vultisig')}
+                value={address}
+                rows={[{ label: t('address'), value: address }]}
+              />
+            }
           />
         }
         title={t('address')}

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -1086,6 +1086,7 @@ export const en = {
     'Turn your vault into a rewards machine. Create your referral now and start earning.',
   twitter: 'Twitter',
   tx_hash: 'Transaction hash',
+  type: 'Type',
   type_here: 'Type Here',
   unbond: 'Unbond',
   unbond_with_lp: 'Unbond Maya',

--- a/core/ui/mpc/keygen/qr/DownloadKeygenQrCode.tsx
+++ b/core/ui/mpc/keygen/qr/DownloadKeygenQrCode.tsx
@@ -3,11 +3,15 @@ import {
   useKeygenVault,
   useKeygenVaultName,
 } from '@core/ui/mpc/keygen/state/keygenVault'
-import { PrintableQrCode } from '@core/ui/qr/PrintableQrCode'
+import { useTargetDeviceCount } from '@core/ui/mpc/keygen/state/targetDeviceCount'
+import {
+  PrintableQrCode,
+  PrintableQrCodeRow,
+} from '@core/ui/qr/PrintableQrCode'
 import { IconButton } from '@lib/ui/buttons/IconButton'
 import { ShareIcon } from '@lib/ui/icons/ShareIcon'
 import { ValueProp } from '@lib/ui/props'
-import { useMemo } from 'react'
+import { getKeygenThreshold } from '@vultisig/core-mpc/getKeygenThreshold'
 import { useTranslation } from 'react-i18next'
 
 import { getVaultExportUid } from '../../../vault/export/core/uid'
@@ -30,14 +34,30 @@ export const DownloadKeygenQrCode = ({
   const { t } = useTranslation()
   const keygenVault = useKeygenVault()
   const vaultName = useKeygenVaultName()
-  const fileName = useMemo(() => {
-    if ('existingVault' in keygenVault) {
-      const uid = getVaultExportUid(keygenVault.existingVault)
-      return [prefix, keygenVault.existingVault.name, uid.slice(-3)].join('-')
-    }
+  const targetDeviceCount = useTargetDeviceCount()
 
-    return [prefix, vaultName].join('-')
-  }, [keygenVault, vaultName])
+  const fileName =
+    'existingVault' in keygenVault
+      ? [
+          prefix,
+          keygenVault.existingVault.name,
+          getVaultExportUid(keygenVault.existingVault).slice(-3),
+        ].join('-')
+      : [prefix, vaultName].join('-')
+
+  const totalSigners =
+    'existingVault' in keygenVault
+      ? keygenVault.existingVault.signers.length
+      : targetDeviceCount
+
+  const rows: PrintableQrCodeRow[] = [{ label: t('vault'), value: vaultName }]
+
+  if (totalSigners !== undefined) {
+    rows.push({
+      label: t('type'),
+      value: `${getKeygenThreshold(totalSigners)}-${totalSigners}`,
+    })
+  }
 
   return (
     <SaveAsImage
@@ -55,7 +75,8 @@ export const DownloadKeygenQrCode = ({
         <PrintableQrCode
           value={value}
           title={t('join_keygen')}
-          description={t('scan_with_devices')}
+          brandLabel={t('vultisig')}
+          rows={rows}
         />
       }
     />

--- a/core/ui/mpc/keysign/DownloadKeysignQrCode.tsx
+++ b/core/ui/mpc/keysign/DownloadKeysignQrCode.tsx
@@ -1,11 +1,22 @@
+import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { SaveAsImage } from '@core/ui/file/SaveAsImage'
 import { useJoinKeysignUrlQuery } from '@core/ui/mpc/keysign/queries/useJoinKeysignUrlQuery'
 import { useCoreViewState } from '@core/ui/navigation/hooks/useCoreViewState'
-import { PrintableQrCode } from '@core/ui/qr/PrintableQrCode'
+import {
+  PrintableQrCode,
+  PrintableQrCodeRow,
+} from '@core/ui/qr/PrintableQrCode'
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { IconButton } from '@lib/ui/buttons/IconButton'
 import { FileUpIcon } from '@lib/ui/icons/FileUpIcon'
+import { HStack } from '@lib/ui/layout/Stack'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
+import { Text } from '@lib/ui/text'
+import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
+import { fromCommCoin } from '@vultisig/core-mpc/types/utils/commCoin'
+import { formatAmount } from '@vultisig/lib-utils/formatAmount'
+import { formatWalletAddress } from '@vultisig/lib-utils/formatWalletAddress'
+import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
 import { useTranslation } from 'react-i18next'
 
 import { getVaultExportUid } from '../../vault/export/core/uid'
@@ -16,6 +27,39 @@ export const DownloadKeysignQrCode = () => {
   const { t } = useTranslation()
   const vault = useCurrentVault()
   const { name } = vault
+
+  const rows: PrintableQrCodeRow[] = [{ label: t('vault'), value: name }]
+
+  matchRecordUnion(keysignPayload, {
+    keysign: payload => {
+      if (payload.toAmount && payload.toAmount !== '0' && payload.coin) {
+        const coin = fromCommCoin(payload.coin)
+        const amountText = formatAmount(
+          fromChainAmount(BigInt(payload.toAmount), coin.decimals),
+          { precision: 'high' }
+        )
+        rows.push({
+          label: t('amount'),
+          value: (
+            <HStack gap={4} alignItems="center">
+              <CoinIcon coin={coin} style={{ fontSize: 16 }} />
+              <Text size={12} weight={500} color="regular" height={1.333}>
+                {`${amountText} ${coin.ticker}`}
+              </Text>
+            </HStack>
+          ),
+        })
+      }
+
+      if (payload.toAddress) {
+        rows.push({
+          label: t('to'),
+          value: formatWalletAddress(payload.toAddress),
+        })
+      }
+    },
+    custom: () => {},
+  })
 
   return (
     <MatchQuery
@@ -32,7 +76,8 @@ export const DownloadKeysignQrCode = () => {
             <PrintableQrCode
               value={data}
               title={t('join_keysign')}
-              description={t('scan_with_devices_to_sign')}
+              brandLabel={t('vultisig')}
+              rows={rows}
             />
           }
         />

--- a/core/ui/qr/PrintableQrCode.tsx
+++ b/core/ui/qr/PrintableQrCode.tsx
@@ -1,57 +1,157 @@
-import { DeprecatedProductLogo } from '@core/ui/product/DeprecatedProductLogo'
-import { VStack } from '@lib/ui/layout/Stack'
-import { FramedQrCode } from '@lib/ui/qr/FramedQrCode'
+import { ProductLogo } from '@core/ui/product/ProductLogo'
+import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
-import styled from 'styled-components'
+import { Fragment, ReactNode } from 'react'
+import QRCode from 'react-qr-code'
+import styled, { useTheme } from 'styled-components'
 
-const Container = styled(VStack)`
-  align-items: center;
-  padding: 40px 20px;
-  background: ${getColor('background')};
-  gap: 40px;
-  min-width: 480px;
-`
-
-const Footer = styled(VStack)`
-  gap: 20px;
-  align-items: center;
-  justify-content: space-between;
-  font-weight: 600;
-`
-
-const Logo = styled(DeprecatedProductLogo)`
-  font-size: 80px;
-`
+export type PrintableQrCodeRow = {
+  label: string
+  value: ReactNode
+}
 
 type PrintableQrCodeProps = {
   value: string
-  title?: string
-  description?: string
+  title: string
+  brandLabel: string
+  rows: PrintableQrCodeRow[]
 }
+
+const canvasWidth = 340
+const canvasMinHeight = 620
+const horizontalPadding = 30
+const cardInnerWidth = canvasWidth - horizontalPadding * 2
+const qrCardHeight = 277
+const qrSize = 240
+
+const Canvas = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: ${canvasWidth}px;
+  min-height: ${canvasMinHeight}px;
+  padding: 29px ${horizontalPadding}px 20px;
+  background: ${getColor('foreground')};
+`
+
+const Stack = styled(VStack)`
+  gap: 22px;
+  align-items: center;
+`
+
+const QrCardFrame = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: ${cardInnerWidth}px;
+  height: ${qrCardHeight}px;
+  padding: 18px;
+  border: 1px solid ${getColor('foregroundExtra')};
+  border-radius: 24px;
+`
+
+const InfoCard = styled(VStack)`
+  width: ${cardInnerWidth}px;
+  padding: 20px;
+  border: 1px solid ${getColor('foregroundExtra')};
+  border-radius: 24px;
+  gap: 16px;
+`
+
+const Rows = styled(VStack)`
+  gap: 14px;
+  padding-top: 12px;
+`
+
+const Divider = styled.div`
+  height: 1px;
+  width: 100%;
+  background: ${getColor('foregroundExtra')};
+`
+
+const Spacer = styled.div`
+  flex-grow: 1;
+  min-height: 28px;
+`
+
+const BrandLogoSquare = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 33px;
+  height: 33px;
+  border-radius: 8px;
+  background: linear-gradient(180deg, #4879fd 0%, #0d39b1 100%);
+  box-shadow: inset 0 0.82px 0.82px 0 rgba(255, 255, 255, 0.35);
+  color: ${getColor('white')};
+  font-size: 22px;
+`
 
 export const PrintableQrCode = ({
   value,
   title,
-  description,
+  brandLabel,
+  rows,
 }: PrintableQrCodeProps) => {
-  return (
-    <Container>
-      <VStack>
-        <FramedQrCode value={value} />
-      </VStack>
+  const { colors } = useTheme()
 
-      <Footer>
-        <Text color="contrast" size={14} family="mono">
-          {title}
-        </Text>
-        {description && (
-          <Text color="contrast" size={14} family="mono">
-            {description}
-          </Text>
+  return (
+    <Canvas>
+      <Stack>
+        <QrCardFrame>
+          <QRCode
+            value={value}
+            size={qrSize}
+            bgColor="transparent"
+            fgColor={colors.white.toCssValue()}
+          />
+        </QrCardFrame>
+        {rows.length > 0 && (
+          <InfoCard>
+            <Text size={14} weight={500} color="regular" height={1.43}>
+              {title}
+            </Text>
+            <Rows>
+              {rows.map((row, index) => (
+                <Fragment key={row.label}>
+                  {index > 0 && <Divider />}
+                  <HStack
+                    justifyContent="space-between"
+                    alignItems="center"
+                    gap={8}
+                  >
+                    <Text size={12} weight={500} color="shy" height={1.333}>
+                      {row.label}
+                    </Text>
+                    {typeof row.value === 'string' ? (
+                      <Text
+                        size={12}
+                        weight={500}
+                        color="regular"
+                        height={1.333}
+                      >
+                        {row.value}
+                      </Text>
+                    ) : (
+                      <HStack alignItems="center">{row.value}</HStack>
+                    )}
+                  </HStack>
+                </Fragment>
+              ))}
+            </Rows>
+          </InfoCard>
         )}
-        <Logo />
-      </Footer>
-    </Container>
+      </Stack>
+      <Spacer />
+      <VStack gap={10} alignItems="center">
+        <BrandLogoSquare>
+          <ProductLogo />
+        </BrandLogoSquare>
+        <Text size={14} weight={500} color="regular">
+          {brandLabel}
+        </Text>
+      </VStack>
+    </Canvas>
   )
 }

--- a/core/ui/qr/PrintableQrCode.tsx
+++ b/core/ui/qr/PrintableQrCode.tsx
@@ -6,6 +6,7 @@ import { Fragment, ReactNode } from 'react'
 import QRCode from 'react-qr-code'
 import styled, { useTheme } from 'styled-components'
 
+/** Metadata row displayed inside the printable QR info card. */
 export type PrintableQrCodeRow = {
   label: string
   value: ReactNode
@@ -88,6 +89,11 @@ const BrandLogoSquare = styled.div`
   font-size: 22px;
 `
 
+/**
+ * Renders a printable QR card that matches the Share-QR Figma spec.
+ * Used as the PNG source when the user saves a Join Keygen/Keysign/address QR.
+ * The info card is hidden when `rows` is empty.
+ */
 export const PrintableQrCode = ({
   value,
   title,


### PR DESCRIPTION
## Summary
- Rewrite `PrintableQrCode` to match the current Figma: 340×620 canvas, framed QR (281×277, 1px border, 24px radius), info card with Vault + dynamic rows, and the Vultisig brand signature at the bottom.
- **Keygen** card renders `Vault` + `Type` rows (threshold-signers, e.g. `2-3`).
- **Keysign** card renders `Vault` + `Amount` (with coin icon) + `To` (truncated address). Rows are hidden when the underlying data is unavailable — e.g., custom dApp payloads (`KeysignMessagePayload.custom`) only show the `Vault` row.
- Update `AddressPage` to the new `PrintableQrCode` API (shared component — collateral from the API change).

Closes #3776

## Test plan
- [ ] **Keygen QR download** — start a new vault keygen, open the peer discovery step, click the download button on the share QR. Saved PNG matches Figma (`Join Keygen` title, `Vault` + `Type` rows, Vultisig signature at bottom).
- [ ] **Keygen reshare QR download** — trigger a vault reshare and verify the same card renders with the existing vault's `Vault` + `Type`.
- [ ] **Keysign QR — standard transfer** — initiate a send transaction (e.g., 100 USDC), click download on the share step. Saved PNG shows `Join Keysign` title with `Vault` + `Amount` (coin icon prefix) + `To` (truncated address) rows.
- [ ] **Keysign QR — dApp custom message** — trigger a raw message signing from a dApp (e.g., `personal_sign`). Saved PNG shows only the `Vault` row (no `Amount`/`To`).
- [ ] **AddressPage QR download** — open an asset's receive/address page, click the save icon. Saved PNG renders the address without errors (minor collateral path).
- [ ] **Visual regression** — compare against Figma nodes `23:5230` (Keygen) and `23:4571` (Keysign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * QR images now use a printable card layout with branded header and labeled rows for clear metadata.
  * QR exports include localized labels (e.g., "Type") and structured fields: vault name, signer/threshold info, amounts, and recipient addresses.
  * Downloaded QR filenames and metadata are improved for clearer identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->