### PR TITLE
fix(extension): Keplr API parity P1+P2 (disable, sendTx, getKeysSettled, signArbitrary stubs)

### DIFF
--- a/clients/extension/src/inpage/providers/station.ts
+++ b/clients/extension/src/inpage/providers/station.ts
@@ -333,7 +333,6 @@ export class Station {
     if (!validateUrl(window.location.href)) {
       addBackgroundEventListener('disconnect', () => {
         this.emitWalletChange()
-        this.keplr.emitAccountsChanged()
       })
     }
   }

--- a/clients/extension/src/inpage/providers/xdefiKeplr.ts
+++ b/clients/extension/src/inpage/providers/xdefiKeplr.ts
@@ -1,4 +1,5 @@
 import { callBackground } from '@core/inpage-provider/background'
+import { addBackgroundEventListener } from '@core/inpage-provider/background/events/inpage'
 import { callPopup } from '@core/inpage-provider/popup'
 import { PopupError } from '@core/inpage-provider/popup/error'
 import { TransactionDetails } from '@core/inpage-provider/popup/view/resolvers/sendTx/interfaces'
@@ -19,6 +20,8 @@ import {
   Key,
   OfflineAminoSigner,
   OfflineDirectSigner,
+  SettledResponses,
+  StdSignature,
   StdSignDoc,
 } from '@keplr-wallet/types'
 import { SignDoc as KeplrSignDoc } from '@keplr-wallet/types/build/cosmjs'
@@ -34,10 +37,10 @@ import {
 } from '@vultisig/core-mpc/types/vultisig/keysign/v1/wasm_execute_contract_payload_pb'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { attempt } from '@vultisig/lib-utils/attempt'
-import { NotImplementedError } from '@vultisig/lib-utils/error/NotImplementedError'
 import { hexToBytes } from '@vultisig/lib-utils/hexToBytes'
 import { match } from '@vultisig/lib-utils/match'
 import { areLowerCaseEqual } from '@vultisig/lib-utils/string/areLowerCaseEqual'
