### PR TITLE
fix(keysign): await async signing inputs to support Cardano CNT

### DIFF
--- a/core/ui/agent/tools/handlers/signTx.ts
+++ b/core/ui/agent/tools/handlers/signTx.ts
@@ -13,7 +13,7 @@ import { decodeSigningOutput } from '@vultisig/core-chain/tw/signingOutput'
 import { broadcastTx } from '@vultisig/core-chain/tx/broadcast'
 import { getTxHash } from '@vultisig/core-chain/tx/hash'
 import type { KeysignSignature } from '@vultisig/core-mpc/keysign/KeysignSignature'
-import { getEncodedSigningInputs } from '@vultisig/core-mpc/keysign/signingInputs'
+import { getEncodedSigningInputsAsync } from '@vultisig/core-mpc/keysign/signingInputs'
 import { getKeysignChain } from '@vultisig/core-mpc/keysign/utils/getKeysignChain'
 import { compileTx } from '@vultisig/core-mpc/tx/compile/compileTx'
 import { getPreSigningHashes } from '@vultisig/core-mpc/tx/preSigningHashes'
@@ -62,7 +62,7 @@ export const handleSignTx: ToolHandler = async (input, context) => {
   const coinType = getCoinType({ walletCore, chain })
   const derivePath = walletCore.CoinTypeExt.derivationPath(coinType)
 
-  const encodedInputs = getEncodedSigningInputs({
+  const encodedInputs = await getEncodedSigningInputsAsync({
     keysignPayload,
     walletCore,
     publicKey,

--- a/core/ui/mpc/keysign/action/mutations/useKeysignMutation.ts
+++ b/core/ui/mpc/keysign/action/mutations/useKeysignMutation.ts
@@ -30,7 +30,7 @@ import {
 import { getBlockchainSpecificValue } from '@vultisig/core-mpc/keysign/chainSpecific/KeysignChainSpecific'
 import { KeysignMessagePayload } from '@vultisig/core-mpc/keysign/keysignPayload/KeysignMessagePayload'
 import { KeysignResult } from '@vultisig/core-mpc/keysign/KeysignResult'
-import { getEncodedSigningInputs } from '@vultisig/core-mpc/keysign/signingInputs'
+import { getEncodedSigningInputsAsync } from '@vultisig/core-mpc/keysign/signingInputs'
 import { getKeysignChain } from '@vultisig/core-mpc/keysign/utils/getKeysignChain'
 import { compileTx } from '@vultisig/core-mpc/tx/compile/compileTx'
 import { getPreSigningHashes } from '@vultisig/core-mpc/tx/preSigningHashes'
@@ -150,7 +150,7 @@ export const useKeysignMutation = (payload: KeysignMessagePayload) => {
               chainPublicKeys: vault.chainPublicKeys,
             })
 
-            const inputs = getEncodedSigningInputs({
+            const inputs = await getEncodedSigningInputsAsync({
               keysignPayload: payload,
               walletCore,
               publicKey,

--- a/core/ui/mpc/keysign/fast/FastKeysignServerStep.tsx
+++ b/core/ui/mpc/keysign/fast/FastKeysignServerStep.tsx
@@ -20,7 +20,7 @@ import { assertChainField } from '@vultisig/core-chain/utils/assertChainField'
 import { getQBTCPreSignedImageHash } from '@vultisig/core-mpc/chains/cosmos/qbtc/QBTCHelper'
 import { signWithServer } from '@vultisig/core-mpc/fast/api/signWithServer'
 import { getBlockchainSpecificValue } from '@vultisig/core-mpc/keysign/chainSpecific/KeysignChainSpecific'
-import { getEncodedSigningInputs } from '@vultisig/core-mpc/keysign/signingInputs'
+import { getEncodedSigningInputsAsync } from '@vultisig/core-mpc/keysign/signingInputs'
 import { getPreSigningHashes } from '@vultisig/core-mpc/tx/preSigningHashes'
 import { isOneOf } from '@vultisig/lib-utils/array/isOneOf'
 import { attempt } from '@vultisig/lib-utils/attempt'
@@ -134,7 +134,7 @@ export const FastKeysignServerStep: React.FC<FastKeysignServerStepProps> = ({
             publicKeys,
             chainPublicKeys,
           })
-          const inputs = getEncodedSigningInputs({
+          const inputs = await getEncodedSigningInputsAsync({
             keysignPayload,
             walletCore,
             publicKey,


### PR DESCRIPTION
## Summary

- The Cardano signing-input resolver is async — it fetches per-UTxO `asset_list` from Koios at sign time so the WalletCore planner can balance a `TokenBundle` output against the inputs.
- The dispatcher in `@vultisig/core-mpc/keysign/signingInputs` exposes both a sync (`getEncodedSigningInputs`) and an async (`getEncodedSigningInputsAsync`) entrypoint. The sync entry throws when invoked for Cardano so non-Cardano callers (Blockaid simulation/validation) keep their sync contract.
- Three keysign call sites were still using the sync entry, breaking Cardano native-token sends through Fast Vault, Secure Vault, and the agent sign-tx tool.

## Changes

Switch to `await getEncodedSigningInputsAsync(...)` in:

- `core/ui/mpc/keysign/fast/FastKeysignServerStep.tsx` — Fast Vault server cosign step
- `core/ui/mpc/keysign/action/mutations/useKeysignMutation.ts` — Secure Vault keysign mutation
- `core/ui/agent/tools/handlers/signTx.ts` — agent sign-tx tool handler

The sync entry remains for Blockaid (Cardano isn't a Blockaid-supported chain).

## Dependency

This requires the corresponding SDK change that exports `getEncodedSigningInputsAsync` from `@vultisig/core-mpc/keysign/signingInputs`. Until that lands and is published, CI typecheck on this branch will fail. Drafted for that reason.

## Test plan

- [x] Fast Vault — Cardano CNT (USDM) send + broadcast end-to-end (verified locally with `scripts/use-local-sdk.sh`)
- [ ] Secure Vault — Cardano CNT send + broadcast
- [ ] Cardano ADA-only send (regression — must still work; ADA-only path skips the Koios extended-UTxO fetch)
- [ ] Non-Cardano send on a representative chain (regression — async path is a no-op for sync resolvers)
- [ ] Agent sign-tx tool against any chain (regression — same dispatcher, just awaited)

🤖 Generated with [Claude Code](https://claude.com/claude-code)