### PR TITLE
fix(passcode): mask digits while typing on set/change/unlock

### DIFF
--- a/core/ui/passcodeEncryption/manage/PasscodeInput.tsx
+++ b/core/ui/passcodeEncryption/manage/PasscodeInput.tsx
@@ -33,6 +33,7 @@ export const PasscodeInput = ({
         validation={validation}
         validationMessages={validationMessages}
         value={value}
+        secureEntry
       />
     </>
   )

--- a/lib/ui/inputs/MultiCharacterInput/index.tsx
+++ b/lib/ui/inputs/MultiCharacterInput/index.tsx
@@ -23,6 +23,7 @@ export type MultiCharacterInputProps = InputProps<string | null> &
     includePasteButton?: boolean
     autoFocusFirst?: boolean
     validationMessages?: ValidationMessages
+    secureEntry?: boolean
   }
 
 export const MultiCharacterInput = ({
@@ -34,6 +35,7 @@ export const MultiCharacterInput = ({
   includePasteButton = true,
   autoFocusFirst = true,
   className,
+  secureEntry = false,
   ...rest
 }: MultiCharacterInputProps) => {
   const { t } = useTranslation()
@@ -54,7 +56,7 @@ export const MultiCharacterInput = ({
         {digits.map((digit, idx) => (
           <DigitInput
             key={idx}
-            type="text"
+            type={secureEntry ? 'password' : 'text'}
             inputMode="numeric"
             pattern="[0-9]*"
             maxLength={1}


### PR DESCRIPTION
## Summary
- Passcode entry rendered typed digits in plaintext (`type="text"`). Switches to `type="password"` for set / change / unlock.
- Adds opt-in `secureEntry?: boolean` prop on the shared `MultiCharacterInput`; default `false`. `PasscodeInput` passes `secureEntry`.
- Email-OTP path on fast vault backup (`core/ui/vault/backup/fast/index.tsx`) is unchanged — still plaintext, intentional.

Closes #3874.

## Test plan
- [x] `yarn check:all` (112 tests pass, no type/lint errors)
- [ ] Visual: passcode digits render as masked dots while typing on extension and desktop (set/change/unlock)
- [ ] Visual: email confirmation code on fast vault backup still renders in plaintext
- [ ] Numeric keyboard still appears on touch devices (`inputMode="numeric"` preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added masked entry mode for multi-character input fields, allowing digit values to be hidden during entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->