### PR TITLE
fix(extension): remove CSP-blocked SDK globals

### DIFF
--- a/clients/extension/vite.config.ts
+++ b/clients/extension/vite.config.ts
@@ -12,6 +12,14 @@ import { getCommonPlugins } from '../../core/ui/vite/plugins'
 import { getStaticCopyTargets } from '../../core/ui/vite/staticCopy'
 
 const rootDir = path.resolve(__dirname, '../..')
+const extensionNodePolyfills = () =>
+  nodePolyfills({
+    exclude: ['fs'],
+    globals: {
+      process: false,
+    },
+  })
+const extensionVultisigSdk = () => vultisigSdk({ browserGlobals: false })
 
 /** One physical copy of MPC entry + types across chunks (vultisig-windows#3831 / #3777). */
 const vultisigMpcDedupe: readonly string[] = [
@@ -45,7 +53,7 @@ export default defineConfig(async ({ mode }) => {
 
     switch (chunk) {
       case 'background':
-        plugins = [nodePolyfills({ exclude: ['fs'] }), wasm(), topLevelAwait()]
+        plugins = [extensionNodePolyfills(), wasm(), topLevelAwait()]
         break
       case 'inpage':
         format = 'iife'
@@ -63,7 +71,11 @@ export default defineConfig(async ({ mode }) => {
     return {
       define: { ...featureFlagDefines, ...envDefines },
       resolve: { dedupe: [...vultisigMpcDedupe] },
-      plugins: [vultisigSdk(), tsconfigPaths({ root: rootDir }), ...plugins],
+      plugins: [
+        extensionVultisigSdk(),
+        tsconfigPaths({ root: rootDir }),
+        ...plugins,
+      ],
       build: {
         copyPublicDir: false,
         emptyOutDir: false,
@@ -89,7 +101,10 @@ export default defineConfig(async ({ mode }) => {
       resolve: { dedupe: [...vultisigMpcDedupe] },
       plugins: [
         tsconfigPaths({ root: rootDir }),
-        ...getCommonPlugins(),
+        ...getCommonPlugins({
+          nodePolyfills: extensionNodePolyfills(),
+          vultisigSdk: extensionVultisigSdk(),
+        }),
         viteStaticCopy({
           targets: getStaticCopyTargets(),
         }),

--- a/core/ui/vite/plugins.ts
+++ b/core/ui/vite/plugins.ts
@@ -5,18 +5,26 @@ import { nodePolyfills } from 'vite-plugin-node-polyfills'
 import topLevelAwait from 'vite-plugin-top-level-await'
 import wasm from 'vite-plugin-wasm'
 
-export const getCommonPlugins = (): PluginOption[] => [
+type GetCommonPluginsInput = {
+  nodePolyfills?: PluginOption
+  vultisigSdk?: PluginOption
+}
+
+export const getCommonPlugins = ({
+  nodePolyfills: nodePolyfillsPlugin = nodePolyfills({ exclude: ['fs'] }),
+  vultisigSdk: vultisigSdkPlugin = vultisigSdk(),
+}: GetCommonPluginsInput = {}): PluginOption[] => [
   // Configures `optimizeDeps.exclude` for the wasm-bindgen glue packages so
   // `new URL('*.wasm', import.meta.url)` inside them resolves next to the real
   // .wasm payload rather than against `.vite/deps/`. Owned by the SDK so we
   // get updates for free when new wasm packages are added.
-  vultisigSdk(),
+  vultisigSdkPlugin,
   react({
     babel: {
       plugins: [['babel-plugin-react-compiler', {}]],
     },
   }),
-  nodePolyfills({ exclude: ['fs'] }),
+  nodePolyfillsPlugin,
   wasm(),
   topLevelAwait(),
 ]


### PR DESCRIPTION
Summary
- Disable the SDK browser-global HTML injection for extension builds.
- Disable process global polyfill injection in extension chunks.
- Keep default shared Vite plugin behavior unchanged for non-extension callers.

Context
- This does not change Solana broadcast semantics directly. It removes the CSP-blocked inline process shim seen in the temp build, so Solana broadcast testing happens in a clean extension runtime.

Test Plan
- NODE_OPTIONS=--max-old-space-size=8192 yarn workspace @clients/extension build
- yarn check
- Verified clients/extension/dist/index.html and popup.html have no inline globalThis.process shim.