### PR TITLE
fix(defi): gate Unbond button per-node for Maya/THORChain (#3917)

### DIFF
--- a/core/ui/defi/chain/queries/services/mayachainBondService.ts
+++ b/core/ui/defi/chain/queries/services/mayachainBondService.ts
@@ -14,6 +14,7 @@ import { mayaCoin } from '../tokens'
 import { ThorchainBondPosition } from '../types'
 import { toDecimalFactor } from '../utils/decimals'
 import {
+  canUnbondNode,
   estimateNextChurn,
   parseBigint,
   parseNumber,
@@ -149,7 +150,6 @@ export const fetchBondPositions = async ({
       positions: [],
       totalBonded: 0n,
       availableNodes: [],
-      canUnbond: true,
     }
   }
 
@@ -194,6 +194,7 @@ export const fetchBondPositions = async ({
       nextChurn,
       status: metrics.status,
       fiatValue,
+      canUnbond: canUnbondNode(metrics.status),
     })
   }
 
@@ -228,6 +229,5 @@ export const fetchBondPositions = async ({
     positions,
     totalBonded,
     availableNodes,
-    canUnbond: true,
   }
 }

--- a/core/ui/defi/chain/queries/services/thorchainBondService.ts
+++ b/core/ui/defi/chain/queries/services/thorchainBondService.ts
@@ -14,6 +14,7 @@ import { runeCoin } from '../tokens'
 import { ThorchainBondPosition } from '../types'
 import { toDecimalFactor } from '../utils/decimals'
 import {
+  canUnbondNode,
   estimateNextChurn,
   parseBigint,
   parseNumber,
@@ -140,7 +141,7 @@ export const fetchBondPositions = async (
   churns: ChurnEntry[],
   networkInfo: NetworkInfo,
   health: HealthInfo,
-  canUnbond: boolean
+  chainAllowsUnbond: boolean
 ) => {
   // Return mock data for testing when no real bonded positions exist
   if (useMockBondPositions) {
@@ -162,6 +163,7 @@ export const fetchBondPositions = async (
           decimals: runeCoin.decimals,
           price: runePrice,
         }),
+        canUnbond: chainAllowsUnbond && canUnbondNode('churned out'),
       },
       {
         id: 'thor-bond-rune',
@@ -176,6 +178,7 @@ export const fetchBondPositions = async (
           decimals: runeCoin.decimals,
           price: runePrice,
         }),
+        canUnbond: chainAllowsUnbond && canUnbondNode('active'),
       },
     ]
 
@@ -183,7 +186,6 @@ export const fetchBondPositions = async (
       positions: mockPositions,
       totalBonded: mockAmount1 + mockAmount2,
       availableNodes: [],
-      canUnbond: true,
     }
   }
 
@@ -215,6 +217,7 @@ export const fetchBondPositions = async (
       price: prices[coinKeyToString(runeCoin)] ?? 0,
     })
 
+    const status = metrics?.status ?? toBondStatusLabel(node.status)
     positions.push({
       id: 'thor-bond-rune',
       nodeAddress: node.address,
@@ -222,8 +225,9 @@ export const fetchBondPositions = async (
       apy,
       nextReward,
       nextChurn,
-      status: metrics?.status ?? toBondStatusLabel(node.status),
+      status,
       fiatValue,
+      canUnbond: chainAllowsUnbond && canUnbondNode(status),
     })
   }
 
@@ -260,6 +264,5 @@ export const fetchBondPositions = async (
     positions,
     totalBonded,
     availableNodes,
-    canUnbond,
   }
 }

--- a/core/ui/defi/chain/queries/types.ts
+++ b/core/ui/defi/chain/queries/types.ts
@@ -7,6 +7,7 @@ export type ThorchainBondPosition = {
   nextChurn?: Date
   status: string
   fiatValue: number
+  canUnbond: boolean
 }
 
 export type ThorchainStakePosition = {
@@ -29,7 +30,6 @@ export type DefiChainPositions = {
     totalBonded: bigint
     positions: ThorchainBondPosition[]
     availableNodes: string[]
-    canUnbond: boolean
   }
   stake?: {
     positions: ThorchainStakePosition[]

--- a/core/ui/defi/chain/queries/utils/parsers.ts
+++ b/core/ui/defi/chain/queries/utils/parsers.ts
@@ -44,6 +44,9 @@ export const toBondStatusLabel = (status?: string) => {
   return bondStatusMap[normalized] ?? 'unknown'
 }
 
+export const canUnbondNode = (status: string) =>
+  status.toLowerCase() !== 'active'
+
 type EstimateNextChurnInput = {
   nextChurnHeight?: number
   currentHeight: number

--- a/core/ui/defi/chain/tabs/BondedPositions.tsx
+++ b/core/ui/defi/chain/tabs/BondedPositions.tsx
@@ -156,7 +156,6 @@ export const BondedPositions = () => {
     0n
   )
   const totalFiat = sum(positions.map(position => position.fiatValue))
-  const canUnbond = Boolean(data?.bond?.canUnbond)
   const availableNodes = data?.bond?.availableNodes ?? []
 
   const navigateToBond = async (overrides?: { nodeAddress?: string }) => {
@@ -254,7 +253,7 @@ export const BondedPositions = () => {
                     onUnbond={() =>
                       navigateToUnbond(position.nodeAddress, position.amount)
                     }
-                    canUnbond={canUnbond}
+                    canUnbond={position.canUnbond}
                     fiatValue={position.fiatValue}
                     isBondingDisabled={isBondingDisabled}
                   />


### PR DESCRIPTION
## Summary

- Move `canUnbond` from chain-level to per-position so the Unbond button on `Active` Maya/THORChain nodes is correctly disabled (matches iOS/Android intent).
- Adds a small helper `canUnbondNode(status)` in `parsers.ts` that returns `false` only when the node status is `active`.
- For THORChain, the per-node flag is ANDed with the existing chain-level migration gate (`!network.vaults_migrating`).

Fixes #3917

## Behavior

| Status | Unbond enabled? |
|---|---|
| `Active` | ❌ disabled |
| `Standby`, `Ready`, `Whitelisted`, `Disabled`, `Unknown` | ✅ enabled |

## Test plan

- [ ] On a vault with a MayaChain bonded `Active` node → Unbond button is disabled, "Wait until node is churned out" message is visible.
- [ ] On a MayaChain node in `Standby`/`Ready`/`Whitelisted`/`Disabled` → Unbond button is enabled.
- [ ] Same behavior for THORChain bonded nodes.
- [ ] When THORChain network is mid-migration (`vaults_migrating: true`) → Unbond is disabled for all nodes regardless of status.
- [ ] Same behavior in the Chrome extension build.
- [ ] No regression: tapping Unbond on a `Standby` node still routes to the existing unbond flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed bond unbond eligibility to be determined individually for each position based on its current status, enabling more accurate control over which bonds can be unbound.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-windows/pull/3921)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->