### PR TITLE
fix: render THORChain LP deposits with Pool/Paired Address

### DIFF
--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -1280,6 +1280,8 @@ export const en = {
   remove_cacao_pool: 'Remove from CACAO Pool',
   add_thor_lp: 'Add THORChain LP',
   remove_thor_lp: 'Remove THORChain LP',
+  pool: 'Pool',
+  paired_address: 'Paired Address',
   lp_dust_amount_error:
     'Insufficient RUNE balance. At least {{amount}} RUNE is required as dust for LP withdrawal.',
   lp_withdraw_percentage: 'Withdraw percentage',

--- a/core/ui/mpc/keysign/join/JoinKeysignVerifyStep.tsx
+++ b/core/ui/mpc/keysign/join/JoinKeysignVerifyStep.tsx
@@ -1,8 +1,6 @@
-import { TxOverviewPanel } from '@core/ui/chain/tx/TxOverviewPanel'
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { JoinKeysignCustomMessageVerify } from '@core/ui/mpc/keysign/join/JoinKeysignCustomMessageVerify'
-import { JoinKeysignSwapVerify } from '@core/ui/mpc/keysign/join/tx/JoinKeysignSwapVerify'
-import { JoinKeysignTxPrimaryInfo } from '@core/ui/mpc/keysign/join/tx/JoinKeysignTxPrimaryInfo'
+import { JoinKeysignTransactionVerify } from '@core/ui/mpc/keysign/join/tx/JoinKeysignTransactionVerify'
 import { useCoreViewState } from '@core/ui/navigation/hooks/useCoreViewState'
 import { MatchRecordUnion } from '@lib/ui/base/MatchRecordUnion'
 import { Button } from '@lib/ui/buttons/Button'
@@ -35,14 +33,9 @@ export const JoinKeysignVerifyStep = ({ onFinish }: OnFinishProp) => {
           <MatchRecordUnion
             value={keysignPayload}
             handlers={{
-              keysign: payload =>
-                payload.swapPayload?.value ? (
-                  <JoinKeysignSwapVerify value={payload} />
-                ) : (
-                  <TxOverviewPanel>
-                    <JoinKeysignTxPrimaryInfo value={payload} />
-                  </TxOverviewPanel>
-                ),
+              keysign: payload => (
+                <JoinKeysignTransactionVerify value={payload} />
+              ),
               custom: value => <JoinKeysignCustomMessageVerify value={value} />,
             }}
           />

--- a/core/ui/mpc/keysign/join/tx/JoinKeysignLpVerify.tsx
+++ b/core/ui/mpc/keysign/join/tx/JoinKeysignLpVerify.tsx
@@ -1,0 +1,38 @@
+import { TxOverviewPanel } from '@core/ui/chain/tx/TxOverviewPanel'
+import {
+  TxOverviewChainDataRow,
+  TxOverviewPrimaryRowTitle,
+  TxOverviewRow,
+} from '@core/ui/chain/tx/TxOverviewRow'
+import { ValueProp } from '@lib/ui/props'
+import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { useTranslation } from 'react-i18next'
+
+import { JoinKeysignTxPrimaryInfo } from './JoinKeysignTxPrimaryInfo'
+import { ThorLpMemo } from './parseThorLpMemo'
+
+type Props = ValueProp<KeysignPayload> & {
+  lp: ThorLpMemo
+}
+
+export const JoinKeysignLpVerify = ({ value, lp }: Props) => {
+  const { t } = useTranslation()
+
+  return (
+    <TxOverviewPanel>
+      <TxOverviewRow>
+        <span>{t('pool')}</span>
+        <span>{lp.pool}</span>
+      </TxOverviewRow>
+      {lp.kind === 'add' && lp.pairedAddress && (
+        <TxOverviewChainDataRow>
+          <TxOverviewPrimaryRowTitle>
+            {t('paired_address')}
+          </TxOverviewPrimaryRowTitle>
+          <span>{lp.pairedAddress}</span>
+        </TxOverviewChainDataRow>
+      )}
+      <JoinKeysignTxPrimaryInfo value={value} />
+    </TxOverviewPanel>
+  )
+}

--- a/core/ui/mpc/keysign/join/tx/JoinKeysignLpVerify.tsx
+++ b/core/ui/mpc/keysign/join/tx/JoinKeysignLpVerify.tsx
@@ -15,6 +15,10 @@ type Props = ValueProp<KeysignPayload> & {
   lp: ThorLpMemo
 }
 
+/**
+ * Joiner verify view for THORChain LP add/remove deposits. Renders Pool and
+ * (when present) Paired Address rows alongside the standard transaction info.
+ */
 export const JoinKeysignLpVerify = ({ value, lp }: Props) => {
   const { t } = useTranslation()
 

--- a/core/ui/mpc/keysign/join/tx/JoinKeysignTransactionVerify.tsx
+++ b/core/ui/mpc/keysign/join/tx/JoinKeysignTransactionVerify.tsx
@@ -7,6 +7,12 @@ import { JoinKeysignSwapVerify } from './JoinKeysignSwapVerify'
 import { JoinKeysignTxPrimaryInfo } from './JoinKeysignTxPrimaryInfo'
 import { parseThorLpMemo } from './parseThorLpMemo'
 
+/**
+ * Routes a join keysign payload to the correct verify view. THORChain LP
+ * add/remove is detected via memo first so iOS-initiated LP deposits (which
+ * carry a synthesized `thorchainSwapPayload` for the EVM router signing path)
+ * still render as deposits. Falls back to swap, then to a generic transfer.
+ */
 export const JoinKeysignTransactionVerify = ({
   value,
 }: ValueProp<KeysignPayload>) => {

--- a/core/ui/mpc/keysign/join/tx/JoinKeysignTransactionVerify.tsx
+++ b/core/ui/mpc/keysign/join/tx/JoinKeysignTransactionVerify.tsx
@@ -1,0 +1,28 @@
+import { TxOverviewPanel } from '@core/ui/chain/tx/TxOverviewPanel'
+import { ValueProp } from '@lib/ui/props'
+import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+
+import { JoinKeysignLpVerify } from './JoinKeysignLpVerify'
+import { JoinKeysignSwapVerify } from './JoinKeysignSwapVerify'
+import { JoinKeysignTxPrimaryInfo } from './JoinKeysignTxPrimaryInfo'
+import { parseThorLpMemo } from './parseThorLpMemo'
+
+export const JoinKeysignTransactionVerify = ({
+  value,
+}: ValueProp<KeysignPayload>) => {
+  const lp = value.memo ? parseThorLpMemo(value.memo) : null
+
+  if (lp) {
+    return <JoinKeysignLpVerify value={value} lp={lp} />
+  }
+
+  if (value.swapPayload?.value) {
+    return <JoinKeysignSwapVerify value={value} />
+  }
+
+  return (
+    <TxOverviewPanel>
+      <JoinKeysignTxPrimaryInfo value={value} />
+    </TxOverviewPanel>
+  )
+}

--- a/core/ui/mpc/keysign/join/tx/parseThorLpMemo.test.ts
+++ b/core/ui/mpc/keysign/join/tx/parseThorLpMemo.test.ts
@@ -38,4 +38,10 @@ describe('parseThorLpMemo', () => {
     expect(parseThorLpMemo('-:ETH.USDC:not-a-number')).toBeNull()
     expect(parseThorLpMemo('-:ETH.USDC')).toBeNull()
   })
+
+  it('rejects out-of-range or non-integer basis points', () => {
+    expect(parseThorLpMemo('-:ETH.USDC:-100')).toBeNull()
+    expect(parseThorLpMemo('-:ETH.USDC:10001')).toBeNull()
+    expect(parseThorLpMemo('-:ETH.USDC:50.5')).toBeNull()
+  })
 })

--- a/core/ui/mpc/keysign/join/tx/parseThorLpMemo.test.ts
+++ b/core/ui/mpc/keysign/join/tx/parseThorLpMemo.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseThorLpMemo } from './parseThorLpMemo'
+
+describe('parseThorLpMemo', () => {
+  it('parses an LP add with paired address', () => {
+    expect(parseThorLpMemo('+:ETH.USDC:thor1abc')).toEqual({
+      kind: 'add',
+      pool: 'ETH.USDC',
+      pairedAddress: 'thor1abc',
+    })
+  })
+
+  it('parses an LP add without paired address', () => {
+    expect(parseThorLpMemo('+:BTC.BTC')).toEqual({
+      kind: 'add',
+      pool: 'BTC.BTC',
+      pairedAddress: undefined,
+    })
+  })
+
+  it('parses an LP remove with basis points', () => {
+    expect(parseThorLpMemo('-:ETH.USDC:5000')).toEqual({
+      kind: 'remove',
+      pool: 'ETH.USDC',
+      basisPoints: 5000,
+    })
+  })
+
+  it('returns null for non-LP memos', () => {
+    expect(parseThorLpMemo('=:ETH.USDC:0xabc:0/1/0')).toBeNull()
+    expect(parseThorLpMemo('SWAP:ETH.USDC:0xabc')).toBeNull()
+    expect(parseThorLpMemo('')).toBeNull()
+  })
+
+  it('returns null for malformed LP memos', () => {
+    expect(parseThorLpMemo('+:')).toBeNull()
+    expect(parseThorLpMemo('-:ETH.USDC:not-a-number')).toBeNull()
+    expect(parseThorLpMemo('-:ETH.USDC')).toBeNull()
+  })
+})

--- a/core/ui/mpc/keysign/join/tx/parseThorLpMemo.ts
+++ b/core/ui/mpc/keysign/join/tx/parseThorLpMemo.ts
@@ -1,7 +1,18 @@
+/**
+ * Parsed THORChain LP memo. Pool deposits are encoded as
+ * `+:POOL[:PAIRED_ADDRESS]` (add) or `-:POOL:BASIS_POINTS` (remove).
+ */
 export type ThorLpMemo =
   | { kind: 'add'; pool: string; pairedAddress?: string }
   | { kind: 'remove'; pool: string; basisPoints: number }
 
+/**
+ * Parses a THORChain LP memo so the joiner can render Pool / Paired Address
+ * rows even when the initiator wraps the deposit in a swap payload (which
+ * iOS does for ERC20 LP adds because the EVM signing path needs it).
+ *
+ * @returns null when the memo is not an LP add/remove or is malformed.
+ */
 export const parseThorLpMemo = (memo: string): ThorLpMemo | null => {
   const [prefix, pool, third] = memo.split(':')
 
@@ -17,7 +28,13 @@ export const parseThorLpMemo = (memo: string): ThorLpMemo | null => {
 
   if (prefix === '-') {
     const basisPoints = Number(third)
-    if (!Number.isFinite(basisPoints)) return null
+    if (
+      !Number.isInteger(basisPoints) ||
+      basisPoints < 0 ||
+      basisPoints > 10_000
+    ) {
+      return null
+    }
     return { kind: 'remove', pool, basisPoints }
   }
 

--- a/core/ui/mpc/keysign/join/tx/parseThorLpMemo.ts
+++ b/core/ui/mpc/keysign/join/tx/parseThorLpMemo.ts
@@ -1,0 +1,25 @@
+export type ThorLpMemo =
+  | { kind: 'add'; pool: string; pairedAddress?: string }
+  | { kind: 'remove'; pool: string; basisPoints: number }
+
+export const parseThorLpMemo = (memo: string): ThorLpMemo | null => {
+  const [prefix, pool, third] = memo.split(':')
+
+  if (!pool) return null
+
+  if (prefix === '+') {
+    return {
+      kind: 'add',
+      pool,
+      pairedAddress: third || undefined,
+    }
+  }
+
+  if (prefix === '-') {
+    const basisPoints = Number(third)
+    if (!Number.isFinite(basisPoints)) return null
+    return { kind: 'remove', pool, basisPoints }
+  }
+
+  return null
+}


### PR DESCRIPTION
## Summary
- Joiner verify screen used `swapPayload` presence as the only signal, so iOS-initiated THORChain LP add/remove payloads (which reuse `thorchainSwapPayload`) rendered as `You're swapping X → X` with no Pool, Paired Address, or Memo rows.
- Detect LP memos (`+:POOL[:PAIRED_ADDRESS]` / `-:POOL:BASIS_POINTS`) on the joiner and route them to a deposit-style view via a new `JoinKeysignTransactionVerify` router. Memo detection wins over `swapPayload`, so the fix is correct regardless of how the initiator builds the payload.
- Added `pool` / `paired_address` i18n keys (en only — `yarn translate` propagates).

Closes #3781

## Test plan
- [x] `yarn check` (typecheck + lint:fix + knip) passes
- [x] `parseThorLpMemo` unit tests pass (5/5)
- [ ] Manual: iOS initiates THORChain LP add to ETH.USDC → Windows joiner shows Pool, Paired Address, Memo, Amount, Network fee (no `You're swapping`)
- [ ] Manual: iOS initiates LP remove → Windows joiner shows Pool, Memo, Amount, Network fee
- [ ] Manual: iOS initiates a regular THORChain swap → Windows joiner still renders the swap view
- [ ] Manual: non-THORChain sends and other deposits unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved keysign verification: LP (add/remove) transactions are now detected and shown with a dedicated LP verification screen; other transaction types route to appropriate verification views.

* **Localization**
  * Added English labels for "pool" and "paired address" in the UI.

* **Tests**
  * Added unit tests to validate LP memo parsing and edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-windows/pull/3891)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->