### PR TITLE
fix(extension): import vault back button creates navigation loop

### DIFF
--- a/core/ui/vault/import/components/UploadBackupFileStep.tsx
+++ b/core/ui/vault/import/components/UploadBackupFileStep.tsx
@@ -15,15 +15,12 @@ import { extractErrorMsg } from '@vultisig/lib-utils/error/extractErrorMsg'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { useCoreNavigate } from '../../../navigation/hooks/useCoreNavigate'
-
 export const UploadBackupFileStep = ({
   onFinish,
 }: OnFinishProp<FileBasedVaultBackupResult>) => {
   const { t } = useTranslation()
   const [file, setFile] = useState<File | null>(null)
   const [error, setError] = useState<Error | null>(null)
-  const navigate = useCoreNavigate()
 
   const { mutate, isPending } = useMutation({
     mutationFn: vaultBackupResultFromFile,
@@ -35,10 +32,7 @@ export const UploadBackupFileStep = ({
 
   return (
     <>
-      <FlowPageHeader
-        title={t('import_vault')}
-        onBack={() => navigate({ id: 'newVault' })}
-      />
+      <FlowPageHeader title={t('import_vault')} />
       <PageContent
         as="form"
         data-testid="import-vault-form"


### PR DESCRIPTION
## Summary
- Closes #3889
- Removes the explicit `onBack={() => navigate({ id: 'newVault' })}` override on the import vault page. `navigate` pushes onto the history stack, so back from `importVault` produced `[vault, importVault, newVault]` in the expanded view; NewVaultPage's real-pop back button then returned to `importVault`, creating a loop.
- After the fix, `FlowPageHeader` falls through to `PageHeaderBackButton`'s default (`useCore().goBack` → `useNavigateBack`), which performs a real history pop. `ExtensionVaultPage` still redirects `vault` → `newVault` when no vaults exist, so the destination is unchanged.

## Test plan
- [ ] Open extension popup → Import → "Import vault share" → expanded view opens with the import page.
- [ ] Click back on the import page → lands on the new-vault page.
- [ ] Click back again on the new-vault page → exits the flow (no loop).
- [ ] Repeat in popup-only mode (Windows or with vaults present) — no loop.
- [ ] Desktop import flow still works (uses `ReadBackupFileStep`, not `UploadBackupFileStep`).
- [ ] `yarn check:all` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the backup file upload step by removing internal navigation dependencies. All file selection, upload, and error handling functionality remains intact.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-windows/pull/3890)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->