### PR TITLE
fix(extension): align TSS batching keygen with Android and iOS

### DIFF
--- a/core/ui/mpc/keygen/create/CreateVaultKeygenActionProvider.tsx
+++ b/core/ui/mpc/keygen/create/CreateVaultKeygenActionProvider.tsx
@@ -1,11 +1,11 @@
 import { featureFlags } from '@core/ui/featureFlags'
 import { useCurrentHexEncryptionKey } from '@core/ui/mpc/state/currentHexEncryptionKey'
 import { useIsInitiatingDevice } from '@core/ui/mpc/state/isInitiatingDevice'
+import { useIsTssBatching } from '@core/ui/mpc/state/isTssBatching'
 import { useMpcLocalPartyId } from '@core/ui/mpc/state/mpcLocalPartyId'
 import { useMpcServerUrl } from '@core/ui/mpc/state/mpcServerUrl'
 import { useMpcSessionId } from '@core/ui/mpc/state/mpcSession'
 import { useIsMLDSAEnabled } from '@core/ui/storage/mldsaEnabled'
-import { useIsTssBatchingEnabled } from '@core/ui/storage/tssBatchingEnabled'
 import { useVaultOrders } from '@core/ui/storage/vaults'
 import { ChildrenProp } from '@lib/ui/props'
 import { hasServer } from '@vultisig/core-mpc/devices/localPartyId'
