### PR TITLE
Include extension and desktop unit tests in check:all and CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,10 @@ jobs:
         run: yarn test
 
       - name: Run unit tests (extension)
-        run: yarn exec vitest run --config clients/extension/tests/unit/vitest.config.ts
+        run: yarn workspace @clients/extension test
+
+      - name: Run unit tests (desktop)
+        run: yarn workspace @clients/desktop test:ci
 
       - name: Run typecheck
         run: yarn typecheck

--- a/clients/desktop/package.json
+++ b/clients/desktop/package.json
@@ -10,7 +10,8 @@
     "dev": "vite",
     "build": "node --max-old-space-size=8192 ../../node_modules/typescript/bin/tsc && node --max-old-space-size=8192 ../../node_modules/vite/bin/vite.js build",
     "preview": "vite preview",
-    "test": "vitest",
+    "test": "vitest --config vitest.config.mts",
+    "test:ci": "vitest run --config vitest.config.mts",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/clients/desktop/vitest.config.mts
+++ b/clients/desktop/vitest.config.mts
@@ -1,0 +1,24 @@
+import path from 'path'
+import { fileURLToPath } from 'url'
+import tsconfigPaths from 'vite-tsconfig-paths'
+import { defineConfig } from 'vitest/config'
+
+const desktopDir = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(desktopDir, '../..')
+
+// node-stdlib-browser's url proxy imports `punycode/` (directory spec). Node ESM and
+// Vitest reject that; point the trailing-slash form at the package entry file.
+const punycodeEntry = path.join(repoRoot, 'node_modules/punycode/punycode.js')
+
+export default defineConfig({
+  plugins: [tsconfigPaths({ root: repoRoot })],
+  resolve: {
+    alias: {
+      'punycode/': `${punycodeEntry}`,
+    },
+  },
+  test: {
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+  },
+})

--- a/clients/extension/package.json
+++ b/clients/extension/package.json
@@ -97,6 +97,7 @@
     "vite-plugin-static-copy": "^3.3.0",
     "vite-plugin-top-level-await": "^1.6.0",
     "vite-plugin-wasm": "^3.6.0",
+    "vitest": "^4.1.0",
     "web-push": "^3.6.7",
     "ws": "^8.19.0"
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typecheck": "tsgo --noEmit",
     "test": "vitest run",
     "knip": "knip",
-    "check:all": "yarn lint && yarn typecheck && yarn test && yarn knip",
+    "check:all": "yarn lint && yarn typecheck && yarn test && yarn workspace @clients/extension test && yarn workspace @clients/desktop test:ci && yarn knip",
     "knip:fix": "knip --fix --allow-remove-files",
     "check": "concurrently --kill-others-on-fail \"yarn typecheck\" \"yarn lint:fix\" && yarn knip",
     "translate": "yarn workspace @core/ui translate",

--- a/yarn.lock
+++ b/yarn.lock
@@ -656,6 +656,7 @@ __metadata:
     vite-plugin-static-copy: "npm:^3.3.0"
     vite-plugin-top-level-await: "npm:^1.6.0"
     vite-plugin-wasm: "npm:^3.6.0"
+    vitest: "npm:^4.1.0"
     web-push: "npm:^3.6.7"
     ws: "npm:^8.19.0"
     zod: "npm:^4.3.6"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched to workspace-specific test commands for clearer per-package test runs.
  * Added a CI-focused desktop test script and a desktop-specific test configuration.
  * Added Vitest to the extension package devDependencies.
  * Expanded the top-level check script to run extension and desktop tests as part of verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-windows/pull/3919?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->