### PR TITLE
feat(qbtc): implement getTx resolver via Cosmos REST API

### DIFF
--- a/core/inpage-provider/background/resolvers/getTx.ts
+++ b/core/inpage-provider/background/resolvers/getTx.ts
@@ -6,6 +6,7 @@ import {
 } from '@vultisig/core-chain/ChainKind'
 import { getCosmosClient } from '@vultisig/core-chain/chains/cosmos/client'
 import { cosmosRpcUrl } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
+import { qbtcRestUrl } from '@vultisig/core-chain/chains/cosmos/qbtc/tendermintRpcUrl'
 import { getEvmClient } from '@vultisig/core-chain/chains/evm/client'
 import { getBlockchairBaseUrl } from '@vultisig/core-chain/chains/utxo/client/getBlockchairBaseUrl'
 import { NotImplementedError } from '@vultisig/lib-utils/error/NotImplementedError'
@@ -38,9 +39,7 @@ export const getTx: BackgroundResolver<'getTx'> = async ({
 
         return client.getTx(hash)
       },
-      qbtc: () => {
-        throw new NotImplementedError('Get tx for QBTC chain')
-      },
+      qbtc: () => queryUrl(`${qbtcRestUrl}/cosmos/tx/v1beta1/txs/${hash}`),
       utxo: async chain => {
         const url = `${getBlockchairBaseUrl(chain)}/dashboards/transaction/${hash}`
 


### PR DESCRIPTION
## Summary

Closes #3711. The \`getTx\` resolver was throwing \`NotImplementedError\` for QBTC, so anything that looks up a tx by hash (claim flow verification, transaction history) failed for that chain.

QBTC is a standard CometBFT / Cosmos SDK chain, so the REST endpoint \`/cosmos/tx/v1beta1/txs/{hash}\` works without further translation. Route through \`qbtcRestUrl\` — the same constant the rest of the QBTC code uses for the \`restOnlyChains\` pattern (QBTC bypasses StargateClient because MLDSA keys aren't supported there).

## What changed

\`core/inpage-provider/background/resolvers/getTx.ts\`:

- Drop the \`NotImplementedError\` for the \`qbtc\` branch.
- Call \`queryUrl(\`\${qbtcRestUrl}/cosmos/tx/v1beta1/txs/\${hash}\`)\` — \`queryUrl\` already throws on non-2xx, so 404 propagates naturally.

## Test plan

- [x] \`yarn check\` clean (typecheck + lint + knip)
- [ ] CI green
- [ ] Manual: broadcast a QBTC tx and look it up by hash via this resolver

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added QBTC Cosmos transaction lookup support via REST API integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->