### PR TITLE
[codex] Add Firefox extension build

### DIFF
--- a/clients/extension/package.json
+++ b/clients/extension/package.json
@@ -15,7 +15,7 @@
     "build:content": "tsc -b && cross-env CHUNK=content vite build",
     "build:inpage": "tsc -b && cross-env CHUNK=inpage vite build",
     "build": "npm-run-all --serial build:app build:background build:content build:inpage",
-    "build:firefox": "cross-env NODE_OPTIONS=--max-old-space-size=8192 yarn build && node scripts/prepare-firefox-build.mjs",
+    "build:firefox": "node scripts/clean-dist.mjs && cross-env NODE_OPTIONS=--max-old-space-size=8192 VULTISIG_EXTENSION_TARGET=firefox yarn build && node scripts/prepare-firefox-build.mjs",
     "dev": "node watch.js",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/clients/extension/package.json
+++ b/clients/extension/package.json
@@ -15,6 +15,7 @@
     "build:content": "tsc -b && cross-env CHUNK=content vite build",
     "build:inpage": "tsc -b && cross-env CHUNK=inpage vite build",
     "build": "npm-run-all --serial build:app build:background build:content build:inpage",
+    "build:firefox": "cross-env NODE_OPTIONS=--max-old-space-size=8192 yarn build && node scripts/prepare-firefox-build.mjs",
     "dev": "node watch.js",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/clients/extension/scripts/clean-dist.mjs
+++ b/clients/extension/scripts/clean-dist.mjs
@@ -1,0 +1,8 @@
+import { rm } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url))
+const distPath = path.resolve(currentDir, '../dist')
+
+await rm(distPath, { force: true, recursive: true })

--- a/clients/extension/scripts/prepare-firefox-build.mjs
+++ b/clients/extension/scripts/prepare-firefox-build.mjs
@@ -6,6 +6,8 @@ const currentDir = path.dirname(fileURLToPath(import.meta.url))
 const manifestPath = path.resolve(currentDir, '../dist/manifest.json')
 const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
 
+manifest.author = 'Vultisig <info@vultisig.com>'
+
 const backgroundServiceWorker = manifest.background?.service_worker
 if (!backgroundServiceWorker) {
   throw new Error('Firefox build expected background.service_worker')
@@ -17,15 +19,30 @@ manifest.background = {
 }
 
 manifest.permissions = manifest.permissions.filter(
-  permission => permission !== 'sidePanel'
+  permission => !['sidePanel', 'windows'].includes(permission)
 )
 
+delete manifest.version_name
 delete manifest.side_panel
+
+manifest.content_security_policy = {
+  extension_pages: "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'",
+}
+
+manifest.web_accessible_resources = manifest.web_accessible_resources.map(
+  entry =>
+    entry.resources.includes('inpage.js')
+      ? {
+          resources: [...entry.resources, 'assets/*.js'],
+          matches: entry.matches,
+        }
+      : { resources: entry.resources, matches: entry.matches }
+)
 
 manifest.browser_specific_settings = {
   gecko: {
     id: 'vultisig-extension@vultisig.com',
-    strict_min_version: '121.0',
+    strict_min_version: '142.0',
     data_collection_permissions: {
       required: ['financialAndPaymentInfo', 'websiteActivity'],
     },

--- a/clients/extension/scripts/prepare-firefox-build.mjs
+++ b/clients/extension/scripts/prepare-firefox-build.mjs
@@ -1,0 +1,35 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url))
+const manifestPath = path.resolve(currentDir, '../dist/manifest.json')
+const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+
+const backgroundServiceWorker = manifest.background?.service_worker
+if (!backgroundServiceWorker) {
+  throw new Error('Firefox build expected background.service_worker')
+}
+
+manifest.background = {
+  scripts: [backgroundServiceWorker],
+  type: manifest.background.type,
+}
+
+manifest.permissions = manifest.permissions.filter(
+  permission => permission !== 'sidePanel'
+)
+
+delete manifest.side_panel
+
+manifest.browser_specific_settings = {
+  gecko: {
+    id: 'vultisig-extension@vultisig.com',
+    strict_min_version: '121.0',
+    data_collection_permissions: {
+      required: ['financialAndPaymentInfo', 'websiteActivity'],
+    },
+  },
+}
+
+await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)

