### PR TITLE
fix(deposit): move DeFi Continue button into PageFooter for consistent height

### DIFF
--- a/core/ui/vault/components/action-form/ActionForm.tsx
+++ b/core/ui/vault/components/action-form/ActionForm.tsx
@@ -5,6 +5,5 @@ import styled from 'styled-components'
 export const ActionForm = styled(PageContent)`
   width: min(468px, 100%);
   margin-inline: auto;
-  overflow: auto;
   ${hideScrollbars}
 `

--- a/core/ui/vault/deposit/DepositForm/index.tsx
+++ b/core/ui/vault/deposit/DepositForm/index.tsx
@@ -21,6 +21,7 @@ import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { InputContainer } from '@lib/ui/inputs/InputContainer'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { PageContent } from '@lib/ui/page/PageContent'
+import { PageFooter } from '@lib/ui/page/PageFooter'
 import { PageHeader } from '@lib/ui/page/PageHeader'
 import { Text } from '@lib/ui/text'
 import { TronResourceType } from '@vultisig/core-chain/chains/tron/resources'
@@ -125,9 +126,6 @@ export const DepositForm: FC<DepositFormProps> = ({ onSubmit }) => {
   }
 
   const pageTitle = getPageTitle()
-  const FormComponent = (
-    shouldUseActionForm ? ActionForm : PageContent
-  ) as typeof PageContent
 
   return (
     <DepositFormHandlersProvider
@@ -142,171 +140,174 @@ export const DepositForm: FC<DepositFormProps> = ({ onSubmit }) => {
         setTronResourceType,
       }}
     >
