### PR TITLE
fix(popup): queue popup requests to prevent Hyperliquid signature loop

### DIFF
--- a/core/inpage-provider/popup/resolvers/background/inNewWindow.ts
+++ b/core/inpage-provider/popup/resolvers/background/inNewWindow.ts
@@ -28,103 +28,13 @@ const getPopupPosition = async (): Promise<
   return { left, top }
 }
 
-const findExistingPopupWindow = async (): Promise<number | null> => {
-  const allWindows = await chrome.windows.getAll({ windowTypes: ['popup'] })
-  const runtimeUrl = chrome.runtime.getURL('popup.html')
-
-  for (const window of allWindows) {
-    if (!window.id) continue
-
-    const tabs = await chrome.tabs.query({ windowId: window.id })
-    const matchingTab = tabs.find(tab => {
-      const tabUrl = tab.url
-      return tabUrl?.startsWith(runtimeUrl.split('?')[0])
-    })
-
-    if (matchingTab) {
-      return window.id
-    }
-  }
-
-  return null
-}
+let popupQueue: Promise<unknown> = Promise.resolve()
 
 export const inNewWindow = async <T>({
   url,
   execute,
 }: Input<T>): Promise<T> => {
-  // Check if there's an existing popup window we can reuse
-  const existingWindowId = await findExistingPopupWindow()
-
-  let windowId: number | undefined
-  if (existingWindowId !== null) {
-    // Reuse existing window by updating its tab URL and focusing it
-    windowId = existingWindowId
-    const tabs = await chrome.tabs.query({ windowId })
-
-    if (tabs.length === 0) {
-      windowId = undefined // Fall back to creating new window
-    } else {
-      const tabId = tabs[0].id
-      if (!tabId) {
-        windowId = undefined // Fall back to creating new window
-      } else {
-        const tabUpdateResult = await attempt(
-          chrome.tabs.update(tabId, { url })
-        )
-        if ('error' in tabUpdateResult) {
-          windowId = undefined // Fall back to creating new window
-        }
-
-        if (windowId !== undefined) {
-          const focusResult = await attempt(
-            chrome.windows.update(windowId, { focused: true })
-          )
-          if ('error' in focusResult) {
-            // Best-effort fallback: try to create a new focused window
-            const position = await getPopupPosition()
-            const fallbackResult = await attempt(
-              new Promise<chrome.windows.Window | undefined>(resolve =>
-                chrome.windows.create(
-                  {
-                    url,
-                    type: 'popup',
-                    height: windowHeight,
-                    width: windowWidth,
-                    focused: true,
-                    ...(position ?? {}),
-                  },
-                  resolve
-                )
-              )
-            )
-            const popupWindow = fallbackResult.data
-            if (popupWindow?.id) {
-              windowId = popupWindow.id
-              if (
-                position &&
-                popupWindow.state !== 'fullscreen' &&
-                (popupWindow.left !== position.left ||
-                  popupWindow.top !== position.top)
-              ) {
-                await chrome.windows.update(windowId, {
-                  left: position.left,
-                  top: position.top,
-                })
-              }
-            } else {
-              throw new Error(
-                `Failed to reuse or create popup window: ${focusResult.error instanceof Error ? focusResult.error.message : String(focusResult.error)}`
-              )
-            }
-          }
-        }
-      }
-    }
-  }
-
-  // Create a new window if we couldn't reuse an existing one
-  if (existingWindowId === null || windowId === undefined) {
+  const run = async (): Promise<T> => {
     const position = await getPopupPosition()
     const newWindow = await new Promise<chrome.windows.Window | undefined>(
       resolve =>
@@ -139,14 +49,12 @@ export const inNewWindow = async <T>({
           resolve
         )
     )
-    const id = newWindow?.id
-    if (!id) {
+    const windowId = newWindow?.id
+    if (!windowId) {
       throw new Error('Failed to create new window')
     }
-    windowId = id
     // Firefox ignores left/top on create; apply via update
     if (
-      newWindow &&
       position &&
       newWindow.state !== 'fullscreen' &&
       (newWindow.left !== position.left || newWindow.top !== position.top)
@@ -156,26 +64,30 @@ export const inNewWindow = async <T>({
         top: position.top,
       })
     }
-  }
 
-  const controller = new AbortController()
-  const handleRemoved = (removedId: number) => {
-    if (removedId === windowId) {
+    const controller = new AbortController()
+    const handleRemoved = (removedId: number) => {
+      if (removedId === windowId) {
+        chrome.windows.onRemoved.removeListener(handleRemoved)
+        controller.abort()
+      }
+    }
+    chrome.windows.onRemoved.addListener(handleRemoved)
+
+    try {
+      return await execute({
+        abortSignal: controller.signal,
+        close: () => {
+          chrome.windows.onRemoved.removeListener(handleRemoved)
+          chrome.windows.remove(windowId)
+        },
+      })
+    } finally {
       chrome.windows.onRemoved.removeListener(handleRemoved)
-      controller.abort()
     }
   }
-  chrome.windows.onRemoved.addListener(handleRemoved)
 
-  try {
-    return await execute({
-      abortSignal: controller.signal,
-      close: () => {
-        chrome.windows.onRemoved.removeListener(handleRemoved)
-        chrome.windows.remove(windowId)
-      },
-    })
-  } finally {
-    chrome.windows.onRemoved.removeListener(handleRemoved)
-  }
+  const next = popupQueue.then(run, run)
+  popupQueue = next.catch(() => {})
+  return next
 }


### PR DESCRIPTION
## Summary
- Replace the popup-window reuse logic in `inNewWindow` with a serial popup queue. Each `inNewWindow` call now waits for the previous popup to finish, then opens its own fresh `chrome.windows.create` popup.
- Fixes the infinite signature loop on Hyperliquid where confirming "Enable Trading" looped back to "Establish Connection" instead of advancing to USDC deposit.

## Why
When a dapp fires two popup-requiring RPCs back-to-back (Hyperliquid does this for Establish Connection → Enable Trading), the previous code did:

```ts
const existingWindowId = await findExistingPopupWindow()
if (existingWindowId !== null) {
  await chrome.tabs.update(tabId, { url })  // navigate the live popup to the new callId
}
```

That navigated the in-flight popup mid-flow, destroying the React listener for call #1 while its background `handleMessage` was still registered. The user then signed call #2 thinking they were signing call #1. Call #1 never received a matching `response.callId`, hung until window close, and rejected with `PopupError.RejectedByUser`. That `Error` instance does not survive `postMessage` / `chrome.runtime.sendMessage` serialization (its fields are non-enumerable), so the dapp received `{}`, viem could not classify it and threw `UnknownRpcError`, and Hyperliquid retried call #1 → infinite loop.

The new path uses a module-level `popupQueue: Promise<unknown>`. Each `inNewWindow` chains its `run()` onto the queue via `popupQueue.then(run, run)`, so calls execute strictly in order regardless of whether the prior call resolved or rejected. `popupQueue = next.catch(() => {})` keeps the chain alive across failures while the returned `next` promise still rejects to the caller. `findExistingPopupWindow` is removed.

## Behavior
- Single-popup dapps: unchanged.
- Multi-popup dapps (Hyperliquid, 1inch approve+swap): popups now appear sequentially, each in its own window. The user signs them in order.
- Failures don't break later calls.

Fixes #3820

## Test plan
- [ ] Hyperliquid: connect, click Enable Trading, sign Establish Connection → sign Enable Trading → flow advances to USDC deposit (no loop).
- [ ] Uniswap (or any single-popup dapp): connect + `personal_sign` + `eth_sendTransaction` work as before.
- [ ] 1inch: approve + swap (two consecutive popups) — both popups appear in order, each in its own window.
- [ ] User cancels first popup mid-queue → next request still opens normally.
- [ ] `yarn check:all` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced popup window creation to reliably handle multiple concurrent requests through sequential queue-based processing. This ensures proper window lifecycle management, consistent resource cleanup, and prevents potential conflicts from simultaneous popup operations.

* **Refactor**
  * Restructured popup creation workflow to streamline the implementation and improve code maintainability by simplifying window management logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->