### PR TITLE
fix(search): use regular font weight in SearchField

### DIFF
--- a/lib/ui/search/SearchField.tsx
+++ b/lib/ui/search/SearchField.tsx
@@ -85,10 +85,10 @@ const StyledInput = styled.input.attrs({ autoComplete: 'off' })`
   transition: border-color 0.2s;
   background-color: transparent;
   color: ${getColor('contrast')};
-  font-weight: 700;
+  font-weight: 400;
 
   &::placeholder {
     color: ${getColor('textShy')};
-    font-weight: 500;
+    font-weight: 400;
   }
 `


### PR DESCRIPTION
## Summary
- Closes #3770
- The shared `SearchField` (used in token search, chain search, asset receive modal, etc.) was rendering the typed input in **bold (700)** and the placeholder in **500**, which made search results look heavier than the design system specifies.
- Switched both the input value and the placeholder to **regular (400)** so token search now renders in the expected weight.

## Test plan
- [ ] `yarn check:all` succeeds
- [ ] Open the desktop app, navigate to *Manage Tokens* (or any other screen that uses the shared search field) and type a query — text should render in regular weight, not bold
- [ ] Verify the placeholder still reads naturally in regular weight
- [ ] Confirm the change is consistent across other consumers of `SearchField` (chain search, receive modal, select-item modal)

## Before
<img width="465" height="182" alt="IMAGE 2026-05-02 17:07:07" src="https://github.com/user-attachments/assets/db8cdd31-4f18-4af6-b343-d2d1215ca567" />

## After
<img width="460" height="165" alt="IMAGE 2026-05-02 17:07:16" src="https://github.com/user-attachments/assets/e7dca646-640b-4f32-b7a5-84de8c48251e" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated search field typography styling for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->