### PR TITLE
feat: parse all Blockaid simulation assets_diffs (Phase 1.1)

### DIFF
--- a/core/inpage-provider/popup/view/resolvers/sendTx/blockaid/BlockaidBalanceChanges.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/blockaid/BlockaidBalanceChanges.tsx
@@ -1,0 +1,100 @@
+import { MemoSection } from '@core/inpage-provider/popup/view/resolvers/sendTx/components/MemoSection'
+import {
+  NetworkFeeSection,
+  NetworkFeeSectionProps,
+} from '@core/inpage-provider/popup/view/resolvers/sendTx/components/NetworkFeeSection'
+import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
+import { ArrowUpRightIcon } from '@lib/ui/icons/ArrowUpRightIcon'
+import { TransactionReceiveIcon } from '@lib/ui/icons/TransactionReceiveIcon'
+import { HStack, VStack } from '@lib/ui/layout/Stack'
+import { Text } from '@lib/ui/text'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { BlockaidEvmBalanceChange } from '@vultisig/core-chain/security/blockaid/tx/simulation/core'
+import { formatAmount } from '@vultisig/lib-utils/formatAmount'
+import { match } from '@vultisig/lib-utils/match'
+import { formatUnits } from 'ethers'
+import { useTranslation } from 'react-i18next'
+
+type BlockaidBalanceChangesProps = {
+  changes: BlockaidEvmBalanceChange[]
+  memo: string | undefined
+  chain: Chain
+  networkFeeProps: NetworkFeeSectionProps
+}
+
+export const BlockaidBalanceChanges = ({
+  changes,
+  memo,
+  chain,
+  networkFeeProps,
+}: BlockaidBalanceChangesProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <>
+      <VStack bgColor="foreground" gap={16} padding={24} radius={16}>
+        <Text color="supporting" size={15}>
+          {t('balance_changes')}
+        </Text>
+        <VStack gap={12}>
+          {changes.map((change, index) => (
+            <BalanceChangeRow key={index} change={change} />
+          ))}
+        </VStack>
+      </VStack>
+      <MemoSection memo={memo} chain={chain} />
+      <NetworkFeeSection {...networkFeeProps} />
+    </>
+  )
+}
+
+type BalanceChangeRowProps = {
+  change: BlockaidEvmBalanceChange
+}
+
+const BalanceChangeRow = ({ change }: BalanceChangeRowProps) => {
+  const { t } = useTranslation()
+  const { coin, direction, amount, usdValue } = change
+
+  const formattedAmount = formatAmount(
+    Number(formatUnits(amount, coin.decimals)),
+    coin
+  )
+  const directionIcon = match(direction, {
+    send: () => <Text as={ArrowUpRightIcon} color="danger" size={16} />,
+    receive: () => (
+      <Text as={TransactionReceiveIcon} color="success" size={16} />
+    ),
+  })
+  const directionLabel = match(direction, {
+    send: () => t('send'),
+    receive: () => t('receive'),
+  })
+  const amountColor = match(direction, {
+    send: () => 'danger' as const,
+    receive: () => 'success' as const,
+  })
+
+  return (
+    <HStack alignItems="center" gap={12} fullWidth>
+      <HStack alignItems="center" gap={8}>
+        {directionIcon}
+        <Text color="shy" size={13}>
+          {directionLabel}
+        </Text>
+      </HStack>
+      <HStack alignItems="center" gap={8} flexGrow>
+        <CoinIcon coin={coin} style={{ fontSize: 20 }} />
+        <Text color={amountColor} size={15} weight="500">
+          {direction === 'send' ? '−' : '+'}
+          {formattedAmount}
+        </Text>
+      </HStack>
+      {usdValue !== undefined ? (
+        <Text color="shy" size={13}>
+          ~{formatAmount(usdValue, { currency: 'usd' })}
+        </Text>
+      ) : null}
+    </HStack>
+  )
+}

