### PR TITLE
fix(keysign): show THORChain flat network fee on dApp MsgSend

### DIFF
--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/applyCosmosFeeFromSignData.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/applyCosmosFeeFromSignData.ts
@@ -1,9 +1,10 @@
 import { fromBase64 } from '@cosmjs/encoding'
 import { CosmosChain } from '@vultisig/core-chain/Chain'
+import { CosmosMsgType } from '@vultisig/core-chain/chains/cosmos/cosmosMsgTypes'
 import { sumFeeAmountForCosmosChainFeeDenom } from '@vultisig/core-chain/chains/cosmos/sumFeeAmountForCosmosChainFeeDenom'
 import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
 import { attempt } from '@vultisig/lib-utils/attempt'
-import { AuthInfo } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
+import { AuthInfo, TxBody } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
 
 type FeeAmount = { denom: string; amount: string }
 
@@ -23,16 +24,51 @@ const getDappFeeAmounts = (
   return undefined
 }
 
+const executeContractMsgTypes: ReadonlySet<string> = new Set([
+  CosmosMsgType.MSG_EXECUTE_CONTRACT,
+  CosmosMsgType.MSG_EXECUTE_CONTRACT_URL,
+])
+
+const isExecuteContractSignData = (
+  signData: KeysignPayload['signData']
+): boolean => {
+  if (signData.case === 'signAmino') {
+    return signData.value.msgs.some(msg =>
+      executeContractMsgTypes.has(msg.type)
+    )
+  }
+  if (signData.case === 'signDirect') {
+    const result = attempt(() =>
+      TxBody.decode(fromBase64(signData.value.bodyBytes))
+    )
+    if ('error' in result) return false
+    return result.data.messages.some(msg =>
+      executeContractMsgTypes.has(msg.typeUrl)
+    )
+  }
+  return false
+}
+
 type ApplyCosmosFeeFromSignDataInput = {
   keysignPayload: KeysignPayload
   chain: CosmosChain
 }
 
 /**
- * Copies the dapp-supplied fee from `signData` (signAmino or signDirect) into
- * `blockchainSpecific.thorchainSpecific.fee` / `cosmosSpecific.gas`, so the
- * Network Fee row on the keysign popup — and any other consumer of
- * `blockchainSpecific` — reads the same value the chain will actually charge.
+ * Reconciles the dapp-supplied fee from `signData` (signAmino or signDirect)
+ * with the chain-default fee already in `blockchainSpecific`, writing the
+ * resulting estimate to `thorchainSpecific.fee` / `cosmosSpecific.gas` so the
+ * Network Fee row on the keysign popup matches what the user will actually pay.
+ *
+ * Reconciliation rule:
+ *   - `MsgExecuteContract` (any cosmos chain): use signed. Contract calls pay
+ *     exactly what's in `fee.amount` (gas × gas_price the dapp simulated).
+ *   - Non-contract on vaultBased chains (THORChain): keep the chain-default
+ *     already in `thorchainSpecific.fee`. THORChain ignores `fee.amount` and
+ *     deducts a flat `NativeTransactionFee` (currently 0.02 RUNE); whatever
+ *     the dapp signed is decorative.
+ *   - Non-contract on ibcEnabled chains (Osmosis, Cosmos Hub, etc.): use
+ *     signed. The chain deducts exactly `fee.amount`.
  *
  * No-op when:
  *   - the chain isn't cosmos-routed (caller guards on `isChainOfKind('cosmos')`)
@@ -49,13 +85,23 @@ export const applyCosmosFeeFromSignData = ({
   const feeAmounts = getDappFeeAmounts(keysignPayload.signData)
   if (!feeAmounts) return
 
-  const fee = sumFeeAmountForCosmosChainFeeDenom({ amounts: feeAmounts, chain })
-  if (fee === null) return
+  const signedFee = sumFeeAmountForCosmosChainFeeDenom({
+    amounts: feeAmounts,
+    chain,
+  })
+  if (signedFee === null) return
 
   const { blockchainSpecific } = keysignPayload
+  const isExecuteContract = isExecuteContractSignData(keysignPayload.signData)
+
   if (blockchainSpecific.case === 'thorchainSpecific') {
-    blockchainSpecific.value.fee = fee
-  } else if (blockchainSpecific.case === 'cosmosSpecific') {
-    blockchainSpecific.value.gas = fee
+    if (isExecuteContract) {
+      blockchainSpecific.value.fee = signedFee
+    }
+    return
+  }
+
+  if (blockchainSpecific.case === 'cosmosSpecific') {
+    blockchainSpecific.value.gas = signedFee
   }
 }


### PR DESCRIPTION
## Summary

- Stop overwriting `thorchainSpecific.fee` with the dApp's signed `fee.amount` for non-contract THORChain txs. THORChain ignores `fee.amount` and deducts a flat `NativeTransactionFee` (currently 0.02 RUNE), so the chain-default written by `getChainSpecific` was the correct value all along; the dApp's 0 was decorative.
- Keep the existing behavior for ibcEnabled chains (Osmosis, Cosmos Hub, etc.) where `fee.amount` *is* what the chain charges.
- Detect `MsgExecuteContract` (amino `msgs[].type` / direct `TxBody.messages[].typeUrl`) and always trust the signed fee on contract calls — the dApp simulated `gas × gas_price` and that's the authoritative amount on any cosmos chain.

Closes #3887.

### Reconciliation rule

| Case | Branch | Final fee |
|---|---|---|
| `MsgExecuteContract` (any cosmos chain) | both | signed |
| Non-contract, vaultBased (THORChain) | `thorchainSpecific` | previous (chain default — left untouched) |
| Non-contract, ibcEnabled (Osmosis, Hub, …) | `cosmosSpecific` | signed |
| `mayachainSpecific` | n/a | no-op (schema has no fee field) |

`gasLimit` is intentionally ignored — THORChain has no gas price, and on ibcEnabled chains `fee.amount` already represents `gas × gas_price` from the dApp's simulate call.

## Test plan

- [ ] Rujira native send (`MsgSend`, signed `fee.amount: 0 RUNE`, `gasLimit: 99537`) → keysign popup shows **Est. Network Fee: 0.02 RUNE**, matching the dApp's confirm dialog.
- [ ] THORChain `MsgDeposit` swap/deposit initiated from a dApp → popup shows 0.02 RUNE.
- [ ] Vultisig-built THORChain native send (no `signData`) → unchanged, shows the existing chain-default.
- [ ] Osmosis `MsgSend` from a dApp → popup shows the dApp's `fee.amount` (uosmo), not `signed + previous`.
- [ ] Osmosis `MsgExecuteContract` (e.g. swap) → popup shows the dApp's `fee.amount`.
- [ ] MAYA dApp send → unchanged (function still a no-op for `mayachainSpecific`).
- [ ] `yarn check` clean (lint + typecheck + knip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced fee handling for smart contract transactions to properly apply network-specific rules.
  * Improved fee reconciliation during transaction signing when dapps supply custom fee information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-windows/pull/3916?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->