+import { validateUrl } from '@vultisig/lib-utils/validation/url'
 import { bech32 } from 'bech32'
 import { MsgSend } from 'cosmjs-types/cosmos/bank/v1beta1/tx'
 import { TxBody, TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
@@ -394,15 +397,29 @@ const stripEndpoints = ({
   nodeProvider: undefined,
 })
 
+// Every method on the inherited Keplr base class that we don't explicitly
+// override routes through this requester (the base wraps calls in
+// `sendSimpleMessage(this.requester, ...)`). The previous no-op silently
+// resolved `undefined`, which let any unhandled method "succeed" with a
+// nonsense value — dApps then exploded on `q.chainInfos` or similar with
+// no path back to the root cause.
+//
+// Throwing here makes unhandled methods fail loudly and uniformly. dApps
+// can catch and fall back; bugs in our override coverage surface at the
+// call site instead of three layers downstream. For the methods cosmos-kit
+// actually exercises (`getKeysSettled`, `getKey`, `enable`, ...) we
+// override on `XDEFIKeplrProvider`, so this requester is reached only by
+// truly unhandled paths.
 class XDEFIMessageRequester {
   constructor() {
     this.sendMessage = this.sendMessage.bind(this)
   }
-  // Expected for Ctrl
-  public async sendMessage(_message: any, _params: any): Promise<void> {
-    return new Promise(resolve => {
-      resolve()
-    })
+  public async sendMessage(message: any, params: any): Promise<void> {
+    const method =
+      (params && (params.type ?? params.method)) ??
+      (message && (message.type ?? message.method)) ??
+      'unknown'
+    throw new Error(`Keplr method '${method}' is not supported by Vultisig`)
   }
 }
 
@@ -446,6 +463,20 @@ export class XDEFIKeplrProvider extends Keplr {
     window.ctrlKeplrProviders = {}
     window.ctrlKeplrProviders['Ctrl Wallet'] = this
     this.cosmosProvider = cosmosProvider
+
+    // `keplr_keystorechange` is Keplr's stale-key signal — dApps re-fetch
+    // `getKey` when they see it. The background fires `disconnect` when
+    // the host's appSession is removed (either via our `disable` /
+    // `signOut` flow or because the user revoked the dApp grant). Until
+    // now, the dispatch lived on the Station provider's constructor, so
+    // dApps that loaded only `window.keplr` (no Terra Station) never
+    // saw the event. Skip on the wallet's own UI to avoid wiring the
+    // listener inside the extension popup.
+    if (!validateUrl(window.location.href)) {
+      addBackgroundEventListener('disconnect', () => {
+        this.emitAccountsChanged()
+      })
+    }
   }
 
   private async runWithChain<T>(
@@ -516,6 +547,22 @@ export class XDEFIKeplrProvider extends Keplr {
   }
 
   /**
+   * Revokes the dApp's permission to query the wallet, mirroring Keplr's
+   * `disable`. Subsequent `enable` / `getKey` / `getOfflineSigner` calls
+   * will surface the grant-vault popup again.
+   *
+   * Vultisig's `appSession` is host-keyed (not host+chain-keyed), so we
+   * can't selectively revoke a single chain — `disable(['cosmoshub-4'])`
+   * has the same effect as `disable()`. The `chainIds` argument is
+   * accepted for API compatibility but otherwise ignored. Most dApps
+   * that call this only care about the all-chains "log out" outcome.
+   */
+  async disable(_chainIds?: string | string[]): Promise<void> {
+    await callBackground({ signOut: {} })
+    this.emitAccountsChanged()
+  }
+
+  /**
    * Keplr-shaped chain list for every Cosmos chain Vultisig exposes natively
    * plus any chains a dApp has registered via `experimentalSuggestChain`.
    * cosmos-kit dApps probe this BEFORE showing their
@@ -569,9 +616,31 @@ export class XDEFIKeplrProvider extends Keplr {
     return cosmSigner as OfflineAminoSigner
   }
 
+  /**
+   * Keplr's reference implementation returns the amino-only signer when
+   * the active key is on a hardware Ledger (Ledger can't sign protobuf
+   * direct payloads) and the combined amino+direct signer otherwise.
+   * Vultisig is an MPC wallet — there is no Ledger in the signing path
+   * (`getKey` hardcodes `isNanoLedger: false`), so always return the
+   * combined signer. Overriding the inherited base — which would call
+   * `XDEFIMessageRequester.sendMessage` and silently resolve `undefined`
+   * — makes the cosmos-kit pre-connect probe see a usable signer.
+   */
+  async getOfflineSignerAuto(
+    chainId: string,
+    signOptions?: KeplrSignOptions
+  ): Promise<OfflineAminoSigner | OfflineDirectSigner> {
+    return this.getOfflineSigner(chainId, signOptions)
+  }
+
   async sendTx(): Promise<Uint8Array> {
-    // This method accepts a transaction of type StdTx | Uint8Array; however, the previous implementation did not support handling this type.
-    throw new NotImplementedError('Keplr sendTx method')
+    // Keplr's `sendTx` broadcasts a fully signed transaction via Keplr's
+    // background relay. Vultisig has no equivalent relay — dApps that
+    // need to broadcast should do so via their own RPC client after
+    // `signAmino` / `signDirect`. Throwing here (instead of resolving
+    // `undefined` from the inherited base requester) gives the dApp a
+    // deterministic signal to fall back to its own broadcast.
+    throw new Error('Keplr.sendTx is not supported by Vultisig')
   }
   async sendMessage() {}
 
@@ -726,6 +795,71 @@ export class XDEFIKeplrProvider extends Keplr {
   }
 
   /**
+   * ADR-36 arbitrary-message signing — used by Leap-style "sign-in-with-
+   * cosmos" auth flows and several governance dApps.
+   *
+   * Not yet implemented: ADR-36 signs the canonical JSON of a
+   * `StdSignDoc{MsgSignData}` directly, which doesn't fit Vultisig's
+   * existing keysign pipeline (TW.Cosmos signs transaction sign-docs,
+   * not raw amino bytes). Wiring this requires a new MPC primitive that
+   * signs raw bytes with the Cosmos-Hub secp256k1 key.
+   *
+   * Throwing here (instead of resolving `undefined` from the inherited
+   * base requester) gives dApps a deterministic signal to fall back to
+   * alternative auth methods.
+   */
+  async signArbitrary(
+    _chainId: string,
+    _signer: string,
+    _data: string | Uint8Array
+  ): Promise<StdSignature> {
+    throw new Error('Keplr.signArbitrary is not supported by Vultisig')
+  }
+
+  /**
+   * Paired with `signArbitrary`. Pure signature verification could be
+   * implemented standalone (it's just secp256k1 against the ADR-36
+   * canonical sign-doc), but verifying a signature we can't produce has
+   * limited utility — defer until `signArbitrary` lands.
+   */
+  async verifyArbitrary(
+    _chainId: string,
+    _signer: string,
+    _data: string | Uint8Array,
+    _signature: StdSignature
+  ): Promise<boolean> {
+    throw new Error('Keplr.verifyArbitrary is not supported by Vultisig')
+  }
+
+  /**
+   * EIP-712-typed-data Cosmos signing for Evmos / Injective / dymension and
+   * other Ethermint-style chains, which derive their signer from a secp256k1
+   * Ethereum key and sign amino docs wrapped in an EIP-712 envelope.
+   *
+   * Not yet implemented: needs (a) an Ethermint-aware key derivation path
+   * since Vultisig's Cosmos signer assumes coinType-118 secp256k1 and (b)
+   * an EIP-712 hashing pass on top of the amino doc. Throwing here gives
+   * Evmos/Injective dApps a deterministic signal to fall back to
+   * `signAmino` (which several of them do) instead of resolving `undefined`
+   * from the inherited base requester.
+   */
+  async experimentalSignEIP712CosmosTx_v0(
+    _chainId: string,
+    _signer: string,
+    _eip712: {
+      types: Record<string, { name: string; type: string }[] | undefined>
+      domain: Record<string, unknown>
+      primaryType: string
+    },
+    _signDoc: StdSignDoc,
+    _signOptions?: KeplrSignOptions
+  ): Promise<AminoSignResponse> {
+    throw new Error(
+      'Keplr.experimentalSignEIP712CosmosTx_v0 is not supported by Vultisig'
+    )
+  }
+
+  /**
    * Registers a Cosmos chain that the dApp has asked the wallet to support.
    *
    * - Validates the ChainInfo shape and rejects malformed input with a
@@ -811,5 +945,29 @@ export class XDEFIKeplrProvider extends Keplr {
       name: vault.name,
       algo,
     }
+  }
+
+  /**
+   * Batch variant of {@link getKey} — cosmos-kit's pre-connect probe calls
+   * this with the full chain set instead of N serial `getKey` calls, so an
+   * unhandled implementation routed through the inherited base (and our
+   * now-throwing requester) would explode the whole probe. Mirror Keplr's
+   * `Promise.allSettled`-shaped result so unknown chains surface as
+   * per-entry `rejected` instead of failing the whole batch.
+   */
+  async getKeysSettled(chainIds: string[]): Promise<SettledResponses<Key>> {
+    return Promise.all(
+      chainIds.map(async chainId => {
+        const result = await attempt(() => this.getKey(chainId))
+        if ('error' in result) {
+          const reason =
+            result.error instanceof Error
+              ? result.error
+              : new Error(String(result.error))
+          return { status: 'rejected', reason } as const
+        }
+        return { status: 'fulfilled', value: result.data } as const
+      })
+    )
   }
 }


### PR DESCRIPTION
Layers the **P1 + P2** items from #3888 on top of the P0
`experimentalSuggestChain` work that landed in #3903.

cosmos-kit dApps that probed via `getKeysSettled` or invoked `disable` /
`sendTx` / `signArbitrary` / `experimentalSignEIP712CosmosTx_v0` were
quietly broken: those methods either threw a non-Keplr-shaped error or
fell through to `XDEFIMessageRequester.sendMessage`'s `undefined`-resolve
no-op, and the dApp exploded three layers downstream with no path back
to the cause.

## Summary

### P1
- **`disable(chainIds?)`** — revokes the dApp's `appSession` via the
  existing `signOut` background resolver and emits
  `keplr_keystorechange`. App sessions are host-keyed (not
  host+chain-keyed) so per-chain revocation isn't supported;
  `chainIds` is accepted for API compat and documented in JSDoc.
- **`getOfflineSignerAuto`** — returns the combined amino+direct signer.
  Vultisig is MPC, never Ledger, so the Keplr-reference Ledger branch
  doesn't apply. Overrides the broken inherited base whose underlying
  `sendMessage` returned `undefined`.
- **`sendTx`** — throws a Keplr-shaped not-supported error so dApps
  fall back to broadcasting via their own RPC client (Vultisig has no
  background-relay equivalent to Keplr's broadcast endpoint).
- **`signArbitrary` / `verifyArbitrary`** — Keplr-shaped throws. JSDoc
  notes that ADR-36 signs the canonical JSON of `StdSignDoc{MsgSignData}`
  directly, which needs a new MPC primitive that signs raw bytes — out
  of scope here.

### P2
- **`XDEFIMessageRequester.sendMessage`** — replaces the
  `undefined`-resolve no-op with a clear throw that includes the
  unhandled method name. Surfaces missing overrides at the call site
  instead of three layers downstream.
- **`getKeysSettled`** — cosmos-kit's pre-connect probe path. Without an
  override, the new throwing requester would explode the whole batch.
  Wraps per-chain `getKey` in `attempt()` to produce a real
  `SettledResponses<Key>` where unknown chains surface as per-entry
  `rejected`.
- **`emitAccountsChanged` on disconnect** — wired directly in
  `XDEFIKeplrProvider`'s constructor. Previously only fired through
  `Station`'s listener, so dApps that loaded only `window.keplr` (no
  Terra Station) never saw the keystore-change event. Removed the
  duplicate dispatch from `station.ts`.
- **`experimentalSignEIP712CosmosTx_v0`** — Keplr-shaped throw so
  Evmos / Injective / dymension dApps fall back to `signAmino` instead
  of resolving `undefined`.

### Out of scope (deferred)
- `suggestToken` — tracked in #3812.
- Proper signing for `signArbitrary`, `verifyArbitrary`, `sendTx`,
  `experimentalSignEIP712CosmosTx_v0` — requires new MPC primitives
  and/or an Ethermint key derivation path.
- P3 version bump — owner's call.

## Test plan

- [x] `yarn check` (typecheck + lint + knip)
- [x] `yarn test` (130/130)
- [ ] On a cosmos-kit dApp, click Disconnect and confirm subsequent
      `getKey` re-surfaces the grant-vault popup.
- [ ] `window.keplr.signArbitrary(...)` rejects with
      `Error: Keplr.signArbitrary is not supported by Vultisig`.
- [ ] `window.keplr.getKeysSettled(['cosmoshub-4', 'not-a-real-chain'])`
      resolves with one fulfilled + one rejected entry (not a thrown
      error).
- [ ] On a dApp that only loads `window.keplr` (no Station), revoke the
      grant from the extension UI and observe the dApp re-fetches the
      key via the `keplr_keystorechange` event.

Closes #3888

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disconnect event handling for more reliable account state updates in connected dApps.
  * Enhanced error messages for unsupported wallet operations with deterministic, clearer feedback.

* **New Features**
  * Added wallet disable/sign-out functionality.
  * Introduced batched key retrieval with improved per-chain error handling.
  * Enhanced offline signer support and additional signing operation capabilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-windows/pull/3908)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->