--- a/core/inpage-provider/popup/view/resolvers/sendTx/blockaid/BlockaidSimulationContent.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/blockaid/BlockaidSimulationContent.tsx
@@ -278,6 +278,9 @@ const BlockaidEvmSimulationContent = ({
         if (!blockaidSimulationInfo) {
           return fallback
         }
+        if (blockaidSimulationInfo.changes.length === 0) {
+          return fallback
+        }
         const shape = classifyEvmChanges(blockaidSimulationInfo.changes)
         if (shape.kind === 'transfer') {
           return (

--- a/core/inpage-provider/popup/view/resolvers/sendTx/blockaid/BlockaidSimulationContent.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/blockaid/BlockaidSimulationContent.tsx
@@ -1,3 +1,4 @@
+import { BlockaidBalanceChanges } from '@core/inpage-provider/popup/view/resolvers/sendTx/blockaid/BlockaidBalanceChanges'
 import { BlockaidSwapDisplay } from '@core/inpage-provider/popup/view/resolvers/sendTx/blockaid/BlockaidSwapDisplay'
 import { BlockaidTransferDisplay } from '@core/inpage-provider/popup/view/resolvers/sendTx/blockaid/BlockaidTransferDisplay'
 import {
@@ -23,6 +24,7 @@ import { Chain, EvmChain } from '@vultisig/core-chain/Chain'
 import { getEvmContractCallInfo } from '@vultisig/core-chain/chains/evm/contract/call/info'
 import { Coin, CoinKey } from '@vultisig/core-chain/coin/Coin'
 import {
+  BlockaidEvmBalanceChange,
   BlockaidEvmSimulationInfo,
   BlockaidSolanaSimulationInfo,
 } from '@vultisig/core-chain/security/blockaid/tx/simulation/core'
@@ -216,6 +218,41 @@ const BlockaidSolanaSimulationContent = ({
   )
 }
 
+type EvmDisplayShape =
+  | { kind: 'transfer'; change: BlockaidEvmBalanceChange }
+  | {
+      kind: 'swap'
+      from: BlockaidEvmBalanceChange
+      to: BlockaidEvmBalanceChange
+    }
+  | { kind: 'complex'; changes: BlockaidEvmBalanceChange[] }
+
+// Pick the right hero/list display from the net balance changes. The simple
+// shapes (single send → transfer, exactly one send + one receive of distinct
+// assets → swap) keep the Phase 1 hero card styling that users are used to;
+// anything else (multicall, multi-asset DeFi, receive-only) renders as a
+// compact balance-changes list.
+const classifyEvmChanges = (
+  changes: BlockaidEvmBalanceChange[]
+): EvmDisplayShape => {
+  if (changes.length === 1 && changes[0].direction === 'send') {
+    return { kind: 'transfer', change: changes[0] }
+  }
+  if (changes.length === 2) {
+    const [first, second] = changes
+    const send = first.direction === 'send' ? first : second
+    const receive = first.direction === 'receive' ? first : second
+    if (send.direction === 'send' && receive.direction === 'receive') {
+      const sendId = send.coin.id?.toLowerCase()
+      const receiveId = receive.coin.id?.toLowerCase()
+      if (sendId !== receiveId) {
+        return { kind: 'swap', from: send, to: receive }
+      }
+    }
+  }
+  return { kind: 'complex', changes }
+}
+
 const BlockaidEvmSimulationContent = ({
   blockaidSimulationQuery,
   keysignPayload,
@@ -241,26 +278,45 @@ const BlockaidEvmSimulationContent = ({
         if (!blockaidSimulationInfo) {
           return fallback
         }
-        return matchRecordUnion(blockaidSimulationInfo, {
-          swap: swap => (
-            <BlockaidSwapDisplay
-              swap={swap}
-              memo={keysignPayload.memo}
-              chain={chain}
-              networkFeeProps={networkFeeProps}
-            />
-          ),
-          transfer: transfer => (
+        const shape = classifyEvmChanges(blockaidSimulationInfo.changes)
+        if (shape.kind === 'transfer') {
+          return (
             <BlockaidTransferDisplay
-              transfer={transfer}
+              transfer={{
+                fromCoin: shape.change.coin,
+                fromAmount: shape.change.amount,
+              }}
               fromAddress={address}
               toAddress={keysignPayload.toAddress}
               memo={keysignPayload.memo}
               chain={chain}
               networkFeeProps={networkFeeProps}
             />
-          ),
-        })
+          )
+        }
+        if (shape.kind === 'swap') {
+          return (
+            <BlockaidSwapDisplay
+              swap={{
+                fromCoin: shape.from.coin,
+                fromAmount: shape.from.amount,
+                toCoin: shape.to.coin,
+                toAmount: shape.to.amount,
+              }}
+              memo={keysignPayload.memo}
+              chain={chain}
+              networkFeeProps={networkFeeProps}
+            />
+          )
+        }
+        return (
+          <BlockaidBalanceChanges
+            changes={shape.changes}
+            memo={keysignPayload.memo}
+            chain={chain}
+            networkFeeProps={networkFeeProps}
+          />
+        )
       }}
       error={() => fallback}
       pending={() => null}

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -102,6 +102,7 @@ export const en = {
   backup_without_password: 'Backup without password',
   balance: 'Balance',
   balance_available: 'Balance available',
+  balance_changes: 'Balance Changes',
   base_fee: 'Base Fee',
   blockaid_security_scan: 'Blockaid Security Scan',
   blockaid_simulation_failed: 'Transaction Simulation Failed',

--- a/core/ui/mpc/keysign/tx/TxSuccess.tsx
+++ b/core/ui/mpc/keysign/tx/TxSuccess.tsx
@@ -148,14 +148,10 @@ export const TxSuccess = ({
 
   const simulationSend = useMemo(() => {
     const data = blockaidSimulationQuery.data
-    if (!data) return null
-    if ('swap' in data && 'fromCoin' in data.swap) {
-      return { coin: data.swap.fromCoin, amount: data.swap.fromAmount }
-    }
-    if ('transfer' in data && 'fromCoin' in data.transfer) {
-      return { coin: data.transfer.fromCoin, amount: data.transfer.fromAmount }
-    }
-    return null
+    if (!data || !('changes' in data)) return null
+    const sendChange = data.changes.find(c => c.direction === 'send')
+    if (!sendChange) return null
+    return { coin: sendChange.coin, amount: sendChange.amount }
   }, [blockaidSimulationQuery.data])
 
   const displayCoin = simulationSend?.coin ?? resolvedToken?.coin ?? coin

--- a/core/ui/mpc/keysign/tx/TxSuccess.tsx
+++ b/core/ui/mpc/keysign/tx/TxSuccess.tsx
@@ -149,8 +149,13 @@ export const TxSuccess = ({
   const simulationSend = useMemo(() => {
     const data = blockaidSimulationQuery.data
     if (!data || !('changes' in data)) return null
-    const sendChange = data.changes.find(c => c.direction === 'send')
-    if (!sendChange) return null
+    // Only adopt the simulation's send leg as the success hero when there's
+    // exactly one — multi-send shapes (e.g. multicalls that send several
+    // tokens) can't be summarised by a single coin/amount, so let the
+    // fallbacks (resolved token, txAction) handle them.
+    const sendChanges = data.changes.filter(c => c.direction === 'send')
+    if (sendChanges.length !== 1) return null
+    const [sendChange] = sendChanges
     return { coin: sendChange.coin, amount: sendChange.amount }
   }, [blockaidSimulationQuery.data])
 


### PR DESCRIPTION
## Summary
- Parse every entry in `assets_diffs[]` (not just 1- or 2-diff shapes) so multicalls, staking, and complex DeFi flows render balance changes instead of dropping to the ABI fallback
- Net per asset (grouped by lowercased address; native uses a sentinel key) so refund-shaped legs and EIP-55 casing duplicates cancel cleanly
- New `BlockaidBalanceChanges.tsx` compact list view (up/down arrow per row, ± sign + danger/success color, optional USD)
- Phase 1 hero displays preserved for simple cases — `BlockaidSimulationContent` classifies the change list and routes to `BlockaidTransferDisplay` (1 send), `BlockaidSwapDisplay` (1 send + 1 receive of distinct assets), or the new component (everything else)

Closes #3733

## SDK dependency
This depends on a companion change in `vultisig/vultisig-sdk` to `parseBlockaidEvmSimulation` and `BlockaidEvmSimulationInfo` (now `{ changes: BlockaidEvmBalanceChange[] } | null`). The SDK PR + sync into this repo must land first for CI to pass here.

SDK files modified:
- `packages/core/chain/security/blockaid/tx/simulation/core.ts` — new `BlockaidEvmBalanceChange` type, refactored `BlockaidEvmSimulationInfo`
- `packages/core/chain/security/blockaid/tx/simulation/api/core.ts` — net-per-asset parser
- `packages/core/chain/security/blockaid/tx/simulation/api/core.test.ts` — 11 tests covering single transfer, 3-diff `permitAndCall` swap, 2-diff swap, EIP-55 grouping, refund detection, multicall (4-diff), USD aggregation, and net-send when out > in

## Out of scope
Approvals (`exposures` field) — not in current SDK types and the issue title only covers `assets_diffs`. The new component layout leaves room to add an Approvals section in a follow-up.

iOS/Android Phase 1.1 are separate platform tickets — TS SDK changes don't touch their parsers.

## Test plan
- [ ] Aave deposit (multicall) → verify screen shows grouped balance changes (USDC out, aUSDC in)
- [ ] Uniswap V3 swap (`permitAndCall`, 3 diffs) → renders Phase 1 swap hero
- [ ] Plain ERC20 transfer → renders Phase 1 transfer hero
- [ ] Receive-only flow → balance changes list with one ↓ Receive row
- [ ] Refund-shaped tx (same asset on both sides, equal amounts) → falls through to ABI fallback (null result)
- [ ] Complex multicall with > 2 distinct assets → renders compact list with all changes
- [ ] `yarn typecheck`, `yarn lint`, `yarn test` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Balance Changes" panel showing per-asset send/receive rows with direction icons, colored signed amounts, and optional USD values; includes memo and network fee sections.
  * Simulation view now classifies changes to render transfer, swap, or a comprehensive balance-changes view; falls back to calldata display when no changes exist.
  * Success screen now derives the primary send amount from single-send simulation changes.
* **Localization**
  * Added "Balance Changes" UI string.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->