### PR TITLE
test(extension/e2e): dismiss post-import prompt sheet, off-screen flag

### DIFF
--- a/clients/extension/tests/e2e/page-objects/VaultPage.po.ts
+++ b/clients/extension/tests/e2e/page-objects/VaultPage.po.ts
@@ -82,6 +82,22 @@ export class VaultPage extends BasePage {
       }
       throw new Error(`Vault page did not appear within ${timeout}ms. Check if a vault exists.`)
     }
+    await this.dismissPromptSheets()
+  }
+
+  /**
+   * Dismiss any modal PromptSheet (e.g. EnableNotificationsPromptSheet shown
+   * once after first vault load). The PromptSheet renders as a fixed Overlay
+   * with z-index 1 that intercepts pointer events on header buttons. Pressing
+   * Escape triggers its useKeyDown handler, which calls onClose and persists
+   * hasSeenNotificationPrompt so subsequent loads skip it.
+   */
+  async dismissPromptSheets(): Promise<void> {
+    const dialog = this.page.locator('[role="dialog"][aria-modal="true"]').first()
+    const visible = await dialog.isVisible({ timeout: 1000 }).catch(() => false)
+    if (!visible) return
+    await this.page.keyboard.press('Escape')
+    await dialog.waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {})
   }
 
   /**

--- a/clients/extension/tests/e2e/playwright.config.ts
+++ b/clients/extension/tests/e2e/playwright.config.ts
@@ -32,6 +32,13 @@ config({ path: path.resolve(__dirname, '.env') })
 const extensionPath = path.resolve(__dirname, '../../dist')
 
 // Common launch args for extension loading
+// PLAYWRIGHT_OFFSCREEN=1 pushes Chrome windows off-screen so local runs don't
+// steal focus while you work. Extension tests can't run headless, so this is
+// the closest equivalent. CI keeps default positioning.
+const offscreenArgs = process.env.PLAYWRIGHT_OFFSCREEN === '1'
+  ? ['--window-position=-3000,-3000', '--window-size=480,600']
+  : []
+
 const extensionLaunchArgs = [
   `--disable-extensions-except=${extensionPath}`,
   `--load-extension=${extensionPath}`,
@@ -39,6 +46,7 @@ const extensionLaunchArgs = [
   '--no-default-browser-check',
   '--disable-default-apps',
   '--disable-popup-blocking',
+  ...offscreenArgs,
 ]
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
Two test-infra improvements caught during the v1.0.59 release sweep.

- **`VaultPage.waitForView()` now dismisses prompt sheets after the vault container appears.** The `EnableNotificationsPromptSheet` renders a fixed `Overlay` (z-index 1) on first vault load and intercepts pointer events on header buttons including the settings button. Three tests in `address-book.spec.ts` were failing on settings click because of this, which cascaded via Playwright project dependencies and blocked all 175 network + fund-dependent specs from running. Pressing `Escape` triggers `PromptSheet`'s `useKeyDown` handler which calls `onClose` and persists `hasSeenNotificationPrompt` so subsequent loads skip it.
- **`playwright.config.ts` honors `PLAYWRIGHT_OFFSCREEN=1`** to push Chromium windows to `(-3000,-3000)` during local runs. Extension tests can't run headless, so this is the closest equivalent for unattended local sweeps. CI keeps default positioning.

Net effect: unblocks the 175-spec dependency chain in local + CI runs.

## Test plan
- [x] `yarn check:all` (112 unit tests pass)
- [ ] `yarn test:e2e` against extension — confirm `address-book.spec.ts` settings-click no longer fails on overlay
- [ ] Sanity: `PLAYWRIGHT_OFFSCREEN=1 yarn test:e2e` keeps Chromium off-screen locally
- [ ] CI run confirms default window positioning unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)