-      <PageHeader
-        primaryControls={<PageHeaderBackButton />}
-        title={pageTitle}
-        hasBorder
-      />
-      <FormComponent
-        as="form"
-        flexGrow
-        gap={40}
-        onSubmit={handleSubmit(handleFormSubmit)}
-      >
-        {shouldUseBondRedesign ? (
-          <DepositDataProvider value={formValues}>
-            <BondForm
-              balance={balance}
-              errors={errors}
-              formValues={formValues}
-            />
-          </DepositDataProvider>
-        ) : shouldUseUnbondRedesign ? (
-          <DepositDataProvider value={formValues}>
-            <UnbondForm
-              balance={balance}
-              errors={errors}
-              isValid={isValid}
-              formValues={formValues}
-            />
-          </DepositDataProvider>
-        ) : shouldUseStakeRedesign ? (
-          <DepositDataProvider value={formValues}>
-            <StakeForm
-              balance={balance}
-              errors={errors}
-              formValues={formValues}
-              isUnstake={isUnstakeAction || isRedeemAction}
-            />
-          </DepositDataProvider>
-        ) : (
-          <WithProgressIndicator value={0.2}>
-            <InputContainer>
-              <InputFieldWrapper>
-                {t('chain_message_deposit', {
-                  chain: coin.chain,
-                })}
-              </InputFieldWrapper>
-            </InputContainer>
-            <Opener
-              renderOpener={({ onOpen }) => (
-                <Container onClick={onOpen}>
-                  <HStack alignItems="center" gap={8}>
-                    <Text weight="400" family="mono" size={16}>
-                      {t(selectedChainAction)}
-                    </Text>
-                  </HStack>
-                  <IconWrapper style={{ fontSize: 20 }}>
-                    <ChevronRightIcon />
-                  </IconWrapper>
-                </Container>
-              )}
-              renderContent={({ onClose }) => (
-                <DepositActionItemExplorer
-                  onClose={onClose}
-                  activeOption={selectedChainAction}
-                  options={availableActions}
-                  onOptionClick={option => {
-                    onClose()
-                    setSelectedChainAction(option)
-                  }}
+      <VStack as="form" fullHeight onSubmit={handleSubmit(handleFormSubmit)}>
+        <PageHeader
+          primaryControls={<PageHeaderBackButton />}
+          title={pageTitle}
+          hasBorder
+        />
+        {shouldUseActionForm ? (
+          <ActionForm flexGrow>
+            {shouldUseBondRedesign ? (
+              <DepositDataProvider value={formValues}>
+                <BondForm
+                  balance={balance}
+                  errors={errors}
+                  formValues={formValues}
                 />
-              )}
-            />
-
-            <DepositActionSpecific value={selectedChainAction} />
-
-            {selectedChainAction && fields.length > 0 && (
-              <VStack gap={12}>
-                {fields
-                  .filter(field => !field.hidden)
-                  .map(field => {
-                    const config = getBalanceDisplayConfig({
-                      chainAction: selectedChainAction,
-                      chain: coin.chain,
-                    })
-                    const showBalance = shouldShowBalance({
-                      fieldName: field.name,
-                      chainAction: selectedChainAction,
-                    })
-                    const showTickerWithBalance = shouldShowTicker({
-                      fieldName: field.name,
-                      chainAction: selectedChainAction,
-                      chain: coin.chain,
-                    })
-
-                    return (
-                      <InputContainer key={field.name}>
-                        <Text size={15} weight="400">
-                          {field.label}{' '}
-                          {showBalance && (
-                            <>
-                              (
-                              {config.balanceLabel === 'shares' ? (
-                                <>
-                                  {t('shares')}: {balance}
-                                </>
-                              ) : (
-                                <>
-                                  {t('balance')}: {balance}
-                                  {showTickerWithBalance &&
-                                    coin.ticker &&
-                                    ` ${coin.ticker}`}
-                                </>
-                              )}
-                              )
-                            </>
-                          )}
-                          {field.required ? (
-                            <Text as="span" color="danger" size={14}>
-                              *
-                            </Text>
-                          ) : (
-                            <Text as="span" size={14}>
-                              ({t('chainFunctions.optional_validation')})
-                            </Text>
-                          )}
-                        </Text>
-
-                        <TextInputWithPasteAction
-                          onWheel={e => e.currentTarget.blur()}
-                          type={field.type}
-                          step={
-                            field.name === 'amount'
-                              ? stepFromDecimals(coin.decimals)
-                              : undefined
-                          }
-                          min={0}
-                          {...register(field.name)}
-                          required={field.required}
-                        />
-
-                        {(touchedFields[field.name] ||
-                          dirtyFields[field.name]) &&
-                          errors[field.name] && (
-                            <ErrorText
-                              color="danger"
-                              size={13}
-                              className="error"
-                            >
-                              {t(errors[field.name]?.message as string, {
-                                defaultValue: t(
-                                  'chainFunctions.default_validation'
-                                ),
-                              })}
-                            </ErrorText>
-                          )}
-                      </InputContainer>
-                    )
-                  })}
-              </VStack>
+              </DepositDataProvider>
+            ) : shouldUseUnbondRedesign ? (
+              <DepositDataProvider value={formValues}>
+                <UnbondForm
+                  balance={balance}
+                  errors={errors}
+                  isValid={isValid}
+                  formValues={formValues}
+                />
+              </DepositDataProvider>
+            ) : (
+              <DepositDataProvider value={formValues}>
+                <StakeForm
+                  balance={balance}
+                  errors={errors}
+                  formValues={formValues}
+                  isUnstake={isUnstakeAction || isRedeemAction}
+                />
+              </DepositDataProvider>
             )}
-          </WithProgressIndicator>
+          </ActionForm>
+        ) : (
+          <PageContent flexGrow scrollable>
+            <WithProgressIndicator value={0.2}>
+              <InputContainer>
+                <InputFieldWrapper>
+                  {t('chain_message_deposit', {
+                    chain: coin.chain,
+                  })}
+                </InputFieldWrapper>
+              </InputContainer>
+              <Opener
+                renderOpener={({ onOpen }) => (
+                  <Container onClick={onOpen}>
+                    <HStack alignItems="center" gap={8}>
+                      <Text weight="400" family="mono" size={16}>
+                        {t(selectedChainAction)}
+                      </Text>
+                    </HStack>
+                    <IconWrapper style={{ fontSize: 20 }}>
+                      <ChevronRightIcon />
+                    </IconWrapper>
+                  </Container>
+                )}
+                renderContent={({ onClose }) => (
+                  <DepositActionItemExplorer
+                    onClose={onClose}
+                    activeOption={selectedChainAction}
+                    options={availableActions}
+                    onOptionClick={option => {
+                      onClose()
+                      setSelectedChainAction(option)
+                    }}
+                  />
+                )}
+              />
+
+              <DepositActionSpecific value={selectedChainAction} />
+
+              {selectedChainAction && fields.length > 0 && (
+                <VStack gap={12}>
+                  {fields
+                    .filter(field => !field.hidden)
+                    .map(field => {
+                      const config = getBalanceDisplayConfig({
+                        chainAction: selectedChainAction,
+                        chain: coin.chain,
+                      })
+                      const showBalance = shouldShowBalance({
+                        fieldName: field.name,
+                        chainAction: selectedChainAction,
+                      })
+                      const showTickerWithBalance = shouldShowTicker({
+                        fieldName: field.name,
+                        chainAction: selectedChainAction,
+                        chain: coin.chain,
+                      })
+
+                      return (
+                        <InputContainer key={field.name}>
+                          <Text size={15} weight="400">
+                            {field.label}{' '}
+                            {showBalance && (
+                              <>
+                                (
+                                {config.balanceLabel === 'shares' ? (
+                                  <>
+                                    {t('shares')}: {balance}
+                                  </>
+                                ) : (
+                                  <>
+                                    {t('balance')}: {balance}
+                                    {showTickerWithBalance &&
+                                      coin.ticker &&
+                                      ` ${coin.ticker}`}
+                                  </>
+                                )}
+                                )
+                              </>
+                            )}
+                            {field.required ? (
+                              <Text as="span" color="danger" size={14}>
+                                *
+                              </Text>
+                            ) : (
+                              <Text as="span" size={14}>
+                                ({t('chainFunctions.optional_validation')})
+                              </Text>
+                            )}
+                          </Text>
+
+                          <TextInputWithPasteAction
+                            onWheel={e => e.currentTarget.blur()}
+                            type={field.type}
+                            step={
+                              field.name === 'amount'
+                                ? stepFromDecimals(coin.decimals)
+                                : undefined
+                            }
+                            min={0}
+                            {...register(field.name)}
+                            required={field.required}
+                          />
+
+                          {(touchedFields[field.name] ||
+                            dirtyFields[field.name]) &&
+                            errors[field.name] && (
+                              <ErrorText
+                                color="danger"
+                                size={13}
+                                className="error"
+                              >
+                                {t(errors[field.name]?.message as string, {
+                                  defaultValue: t(
+                                    'chainFunctions.default_validation'
+                                  ),
+                                })}
+                              </ErrorText>
+                            )}
+                        </InputContainer>
+                      )
+                    })}
+                </VStack>
+              )}
+            </WithProgressIndicator>
+          </PageContent>
         )}
-        <Button disabled={!isValid} type="submit">
-          {t('continue')}
-        </Button>
-      </FormComponent>
+        <PageFooter>
+          <Button disabled={!isValid} type="submit">
+            {t('continue')}
+          </Button>
+        </PageFooter>
+      </VStack>
     </DepositFormHandlersProvider>
   )
 }

--- a/core/ui/vault/deposit/DepositForm/index.tsx
+++ b/core/ui/vault/deposit/DepositForm/index.tsx
@@ -147,7 +147,7 @@ export const DepositForm: FC<DepositFormProps> = ({ onSubmit }) => {
           hasBorder
         />
         {shouldUseActionForm ? (
-          <ActionForm flexGrow>
+          <ActionForm flexGrow scrollable>
             {shouldUseBondRedesign ? (
               <DepositDataProvider value={formValues}>
                 <BondForm

--- a/lib/ui/buttons/Button/index.tsx
+++ b/lib/ui/buttons/Button/index.tsx
@@ -48,6 +48,7 @@ const StyledButton = styled(UnstyledButton)<{
             font-size: 12px;
             font-weight: 500;
             height: 26px;
+            min-height: 26px;
             min-width: 26px;
             ${horizontalPadding(4)}
           `,
@@ -56,6 +57,7 @@ const StyledButton = styled(UnstyledButton)<{
             font-size: 14px;
             font-weight: 500;
             height: 28px;
+            min-height: 28px;
             min-width: 28px;
             ${horizontalPadding(4)}
           `,
@@ -82,6 +84,7 @@ const StyledButton = styled(UnstyledButton)<{
             font-size: 12px;
             font-weight: 500;
             height: 36px;
+            min-height: 36px;
             min-width: 36px;
             ${horizontalPadding(16)}
           `,
@@ -90,6 +93,7 @@ const StyledButton = styled(UnstyledButton)<{
             font-size: 14px;
             font-weight: 500;
             height: 46px;
+            min-height: 46px;
             min-width: 46px;
             ${horizontalPadding(24)}
           `,
@@ -146,6 +150,7 @@ const StyledButton = styled(UnstyledButton)<{
             font-size: 12px;
             font-weight: 500;
             height: 36px;
+            min-height: 36px;
             min-width: 36px;
             ${horizontalPadding(16)}
           `,
@@ -154,6 +159,7 @@ const StyledButton = styled(UnstyledButton)<{
             font-size: 14px;
             font-weight: 500;
             height: 46px;
+            min-height: 46px;
             min-width: 46px;
             ${horizontalPadding(24)}
           `,
@@ -183,6 +189,7 @@ const StyledButton = styled(UnstyledButton)<{
             font-size: 12px;
             font-weight: 500;
             height: 36px;
+            min-height: 36px;
             min-width: 36px;
             ${horizontalPadding(16)}
           `,
@@ -191,6 +198,7 @@ const StyledButton = styled(UnstyledButton)<{
             font-size: 14px;
             font-weight: 500;
             height: 46px;
+            min-height: 46px;
             min-width: 46px;
             ${horizontalPadding(24)}
           `,

--- a/lib/ui/page/PageFooter.tsx
+++ b/lib/ui/page/PageFooter.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components'
 export const PageFooter = styled(VStack)`
   ${horizontalPadding(pageConfig.horizontalPadding)};
   ${verticalPadding(pageConfig.verticalPadding)};
+  flex-shrink: 0;
 
   @media (min-width: 1024px) {
     ${horizontalPadding(32)};


### PR DESCRIPTION
Closes #3922

## Summary
- The Continue button on the redesigned DeFi deposit screens (Bond / Unbond / Stake / Mint / Redeem) was nested inside `ActionForm`, whose `min(468px, 100%)` width cap made it visibly narrower than primary Continue buttons elsewhere in the app.
- Restructured `DepositForm` to use the standard primary-action page pattern (form wraps the whole component, `PageHeader` / scrollable content / `PageFooter` as siblings — same shape used by `SetServerPasswordStep` etc.).
- Form fields keep their existing 468px-capped scrollable layout via `ActionForm` (legacy path still uses `PageContent` with `scrollable`); the Continue button now sits in `PageFooter` and spans the standard footer width.

##
<img width="500" height="211" alt="image" src="https://github.com/user-attachments/assets/a580cc98-7285-4569-954e-c27c62b2ba10" />

## Test plan
- [ ] `yarn check` passes locally (typecheck + lint + knip).
- [ ] Vault → DeFi → Bond a RUNE node: Continue button at the bottom of the Bond form spans the standard footer width and matches Continue buttons on other primary screens (e.g. fast vault password step).
- [ ] Repeat for Unbond / Stake / Unstake / Mint / Redeem actions — same wider Continue button, form fields layout unchanged.
- [ ] Non-redesigned deposit actions (legacy path) still render with the same field layout and submit correctly.
- [ ] Form still submits via Continue button click and via pressing Enter inside an input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured the deposit form layout for clearer flow and consistent header/footer placement; submit action now lives inside the form footer.

* **UI Improvements**
  * Improved scroll/overflow behavior in action panels to hide scrollbars.
  * Footer prevented from shrinking in flexible layouts.
  * Button sizing standardized with minimum heights for visual consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-windows/pull/3923)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->