@@ -32,7 +32,7 @@ export const CreateVaultKeygenActionProvider = ({ children }: ChildrenProp) => {
   const localPartyId = useMpcLocalPartyId()
   const isInitiatingDevice = useIsInitiatingDevice()
   const isMLDSAEnabled = useIsMLDSAEnabled()
-  const isTssBatchingEnabled = useIsTssBatchingEnabled()
+  const isTssBatchingEnabled = useIsTssBatching()
 
   const vaultOrders = useVaultOrders()
 
@@ -73,7 +73,19 @@ export const CreateVaultKeygenActionProvider = ({ children }: ChildrenProp) => {
       )
 
       await initializeMpcLib('ecdsa')
-      await dklsKeygen.prepareKeygenSetup()
+      // Cross-platform setup-message namespaces: different peers look for the
+      // shared DKLS setup under different `message_id` headers depending on
+      // their platform/version.
+      //   - default (no header): Android, pre-#4246 iOS, Windows extension
+      //   - "p-ecdsa": post-#4246 iOS DKLS task
+      //   - "p-eddsa": post-#4246 iOS Schnorr task (looks here because its
+      //     messenger.messageID is "p-eddsa" and #4246 folds that into setup
+      //     headers — without us writing here, iOS Schnorr throws after retries
+      //     and tears down the peer DKLS task, leaving our message poll
+      //     returning [] forever)
+      // The extension publishes (initiator) and back-fills (joiner) all three
+      // so any peer combination interops.
+      await dklsKeygen.prepareKeygenSetup(undefined, ['p-ecdsa', 'p-eddsa'])
 
       const schnorrKeygen = new Schnorr(
         { create: true },

--- a/core/ui/mpc/keygen/create/KeygenSessionProviders.tsx
+++ b/core/ui/mpc/keygen/create/KeygenSessionProviders.tsx
@@ -2,36 +2,41 @@ import { CreateFlowKeygenVaultProvider } from '@core/ui/mpc/keygen/create/state/
 import { GeneratedHexChainCodeProvider } from '@core/ui/mpc/state/currentHexChainCode'
 import { GeneratedHexEncryptionKeyProvider } from '@core/ui/mpc/state/currentHexEncryptionKey'
 import { IsInitiatingDeviceProvider } from '@core/ui/mpc/state/isInitiatingDevice'
+import { IsTssBatchingProvider } from '@core/ui/mpc/state/isTssBatching'
 import { GeneratedMpcLocalPartyIdProvider } from '@core/ui/mpc/state/mpcLocalPartyId'
 import { MpcPeersSelectionProvider } from '@core/ui/mpc/state/mpcSelectedPeers'
 import { MpcServerTypeProvider } from '@core/ui/mpc/state/mpcServerType'
 import { GeneratedMpcServiceNameProvider } from '@core/ui/mpc/state/mpcServiceName'
 import { GeneratedMpcSessionIdProvider } from '@core/ui/mpc/state/mpcSession'
 import { ServerUrlDerivedFromServerTypeProvider } from '@core/ui/mpc/state/serverUrlDerivedFromServerType'
+import { useIsTssBatchingEnabled } from '@core/ui/storage/tssBatchingEnabled'
 import { ChildrenProp } from '@lib/ui/props'
 
 export const KeygenSessionProviders = ({ children }: ChildrenProp) => {
+  const isTssBatchingEnabled = useIsTssBatchingEnabled()
   return (
     <IsInitiatingDeviceProvider value={true}>
-      <GeneratedMpcSessionIdProvider>
-        <GeneratedHexEncryptionKeyProvider>
-          <GeneratedHexChainCodeProvider>
-            <GeneratedMpcServiceNameProvider>
-              <MpcServerTypeProvider initialValue="relay">
-                <GeneratedMpcLocalPartyIdProvider>
-                  <ServerUrlDerivedFromServerTypeProvider>
-                    <CreateFlowKeygenVaultProvider>
-                      <MpcPeersSelectionProvider>
-                        {children}
-                      </MpcPeersSelectionProvider>
-                    </CreateFlowKeygenVaultProvider>
-                  </ServerUrlDerivedFromServerTypeProvider>
-                </GeneratedMpcLocalPartyIdProvider>
-              </MpcServerTypeProvider>
-            </GeneratedMpcServiceNameProvider>
-          </GeneratedHexChainCodeProvider>
-        </GeneratedHexEncryptionKeyProvider>
-      </GeneratedMpcSessionIdProvider>
+      <IsTssBatchingProvider value={isTssBatchingEnabled}>
+        <GeneratedMpcSessionIdProvider>
+          <GeneratedHexEncryptionKeyProvider>
+            <GeneratedHexChainCodeProvider>
+              <GeneratedMpcServiceNameProvider>
+                <MpcServerTypeProvider initialValue="relay">
+                  <GeneratedMpcLocalPartyIdProvider>
+                    <ServerUrlDerivedFromServerTypeProvider>
+                      <CreateFlowKeygenVaultProvider>
+                        <MpcPeersSelectionProvider>
+                          {children}
+                        </MpcPeersSelectionProvider>
+                      </CreateFlowKeygenVaultProvider>
+                    </ServerUrlDerivedFromServerTypeProvider>
+                  </GeneratedMpcLocalPartyIdProvider>
+                </MpcServerTypeProvider>
+              </GeneratedMpcServiceNameProvider>
+            </GeneratedHexChainCodeProvider>
+          </GeneratedHexEncryptionKeyProvider>
+        </GeneratedMpcSessionIdProvider>
+      </IsTssBatchingProvider>
     </IsInitiatingDeviceProvider>
   )
 }

--- a/core/ui/mpc/keygen/create/fast/CreateFastKeygenServerActionProvider.tsx
+++ b/core/ui/mpc/keygen/create/fast/CreateFastKeygenServerActionProvider.tsx
@@ -1,5 +1,6 @@
 import { useCurrentHexChainCode } from '@core/ui/mpc/state/currentHexChainCode'
 import { useCurrentHexEncryptionKey } from '@core/ui/mpc/state/currentHexEncryptionKey'
+import { useIsTssBatching } from '@core/ui/mpc/state/isTssBatching'
 import { useMpcSessionId } from '@core/ui/mpc/state/mpcSession'
 import { ChildrenProp } from '@lib/ui/props'
 import { generateLocalPartyId } from '@vultisig/core-mpc/devices/localPartyId'
@@ -11,7 +12,6 @@ import { getRecordUnionValue } from '@vultisig/lib-utils/record/union/getRecordU
 import { featureFlags } from '../../../../featureFlags'
 import { useCore } from '../../../../state/core'
 import { useIsMLDSAEnabled } from '../../../../storage/mldsaEnabled'
-import { useIsTssBatchingEnabled } from '../../../../storage/tssBatchingEnabled'
 import { FastKeygenServerActionProvider } from '../../fast/state/fastKeygenServerAction'
 import { useVaultCreationInput } from '../state/vaultCreationInput'
 
@@ -25,7 +25,7 @@ export const CreateFastKeygenServerActionProvider = ({
   const hexChainCode = useCurrentHexChainCode()
   const hexEncryptionKey = useCurrentHexEncryptionKey()
   const isMLDSAEnabled = useIsMLDSAEnabled()
-  const isTssBatchingEnabled = useIsTssBatchingEnabled()
+  const isTssBatchingEnabled = useIsTssBatching()
   const { vaultCreationMpcLib } = useCore()
 
   const action = async () => {

--- a/core/ui/mpc/keygen/join/JoinKeygenProviders.tsx
+++ b/core/ui/mpc/keygen/join/JoinKeygenProviders.tsx
@@ -1,6 +1,7 @@
 import { KeygenOperationProvider } from '@core/ui/mpc/keygen/state/currentKeygenOperationType'
 import { CurrentHexEncryptionKeyProvider } from '@core/ui/mpc/state/currentHexEncryptionKey'
 import { IsInitiatingDeviceProvider } from '@core/ui/mpc/state/isInitiatingDevice'
+import { IsTssBatchingProvider } from '@core/ui/mpc/state/isTssBatching'
 import { MpcServerTypeProvider } from '@core/ui/mpc/state/mpcServerType'
 import { MpcServiceNameProvider } from '@core/ui/mpc/state/mpcServiceName'
 import { MpcSessionIdProvider } from '@core/ui/mpc/state/mpcSession'
@@ -21,25 +22,31 @@ export const JoinKeygenProviders = ({ children }: ChildrenProp) => {
 
   const keyImportChains = 'chains' in keygenMsg ? keygenMsg.chains : []
 
+  // Joiner respects the initiator's choice carried on the QR. SingleKeygenMessage
+  // has no batching path, so missing field defaults to false.
+  const isTssBatch = 'isTssBatch' in keygenMsg ? keygenMsg.isTssBatch : false
+
   return (
     <IsInitiatingDeviceProvider value={false}>
-      <MpcServiceNameProvider value={serviceName}>
-        <MpcServerTypeProvider initialValue={serverType}>
-          <MpcSessionIdProvider value={sessionId}>
-            <KeygenOperationProvider value={keygenOperation}>
-              <CurrentHexEncryptionKeyProvider value={encryptionKeyHex}>
-                <KeyImportChainsProvider value={keyImportChains}>
-                  <DklsInboundSequenceNoProvider initialValue={0}>
-                    <JoinKeygenVaultProvider>
-                      {children}
-                    </JoinKeygenVaultProvider>
-                  </DklsInboundSequenceNoProvider>
-                </KeyImportChainsProvider>
-              </CurrentHexEncryptionKeyProvider>
-            </KeygenOperationProvider>
-          </MpcSessionIdProvider>
-        </MpcServerTypeProvider>
-      </MpcServiceNameProvider>
+      <IsTssBatchingProvider value={isTssBatch}>
+        <MpcServiceNameProvider value={serviceName}>
+          <MpcServerTypeProvider initialValue={serverType}>
+            <MpcSessionIdProvider value={sessionId}>
+              <KeygenOperationProvider value={keygenOperation}>
+                <CurrentHexEncryptionKeyProvider value={encryptionKeyHex}>
+                  <KeyImportChainsProvider value={keyImportChains}>
+                    <DklsInboundSequenceNoProvider initialValue={0}>
+                      <JoinKeygenVaultProvider>
+                        {children}
+                      </JoinKeygenVaultProvider>
+                    </DklsInboundSequenceNoProvider>
+                  </KeyImportChainsProvider>
+                </CurrentHexEncryptionKeyProvider>
+              </KeygenOperationProvider>
+            </MpcSessionIdProvider>
+          </MpcServerTypeProvider>
+        </MpcServiceNameProvider>
+      </IsTssBatchingProvider>
     </IsInitiatingDeviceProvider>
   )
 }

--- a/core/ui/mpc/keygen/keyimport/JoinKeyImportKeygenActionProvider.tsx
+++ b/core/ui/mpc/keygen/keyimport/JoinKeyImportKeygenActionProvider.tsx
@@ -2,11 +2,11 @@ import { featureFlags } from '@core/ui/featureFlags'
 import { useCurrentHexChainCode } from '@core/ui/mpc/state/currentHexChainCode'
 import { useCurrentHexEncryptionKey } from '@core/ui/mpc/state/currentHexEncryptionKey'
 import { useIsInitiatingDevice } from '@core/ui/mpc/state/isInitiatingDevice'
+import { useIsTssBatching } from '@core/ui/mpc/state/isTssBatching'
 import { useMpcLocalPartyId } from '@core/ui/mpc/state/mpcLocalPartyId'
 import { useMpcServerUrl } from '@core/ui/mpc/state/mpcServerUrl'
 import { useMpcSessionId } from '@core/ui/mpc/state/mpcSession'
 import { useIsMLDSAEnabled } from '@core/ui/storage/mldsaEnabled'
-import { useIsTssBatchingEnabled } from '@core/ui/storage/tssBatchingEnabled'
 import { useVaultOrders } from '@core/ui/storage/vaults'
 import { ChildrenProp } from '@lib/ui/props'
 import { Chain } from '@vultisig/core-chain/Chain'
@@ -47,7 +47,7 @@ export const JoinKeyImportKeygenActionProvider = ({
   const isInitiatingDevice = useIsInitiatingDevice()
   const vaultOrders = useVaultOrders()
   const keyImportChainsRaw = useKeyImportChains()
-  const isTssBatchingEnabled = useIsTssBatchingEnabled()
+  const isTssBatchingEnabled = useIsTssBatching()
   const isMLDSAEnabled = useIsMLDSAEnabled()
 
   const keygenAction: KeygenAction = async ({

--- a/core/ui/mpc/keygen/keyimport/KeyImportKeygenActionProvider.tsx
+++ b/core/ui/mpc/keygen/keyimport/KeyImportKeygenActionProvider.tsx
@@ -3,11 +3,11 @@ import { featureFlags } from '@core/ui/featureFlags'
 import { useCurrentHexChainCode } from '@core/ui/mpc/state/currentHexChainCode'
 import { useCurrentHexEncryptionKey } from '@core/ui/mpc/state/currentHexEncryptionKey'
 import { useIsInitiatingDevice } from '@core/ui/mpc/state/isInitiatingDevice'
+import { useIsTssBatching } from '@core/ui/mpc/state/isTssBatching'
 import { useMpcLocalPartyId } from '@core/ui/mpc/state/mpcLocalPartyId'
 import { useMpcServerUrl } from '@core/ui/mpc/state/mpcServerUrl'
 import { useMpcSessionId } from '@core/ui/mpc/state/mpcSession'
 import { useIsMLDSAEnabled } from '@core/ui/storage/mldsaEnabled'
-import { useIsTssBatchingEnabled } from '@core/ui/storage/tssBatchingEnabled'
 import { useVaultOrders } from '@core/ui/storage/vaults'
 import { ChildrenProp } from '@lib/ui/props'
 import { Chain } from '@vultisig/core-chain/Chain'
@@ -96,7 +96,7 @@ export const KeyImportKeygenActionProvider = ({ children }: ChildrenProp) => {
   const vaultOrders = useVaultOrders()
   const walletCore = useAssertWalletCore()
   const keyImportInput = useKeyImportInput()
-  const isTssBatchingEnabled = useIsTssBatchingEnabled()
+  const isTssBatchingEnabled = useIsTssBatching()
   const isMLDSAEnabled = useIsMLDSAEnabled()
 
   const keygenAction: KeygenAction = useCallback(

--- a/core/ui/mpc/keygen/keyimport/fast/KeyImportFastKeygenServerActionProvider.tsx
+++ b/core/ui/mpc/keygen/keyimport/fast/KeyImportFastKeygenServerActionProvider.tsx
@@ -1,8 +1,8 @@
 import { useVaultCreationInput } from '@core/ui/mpc/keygen/create/state/vaultCreationInput'
 import { useCurrentHexChainCode } from '@core/ui/mpc/state/currentHexChainCode'
 import { useCurrentHexEncryptionKey } from '@core/ui/mpc/state/currentHexEncryptionKey'
+import { useIsTssBatching } from '@core/ui/mpc/state/isTssBatching'
 import { useMpcSessionId } from '@core/ui/mpc/state/mpcSession'
-import { useIsTssBatchingEnabled } from '@core/ui/storage/tssBatchingEnabled'
 import { ChildrenProp } from '@lib/ui/props'
 import { generateLocalPartyId } from '@vultisig/core-mpc/devices/localPartyId'
 import { keyImportWithServer } from '@vultisig/core-mpc/fast/api/keyImportWithServer'
@@ -24,7 +24,7 @@ export const KeyImportFastKeygenServerActionProvider = ({
   const hexChainCode = useCurrentHexChainCode()
   const hexEncryptionKey = useCurrentHexEncryptionKey()
   const { chains } = useKeyImportInput()
-  const isTssBatchingEnabled = useIsTssBatchingEnabled()
+  const isTssBatchingEnabled = useIsTssBatching()
 
   const action = async () => {
     const derivationGroups = getKeyImportDerivationGroups(chains)

--- a/core/ui/mpc/keygen/queries/useJoinKeygenUrlQuery.ts
+++ b/core/ui/mpc/keygen/queries/useJoinKeygenUrlQuery.ts
@@ -8,6 +8,7 @@ import {
 } from '@core/ui/mpc/keygen/state/keygenVault'
 import { useCurrentHexChainCode } from '@core/ui/mpc/state/currentHexChainCode'
 import { useCurrentHexEncryptionKey } from '@core/ui/mpc/state/currentHexEncryptionKey'
+import { useIsTssBatching } from '@core/ui/mpc/state/isTssBatching'
 import { useMpcServerType } from '@core/ui/mpc/state/mpcServerType'
 import { useMpcServiceName } from '@core/ui/mpc/state/mpcServiceName'
 import { useMpcSessionId } from '@core/ui/mpc/state/mpcSession'
@@ -41,6 +42,8 @@ export const useJoinKeygenUrlQuery = () => {
 
   const keygenVault = useKeygenVault()
 
+  const isTssBatch = useIsTssBatching()
+
   const { vaultCreationMpcLib } = useCore()
 
   return useTransformQueryData(
@@ -70,6 +73,7 @@ export const useJoinKeygenUrlQuery = () => {
                 useVultisigRelay,
                 vaultName,
                 libType,
+                isTssBatch,
               })
               return toBinary(KeygenMessageSchema, message)
             },
@@ -82,6 +86,7 @@ export const useJoinKeygenUrlQuery = () => {
                 vaultName,
                 ...assertKeygenReshareFields(keygenVault),
                 libType,
+                isTssBatch,
               })
               return toBinary(ReshareMessageSchema, message)
             },
@@ -95,6 +100,7 @@ export const useJoinKeygenUrlQuery = () => {
                 vaultName,
                 libType,
                 chains,
+                isTssBatch,
               })
               return toBinary(KeygenMessageSchema, message)
             },
@@ -132,6 +138,7 @@ export const useJoinKeygenUrlQuery = () => {
       [
         hexChainCode,
         hexEncryptionKey,
+        isTssBatch,
         keygenOperation,
         keygenVault,
         keyImportChains,

--- a/core/ui/mpc/keygen/reshare/ReshareFastKeygenServerActionProvider.tsx
+++ b/core/ui/mpc/keygen/reshare/ReshareFastKeygenServerActionProvider.tsx
@@ -1,8 +1,8 @@
 import { useCurrentHexEncryptionKey } from '@core/ui/mpc/state/currentHexEncryptionKey'
+import { useIsTssBatching } from '@core/ui/mpc/state/isTssBatching'
 import { useMpcSessionId } from '@core/ui/mpc/state/mpcSession'
 import { useEmail } from '@core/ui/state/email'
 import { usePassword } from '@core/ui/state/password'
-import { useIsTssBatchingEnabled } from '@core/ui/storage/tssBatchingEnabled'
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { ChildrenProp } from '@lib/ui/props'
 import {
@@ -26,7 +26,7 @@ export const ReshareFastKeygenServerActionProvider = ({
     useCurrentVault()
 
   const [email] = useEmail()
-  const isTssBatchingEnabled = useIsTssBatchingEnabled()
+  const isTssBatchingEnabled = useIsTssBatching()
 
   const action = async () => {
     if (isTssBatchingEnabled) {

--- a/core/ui/mpc/keygen/reshare/ReshareVaultFlowProviders.tsx
+++ b/core/ui/mpc/keygen/reshare/ReshareVaultFlowProviders.tsx
@@ -4,11 +4,13 @@ import {
   GeneratedHexEncryptionKeyProvider,
 } from '@core/ui/mpc/state/currentHexEncryptionKey'
 import { IsInitiatingDeviceProvider } from '@core/ui/mpc/state/isInitiatingDevice'
+import { IsTssBatchingProvider } from '@core/ui/mpc/state/isTssBatching'
 import {
   ExternalSessionIdProvider,
   GeneratedMpcSessionIdProvider,
   MpcSessionIdProvider,
 } from '@core/ui/mpc/state/mpcSession'
+import { useIsTssBatchingEnabled } from '@core/ui/storage/tssBatchingEnabled'
 import { ChildrenProp } from '@lib/ui/props'
 
 import { CurrentVaultHexChainCodeProvider } from '../../state/currentHexChainCode'
@@ -69,6 +71,7 @@ export const ReshareVaultFlowProviders = ({
   externalEncryptionKey,
   externalSessionId,
 }: ReshareVaultFlowProvidersProps) => {
+  const isTssBatchingEnabled = useIsTssBatchingEnabled()
   return (
     <SessionIdProviderWrapper externalSessionId={externalSessionId}>
       <EncryptionKeyProviderWrapper
@@ -81,13 +84,15 @@ export const ReshareVaultFlowProviders = ({
                 <ServerUrlDerivedFromServerTypeProvider>
                   <CurrentVaultHexChainCodeProvider>
                     <IsInitiatingDeviceProvider value={true}>
-                      <GeneratedMpcServiceNameProvider>
-                        <KeyImportChainsProvider value={[]}>
-                          <MpcPeersSelectionProvider>
-                            {children}
-                          </MpcPeersSelectionProvider>
-                        </KeyImportChainsProvider>
-                      </GeneratedMpcServiceNameProvider>
+                      <IsTssBatchingProvider value={isTssBatchingEnabled}>
+                        <GeneratedMpcServiceNameProvider>
+                          <KeyImportChainsProvider value={[]}>
+                            <MpcPeersSelectionProvider>
+                              {children}
+                            </MpcPeersSelectionProvider>
+                          </KeyImportChainsProvider>
+                        </GeneratedMpcServiceNameProvider>
+                      </IsTssBatchingProvider>
                     </IsInitiatingDeviceProvider>
                   </CurrentVaultHexChainCodeProvider>
                 </ServerUrlDerivedFromServerTypeProvider>

--- a/core/ui/mpc/keygen/reshare/ReshareVaultKeygenActionProvider.tsx
+++ b/core/ui/mpc/keygen/reshare/ReshareVaultKeygenActionProvider.tsx
@@ -1,10 +1,10 @@
 import { useCurrentHexEncryptionKey } from '@core/ui/mpc/state/currentHexEncryptionKey'
 import { useIsInitiatingDevice } from '@core/ui/mpc/state/isInitiatingDevice'
+import { useIsTssBatching } from '@core/ui/mpc/state/isTssBatching'
 import { useMpcLocalPartyId } from '@core/ui/mpc/state/mpcLocalPartyId'
 import { useMpcServerUrl } from '@core/ui/mpc/state/mpcServerUrl'
 import { useMpcSessionId } from '@core/ui/mpc/state/mpcSession'
 import { useCore } from '@core/ui/state/core'
-import { useIsTssBatchingEnabled } from '@core/ui/storage/tssBatchingEnabled'
 import { useVaultOrders } from '@core/ui/storage/vaults'
 import { ChildrenProp } from '@lib/ui/props'
 import { DKLS } from '@vultisig/core-mpc/dkls/dkls'
@@ -39,7 +39,7 @@ export const ReshareVaultKeygenActionProvider = ({
   const operation = useKeygenOperation()
   const { getDeveloperOptions } = useCore()
   const [, setDklsInboundSequenceNo] = useDklsInboundSequenceNoState()
-  const isTssBatchingEnabled = useIsTssBatchingEnabled()
+  const isTssBatchingEnabled = useIsTssBatching()
 
   const vaultOrders = useVaultOrders()
 
@@ -112,9 +112,13 @@ export const ReshareVaultKeygenActionProvider = ({
     if (isTssBatchingEnabled) {
       onStepStart('ecdsa')
       onStepStart('eddsa')
+      // Match iOS's setup-message namespacing in batched parallel reshare:
+      // each protocol uploads/downloads its own setup at the same key as its
+      // exchange channel, so DKLS uses 'p-ecdsa' and Schnorr uses 'p-eddsa'
+      // for both setup and exchange.
       ;[dklsResult, schnorrResult] = await Promise.all([
         dklsKeygen
-          .startReshareWithRetry(oldEcdsaKeyshare, 'p-ecdsa')
+          .startReshareWithRetry(oldEcdsaKeyshare, 'p-ecdsa', 'p-ecdsa')
           .then(r => {
             onStepComplete('ecdsa')
             return r

--- a/core/ui/mpc/state/isTssBatching.ts
+++ b/core/ui/mpc/state/isTssBatching.ts
@@ -1,0 +1,4 @@
+import { setupValueProvider } from '@lib/ui/state/setupValueProvider'
+
+export const [IsTssBatchingProvider, useIsTssBatching] =
+  setupValueProvider<boolean>('IsTssBatching')


### PR DESCRIPTION
## Summary

Fix batched parallel keygen between the extension and Android / iOS. Closes #3864.

In batched mode the DKLS setup message is *shared* with the parallel Schnorr task, but each platform publishes/consumes it under a different relay `message_id` namespace — every cross-platform pairing deadlocks at `/setup-message/<sessionID>` because the joiner polls one namespace while the initiator wrote to another:

| Platform | Setup namespace |
|---|---|
| Android (current), pre-#4246 iOS, extension | default (no `message_id` header) |
| post-#4246 iOS DKLS task | `p-ecdsa` |
| post-#4246 iOS Schnorr task | `p-eddsa` (looks up the *shared* setup here, after vultisig/vultisig-ios#4246) |

The iOS Schnorr lookup is itself an iOS regression (vultisig/vultisig-ios#4246 folded `messenger.messageID` into setup-message HTTP headers — correct for reshare, but breaks the shared-setup invariant of keygen). This PR makes the extension interop with both behaviours so users aren't blocked while the iOS revert lands.

## Changes

- **`core/ui/mpc/state/isTssBatching.ts`** (new) — value provider exposing the resolved batching choice to the keygen action providers.
- **Initiator-side providers** (`KeygenSessionProviders`, `ReshareVaultFlowProviders`) seed the new provider from `useIsTssBatchingEnabled()` (local toggle + remote feature flag). **Joiner-side** (`JoinKeygenProviders`) seeds it from the QR-decoded `keygenMsg.isTssBatch` so the joiner respects the initiator's choice deterministically (matching iOS).
- All keygen action providers (`CreateVaultKeygenActionProvider`, `JoinKeyImportKeygenActionProvider`, `KeyImportKeygenActionProvider`, `ReshareVaultKeygenActionProvider`, all three `*FastKeygenServerActionProvider`s) switched from `useIsTssBatchingEnabled()` → `useIsTssBatching()`.
- **`useJoinKeygenUrlQuery`** stamps `isTssBatch` on the `KeygenMessage` and `ReshareMessage` protos when generating the QR, so iOS / Android joiners read the initiator's choice from the message instead of relying on a per-device feature toggle.
- **`CreateVaultKeygenActionProvider`** batched branch calls `prepareKeygenSetup(undefined, ['p-ecdsa', 'p-eddsa'])`. As initiator, the extension publishes the setup to default + `p-ecdsa` + `p-eddsa`. As joiner, the SDK races a poll across all three and back-fills any namespace where the bytes weren't already, so a peer using a different convention still finds them.
- **`ReshareVaultKeygenActionProvider`** batched branch passes `'p-ecdsa'` as both `messageId` and `setupMessageId` to `dklsKeygen.startReshareWithRetry` — matches iOS's per-protocol setup namespacing for reshare. Schnorr's reshare already keys setup off the exchange `messageId`, so `'p-eddsa'` works as the existing second arg.

## Dependency

Requires the paired SDK release: vultisig/vultisig-sdk#438. That PR adds `prepareKeygenSetup(setupMessageId?, mirrorSetupMessageIds = [])`, `startReshareWithRetry(keyshare, messageId?, setupMessageId?)`, `waitForSetupMessageInAny`, and regenerates the `KeygenMessage` / `ReshareMessage` protos to expose `is_tss_batch`. **CI will fail until `@vultisig/core-mpc` is published with those changes and the dep is bumped here.**

## Interop matrix after this fix (both batching ON)

| Pair | Initiator writes setup at | Joiner reads from | Result |
|---|---|---|---|
| Extension ↔ Extension | default + `p-ecdsa` + `p-eddsa` | default wins | ✓ |
| Extension → Android | default + `p-ecdsa` + `p-eddsa` | Android polls default | ✓ |
| Android → Extension | default | races, default wins | ✓ |
| Extension → iOS | default + `p-ecdsa` + `p-eddsa` | iOS DKLS reads `p-ecdsa`, iOS Schnorr reads `p-eddsa` | ✓ |
| iOS → Extension | `p-ecdsa` | races, `p-ecdsa` wins, then back-fills default + `p-eddsa` | ✓ |
| 3-way (any of the above + iOS as second peer) | initiator writes wherever | joiner back-fills so iOS Schnorr can resolve `p-eddsa` | ✓ |
| Android ↔ iOS | (still broken — iOS-side bug, extension not in path) | — | ✗ unchanged |

## Test plan
- [ ] `yarn check:all` passes once SDK is bumped.
- [ ] Secure Vault keygen with **Android initiator + extension joiner** completes successfully (the case in #3864).
- [ ] Secure Vault keygen with **extension initiator + Android joiner** completes successfully.
- [ ] Secure Vault keygen with **iOS initiator + extension joiner** completes successfully (with iOS toggle ON).
- [ ] Secure Vault keygen with **extension initiator + iOS joiner** completes successfully (with iOS toggle ON).
- [ ] Secure Vault keygen with **extension ↔ extension** still completes (regression check).
- [ ] Reshare with extension initiator + iOS/Android joiner completes successfully.
- [ ] Non-batched keygen (toggles OFF on both sides) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved state management for TSS batching across key generation flows (create, join, reshare, key import)
  * TSS batching preference is now properly synchronized and communicated through QR code sharing during multi-party key generation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-windows/pull/3892)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->