--- a/clients/extension/scripts/prepare-firefox-build.mjs
+++ b/clients/extension/scripts/prepare-firefox-build.mjs
@@ -42,7 +42,7 @@ manifest.web_accessible_resources = manifest.web_accessible_resources.map(
 manifest.browser_specific_settings = {
   gecko: {
     id: 'vultisig-extension@vultisig.com',
-    strict_min_version: '142.0',
+    strict_min_version: '139.0',
     data_collection_permissions: {
       required: ['financialAndPaymentInfo', 'websiteActivity'],
     },

--- a/clients/extension/src/background/common.ts
+++ b/clients/extension/src/background/common.ts
@@ -1,0 +1,47 @@
+import { runBackgroundEventsAgent } from '@core/inpage-provider/background/events/background'
+import { runInpageProviderBridgeBackgroundAgent } from '@core/inpage-provider/bridge/background'
+
+import { getIsSidePanelEnabled } from '../storage/isSidePanelEnabled'
+import { registerFreshInstallStorageClear } from './registerFreshInstallStorageClear'
+
+registerFreshInstallStorageClear()
+
+export const initExtensionBackground = () => {
+  if (!navigator.userAgent.toLowerCase().includes('firefox')) {
+    ;[
+      Object,
+      Object.prototype,
+      Function,
+      Function.prototype,
+      Array,
+      Array.prototype,
+      String,
+      String.prototype,
+      Number,
+      Number.prototype,
+      Boolean,
+      Boolean.prototype,
+    ].forEach(Object.freeze)
+  }
+
+  runInpageProviderBridgeBackgroundAgent()
+
+  runBackgroundEventsAgent()
+
+  if (!__IS_FIREFOX_EXTENSION_BUILD__ && chrome.sidePanel) {
+    getIsSidePanelEnabled().then(enabled =>
+      chrome.sidePanel
+        .setPanelBehavior({ openPanelOnActionClick: enabled })
+        .catch(console.error)
+    )
+  }
+
+  if (import.meta.env.VITE_DEV_RELOAD) {
+    const connect = () => {
+      const ws = new WebSocket('ws://localhost:18732')
+      ws.onmessage = () => chrome.runtime.reload()
+      ws.onclose = () => setTimeout(connect, 1000)
+    }
+    connect()
+  }
+}

--- a/clients/extension/src/background/common.ts
+++ b/clients/extension/src/background/common.ts
@@ -7,7 +7,7 @@ import { registerFreshInstallStorageClear } from './registerFreshInstallStorageC
 registerFreshInstallStorageClear()
 
 export const initExtensionBackground = () => {
-  if (!navigator.userAgent.toLowerCase().includes('firefox')) {
+  if (!__IS_FIREFOX_EXTENSION_BUILD__) {
     ;[
       Object,
       Object.prototype,
@@ -29,11 +29,11 @@ export const initExtensionBackground = () => {
   runBackgroundEventsAgent()
 
   if (!__IS_FIREFOX_EXTENSION_BUILD__ && chrome.sidePanel) {
-    getIsSidePanelEnabled().then(enabled =>
-      chrome.sidePanel
-        .setPanelBehavior({ openPanelOnActionClick: enabled })
-        .catch(console.error)
-    )
+    getIsSidePanelEnabled()
+      .then(enabled =>
+        chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: enabled })
+      )
+      .catch(console.error)
   }
 
   if (import.meta.env.VITE_DEV_RELOAD) {

--- a/clients/extension/src/background/common.ts
+++ b/clients/extension/src/background/common.ts
@@ -6,6 +6,11 @@ import { registerFreshInstallStorageClear } from './registerFreshInstallStorageC
 
 registerFreshInstallStorageClear()
 
+/**
+ * Bootstraps the extension background: locks down built-in prototypes (non-Firefox),
+ * starts the inpage-provider bridge and background event agents, applies the persisted
+ * side panel behavior on Chromium, and wires the dev WebSocket reload when enabled.
+ */
 export const initExtensionBackground = () => {
   if (!__IS_FIREFOX_EXTENSION_BUILD__) {
     ;[

--- a/clients/extension/src/background/firefox.ts
+++ b/clients/extension/src/background/firefox.ts
@@ -1,0 +1,5 @@
+import '../polyfills/installFirefoxProcessGlobal'
+
+import { initExtensionBackground } from './common'
+
+initExtensionBackground()

--- a/clients/extension/src/background/index.ts
+++ b/clients/extension/src/background/index.ts
@@ -2,59 +2,8 @@
 // listeners during initial synchronous service worker evaluation.
 import '../notifications/pushServiceWorkerBindings'
 
-import { registerFreshInstallStorageClear } from './registerFreshInstallStorageClear'
-
-registerFreshInstallStorageClear()
-
-// MPC note — see vultisig/vultisig-windows#3777.
-// This service-worker chunk intentionally does NOT import @core/ui/mpc/bootstrapMpcEngine.
-// The background worker does not call getMpcEngine() today; bootstrapping here
-// would pull DKLS/Schnorr JS + WASM into the SW bundle for no reason. If you
-// add MPC code paths to this chunk (e.g. a signing helper), import
-// '@core/ui/mpc/bootstrapMpcEngine' at the top of this file BEFORE any other
-// @vultisig/* import. The SW is a separate JS realm from the popup, so the
-// shim must run once per realm.
-import { runBackgroundEventsAgent } from '@core/inpage-provider/background/events/background'
-import { runInpageProviderBridgeBackgroundAgent } from '@core/inpage-provider/bridge/background'
-
 import { initPushExtensionRuntime } from '../notifications/handlePushEvents'
-import { getIsSidePanelEnabled } from '../storage/isSidePanelEnabled'
+import { initExtensionBackground } from './common'
 
 initPushExtensionRuntime()
-
-if (!navigator.userAgent.toLowerCase().includes('firefox')) {
-  ;[
-    Object,
-    Object.prototype,
-    Function,
-    Function.prototype,
-    Array,
-    Array.prototype,
-    String,
-    String.prototype,
-    Number,
-    Number.prototype,
-    Boolean,
-    Boolean.prototype,
-  ].forEach(Object.freeze)
-}
-
-runInpageProviderBridgeBackgroundAgent()
-
-runBackgroundEventsAgent()
-
-if (chrome.sidePanel) {
-  getIsSidePanelEnabled().then(enabled =>
-    chrome.sidePanel
-      .setPanelBehavior({ openPanelOnActionClick: enabled })
-      .catch(console.error)
-  )
-}
-if (import.meta.env.VITE_DEV_RELOAD) {
-  const connect = () => {
-    const ws = new WebSocket('ws://localhost:18732')
-    ws.onmessage = () => chrome.runtime.reload()
-    ws.onclose = () => setTimeout(connect, 1000)
-  }
-  connect()
-}
+initExtensionBackground()

--- a/clients/extension/src/components/developer-options/index.tsx
+++ b/clients/extension/src/components/developer-options/index.tsx
@@ -91,7 +91,9 @@ export const ExtensionDeveloperOptions = () => {
   return (
     <>
       <UnstyledButton onClick={handleClick}>
-        {`VULTISIG EXTENSION V${version}`}
+        <Text size={12} color="shy">
+          {`VULTISIG EXTENSION V${version}`}
+        </Text>
       </UnstyledButton>
 
       {visible && (

--- a/clients/extension/src/components/side-panel/ManageSidePanel.tsx
+++ b/clients/extension/src/components/side-panel/ManageSidePanel.tsx
@@ -9,27 +9,58 @@ import { ListItem } from '@lib/ui/list/item'
 import { attempt } from '@vultisig/lib-utils/attempt'
 import { useTranslation } from 'react-i18next'
 
+type ChromeSidePanel = {
+  open: (options: { windowId: number }) => Promise<void>
+  setPanelBehavior: (options: {
+    openPanelOnActionClick: boolean
+  }) => Promise<void>
+}
+
+type ChromeRuntimeWithContexts = typeof chrome.runtime & {
+  ContextType?: { SIDE_PANEL: string }
+  getContexts?: (options: { contextTypes: string[] }) => Promise<unknown[]>
+}
+
+const getSidePanel = (): ChromeSidePanel | undefined =>
+  (chrome as unknown as { sidePanel?: ChromeSidePanel }).sidePanel
+
+const getRuntimeWithContexts = (): ChromeRuntimeWithContexts =>
+  chrome.runtime as ChromeRuntimeWithContexts
+
 const switchToSidePanel = async () => {
+  const sidePanel = getSidePanel()
+  if (!sidePanel) return false
+
   const currentWindow = await chrome.windows.getCurrent()
   if (currentWindow.id == null) return false
 
-  await chrome.sidePanel.open({ windowId: currentWindow.id })
+  await sidePanel.open({ windowId: currentWindow.id })
 
   await new Promise(resolve => setTimeout(resolve, 500))
 
-  const contexts = await chrome.runtime.getContexts({
-    contextTypes: [chrome.runtime.ContextType.SIDE_PANEL],
-  })
+  const runtime = getRuntimeWithContexts()
+  const sidePanelContextType = runtime.ContextType?.SIDE_PANEL
+  const getContexts = (
+    runtime as {
+      getContexts?: (options: { contextTypes: string[] }) => Promise<unknown[]>
+    }
+  ).getContexts
+  const contexts =
+    getContexts && sidePanelContextType
+      ? await getContexts({
+          contextTypes: [sidePanelContextType],
+        })
+      : []
 
   if (contexts.length === 0) return false
 
-  await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true })
+  await sidePanel.setPanelBehavior({ openPanelOnActionClick: true })
 
   return true
 }
 
 const switchToPopup = async () => {
-  await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false })
+  await getSidePanel()?.setPanelBehavior({ openPanelOnActionClick: false })
 }
 
 export const ManageSidePanel = () => {
@@ -38,7 +69,7 @@ export const ManageSidePanel = () => {
   const { mutateAsync: setSidePanelEnabled } =
     useSetIsSidePanelEnabledMutation()
 
-  if (typeof chrome === 'undefined' || !chrome.sidePanel) return null
+  if (typeof chrome === 'undefined' || !getSidePanel()) return null
 
   const handleToggle = async () => {
     if (!isSidePanelEnabled) {

--- a/clients/extension/src/components/side-panel/ManageSidePanel.tsx
+++ b/clients/extension/src/components/side-panel/ManageSidePanel.tsx
@@ -38,6 +38,8 @@ export const ManageSidePanel = () => {
   const { mutateAsync: setSidePanelEnabled } =
     useSetIsSidePanelEnabledMutation()
 
+  if (typeof chrome === 'undefined' || !chrome.sidePanel) return null
+
   const handleToggle = async () => {
     if (!isSidePanelEnabled) {
       await setSidePanelEnabled(true)

--- a/clients/extension/src/components/side-panel/ManageSidePanel.tsx
+++ b/clients/extension/src/components/side-panel/ManageSidePanel.tsx
@@ -9,67 +9,44 @@ import { ListItem } from '@lib/ui/list/item'
 import { attempt } from '@vultisig/lib-utils/attempt'
 import { useTranslation } from 'react-i18next'
 
-type ChromeSidePanel = {
-  open: (options: { windowId: number }) => Promise<void>
-  setPanelBehavior: (options: {
-    openPanelOnActionClick: boolean
-  }) => Promise<void>
-}
-
-type ChromeRuntimeWithContexts = typeof chrome.runtime & {
-  ContextType?: { SIDE_PANEL: string }
-  getContexts?: (options: { contextTypes: string[] }) => Promise<unknown[]>
-}
-
-const getSidePanel = (): ChromeSidePanel | undefined =>
-  (chrome as unknown as { sidePanel?: ChromeSidePanel }).sidePanel
-
-const getRuntimeWithContexts = (): ChromeRuntimeWithContexts =>
-  chrome.runtime as ChromeRuntimeWithContexts
-
 const switchToSidePanel = async () => {
-  const sidePanel = getSidePanel()
-  if (!sidePanel) return false
+  if (!chrome.sidePanel) return false
 
   const currentWindow = await chrome.windows.getCurrent()
   if (currentWindow.id == null) return false
 
-  await sidePanel.open({ windowId: currentWindow.id })
+  await chrome.sidePanel.open({ windowId: currentWindow.id })
 
   await new Promise(resolve => setTimeout(resolve, 500))
 
-  const runtime = getRuntimeWithContexts()
-  const sidePanelContextType = runtime.ContextType?.SIDE_PANEL
-  const getContexts = (
-    runtime as {
-      getContexts?: (options: { contextTypes: string[] }) => Promise<unknown[]>
-    }
-  ).getContexts
-  const contexts =
-    getContexts && sidePanelContextType
-      ? await getContexts({
-          contextTypes: [sidePanelContextType],
-        })
-      : []
+  if (!chrome.runtime.getContexts) return false
+
+  const contexts = await chrome.runtime.getContexts({
+    contextTypes: [chrome.runtime.ContextType.SIDE_PANEL],
+  })
 
   if (contexts.length === 0) return false
 
-  await sidePanel.setPanelBehavior({ openPanelOnActionClick: true })
+  await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true })
 
   return true
 }
 
 const switchToPopup = async () => {
-  await getSidePanel()?.setPanelBehavior({ openPanelOnActionClick: false })
+  await chrome.sidePanel?.setPanelBehavior({ openPanelOnActionClick: false })
 }
 
+/**
+ * Settings toggle that switches the extension between popup and side panel modes.
+ * Returns null when the side panel API is unavailable (e.g. on Firefox).
+ */
 export const ManageSidePanel = () => {
   const { t } = useTranslation()
   const { data: isSidePanelEnabled } = useIsSidePanelEnabledQuery()
   const { mutateAsync: setSidePanelEnabled } =
     useSetIsSidePanelEnabledMutation()
 
-  if (typeof chrome === 'undefined' || !getSidePanel()) return null
+  if (typeof chrome === 'undefined' || !chrome.sidePanel) return null
 
   const handleToggle = async () => {
     if (!isSidePanelEnabled) {

--- a/clients/extension/src/content/index.ts
+++ b/clients/extension/src/content/index.ts
@@ -8,6 +8,9 @@ const insertInpageScript = () => {
   const script = document.createElement('script')
   script.src = chrome.runtime.getURL('inpage.js')
   script.id = 'inpage'
+  if (__IS_FIREFOX_EXTENSION_BUILD__) {
+    script.type = 'module'
+  }
   script.onload = () => script.remove()
   script.onerror = error => {
     console.error('Failed to load inpage script:', error)

--- a/clients/extension/src/expanded-view/mutations/openInExpandedView.ts
+++ b/clients/extension/src/expanded-view/mutations/openInExpandedView.ts
@@ -10,7 +10,7 @@ export const useOpenInExpandedViewMutation = () => {
   return useMutation({
     mutationFn: async (view: AppView) => {
       await setInitialView(view)
-      openUrl(`chrome-extension://${chrome.runtime.id}/index.html`)
+      openUrl(chrome.runtime.getURL('index.html'))
     },
   })
 }

--- a/clients/extension/src/expanded-view/mutations/openInExpandedView.ts
+++ b/clients/extension/src/expanded-view/mutations/openInExpandedView.ts
@@ -4,6 +4,9 @@ import { useMutation } from '@tanstack/react-query'
 import { AppView } from '../../navigation/AppView'
 import { setInitialView } from '../../storage/initialView'
 
+/**
+ * Mutation hook that persists the target view and opens the extension in an expanded tab.
+ */
 export const useOpenInExpandedViewMutation = () => {
   const { openUrl } = useCore()
 

--- a/clients/extension/src/inpage/index.ts
+++ b/clients/extension/src/inpage/index.ts
@@ -1,3 +1,5 @@
+import '../polyfills/installFirefoxProcessGlobal'
+
 // MPC note — see vultisig/vultisig-windows#3777.
 // This inpage (dapp page) chunk intentionally does NOT import
 // @core/ui/mpc/bootstrapMpcEngine. The inpage script runs in a dapp's realm

--- a/clients/extension/src/navigation/alwaysExpandViews.ts
+++ b/clients/extension/src/navigation/alwaysExpandViews.ts
@@ -5,6 +5,9 @@ const alwaysExpandViews: ReadonlySet<AppViewId> = new Set<AppViewId>([
   'setupVault',
 ])
 
+/**
+ * Returns true when the given view should be opened in an expanded tab instead of the popup.
+ */
 export const shouldAlwaysExpand = (viewId: AppViewId): boolean => {
   return alwaysExpandViews.has(viewId)
 }

--- a/clients/extension/src/navigation/alwaysExpandViews.ts
+++ b/clients/extension/src/navigation/alwaysExpandViews.ts
@@ -1,6 +1,7 @@
 import { AppViewId } from './AppView'
 
 const alwaysExpandViews: ReadonlySet<AppViewId> = new Set<AppViewId>([
+  'importVault',
   'setupVault',
 ])
 

--- a/clients/extension/src/pages/index.tsx
+++ b/clients/extension/src/pages/index.tsx
@@ -1,3 +1,5 @@
+import '../polyfills/installFirefoxProcessGlobal'
+
 import { NavigationProvider } from '@clients/extension/src/navigation/NavigationProvider'
 import { views } from '@clients/extension/src/navigation/views'
 import { ExtensionNotificationManager } from '@clients/extension/src/notifications/ExtensionNotificationManager'
@@ -15,11 +17,30 @@ import {
 import { createGlobalStyle, css } from 'styled-components'
 
 const isPopup = isPopupView()
+const popupWidth = 480
+const popupHeight = 600
 
 const ExtensionGlobalStyle = createGlobalStyle`
+  ${
+    isPopup &&
+    css`
+      html,
+      body,
+      #root {
+        width: ${popupWidth}px;
+        height: ${popupHeight}px;
+        min-width: ${popupWidth}px;
+        min-height: ${popupHeight}px;
+        max-width: ${popupWidth}px;
+        max-height: ${popupHeight}px;
+        overflow: hidden;
+      }
+    `
+  }
+
   body {
-    min-height: 600px;
-    min-width: ${isPopup ? '480px' : 'min(480px, 100vw)'};
+    min-height: ${isPopup ? `${popupHeight}px` : '600px'};
+    min-width: ${isPopup ? `${popupWidth}px` : 'min(480px, 100vw)'};
     overflow: hidden;
 
     ${

--- a/clients/extension/src/pages/popup.tsx
+++ b/clients/extension/src/pages/popup.tsx
@@ -1,3 +1,5 @@
+import '../polyfills/installFirefoxProcessGlobal'
+
 import { PopupApp } from '@core/inpage-provider/popup/app'
 
 import { renderExtensionPage } from './core/render'

--- a/clients/extension/src/polyfills/installFirefoxProcessGlobal.ts
+++ b/clients/extension/src/polyfills/installFirefoxProcessGlobal.ts
@@ -1,0 +1,11 @@
+import processShim from 'process'
+
+if (
+  __IS_FIREFOX_EXTENSION_BUILD__ &&
+  !Object.prototype.hasOwnProperty.call(globalThis, 'process')
+) {
+  Object.defineProperty(globalThis, 'process', {
+    configurable: true,
+    value: processShim,
+  })
+}

--- a/clients/extension/src/vite-env.d.ts
+++ b/clients/extension/src/vite-env.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="vite/client" />
+
+/* eslint-disable @typescript-eslint/naming-convention */
+declare const __IS_FIREFOX_EXTENSION_BUILD__: boolean

--- a/clients/extension/vite.config.ts
+++ b/clients/extension/vite.config.ts
@@ -137,7 +137,7 @@ export default defineConfig(async ({ mode }) => {
             entryFileNames: '[name].js',
             format,
             manualChunks: isFirefoxBuild
-              ? id => getFirefoxManualChunk(chunk, id)
+              ? (id: string) => getFirefoxManualChunk(chunk, id)
               : undefined,
           },
         },
@@ -172,7 +172,7 @@ export default defineConfig(async ({ mode }) => {
             chunkFileNames: 'assets/[name].js',
             entryFileNames: '[name].js',
             manualChunks: isFirefoxBuild
-              ? id => getFirefoxManualChunk('app', id)
+              ? (id: string) => getFirefoxManualChunk('app', id)
               : undefined,
           },
         },

--- a/clients/extension/vite.config.ts
+++ b/clients/extension/vite.config.ts
@@ -12,11 +12,11 @@ import { getCommonPlugins } from '../../core/ui/vite/plugins'
 import { getStaticCopyTargets } from '../../core/ui/vite/staticCopy'
 
 const rootDir = path.resolve(__dirname, '../..')
-const extensionNodePolyfills = () =>
+const extensionNodePolyfills = (isFirefoxBuild = false) =>
   nodePolyfills({
     exclude: ['fs'],
     globals: {
-      process: false,
+      process: isFirefoxBuild ? 'build' : false,
     },
   })
 const extensionVultisigSdk = () => vultisigSdk({ browserGlobals: false })
@@ -27,6 +27,37 @@ const vultisigMpcDedupe: readonly string[] = [
   '@vultisig/mpc-types',
   '@vultisig/mpc-wasm',
 ]
+
+const getFirefoxManualChunk = (buildName: string, id: string) => {
+  const normalized = id.replace(/\\/g, '/')
+  const nodeModulesIndex = normalized.lastIndexOf('/node_modules/')
+  if (nodeModulesIndex >= 0) {
+    const packagePath = normalized.slice(nodeModulesIndex + 14)
+    const parts = packagePath.split('/')
+    const packageName = parts[0]?.startsWith('@')
+      ? `${parts[0]}-${parts[1]}`
+      : parts[0]
+
+    return packageName
+      ? `vendor-${buildName}-${packageName.replace(/[^a-zA-Z0-9_-]/g, '-')}`
+      : `vendor-${buildName}`
+  }
+
+  if (normalized.includes('/clients/extension/src/inpage/providers/')) {
+    const providerPath = normalized.split('/src/inpage/providers/')[1]
+    const providerName = providerPath?.split('/')[0]?.replace(/\.[^.]+$/, '')
+    return providerName
+      ? `inpage-provider-${buildName}-${providerName}`
+      : undefined
+  }
+
+  return undefined
+}
+
+const getChunkInput = (chunk: string, isFirefoxBuild: boolean) =>
+  chunk === 'background' && isFirefoxBuild
+    ? 'src/background/firefox.ts'
+    : `src/${chunk}/index.ts`
 
 export default defineConfig(async ({ mode }) => {
   const env = loadEnv(mode, rootDir)
@@ -42,6 +73,12 @@ export default defineConfig(async ({ mode }) => {
 
   const chunk = process.env.CHUNK
   const isDev = !!process.env.VITE_DEV_RELOAD
+  const isFirefoxBuild = process.env.VULTISIG_EXTENSION_TARGET === 'firefox'
+  const defines = {
+    ...featureFlagDefines,
+    ...envDefines,
+    __IS_FIREFOX_EXTENSION_BUILD__: JSON.stringify(isFirefoxBuild),
+  }
 
   const devBuildOptions = isDev
     ? { minify: false as const, reportCompressedSize: false }
@@ -53,13 +90,20 @@ export default defineConfig(async ({ mode }) => {
 
     switch (chunk) {
       case 'background':
-        plugins = [extensionNodePolyfills(), wasm(), topLevelAwait()]
+        plugins = [
+          extensionNodePolyfills(isFirefoxBuild),
+          wasm(),
+          topLevelAwait(),
+        ]
         break
       case 'inpage':
-        format = 'iife'
+        format = isFirefoxBuild ? undefined : 'iife'
         plugins = [
           nodePolyfills({
             exclude: ['fs'],
+            globals: {
+              process: isFirefoxBuild ? 'build' : true,
+            },
             protocolImports: true,
           }),
         ]
@@ -69,7 +113,7 @@ export default defineConfig(async ({ mode }) => {
     }
 
     return {
-      define: { ...featureFlagDefines, ...envDefines },
+      define: defines,
       resolve: { dedupe: [...vultisigMpcDedupe] },
       plugins: [
         extensionVultisigSdk(),
@@ -83,7 +127,10 @@ export default defineConfig(async ({ mode }) => {
         ...devBuildOptions,
         rollupOptions: {
           input: {
-            [chunk]: path.resolve(__dirname, `src/${chunk}/index.ts`),
+            [chunk]: path.resolve(
+              __dirname,
+              getChunkInput(chunk, isFirefoxBuild)
+            ),
           },
           onwarn: () => {},
           output: {
@@ -91,18 +138,21 @@ export default defineConfig(async ({ mode }) => {
             chunkFileNames: 'assets/[name].js',
             entryFileNames: '[name].js',
             format,
+            manualChunks: isFirefoxBuild
+              ? id => getFirefoxManualChunk(chunk, id)
+              : undefined,
           },
         },
       },
     }
   } else {
     return {
-      define: { ...featureFlagDefines, ...envDefines },
+      define: defines,
       resolve: { dedupe: [...vultisigMpcDedupe] },
       plugins: [
         tsconfigPaths({ root: rootDir }),
         ...getCommonPlugins({
-          nodePolyfills: extensionNodePolyfills(),
+          nodePolyfills: extensionNodePolyfills(isFirefoxBuild),
           vultisigSdk: extensionVultisigSdk(),
         }),
         viteStaticCopy({
@@ -123,6 +173,9 @@ export default defineConfig(async ({ mode }) => {
             assetFileNames: 'assets/[name].[ext]',
             chunkFileNames: 'assets/[name].js',
             entryFileNames: '[name].js',
+            manualChunks: isFirefoxBuild
+              ? id => getFirefoxManualChunk('app', id)
+              : undefined,
           },
         },
       },

--- a/core/ui/qr/components/CameraPermission.tsx
+++ b/core/ui/qr/components/CameraPermission.tsx
@@ -9,6 +9,7 @@ import { Text } from '@lib/ui/text'
 import { useMutation } from '@tanstack/react-query'
 import { getLastItem } from '@vultisig/lib-utils/array/getLastItem'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
+import { attempt, withFallback } from '@vultisig/lib-utils/attempt'
 import { extractErrorMsg } from '@vultisig/lib-utils/error/extractErrorMsg'
 import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -16,6 +17,12 @@ import { useTranslation } from 'react-i18next'
 const initialViewStorageKey = 'initialView'
 
 const isExtensionPopupView = () => {
+  const viewParam = withFallback(
+    attempt(() => new URLSearchParams(window.location.search).get('view')),
+    null
+  )
+  if (viewParam === 'popup') return true
+
   if (typeof chrome === 'undefined') {
     return false
   }
@@ -26,7 +33,7 @@ const isExtensionPopupView = () => {
   }
 
   try {
-    return getViews({ type: 'popup' }).length > 0
+    return getViews({ type: 'popup' }).some(view => view === window)
   } catch {
     return false
   }
@@ -85,14 +92,7 @@ export const CameraPermission = () => {
   })
 
   const openExpandedView = useCallback(async () => {
-    if (typeof chrome === 'undefined') {
-      openUrl(location.href)
-      return
-    }
-
-    const runtimeId = chrome.runtime?.id
-
-    if (!runtimeId) {
+    if (typeof chrome === 'undefined' || !chrome.runtime?.id) {
       openUrl(location.href)
       return
     }
@@ -101,7 +101,7 @@ export const CameraPermission = () => {
       console.error('Failed to persist initial view before expanding', error)
     })
 
-    openUrl(`chrome-extension://${runtimeId}/index.html`)
+    openUrl(chrome.runtime.getURL('index.html'))
   }, [currentView, openUrl])
 
   return (

--- a/core/ui/vault/page/components/VaultOverview.tsx
+++ b/core/ui/vault/page/components/VaultOverview.tsx
@@ -63,7 +63,7 @@ export const VaultOverview = ({ scrollContainerRef }: VaultOverviewProps) => {
   ]
 
   return (
-    <VStack fullHeight>
+    <Container flexGrow>
       <StyledPageContent ref={scrollContainerRef} scrollable gap={32} flexGrow>
         <BlurEffect />
         <BalanceWrapper data-testid="vault-overview-balance-wrapper">
@@ -76,9 +76,13 @@ export const VaultOverview = ({ scrollContainerRef }: VaultOverviewProps) => {
         <Divider />
         <VaultTabs />
       </StyledPageContent>
-    </VStack>
+    </Container>
   )
 }
+
+const Container = styled(VStack)`
+  min-height: 0;
+`
 
 const StyledPageContent = styled(PageContent)`
   ${hideScrollbars};

--- a/core/ui/vault/page/components/VaultPage.tsx
+++ b/core/ui/vault/page/components/VaultPage.tsx
@@ -23,7 +23,7 @@ export const VaultPage = ({ primaryControls }: VaultPageProps = {}) => {
 
   return (
     <Wrapper justifyContent="space-between" flexGrow data-testid="vault-page">
-      <VStack flexGrow>
+      <Content flexGrow>
         <VaultPageHeader
           vault={vault}
           scrollContainerRef={scrollContainerRef}
@@ -31,7 +31,7 @@ export const VaultPage = ({ primaryControls }: VaultPageProps = {}) => {
         />
         <VaultOverview scrollContainerRef={scrollContainerRef} />
         {isFastVault && <FastVaultPasswordVerification key={vaultId} />}
-      </VStack>
+      </Content>
       <BottomNavigation />
     </Wrapper>
   )
@@ -39,4 +39,9 @@ export const VaultPage = ({ primaryControls }: VaultPageProps = {}) => {
 
 const Wrapper = styled(VStack)`
   position: relative;
+  min-height: 0;
+`
+
+const Content = styled(VStack)`
+  min-height: 0;
 `

--- a/knip.json
+++ b/knip.json
@@ -21,6 +21,7 @@
     "clients/extension": {
       "entry": [
         "src/background/index.ts",
+        "src/background/firefox.ts",
         "src/content/index.ts",
         "src/inpage/index.ts",
         "src/pages/popup.tsx",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev:desktop:full": "wails dev",
     "build:desktop": "NODE_OPTIONS=--max-old-space-size=8192 yarn workspace @clients/desktop build",
     "build:extension": "yarn workspace @clients/extension build",
+    "build:extension:firefox": "yarn workspace @clients/extension build:firefox",
     "dev:extension": "yarn workspace @clients/extension dev",
     "build": "NODE_OPTIONS=--max-old-space-size=8192 yarn workspace @clients/desktop build",
     "typecheck": "tsgo --noEmit",

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="chrome" />
+
+/* eslint-disable @typescript-eslint/naming-convention */
+declare const __IS_FIREFOX_EXTENSION_BUILD__: boolean


### PR DESCRIPTION
## Summary
- add a Firefox-specific extension build script
- post-process the generated manifest for Firefox MV3 background scripts and Gecko signing metadata
- remove Chromium-only side panel manifest entries from the Firefox artifact
- hide the side panel setting when the browser API is unavailable

## Safety
This is scoped to extension packaging and browser capability detection. It does not change MPC, key storage, signing, transaction, or provider logic.

## Validation
- yarn build:extension:firefox
- eslint clients/extension/src/components/side-panel/ManageSidePanel.tsx clients/extension/scripts/prepare-firefox-build.mjs

## Notes
The full extension lint command currently fails on pre-existing unrelated test/watch files, so targeted lint was used for the files changed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Firefox extension build support with dedicated build flow and Firefox-specific runtime polyfills; popup gets fixed sizing.

* **Bug Fixes**
  * Safer side-panel behavior when browser APIs are absent.
  * Content/inpage injection adjusted for Firefox compatibility; expanded-view navigation made more robust.

* **Refactor**
  * Background initialization and build tooling reorganized to separate Firefox vs non-Firefox behavior.

* **Style**
  * Minor layout and sizing tweaks in vault pages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-windows/pull/3881)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->