### PR TITLE
fix(keyimport-sign): resolve chain to stored rep before signing with Vultiserver

### DIFF
--- a/core/ui/mpc/keygen/keyimport/JoinKeyImportKeygenActionProvider.tsx
+++ b/core/ui/mpc/keygen/keyimport/JoinKeyImportKeygenActionProvider.tsx
@@ -33,6 +33,7 @@ import {
   useKeyImportChains,
 } from './state/keyImportChains'
 import { getKeyImportDerivationGroups } from './utils/getKeyImportDerivationGroups'
+import { withKeyImportServerChains } from './utils/keyImportServerChains'
 
 export const JoinKeyImportKeygenActionProvider = ({
   children,
@@ -210,7 +211,7 @@ export const JoinKeyImportKeygenActionProvider = ({
         chainKeyShares[chain] = result.keyshare
       }
 
-      const vault: Vault = {
+      const baseVault: Vault = {
         name: vaultName,
         publicKeys: {
           ecdsa: rootEcdsaResult.publicKey,
@@ -232,6 +233,10 @@ export const JoinKeyImportKeygenActionProvider = ({
         publicKeyMldsa: mldsaResult?.publicKey,
         keyShareMldsa: mldsaResult?.keyshare,
       }
+      const vault = withKeyImportServerChains(
+        baseVault,
+        getKeyImportDerivationGroups(chains).map(g => g.representativeChain)
+      )
 
       await setKeygenComplete({
         serverURL: serverUrl,
@@ -364,7 +369,7 @@ export const JoinKeyImportKeygenActionProvider = ({
         keyShareMldsa = seqMldsaResult.keyshare
       }
 
-      const vault: Vault = {
+      const baseVault: Vault = {
         name: vaultName,
         publicKeys: {
           ecdsa: rootEcdsaResult.publicKey,
@@ -386,6 +391,10 @@ export const JoinKeyImportKeygenActionProvider = ({
         publicKeyMldsa,
         keyShareMldsa,
       }
+      const vault = withKeyImportServerChains(
+        baseVault,
+        derivationGroups.map(g => g.representativeChain)
+      )
 
       await setKeygenComplete({
         serverURL: serverUrl,

--- a/core/ui/mpc/keygen/keyimport/KeyImportKeygenActionProvider.tsx
+++ b/core/ui/mpc/keygen/keyimport/KeyImportKeygenActionProvider.tsx
@@ -36,6 +36,7 @@ import { KeygenAction, KeygenActionProvider } from '../state/keygenAction'
 import { useKeygenVaultName } from '../state/keygenVault'
 import { useKeyImportInput } from './state/keyImportInput'
 import { getKeyImportDerivationGroups } from './utils/getKeyImportDerivationGroups'
+import { withKeyImportServerChains } from './utils/keyImportServerChains'
 
 type KeyShareResult = {
   keyshare: string
@@ -273,7 +274,7 @@ export const KeyImportKeygenActionProvider = ({ children }: ChildrenProp) => {
         hdWallet.delete()
       }
 
-      const vault: Vault = {
+      const baseVault: Vault = {
         name: vaultName,
         publicKeys: {
           ecdsa: rootEcdsaResult.publicKey,
@@ -293,6 +294,10 @@ export const KeyImportKeygenActionProvider = ({ children }: ChildrenProp) => {
         chainPublicKeys,
         chainKeyShares,
       }
+      const vault = withKeyImportServerChains(
+        baseVault,
+        derivationGroups.map(g => g.representativeChain)
+      )
 
       await setKeygenComplete({
         serverURL: serverUrl,
@@ -733,7 +738,7 @@ async function runBatchKeyImport({
     }
   }
 
-  const vault: Vault = {
+  const baseVault: Vault = {
     name: vaultName,
     publicKeys: {
       ecdsa: rootEcdsaResult.publicKey,
@@ -753,6 +758,10 @@ async function runBatchKeyImport({
     publicKeyMldsa: mldsaResult?.publicKey,
     keyShareMldsa: mldsaResult?.keyshare,
   }
+  const vault = withKeyImportServerChains(
+    baseVault,
+    derivationGroups.map(g => g.representativeChain)
+  )
 
   await setKeygenComplete({
     serverURL: serverUrl,

--- a/core/ui/mpc/keygen/keyimport/utils/keyImportServerChains.ts
+++ b/core/ui/mpc/keygen/keyimport/utils/keyImportServerChains.ts
@@ -1,0 +1,24 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { Vault } from '@vultisig/core-mpc/vault/Vault'
+
+/**
+ * Extension-only metadata: the chains the extension sent to Vultiserver
+ * during KeyImport keygen (`representativeChains` — one per derivation
+ * group). Persisted alongside the vault so sign-time chain rewrites can
+ * pick a chain the server actually has stored.
+ *
+ * The SDK `Vault` type doesn't declare this field; we attach it directly
+ * to the persisted vault object and read it through this typed accessor.
+ */
+const FIELD = 'keyImportServerChains' as const
+
+type WithServerChains = { [FIELD]?: readonly Chain[] }
+
+export const getKeyImportServerChains = (
+  vault: Vault
+): readonly Chain[] | undefined => (vault as Vault & WithServerChains)[FIELD]
+
+export const withKeyImportServerChains = (
+  vault: Vault,
+  chains: readonly Chain[]
+): Vault => ({ ...vault, [FIELD]: chains }) as Vault & WithServerChains

--- a/core/ui/mpc/keysign/fast/FastKeysignServerStep.tsx
+++ b/core/ui/mpc/keysign/fast/FastKeysignServerStep.tsx
@@ -20,7 +20,6 @@ import { assertChainField } from '@vultisig/core-chain/utils/assertChainField'
 import { signWithServer } from '@vultisig/core-mpc/fast/api/signWithServer'
 import { getEncodedSigningInputs } from '@vultisig/core-mpc/keysign/signingInputs'
 import { getPreSigningHashes } from '@vultisig/core-mpc/tx/preSigningHashes'
-import { isKeyImportVault } from '@vultisig/core-mpc/vault/Vault'
 import { isOneOf } from '@vultisig/lib-utils/array/isOneOf'
 import { attempt } from '@vultisig/lib-utils/attempt'
 import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
@@ -28,6 +27,7 @@ import { assertField } from '@vultisig/lib-utils/record/assertField'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { getKeyImportServerChains } from '../../keygen/keyimport/utils/keyImportServerChains'
 import {
   customMessageDefaultChain,
   customMessageSupportedChains,
@@ -54,9 +54,10 @@ export const FastKeysignServerStep: React.FC<FastKeysignServerStepProps> = ({
 
   const walletCore = useAssertWalletCore()
 
+  const serverChains = getKeyImportServerChains(vault)
   const toServerChain = (chain: Chain): Chain =>
-    isKeyImportVault(vault)
-      ? resolveServerChainForKeyImport({ chain, chainPublicKeys })
+    serverChains
+      ? resolveServerChainForKeyImport({ chain, serverChains })
       : chain
 
   const { mutate, ...state } = useMutation({

--- a/core/ui/mpc/keysign/fast/FastKeysignServerStep.tsx
+++ b/core/ui/mpc/keysign/fast/FastKeysignServerStep.tsx
@@ -12,7 +12,7 @@ import { PageHeader } from '@lib/ui/page/PageHeader'
 import { OnFinishProp } from '@lib/ui/props'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
 import { useMutation } from '@tanstack/react-query'
-import { OtherChain } from '@vultisig/core-chain/Chain'
+import { Chain, OtherChain } from '@vultisig/core-chain/Chain'
 import { getCoinType } from '@vultisig/core-chain/coin/coinType'
 import { getPublicKey } from '@vultisig/core-chain/publicKey/getPublicKey'
 import { getSignatureAlgorithm } from '@vultisig/core-chain/signing/SignatureAlgorithm'
@@ -20,6 +20,7 @@ import { assertChainField } from '@vultisig/core-chain/utils/assertChainField'
 import { signWithServer } from '@vultisig/core-mpc/fast/api/signWithServer'
 import { getEncodedSigningInputs } from '@vultisig/core-mpc/keysign/signingInputs'
 import { getPreSigningHashes } from '@vultisig/core-mpc/tx/preSigningHashes'
+import { isKeyImportVault } from '@vultisig/core-mpc/vault/Vault'
 import { isOneOf } from '@vultisig/lib-utils/array/isOneOf'
 import { attempt } from '@vultisig/lib-utils/attempt'
 import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
@@ -32,6 +33,7 @@ import {
   customMessageSupportedChains,
 } from '../customMessage/chains'
 import { getCustomMessageHex } from '../customMessage/getCustomMessageHex'
+import { resolveServerChainForKeyImport } from './utils/resolveServerChainForKeyImport'
 
 type FastKeysignServerStepProps = OnFinishProp & {
   password: string
@@ -51,6 +53,11 @@ export const FastKeysignServerStep: React.FC<FastKeysignServerStepProps> = ({
   const [{ keysignPayload }] = useCoreViewState<'keysign'>()
 
   const walletCore = useAssertWalletCore()
+
+  const toServerChain = (chain: Chain): Chain =>
+    isKeyImportVault(vault)
+      ? resolveServerChainForKeyImport({ chain, chainPublicKeys })
+      : chain
 
   const { mutate, ...state } = useMutation({
     mutationFn: async () => {
@@ -85,7 +92,7 @@ export const FastKeysignServerStep: React.FC<FastKeysignServerStepProps> = ({
                 ),
                 is_ecdsa: false,
                 vault_password: password,
-                chain,
+                chain: toServerChain(chain),
               })
             }
           }
@@ -123,7 +130,7 @@ export const FastKeysignServerStep: React.FC<FastKeysignServerStepProps> = ({
             ),
             is_ecdsa: getSignatureAlgorithm(chain) === 'ecdsa',
             vault_password: password,
-            chain,
+            chain: toServerChain(chain),
           })
         },
         custom: async ({
@@ -150,7 +157,7 @@ export const FastKeysignServerStep: React.FC<FastKeysignServerStepProps> = ({
             ),
             is_ecdsa: getSignatureAlgorithm(chain) === 'ecdsa',
             vault_password: password,
-            chain,
+            chain: toServerChain(chain),
           })
         },
       })

--- a/core/ui/mpc/keysign/fast/utils/resolveServerChainForKeyImport.ts
+++ b/core/ui/mpc/keysign/fast/utils/resolveServerChainForKeyImport.ts
@@ -1,0 +1,45 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+
+type ResolveServerChainForKeyImportInput = {
+  chain: Chain
+  chainPublicKeys: Partial<Record<Chain, string>> | undefined
+}
+
+/**
+ * At keygen time the extension sends one chain per derivation group to
+ * Vultiserver (the representative, typically the first chain in the group),
+ * so server-side `Vault.ChainPublicKeys` has an entry only for that
+ * representative — not for the other chains sharing its derivation.
+ *
+ * At sign time Vultiserver looks up the chain by name in its stored
+ * `ChainPublicKeys` to find the publicKey that pairs the MPC share
+ * (keysign_dkls.go: `chainInfo.Chain == req.Chain`). Sending a
+ * non-representative chain (e.g. `Ethereum` when the stored rep is
+ * `Arbitrum`) causes the async worker to error with "public key for chain X
+ * not found in vault" — which is never propagated back to the relay, so the
+ * extension hangs polling for messages that never arrive.
+ *
+ * This helper rewrites `chain` to whichever local chain is the first entry
+ * with the same publicKey. For extension-created KeyImport vaults that is
+ * exactly the representative the server has stored. For iOS-created vaults
+ * it's a no-op because the server has per-chain entries already.
+ */
+export const resolveServerChainForKeyImport = ({
+  chain,
+  chainPublicKeys,
+}: ResolveServerChainForKeyImportInput): Chain => {
+  if (!chainPublicKeys) return chain
+
+  const ownPublicKey = chainPublicKeys[chain]
+  if (!ownPublicKey) return chain
+
+  for (const [candidateChain, candidatePublicKey] of Object.entries(
+    chainPublicKeys
+  )) {
+    if (candidatePublicKey === ownPublicKey) {
+      return candidateChain as Chain
+    }
+  }
+
+  return chain
+}

--- a/core/ui/mpc/keysign/fast/utils/resolveServerChainForKeyImport.ts
+++ b/core/ui/mpc/keysign/fast/utils/resolveServerChainForKeyImport.ts
@@ -1,45 +1,32 @@
 import { Chain } from '@vultisig/core-chain/Chain'
 
+import { getKeyImportDerivationGroups } from '../../../keygen/keyimport/utils/getKeyImportDerivationGroups'
+
 type ResolveServerChainForKeyImportInput = {
   chain: Chain
-  chainPublicKeys: Partial<Record<Chain, string>> | undefined
+  serverChains: readonly Chain[]
 }
 
 /**
- * At keygen time the extension sends one chain per derivation group to
- * Vultiserver (the representative, typically the first chain in the group),
- * so server-side `Vault.ChainPublicKeys` has an entry only for that
- * representative — not for the other chains sharing its derivation.
+ * Maps a sign-time chain to a chain Vultiserver actually has stored.
  *
- * At sign time Vultiserver looks up the chain by name in its stored
- * `ChainPublicKeys` to find the publicKey that pairs the MPC share
- * (keysign_dkls.go: `chainInfo.Chain == req.Chain`). Sending a
- * non-representative chain (e.g. `Ethereum` when the stored rep is
- * `Arbitrum`) causes the async worker to error with "public key for chain X
- * not found in vault" — which is never propagated back to the relay, so the
- * extension hangs polling for messages that never arrive.
+ * The extension's KeyImport fast keygen sends one chain per derivation
+ * group to Vultiserver (the representative), so the server's
+ * `Vault.ChainPublicKeys` only has entries for those representatives. The
+ * actual list is persisted in the vault as `keyImportServerChains`.
  *
- * This helper rewrites `chain` to whichever local chain is the first entry
- * with the same publicKey. For extension-created KeyImport vaults that is
- * exactly the representative the server has stored. For iOS-created vaults
- * it's a no-op because the server has per-chain entries already.
+ * If `chain` is in that list, it's a no-op. Otherwise, returns the
+ * server-stored chain in the same derivation group, so the keysign
+ * request hits an entry the server's `chainInfo.Chain == req.Chain`
+ * lookup can match.
  */
 export const resolveServerChainForKeyImport = ({
   chain,
-  chainPublicKeys,
+  serverChains,
 }: ResolveServerChainForKeyImportInput): Chain => {
-  if (!chainPublicKeys) return chain
-
-  const ownPublicKey = chainPublicKeys[chain]
-  if (!ownPublicKey) return chain
-
-  for (const [candidateChain, candidatePublicKey] of Object.entries(
-    chainPublicKeys
-  )) {
-    if (candidatePublicKey === ownPublicKey) {
-      return candidateChain as Chain
-    }
-  }
-
-  return chain
+  if (serverChains.includes(chain)) return chain
+  const myGroup = getKeyImportDerivationGroups([...serverChains, chain]).find(
+    g => g.chains.includes(chain)
+  )
+  return myGroup?.chains.find(c => serverChains.includes(c)) ?? chain
 }


### PR DESCRIPTION
## Summary

The extension's KeyImport fast keygen sends one chain per derivation group to Vultiserver (the representative — the first chain in user-selection order that uses that derivation), so server-side `Vault.ChainPublicKeys` only has entries for those reps. At sign time the server looks the chain up by name (`keysign_dkls.go: chainInfo.Chain == req.Chain`) — sending a non-rep chain (the custom-message default is `Ethereum`, and outgoing sends from any non-rep EVM chain) makes the async worker fail with "public key for chain X not found in vault" without surfacing anything to the relay. The extension just hangs polling `router/message/<session_id>/<partyId>` forever.

The previous attempt resolved the rep at sign time by scanning local `chainPublicKeys` for the first entry sharing the requested chain's publicKey. That assumes the local order matches the order the chain went to the server during keygen — which is not reliable: comparing an extension-keygen `.vult` to its server-stored counterpart shows the local map can have e.g. `Arbitrum` first while the server stored `Ethereum` as the rep, and the rewriter then sends a chain the server doesn't have.

This PR persists the actual `representativeChains` list on the vault at keygen time (`keyImportServerChains`) and resolves sign-time chains against that authoritative list:

- If the requested chain is already in `keyImportServerChains`, send as-is.
- Otherwise, return the chain in `keyImportServerChains` whose derivation group includes the requested chain — that's the entry the server's name-match lookup will hit.

Older vaults created before this change have no `keyImportServerChains` field set, so the rewrite is a safe no-op for them (they keep the original behavior). Non-KeyImport vaults and iOS-imported vaults are unaffected (iOS keygens per-chain, so all chain names are stored on the server already).

Closes #3759

Builds on top of #3801 — merge that first.

## Test plan

- [ ] `yarn check:all` passes
- [ ] Create a new KeyImport Fast Vault in the extension via seed-phrase import, selecting at least Base + Arbitrum + Ethereum (so the EVM rep on the server is whichever is first, not the others). Try Custom Message Sign (defaults to Ethereum) — succeeds (previously hung on relay polling).
- [ ] Send an ETH transaction from that vault — succeeds.
- [ ] Send from the EVM rep itself — still succeeds (no regression on the rep path).
- [ ] Sign with an iOS-imported vault (chains registered individually on the server) — no change in behavior.
- [ ] Sign with a KeyImport vault created **before** this change (no `keyImportServerChains` field) — behavior unchanged from the previous build (no-op rewrite).
- [ ] Non-KeyImport (DKLS) vault signing — unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced chain resolution for key import operations to better handle multi-chain scenarios.
  * Improved chain translation during signing workflows to ensure compatibility with server-supported chains.
  * Refined vault construction in key import flows with better server chain tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->