### PR TITLE
[Add] Expose QBTC via window.vultisig.qbtc dApp provider

### DIFF
--- a/clients/extension/docs/integration-guide.md
+++ b/clients/extension/docs/integration-guide.md
@@ -21,7 +21,7 @@
    - [Ripple](#ripple-windowvultisigripple)
    - [MayaChain](#mayachain-windowvultisigmayachain)
    - [Dash](#dash-windowvultisigdash)
-   - [QBTC](#qbtc-windowvultisigqbtc)
+   - [QBTC](#qbtc-windowvultisigqbtc-and-windowkeplr)
    - [Plugin Provider](#plugin-provider-windowvultisigplugin)
 6. [Wallet Compatibility Layers](#wallet-compatibility-layers)
 7. [Steps to Integrate](#steps-to-integrate-with-vultisig-extension)
@@ -334,19 +334,27 @@ Supports TRC20 token transfers with automatic decoding and contract interaction.
 - `send_transaction`
 - `get_transaction_by_hash`
 
-### QBTC (`window.vultisig.qbtc`)
+### QBTC (`window.vultisig.qbtc` and `window.keplr`)
 
-QBTC is a post-quantum Cosmos SDK chain that signs with **ML-DSA-44** rather than secp256k1/ed25519, so it cannot use the Keplr provider shape. Vultisig exposes a dedicated QBTC provider with QBTC-native methods.
+QBTC is a post-quantum Cosmos SDK chain that signs with **ML-DSA-44** rather than secp256k1/ed25519. Vultisig exposes QBTC via two complementary surfaces:
 
-**Account Management:**
+- **`window.vultisig.qbtc`** -- recommended QBTC-native provider with explicit MLDSA semantics. Use this when you control the dApp client.
+- **`window.keplr`** (chainId `qbtc-testnet`) -- compatibility route for Keplr-shape dApps and cosmjs / cosmos-kit clients that can't be modified. The Keplr `algo` field is reported as `secp256k1` because the Keplr `Algo` union has no MLDSA enum, but the `pubKey` bytes returned are the real ML-DSA-44 key (see "Public key shape" below).
+
+**Account Management (`window.vultisig.qbtc`):**
 - `request_accounts` -- connect and return the QBTC bech32 address
 - `get_accounts` -- return the currently authorized QBTC address (or `[]`)
 
-**Transaction Management:**
+**Transaction Management (`window.vultisig.qbtc`):**
 - `send_transaction` -- sign and broadcast a QBTC transaction; returns the tx hash
 - `get_transaction_by_hash`
 
-**Vault requirement (important):** QBTC requires the user's vault to carry an ML-DSA public key (`vault.publicKeyMldsa`). MLDSA keygen is gated by the `Enable MLDSA` toggle in Vultisig Developer Options at vault creation time -- vaults created with the toggle off cannot use QBTC. If a dApp calls `request_accounts` against a vault without MLDSA support, the provider rejects with:
+**Keplr-compat methods (`window.keplr`):**
+- `enable('qbtc-testnet')`
+- `getKey('qbtc-testnet')` / `getOfflineSigner('qbtc-testnet').getAccounts()`
+- `signDirect(chainId, signer, signDoc)` / `signAmino(chainId, signer, signDoc)`
+
+**Vault requirement (important):** QBTC requires the user's vault to carry an ML-DSA public key (`vault.publicKeyMldsa`). MLDSA keygen is gated by the `Enable MLDSA` toggle in Vultisig Developer Options at vault creation time -- vaults created with the toggle off cannot use QBTC on either surface. If a dApp calls `window.vultisig.qbtc.request({ method: 'request_accounts' })` against a vault without MLDSA support, the provider rejects with:
 
 ```text
 EIP1193Error: QBTC requires an MLDSA-enabled vault. Enable MLDSA in
@@ -354,7 +362,7 @@ Vultisig Developer Options and create a new vault.
 code: 4100 (Unauthorized)
 ```
 
-**Public key shape:** Unlike other chains, the `publicKey` returned for QBTC is the raw ML-DSA-44 hex public key (~1312 bytes), not a 33-byte compressed secp256k1 key. dApps verifying signatures must use ML-DSA-44 verification, not standard Cosmos secp256k1 verification.
+**Public key shape:** Unlike other chains, the `publicKey` (or Keplr `pubKey`) returned for QBTC is the raw ML-DSA-44 hex public key (~1312 bytes), not a 33-byte compressed secp256k1 key. dApps verifying signatures must use ML-DSA-44 verification regardless of which surface they used; the `algo: 'secp256k1'` tag reported by `window.keplr.getKey('qbtc-testnet')` is a compatibility shim and does not describe the actual signing algorithm.
 
 ### Plugin Provider (`window.vultisig.plugin`)
 
@@ -515,6 +523,29 @@ const sendQbtc = async ({ from, to, value, memo }) => {
   });
   console.log("QBTC tx hash:", hash);
   return hash;
+};
+```
+
+#### QBTC via Keplr compatibility
+
+Use this route when a Keplr-shape dApp or a cosmjs / cosmos-kit client needs to talk to QBTC without code changes:
+
+```javascript
+const connectQbtcViaKeplr = async () => {
+  if (!window.keplr) {
+    console.error("Keplr-compat surface not available");
+    return;
+  }
+
+  await window.keplr.enable("qbtc-testnet");
+  const key = await window.keplr.getKey("qbtc-testnet");
+  console.log("QBTC address:", key.bech32Address);
+  // key.pubKey is the raw ML-DSA-44 public key (~1312 bytes).
+  // key.algo is reported as 'secp256k1' for Keplr API compatibility;
+  // verify signatures with ML-DSA-44 regardless.
+
+  const signer = window.keplr.getOfflineSigner("qbtc-testnet");
+  // Use `signer` with cosmjs's StargateClient.connectWithSigner to broadcast.
 };
 ```
 

--- a/clients/extension/docs/integration-guide.md
+++ b/clients/extension/docs/integration-guide.md
@@ -21,6 +21,7 @@
    - [Ripple](#ripple-windowvultisigripple)
    - [MayaChain](#mayachain-windowvultisigmayachain)
    - [Dash](#dash-windowvultisigdash)
+   - [QBTC](#qbtc-windowvultisigqbtc)
    - [Plugin Provider](#plugin-provider-windowvultisigplugin)
 6. [Wallet Compatibility Layers](#wallet-compatibility-layers)
 7. [Steps to Integrate](#steps-to-integrate-with-vultisig-extension)
@@ -42,6 +43,7 @@ The extension provides:
 - **`window.vultisig.ethereum`** for Ethereum and EVM chain integrations.
 - **`window.vultisig.thorchain`** and **`window.thorchain`** for THORChain support.
 - **`window.vultisig.solana`** and **`window.solana`** for Solana support via the Wallet Standard.
+- **`window.vultisig.qbtc`** for QBTC (post-quantum ML-DSA-44) integration.
 - **`window.tronLink`** and **`window.tronWeb`** for Tron/TronLink compatibility.
 - **`window.keplr`** for Keplr-compatible Cosmos chain integration.
 - **`window.phantom`** for Phantom wallet compatibility (Bitcoin, Ethereum, Solana).
@@ -65,6 +67,7 @@ The extension provides:
 | MayaChain   | `MayaChain-1`         | Cosmos        |
 | Osmosis     | `osmosis-1`           | Cosmos        |
 | Polkadot    | `Polkadot_polkadot`   | Custom        |
+| QBTC        | `QBTC_qbtc`           | Custom (MLDSA)|
 | Ripple      | `Ripple_ripple`       | Custom        |
 | Solana      | `Solana_mainnet-beta` | Solana        |
 | THORChain   | `Thorchain_thorchain` | Cosmos        |
@@ -331,6 +334,28 @@ Supports TRC20 token transfers with automatic decoding and contract interaction.
 - `send_transaction`
 - `get_transaction_by_hash`
 
+### QBTC (`window.vultisig.qbtc`)
+
+QBTC is a post-quantum Cosmos SDK chain that signs with **ML-DSA-44** rather than secp256k1/ed25519, so it cannot use the Keplr provider shape. Vultisig exposes a dedicated QBTC provider with QBTC-native methods.
+
+**Account Management:**
+- `request_accounts` -- connect and return the QBTC bech32 address
+- `get_accounts` -- return the currently authorized QBTC address (or `[]`)
+
+**Transaction Management:**
+- `send_transaction` -- sign and broadcast a QBTC transaction; returns the tx hash
+- `get_transaction_by_hash`
+
+**Vault requirement (important):** QBTC requires the user's vault to carry an ML-DSA public key (`vault.publicKeyMldsa`). MLDSA keygen is gated by the `Enable MLDSA` toggle in Vultisig Developer Options at vault creation time -- vaults created with the toggle off cannot use QBTC. If a dApp calls `request_accounts` against a vault without MLDSA support, the provider rejects with:
+
+```text
+EIP1193Error: QBTC requires an MLDSA-enabled vault. Enable MLDSA in
+Vultisig Developer Options and create a new vault.
+code: 4100 (Unauthorized)
+```
+
+**Public key shape:** Unlike other chains, the `publicKey` returned for QBTC is the raw ML-DSA-44 hex public key (~1312 bytes), not a 33-byte compressed secp256k1 key. dApps verifying signatures must use ML-DSA-44 verification, not standard Cosmos secp256k1 verification.
+
 ### Plugin Provider (`window.vultisig.plugin`)
 
 For Vultisig Marketplace plugin developers:
@@ -452,6 +477,44 @@ const connectChain = async (chain) => {
     const accounts = await provider.request({ method: "request_accounts" });
     console.log(`Connected to ${chain}:`, accounts);
   }
+};
+```
+
+#### QBTC
+
+```javascript
+const connectQbtc = async () => {
+  const provider = window.vultisig?.qbtc;
+  if (!provider) {
+    console.error("Vultisig QBTC provider not available");
+    return;
+  }
+
+  try {
+    const [address] = await provider.request({ method: "request_accounts" });
+    console.log("Connected QBTC address:", address);
+  } catch (error) {
+    if (error.code === 4100) {
+      // Unauthorized -- most commonly: vault has no ML-DSA key.
+      // Tell the user to enable MLDSA in Developer Options and create
+      // a new vault.
+      alert(error.message);
+    } else if (error.code === 4001) {
+      console.log("User rejected the QBTC connection");
+    } else {
+      throw error;
+    }
+  }
+};
+
+// Send a QBTC transaction
+const sendQbtc = async ({ from, to, value, memo }) => {
+  const hash = await window.vultisig.qbtc.request({
+    method: "send_transaction",
+    params: [{ from, to, value, memo }],
+  });
+  console.log("QBTC tx hash:", hash);
+  return hash;
 };
 ```
 

--- a/clients/extension/src/background/handlers/errorHandler.ts
+++ b/clients/extension/src/background/handlers/errorHandler.ts
@@ -53,8 +53,8 @@ const errors: Record<Type, { code: number; message: string }> = {
 export class EIP1193Error extends Error {
   code: number
 
-  constructor(type: Type) {
-    super(errors[type].message)
+  constructor(type: Type, customMessage?: string) {
+    super(customMessage ?? errors[type].message)
     this.code = errors[type].code
   }
 }

--- a/clients/extension/src/inpage/providers/keplrChainInfo.ts
+++ b/clients/extension/src/inpage/providers/keplrChainInfo.ts
@@ -1,9 +1,10 @@
 import { callBackground } from '@core/inpage-provider/background'
 import { ChainInfo } from '@keplr-wallet/types'
-import { CosmosChain } from '@vultisig/core-chain/Chain'
+import { CosmosChain, OtherChain } from '@vultisig/core-chain/Chain'
 import { getCosmosChainId } from '@vultisig/core-chain/chains/cosmos/chainInfo'
 import { cosmosFeeCoinDenom } from '@vultisig/core-chain/chains/cosmos/cosmosFeeCoinDenom'
 import { cosmosRpcUrl } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
+import { qbtcRestUrl } from '@vultisig/core-chain/chains/cosmos/qbtc/tendermintRpcUrl'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 
 type SupportedKeplrChain = (typeof supportedKeplrChains)[number]
@@ -13,6 +14,12 @@ type SupportedKeplrChain = (typeof supportedKeplrChains)[number]
 // reject duplicate prefixes within a single chain set — including both
 // makes dApps see Terra as "not in wallet". Terra Classic is still
 // reachable through the Station provider's `switchNetwork('classic')`.
+//
+// QBTC is included here so Keplr-shaped dApps can connect via the
+// standard `window.keplr` API in addition to the dedicated
+// `window.vultisig.qbtc` provider. The signing path lies about `algo`
+// (MLDSA-44 doesn't fit Keplr's `'secp256k1' | 'ed25519'` union) — see
+// the QBTC branch in `getAccounts` inside `xdefiKeplr.ts`.
 const supportedKeplrChains = [
   CosmosChain.Cosmos,
   CosmosChain.Osmosis,
@@ -23,7 +30,20 @@ const supportedKeplrChains = [
   CosmosChain.Akash,
   CosmosChain.THORChain,
   CosmosChain.MayaChain,
+  OtherChain.QBTC,
 ] as const
+
+/** QBTC chain ID. Mirrors the constant used throughout the SDK (QBTCHelper, ClaimRunner) so dApps that query the live block header see the same chain ID Vultisig signs for. */
+const qbtcChainId = 'qbtc-testnet'
+
+/**
+ * QBTC isn't a `CosmosChain` in the SDK (it's `OtherChain.QBTC` because it
+ * signs with MLDSA-44, not secp256k1), so `getCosmosChainId` doesn't know
+ * about it. Centralize the chainId lookup so every site that resolves
+ * Keplr-known chains stays consistent.
+ */
+const getKeplrChainId = (chain: SupportedKeplrChain): string =>
+  chain === OtherChain.QBTC ? qbtcChainId : getCosmosChainId(chain)
 
 const bech32Prefix: Record<SupportedKeplrChain, string> = {
   Cosmos: 'cosmos',
@@ -35,6 +55,7 @@ const bech32Prefix: Record<SupportedKeplrChain, string> = {
   Akash: 'akash',
   THORChain: 'thor',
   MayaChain: 'maya',
+  QBTC: 'qbtc',
 }
 
 const bip44CoinType: Record<SupportedKeplrChain, number> = {
@@ -47,6 +68,7 @@ const bip44CoinType: Record<SupportedKeplrChain, number> = {
   Terra: 330,
   THORChain: 931,
   MayaChain: 931,
+  QBTC: 118,
 }
 
 const chainName: Record<SupportedKeplrChain, string> = {
@@ -59,11 +81,14 @@ const chainName: Record<SupportedKeplrChain, string> = {
   Akash: 'Akash',
   THORChain: 'THORChain',
   MayaChain: 'MayaChain',
+  QBTC: 'QBTC Testnet',
 }
 
 // Average gas price; low/high are derived as ±50% so dApps that read all
 // three slots get a sensible spread. THORChain / MayaChain use flat fees,
-// so 0 is the canonical "ignore gas price" value.
+// so 0 is the canonical "ignore gas price" value. QBTC has a flat
+// `min_tx_fee` of 800 uqbtc — pick a non-zero step so cosmos-kit fee
+// calculators don't underpay.
 const averageGasPrice: Record<SupportedKeplrChain, number> = {
   Cosmos: 0.025,
   Osmosis: 0.025,
@@ -74,6 +99,7 @@ const averageGasPrice: Record<SupportedKeplrChain, number> = {
   Akash: 0.025,
   THORChain: 0,
   MayaChain: 0,
+  QBTC: 0.004,
 }
 
 const buildBech32Config = (prefix: string) => ({
@@ -85,11 +111,19 @@ const buildBech32Config = (prefix: string) => ({
   bech32PrefixConsPub: `${prefix}valconspub`,
 })
 
+/** QBTC's fee denom matches the chain config (`base: 'qbtc'`). `cosmosFeeCoinDenom` is keyed by `CosmosChain` and doesn't include QBTC. */
+const getKeplrFeeDenom = (chain: SupportedKeplrChain): string =>
+  chain === OtherChain.QBTC ? 'qbtc' : cosmosFeeCoinDenom[chain]
+
+const getKeplrRpcUrl = (chain: SupportedKeplrChain): string =>
+  chain === OtherChain.QBTC ? qbtcRestUrl : cosmosRpcUrl[chain]
+
 const buildKeplrChainInfo = (chain: SupportedKeplrChain): ChainInfo => {
   const prefix = bech32Prefix[chain]
-  const denom = cosmosFeeCoinDenom[chain]
+  const denom = getKeplrFeeDenom(chain)
   const { ticker, decimals } = chainFeeCoin[chain]
   const average = averageGasPrice[chain]
+  const rpc = getKeplrRpcUrl(chain)
 
   const currency = {
     coinDenom: ticker,
@@ -107,9 +141,9 @@ const buildKeplrChainInfo = (chain: SupportedKeplrChain): ChainInfo => {
   }
 
   return {
-    rpc: cosmosRpcUrl[chain],
-    rest: cosmosRpcUrl[chain],
-    chainId: getCosmosChainId(chain),
+    rpc,
+    rest: rpc,
+    chainId: getKeplrChainId(chain),
     chainName: chainName[chain],
     bip44: { coinType: bip44CoinType[chain] },
     bech32Config: buildBech32Config(prefix),
@@ -121,8 +155,21 @@ const buildKeplrChainInfo = (chain: SupportedKeplrChain): ChainInfo => {
 }
 
 const nativeChainIds = new Set(
-  supportedKeplrChains.map(chain => getCosmosChainId(chain))
+  supportedKeplrChains.map(chain => getKeplrChainId(chain))
 )
+
+const chainByChainId = new Map<string, SupportedKeplrChain>(
+  supportedKeplrChains.map(chain => [getKeplrChainId(chain), chain])
+)
+
+/**
+ * Resolves a Keplr chain ID to one of Vultisig's supported chains. Combines
+ * the SDK's `getCosmosChainByChainId` (which only knows {@link CosmosChain})
+ * with QBTC, which is {@link OtherChain.QBTC} because it signs with MLDSA.
+ */
+export const getKeplrSupportedChainByChainId = (
+  chainId: string
+): SupportedKeplrChain | undefined => chainByChainId.get(chainId)
 
 /** True if `chainId` is one of Vultisig's hardcoded Cosmos chains. */
 export const isNativeKeplrChainId = (chainId: string): boolean =>

--- a/clients/extension/src/inpage/providers/providerFactory.ts
+++ b/clients/extension/src/inpage/providers/providerFactory.ts
@@ -6,6 +6,7 @@ import { Ethereum } from '@clients/extension/src/inpage/providers/ethereum'
 import { MAYAChain } from '@clients/extension/src/inpage/providers/maya'
 import { Plugin } from '@clients/extension/src/inpage/providers/plugin'
 import { Polkadot } from '@clients/extension/src/inpage/providers/polkadot'
+import { Qbtc } from '@clients/extension/src/inpage/providers/qbtc'
 import { Ripple } from '@clients/extension/src/inpage/providers/ripple'
 import { Solana } from '@clients/extension/src/inpage/providers/solana'
 import { Station } from '@clients/extension/src/inpage/providers/station'
@@ -45,6 +46,7 @@ export const createProviders = () => {
     mayachain: MAYAChain.getInstance(),
     plugin: new Plugin(),
     polkadot: Polkadot.getInstance(),
+    qbtc: Qbtc.getInstance(),
     ripple: Ripple.getInstance(),
     solana: vultisigSolanaProvider,
     station: Station.getInstance(keplrProvider),

--- a/clients/extension/src/inpage/providers/qbtc.ts
+++ b/clients/extension/src/inpage/providers/qbtc.ts
@@ -10,15 +10,33 @@ import { getSharedHandlers } from './core/sharedHandlers'
 const mldsaRequiredMessage =
   'QBTC requires an MLDSA-enabled vault. Enable MLDSA in Vultisig Developer Options and create a new vault.'
 
+type SharedHandlers = ReturnType<typeof getSharedHandlers>
+type SendTransactionParams = Parameters<SharedHandlers['send_transaction']>[0]
+
+// dApp-supplied params arrive typed as `unknown[]`. Validate the routing
+// boundary at runtime, then narrow to the shared handler's parameter shape.
+const parseSendTransactionParams = (
+  params: readonly unknown[]
+): SendTransactionParams => {
+  const [tx] = params
+  if (!tx || typeof tx !== 'object') {
+    throw new EIP1193Error('InvalidParams')
+  }
+  return [tx as SendTransactionParams[0]]
+}
+
 /**
  * Dedicated dApp provider for QBTC, exposed at `window.vultisig.qbtc`.
  *
  * QBTC is a post-quantum Cosmos SDK chain that signs with MLDSA-44 rather
- * than secp256k1/ed25519, so it cannot fit the Keplr provider shape (the
- * `algo` field and signature length don't match). This provider exposes a
- * QBTC-native surface via the shared handlers — `get_accounts`,
- * `request_accounts`, `send_transaction`, `get_transaction_by_hash` — and
- * routes signing through the existing MLDSA keysign pipeline.
+ * than secp256k1/ed25519. This provider is the QBTC-native surface
+ * (`get_accounts`, `request_accounts`, `send_transaction`,
+ * `get_transaction_by_hash`) with explicit MLDSA semantics — no `algo`
+ * spoofing, no Keplr signature-shape compromises.
+ *
+ * QBTC is also reachable via the Keplr compatibility route at chainId
+ * `qbtc-testnet` for dApps that can't be modified; see `xdefiKeplr.ts`.
+ * Both routes funnel into the same MLDSA keysign pipeline.
  */
 export class Qbtc extends EventEmitter {
   public chainId: string
@@ -53,10 +71,18 @@ export class Qbtc extends EventEmitter {
         return accounts
       }
 
-      if (data.method in handlers) {
-        return handlers[data.method as keyof typeof handlers](
-          data.params as any
+      if (data.method === 'send_transaction') {
+        return handlers.send_transaction(
+          parseSendTransactionParams(data.params)
         )
+      }
+
+      if (data.method === 'get_transaction_by_hash') {
+        const [hash] = data.params
+        if (typeof hash !== 'string') {
+          throw new EIP1193Error('InvalidParams')
+        }
+        return handlers.get_transaction_by_hash([hash])
       }
 
       throw new NotImplementedError(`QBTC method ${data.method}`)
@@ -69,8 +95,10 @@ export class Qbtc extends EventEmitter {
 
       return result
     } catch (error) {
-      callback?.(error as Error)
-      throw error
+      const normalizedError =
+        error instanceof Error ? error : new Error(String(error))
+      callback?.(normalizedError)
+      throw normalizedError
     }
   }
 }

--- a/clients/extension/src/inpage/providers/qbtc.ts
+++ b/clients/extension/src/inpage/providers/qbtc.ts
@@ -1,0 +1,76 @@
+import { RequestInput } from '@core/inpage-provider/popup/view/resolvers/sendTx/interfaces'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { NotImplementedError } from '@vultisig/lib-utils/error/NotImplementedError'
+import EventEmitter from 'events'
+
+import { EIP1193Error } from '../../background/handlers/errorHandler'
+import { Callback } from '../constants'
+import { getSharedHandlers } from './core/sharedHandlers'
+
+const mldsaRequiredMessage =
+  'QBTC requires an MLDSA-enabled vault. Enable MLDSA in Vultisig Developer Options and create a new vault.'
+
+/**
+ * Dedicated dApp provider for QBTC, exposed at `window.vultisig.qbtc`.
+ *
+ * QBTC is a post-quantum Cosmos SDK chain that signs with MLDSA-44 rather
+ * than secp256k1/ed25519, so it cannot fit the Keplr provider shape (the
+ * `algo` field and signature length don't match). This provider exposes a
+ * QBTC-native surface via the shared handlers — `get_accounts`,
+ * `request_accounts`, `send_transaction`, `get_transaction_by_hash` — and
+ * routes signing through the existing MLDSA keysign pipeline.
+ */
+export class Qbtc extends EventEmitter {
+  public chainId: string
+  public static instance: Qbtc | null = null
+
+  constructor() {
+    super()
+    this.chainId = 'QBTC_qbtc'
+  }
+
+  static getInstance(): Qbtc {
+    if (!Qbtc.instance) {
+      Qbtc.instance = new Qbtc()
+    }
+    return Qbtc.instance
+  }
+
+  async request(data: RequestInput, callback?: Callback) {
+    const processRequest = async () => {
+      const handlers = getSharedHandlers(Chain.QBTC)
+
+      if (data.method === 'get_accounts') {
+        const accounts = await handlers.get_accounts()
+        return accounts.filter(Boolean)
+      }
+
+      if (data.method === 'request_accounts') {
+        const accounts = await handlers.request_accounts()
+        if (!accounts[0]) {
+          throw new EIP1193Error('Unauthorized', mldsaRequiredMessage)
+        }
+        return accounts
+      }
+
+      if (data.method in handlers) {
+        return handlers[data.method as keyof typeof handlers](
+          data.params as any
+        )
+      }
+
+      throw new NotImplementedError(`QBTC method ${data.method}`)
+    }
+
+    try {
+      const result = await processRequest()
+
+      callback?.(null, result)
+
+      return result
+    } catch (error) {
+      callback?.(error as Error)
+      throw error
+    }
+  }
+}

--- a/clients/extension/src/inpage/providers/xdefiKeplr.ts
+++ b/clients/extension/src/inpage/providers/xdefiKeplr.ts
@@ -272,6 +272,28 @@ const directHandler = (
   } as TransactionDetails
 }
 
+type CosmosSigningOutput = InstanceType<typeof TW.Cosmos.Proto.SigningOutput>
+
+// SDK's `deserializeSigningOutput<T extends Chain>` returns a union driven by
+// `DeriveChainKind<T>`. Both `cosmos` and `qbtc` kinds map to the same
+// `TW.Cosmos.Proto.SigningOutput` class (see `signingOutputs` in
+// `core-chain/tw/signingOutput`), but the generic widens through indexed
+// access. Validate the Cosmos-shape fields at the boundary and narrow.
+function assertCosmosSigningOutput(
+  output: unknown
+): asserts output is CosmosSigningOutput {
+  if (
+    !output ||
+    typeof output !== 'object' ||
+    typeof (output as { json?: unknown }).json !== 'string' ||
+    typeof (output as { serialized?: unknown }).serialized !== 'string'
+  ) {
+    throw new Error(
+      'Expected Cosmos signing output with `.json` and `.serialized` strings'
+    )
+  }
+}
+
 const standardCosmosCoinType = 118
 
 // Signing flows require Vultisig native support for the chain (transaction
@@ -285,10 +307,23 @@ const assertNativeChainForSigning = (chainId: string): void => {
   }
 }
 
+const mldsaRequiredKeplrMessage =
+  'QBTC requires an MLDSA-enabled vault. Enable MLDSA in Vultisig Developer Options and create a new vault.'
+
 const getAccounts = async (chainId: string): Promise<AccountData[]> => {
   const nativeChain = getKeplrSupportedChainByChainId(chainId)
   if (nativeChain) {
     const { publicKey, address } = await requestAccount(nativeChain)
+
+    // `getAccount` returns `{ address: '', publicKey: '' }` for MLDSA chains
+    // when the selected vault has no `publicKeyMldsa`. Surface the same
+    // Unauthorized error the native `window.vultisig.qbtc` provider throws,
+    // otherwise downstream `getKey()` / signing fail at `bech32.decode('')`
+    // with an opaque error.
+    if (nativeChain === OtherChain.QBTC && !address) {
+      throw new EIP1193Error('Unauthorized', mldsaRequiredKeplrMessage)
+    }
+
     return [
       {
         // QBTC signs with MLDSA-44; Keplr's `Algo` union predates
@@ -687,13 +722,8 @@ export class XDEFIKeplrProvider extends Keplr {
         { account: transactionDetails.from }
       )
 
-      // QBTC's signing output is the same `TW.Cosmos.Proto.SigningOutput`
-      // class as Cosmos (see `signingOutputs` in core-chain/tw/signingOutput).
-      // The type system widens through the indexed access though, so cast
-      // back to the concrete Cosmos shape that holds `.json`/`.serialized`.
-      const output = deserializeSigningOutput(chain, data) as InstanceType<
-        typeof TW.Cosmos.Proto.SigningOutput
-      >
+      const output = deserializeSigningOutput(chain, data)
+      assertCosmosSigningOutput(output)
 
       const aminoJson = JSON.parse(output.json)
       const stdTx = aminoJson.tx as {
@@ -790,10 +820,9 @@ export class XDEFIKeplrProvider extends Keplr {
         { account: transactionDetails.from }
       )
 
-      const { serialized } = deserializeSigningOutput(
-        chain,
-        data
-      ) as InstanceType<typeof TW.Cosmos.Proto.SigningOutput>
+      const output = deserializeSigningOutput(chain, data)
+      assertCosmosSigningOutput(output)
+      const { serialized } = output
       const publicKey = Buffer.from(new Uint8Array(account.pubkey)).toString(
         'base64'
       )

--- a/clients/extension/src/inpage/providers/xdefiKeplr.ts
+++ b/clients/extension/src/inpage/providers/xdefiKeplr.ts
@@ -26,7 +26,7 @@ import {
 } from '@keplr-wallet/types'
 import { SignDoc as KeplrSignDoc } from '@keplr-wallet/types/build/cosmjs'
 import { TW } from '@trustwallet/wallet-core'
-import { Chain } from '@vultisig/core-chain/Chain'
+import { Chain, OtherChain } from '@vultisig/core-chain/Chain'
 import { getCosmosChainByChainId } from '@vultisig/core-chain/chains/cosmos/chainInfo'
 import { CosmosMsgType } from '@vultisig/core-chain/chains/cosmos/cosmosMsgTypes'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
@@ -55,6 +55,7 @@ import { Cosmos } from './cosmos'
 import { normalizeCosmosAuthInfoFee } from './cosmos/normalizeAuthInfoFee'
 import {
   getKeplrCosmosChainInfos,
+  getKeplrSupportedChainByChainId,
   isNativeKeplrChainId,
 } from './keplrChainInfo'
 
@@ -279,17 +280,23 @@ const standardCosmosCoinType = 118
 // has no fallback — surface a Keplr-shaped error so dApps display a clear
 // "chain not supported" message instead of our generic assertion throw.
 const assertNativeChainForSigning = (chainId: string): void => {
-  if (!getCosmosChainByChainId(chainId)) {
+  if (!getKeplrSupportedChainByChainId(chainId)) {
     throw new Error(`Chain ${chainId} is not supported for signing`)
   }
 }
 
 const getAccounts = async (chainId: string): Promise<AccountData[]> => {
-  const nativeChain = getCosmosChainByChainId(chainId)
+  const nativeChain = getKeplrSupportedChainByChainId(chainId)
   if (nativeChain) {
     const { publicKey, address } = await requestAccount(nativeChain)
     return [
       {
+        // QBTC signs with MLDSA-44; Keplr's `Algo` union predates
+        // post-quantum signing and only allows secp256k1/ed25519/sr25519.
+        // We declare secp256k1 so the cast typechecks, but the bytes in
+        // `pubkey` are the raw MLDSA hex from the vault. dApps that only
+        // pass the pubkey through to a broadcast are unaffected; dApps
+        // that verify signatures must use MLDSA verification regardless.
         algo: 'secp256k1',
         address,
         pubkey: hexToBytes(publicKey),
@@ -484,19 +491,26 @@ export class XDEFIKeplrProvider extends Keplr {
     fn: () => Promise<T>
   ): Promise<T> {
     return this.mutex.runExclusive(async () => {
-      const selectedChainId = await callBackground({
-        getAppChainId: { chainKind: 'cosmos' },
-      })
+      if (!getKeplrSupportedChainByChainId(chainId)) {
+        throw new EIP1193Error('UnrecognizedChain')
+      }
 
-      if (selectedChainId !== chainId) {
-        const chain = getCosmosChainByChainId(chainId)
-        if (!chain) {
-          throw new EIP1193Error('UnrecognizedChain')
-        }
-
-        await callBackground({
-          setAppChain: { cosmos: chain },
+      // `setAppChain({ cosmos })` drives the wallet UI's Cosmos chain
+      // switcher. QBTC isn't a `CosmosChain` (chain kind is `'qbtc'`) and
+      // has no equivalent active-chain state, so skip the call when the
+      // chainId isn't one of the SDK's CosmosChain values — the popup
+      // keysign payload carries the chain explicitly anyway.
+      const cosmosChain = getCosmosChainByChainId(chainId)
+      if (cosmosChain) {
+        const selectedChainId = await callBackground({
+          getAppChainId: { chainKind: 'cosmos' },
         })
+
+        if (selectedChainId !== chainId) {
+          await callBackground({
+            setAppChain: { cosmos: cosmosChain },
+          })
+        }
       }
 
       return fn()
@@ -520,7 +534,7 @@ export class XDEFIKeplrProvider extends Keplr {
     const suggested = await callBackground({ getKeplrSuggestedChains: {} })
     const nativeChains: Chain[] = []
     for (const chainId of requested) {
-      const chain = getCosmosChainByChainId(chainId)
+      const chain = getKeplrSupportedChainByChainId(chainId)
       if (chain) {
         nativeChains.push(chain)
         continue
@@ -657,7 +671,7 @@ export class XDEFIKeplrProvider extends Keplr {
         throw new Error('Signer does not match current account address')
       }
 
-      const chain = shouldBePresent(getCosmosChainByChainId(chainId))
+      const chain = shouldBePresent(getKeplrSupportedChainByChainId(chainId))
 
       const transactionDetails = aminoHandler(signDoc, chain)
 
@@ -673,7 +687,13 @@ export class XDEFIKeplrProvider extends Keplr {
         { account: transactionDetails.from }
       )
 
-      const output = deserializeSigningOutput(chain, data)
+      // QBTC's signing output is the same `TW.Cosmos.Proto.SigningOutput`
+      // class as Cosmos (see `signingOutputs` in core-chain/tw/signingOutput).
+      // The type system widens through the indexed access though, so cast
+      // back to the concrete Cosmos shape that holds `.json`/`.serialized`.
+      const output = deserializeSigningOutput(chain, data) as InstanceType<
+        typeof TW.Cosmos.Proto.SigningOutput
+      >
 
       const aminoJson = JSON.parse(output.json)
       const stdTx = aminoJson.tx as {
@@ -735,12 +755,17 @@ export class XDEFIKeplrProvider extends Keplr {
         throw new Error('Signer does not match current account address')
       }
 
-      const chain = shouldBePresent(getCosmosChainByChainId(chainId))
+      const chain = shouldBePresent(getKeplrSupportedChainByChainId(chainId))
 
-      const normalizedAuthInfoBytes = normalizeCosmosAuthInfoFee(
-        new Uint8Array(signDoc.authInfoBytes),
-        chain
-      )
+      // `normalizeCosmosAuthInfoFee` swaps fee ticker → canonical denom for
+      // CosmosChain entries. QBTC's fee denom is already canonical (`qbtc`,
+      // matching the chain config base denom), so the normalization is a
+      // no-op and the helper isn't keyed for QBTC anyway.
+      const rawAuthInfoBytes = new Uint8Array(signDoc.authInfoBytes)
+      const normalizedAuthInfoBytes =
+        chain === OtherChain.QBTC
+          ? rawAuthInfoBytes
+          : normalizeCosmosAuthInfoFee(rawAuthInfoBytes, chain)
       const transactionDetails: TransactionDetails = directHandler(
         {
           bodyBytes: Buffer.from(signDoc.bodyBytes).toString('base64'),
@@ -765,7 +790,10 @@ export class XDEFIKeplrProvider extends Keplr {
         { account: transactionDetails.from }
       )
 
-      const { serialized } = deserializeSigningOutput(chain, data)
+      const { serialized } = deserializeSigningOutput(
+        chain,
+        data
+      ) as InstanceType<typeof TW.Cosmos.Proto.SigningOutput>
       const publicKey = Buffer.from(new Uint8Array(account.pubkey)).toString(
         'base64'
       )

--- a/core/inpage-provider/background/resolvers/getAccount.ts
+++ b/core/inpage-provider/background/resolvers/getAccount.ts
@@ -1,8 +1,9 @@
 import { getVault } from '@core/extension/storage/vaults'
 import { getWalletCore } from '@core/extension/tw'
 import { BackgroundResolver } from '@core/inpage-provider/background/resolver'
-import { deriveAddress } from '@vultisig/core-chain/publicKey/address/deriveAddress'
+import { getChainAddress } from '@vultisig/core-chain/publicKey/address/getChainAddress'
 import { getPublicKey } from '@vultisig/core-chain/publicKey/getPublicKey'
+import { getSignatureAlgorithm } from '@vultisig/core-chain/signing/SignatureAlgorithm'
 import { isKeyImportVault } from '@vultisig/core-mpc/vault/Vault'
 import { assertField } from '@vultisig/lib-utils/record/assertField'
 
@@ -20,7 +21,30 @@ export const getAccount: BackgroundResolver<'getAccount'> = async ({
     }
   }
 
+  // MLDSA chains (e.g. QBTC) require a post-quantum key that older vaults
+  // don't carry. Return empty so `requestAccount` re-prompts the user to
+  // pick a vault that supports this chain, instead of throwing.
+  if (getSignatureAlgorithm(chain) === 'mldsa' && !vault.publicKeyMldsa) {
+    return { address: '', publicKey: '' }
+  }
+
   const walletCore = await getWalletCore()
+
+  const address = getChainAddress({
+    chain,
+    walletCore,
+    hexChainCode: vault.hexChainCode,
+    publicKeys: vault.publicKeys,
+    publicKeyMldsa: vault.publicKeyMldsa,
+    chainPublicKeys: vault.chainPublicKeys,
+  })
+
+  if (getSignatureAlgorithm(chain) === 'mldsa') {
+    return {
+      address,
+      publicKey: assertField(vault, 'publicKeyMldsa'),
+    }
+  }
 
   const publicKey = getPublicKey({
     chain,
@@ -28,12 +52,6 @@ export const getAccount: BackgroundResolver<'getAccount'> = async ({
     hexChainCode: vault.hexChainCode,
     publicKeys: vault.publicKeys,
     chainPublicKeys: vault.chainPublicKeys,
-  })
-
-  const address = deriveAddress({
-    chain,
-    publicKey,
-    walletCore,
   })
 
   return {

--- a/core/inpage-provider/background/resolvers/getAccount.ts
+++ b/core/inpage-provider/background/resolvers/getAccount.ts
@@ -21,10 +21,12 @@ export const getAccount: BackgroundResolver<'getAccount'> = async ({
     }
   }
 
+  const signatureAlgorithm = getSignatureAlgorithm(chain)
+
   // MLDSA chains (e.g. QBTC) require a post-quantum key that older vaults
   // don't carry. Return empty so `requestAccount` re-prompts the user to
   // pick a vault that supports this chain, instead of throwing.
-  if (getSignatureAlgorithm(chain) === 'mldsa' && !vault.publicKeyMldsa) {
+  if (signatureAlgorithm === 'mldsa' && !vault.publicKeyMldsa) {
     return { address: '', publicKey: '' }
   }
 
@@ -39,7 +41,7 @@ export const getAccount: BackgroundResolver<'getAccount'> = async ({
     chainPublicKeys: vault.chainPublicKeys,
   })
 
-  if (getSignatureAlgorithm(chain) === 'mldsa') {
+  if (signatureAlgorithm === 'mldsa') {
     return {
       address,
       publicKey: assertField(vault, 'publicKeyMldsa'),

--- a/core/inpage-provider/popup/view/resolvers/sendTx/SendTxOverview.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/SendTxOverview.tsx
@@ -25,7 +25,7 @@ import { SignAminoDisplay } from '@core/ui/mpc/keysign/tx/components/SignAminoDi
 import { SignDirectDisplay } from '@core/ui/mpc/keysign/tx/components/SignDirectDisplay'
 import { SignSolanaDisplay } from '@core/ui/mpc/keysign/tx/components/SignSolanaDisplay'
 import { SignTonDisplay } from '@core/ui/mpc/keysign/tx/components/SignTonDisplay'
-import { useCurrentVaultPublicKey } from '@core/ui/vault/state/currentVault'
+import { useCurrentVaultNullablePublicKey } from '@core/ui/vault/state/currentVault'
 import {
   HorizontalLine,
   IconWrapper,
@@ -64,7 +64,7 @@ type SendTxOverviewProps = {
 export const SendTxOverview = ({ parsedTx }: SendTxOverviewProps) => {
   const { coin, customTxData } = parsedTx
   const walletCore = useAssertWalletCore()
-  const publicKey = useCurrentVaultPublicKey(coin.chain)
+  const publicKey = useCurrentVaultNullablePublicKey(coin.chain)
   const { t } = useTranslation()
   const getCoin = useGetCoin()
   const transactionPayload = usePopupInput<'sendTx'>()

--- a/core/inpage-provider/popup/view/resolvers/sendTx/components/NetworkFeeSection.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/components/NetworkFeeSection.tsx
@@ -1,10 +1,11 @@
 import { ManageEvmFee } from '@core/inpage-provider/popup/view/resolvers/sendTx/ManageEvmFee'
 import { usePopupInput } from '@core/inpage-provider/popup/view/state/input'
 import { useAssertWalletCore } from '@core/ui/chain/providers/WalletCoreProvider'
-import { useCurrentVaultPublicKey } from '@core/ui/vault/state/currentVault'
+import { useCurrentVaultNullablePublicKey } from '@core/ui/vault/state/currentVault'
 import { MatchRecordUnion } from '@lib/ui/base/MatchRecordUnion'
 import { List } from '@lib/ui/list'
 import { ListItem } from '@lib/ui/list/item'
+import { PublicKey } from '@trustwallet/wallet-core/dist/src/wallet-core'
 import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { isChainOfKind } from '@vultisig/core-chain/ChainKind'
@@ -24,7 +25,7 @@ export type NetworkFeeSectionProps = {
   feeSettings: FeeSettings<'evm'> | null
   setFeeSettings: (settings: FeeSettings<'evm'> | null) => void
   walletCore: ReturnType<typeof useAssertWalletCore>
-  publicKey: ReturnType<typeof useCurrentVaultPublicKey>
+  publicKey: ReturnType<typeof useCurrentVaultNullablePublicKey>
 }
 
 export const NetworkFeeSection = ({
@@ -43,10 +44,13 @@ export const NetworkFeeSection = ({
       value={transactionPayload}
       handlers={{
         keysign: transactionPayload => {
+          // MLDSA chains (QBTC) have no WalletCore `PublicKey`. Their fee
+          // resolver doesn't read this field — `getQbtcFeeAmount` returns
+          // `cosmosSpecific.gas` directly — so the cast is safe at runtime.
           const feeAmount = getFeeAmount({
             keysignPayload,
             walletCore,
-            publicKey,
+            publicKey: publicKey as PublicKey,
           })
 
           const getEvmValues = () => {

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/build.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/build.ts
@@ -8,6 +8,7 @@ import { CosmosMsgType } from '@vultisig/core-chain/chains/cosmos/cosmosMsgTypes
 import { polkadotConfig } from '@vultisig/core-chain/chains/polkadot/config'
 import { buildSignBitcoinFromPsbt } from '@vultisig/core-chain/chains/utxo/tx/buildSignBitcoinFromPsbt'
 import { getPsbtTransferInfo } from '@vultisig/core-chain/chains/utxo/tx/getPsbtTransferInfo'
+import { getSignatureAlgorithm } from '@vultisig/core-chain/signing/SignatureAlgorithm'
 import { getChainSpecific } from '@vultisig/core-mpc/keysign/chainSpecific'
 import {
   FeeSettings,
@@ -45,6 +46,7 @@ import {
   TonMessageSchema,
   WasmExecuteContractPayloadSchema,
 } from '@vultisig/core-mpc/types/vultisig/keysign/v1/wasm_execute_contract_payload_pb'
+import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { attempt } from '@vultisig/lib-utils/attempt'
 import { matchDiscriminatedUnion } from '@vultisig/lib-utils/matchDiscriminatedUnion'
 import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
@@ -61,7 +63,10 @@ import { applyCosmosFeeFromSignData } from './applyCosmosFeeFromSignData'
 export type BuildSendTxKeysignPayloadInput = {
   parsedTx: ParsedTx
   feeSettings?: FeeSettings<FeeSettingsChainKind> | null
-  publicKey: PublicKey
+  /** WalletCore public key; null for MLDSA chains (use {@link publicKeyMldsa}). */
+  publicKey: PublicKey | null
+  /** Vault's MLDSA hex public key, used for MLDSA chains (e.g. QBTC). */
+  publicKeyMldsa?: string
   walletCore: WalletCore
   vaultId: string
   localPartyId: string
@@ -90,6 +95,7 @@ export const buildSendTxKeysignPayload = async ({
   feeSettings,
   vaultId,
   publicKey,
+  publicKeyMldsa,
   walletCore,
   localPartyId,
   dappMetadata,
@@ -137,7 +143,12 @@ export const buildSendTxKeysignPayload = async ({
     }
   }
 
-  const hexPublicKey = Buffer.from(publicKey.data()).toString('hex')
+  const hexPublicKey =
+    getSignatureAlgorithm(chain) === 'mldsa'
+      ? shouldBePresent(publicKeyMldsa, 'publicKeyMldsa')
+      : Buffer.from(shouldBePresent(publicKey, 'publicKey').data()).toString(
+          'hex'
+        )
 
   const fromCoin = toCommCoin({
     ...coin,
@@ -555,7 +566,7 @@ export const buildSendTxKeysignPayload = async ({
     keysignPayload = refineKeysignUtxo({
       keysignPayload,
       walletCore,
-      publicKey,
+      publicKey: shouldBePresent(publicKey, 'publicKey'),
     })
   }
 

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/query.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/query.ts
@@ -2,7 +2,7 @@ import { usePopupContext } from '@core/inpage-provider/popup/view/state/context'
 import { useAssertWalletCore } from '@core/ui/chain/providers/WalletCoreProvider'
 import {
   useCurrentVault,
-  useCurrentVaultPublicKey,
+  useCurrentVaultNullablePublicKey,
 } from '@core/ui/vault/state/currentVault'
 import { noRefetchQueryOptions } from '@lib/ui/query/utils/options'
 import { useQuery } from '@tanstack/react-query'
@@ -27,7 +27,7 @@ export const useSendTxKeysignPayloadQuery = ({
 }) => {
   const vault = useCurrentVault()
   const walletCore = useAssertWalletCore()
-  const publicKey = useCurrentVaultPublicKey(parsedTx.coin.chain)
+  const publicKey = useCurrentVaultNullablePublicKey(parsedTx.coin.chain)
   const { requestFavicon, requestName, requestOrigin } =
     usePopupContext<'sendTx'>()
 
@@ -40,6 +40,7 @@ export const useSendTxKeysignPayloadQuery = ({
       vaultId: getVaultId(vault),
       localPartyId: vault.localPartyId,
       publicKey,
+      publicKeyMldsa: vault.publicKeyMldsa,
       dappMetadata: buildDappMetadata({
         requestFavicon,
         requestName,

--- a/core/inpage-provider/popup/view/resolvers/sendTx/queries/parsedTx.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/queries/parsedTx.ts
@@ -8,8 +8,7 @@ import { useQuery } from '@tanstack/react-query'
 import { Chain, OtherChain } from '@vultisig/core-chain/Chain'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { Coin } from '@vultisig/core-chain/coin/Coin'
-import { deriveAddress } from '@vultisig/core-chain/publicKey/address/deriveAddress'
-import { getPublicKey } from '@vultisig/core-chain/publicKey/getPublicKey'
+import { getChainAddress } from '@vultisig/core-chain/publicKey/address/getChainAddress'
 import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
 import { getRecordUnionValue } from '@vultisig/lib-utils/record/union/getRecordUnionValue'
 import { useMemo } from 'react'
@@ -74,18 +73,13 @@ export const useParsedTxQuery = (): Query<ParsedTx> => {
 
       const { chain } = coin
 
-      const publicKey = getPublicKey({
+      const address = getChainAddress({
         chain,
         walletCore,
         hexChainCode: vault.hexChainCode,
         publicKeys: vault.publicKeys,
+        publicKeyMldsa: vault.publicKeyMldsa,
         chainPublicKeys: vault.chainPublicKeys,
-      })
-
-      const address = deriveAddress({
-        chain,
-        publicKey,
-        walletCore,
       })
 
       return {

--- a/core/ui/qbtc/claim/components/ClaimPreparingTxPhase.tsx
+++ b/core/ui/qbtc/claim/components/ClaimPreparingTxPhase.tsx
@@ -75,6 +75,7 @@ export const ClaimPreparingTxPhase = ({
 
       const bodyBytes = buildClaimTxBody({
         claimer: qbtcAddress,
+        broadcaster: qbtcAddress,
         utxos: utxos.map(({ txid, vout }) => ({ txid, vout })),
         proof: proof.proof,
         messageHash: proof.message_hash,

--- a/core/ui/qbtc/claim/components/ClaimPreparingTxPhase.tsx
+++ b/core/ui/qbtc/claim/components/ClaimPreparingTxPhase.tsx
@@ -75,7 +75,6 @@ export const ClaimPreparingTxPhase = ({
 
       const bodyBytes = buildClaimTxBody({
         claimer: qbtcAddress,
-        broadcaster: qbtcAddress,
         utxos: utxos.map(({ txid, vout }) => ({ txid, vout })),
         proof: proof.proof,
         messageHash: proof.message_hash,


### PR DESCRIPTION
## Summary

Exposes QBTC to dApps via two complementary surfaces:

1. **`window.vultisig.qbtc`** — a dedicated, honest QBTC-native provider (`request_accounts`, `get_accounts`, `send_transaction`, `get_transaction_by_hash`).
2. **`window.keplr.enable('qbtc-testnet')` and signing methods** — QBTC added to the existing Keplr proxy so Keplr-shaped dApps work without any client-side changes.

Both routes feed into the same MLDSA keysign pipeline (`useKeysignMutation`'s QBTC branch → `getQBTCPreSignedImageHash` / `getQBTCSignedTransaction` → broadcast via `broadcastQbtcTx`).

Closes #3932

## Why two surfaces

QBTC signs with **ML-DSA-44**, not secp256k1/ed25519. Keplr's API encodes assumptions QBTC violates:
- `getKey().algo` is typed as `'secp256k1' | 'ed25519' | 'sr25519'` — no MLDSA slot.
- Signature length differs (~2420 bytes vs 64).
- Standard cosmos verifiers fail on MLDSA bytes.

The dedicated `window.vultisig.qbtc` provider is honest about MLDSA (no `algo` lie); the Keplr-proxy entry is a pragmatic compatibility shim so the wide ecosystem of Keplr-speaking dApps just works. Both routes share the same backend, so there's no second implementation to maintain.

## Surface 1 — `window.vultisig.qbtc`

```js
window.vultisig.qbtc.request({ method: 'request_accounts' })
  // -> ['qbtc1...']
  // throws EIP1193Error(4100, 'QBTC requires an MLDSA-enabled vault...')
  //   when the current vault has no publicKeyMldsa

window.vultisig.qbtc.request({ method: 'get_accounts' })
  // -> ['qbtc1...'] when connected, [] otherwise

window.vultisig.qbtc.request({
  method: 'send_transaction',
  params: [{ from, to, value, memo? }],
})  // -> tx hash

window.vultisig.qbtc.request({ method: 'get_transaction_by_hash', params: [hash] })
```

Usage docs added to `clients/extension/docs/integration-guide.md`.

## Surface 2 — `window.keplr` Keplr proxy

QBTC is now in `supportedKeplrChains`. `chainId` = `qbtc-testnet`, bech32 prefix `qbtc`, coinType 118, REST endpoint from the SDK's `qbtcRestUrl`. Routes:

- `enable('qbtc-testnet')` → opens grant-access popup, sets up appSession.
- `getKey('qbtc-testnet')` / `getOfflineSigner('qbtc-testnet').getAccounts()` → returns the QBTC bech32 address and the vault's MLDSA hex pubkey as `pubkey` bytes. `algo` is declared `'secp256k1'` because Keplr's union has no MLDSA enum (caveat below).
- `signDirect` / `signAmino` → routes through popup keysign with `chain: Chain.QBTC` → existing MLDSA branch in `useKeysignMutation` → MLDSA-signed `TxRaw` returned to the dApp for broadcast.

`runWithChain` is skipped-but-safe for QBTC: it doesn't touch `setAppChain({ cosmos })` since QBTC isn't a `CosmosChain` and has no Cosmos chain-switcher state. `normalizeCosmosAuthInfoFee` is skipped for QBTC since its denom (`qbtc`) is already canonical.

### Compatibility caveats (documented in code)

- **`algo: 'secp256k1'` is a lie** — Keplr's `Algo` union predates post-quantum signing. The `pubkey` bytes are the real MLDSA-44 key from the vault, but the algo tag is wrong. dApps that pass `pubkey` through to broadcast are unaffected; dApps that locally verify signatures must use MLDSA verification regardless of which provider produced the signature.
- **`SigningOutput` cast** — `deserializeSigningOutput<SupportedKeplrChain>` widens to a proto union TypeScript can't simplify, even though QBTC and Cosmos share the same `TW.Cosmos.Proto.SigningOutput` class. Two narrow casts at the call sites with explanatory comments.

## Key changes

### `window.vultisig.qbtc` (first commit)

| File | Change |
|------|--------|
| `core/inpage-provider/background/resolvers/getAccount.ts` | Swap `getPublicKey + deriveAddress` for `getChainAddress` (MLDSA-aware). Return `publicKeyMldsa` hex for MLDSA chains; defensive empty-return when vault lacks MLDSA. |
| `core/inpage-provider/popup/view/resolvers/sendTx/queries/parsedTx.ts` | Same swap so popup address derivation works for QBTC. |
| `core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/query.ts` | Use `useCurrentVaultNullablePublicKey`; thread `vault.publicKeyMldsa`. |
| `core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/build.ts` | `publicKey: PublicKey \| null`, new `publicKeyMldsa?` input; branch on signature algorithm for `hexPublicKey`. |
| `clients/extension/src/inpage/providers/qbtc.ts` | New dedicated `Qbtc` provider class. |
| `clients/extension/src/inpage/providers/providerFactory.ts` | Register `qbtc: Qbtc.getInstance()`. |
| `clients/extension/src/background/handlers/errorHandler.ts` | `EIP1193Error` accepts optional `customMessage` (backwards-compatible). |
| `clients/extension/docs/integration-guide.md` | TOC, supported-chains row, methods section, integration example with MLDSA error handling. |

### Keplr proxy (second commit)

| File | Change |
|------|--------|
| `clients/extension/src/inpage/providers/keplrChainInfo.ts` | Add QBTC to `supportedKeplrChains` (widened to `CosmosChain \| OtherChain.QBTC`), records for prefix/coinType/name/gas, helpers for QBTC's special denom/RPC endpoint. Export `getKeplrSupportedChainByChainId`. |
| `clients/extension/src/inpage/providers/xdefiKeplr.ts` | Route `enable`/`getAccounts`/`signAmino`/`signDirect`/`assertNativeChainForSigning` through new resolver. Skip `setAppChain` for QBTC. Skip `normalizeCosmosAuthInfoFee` for QBTC. Cast `deserializeSigningOutput` to the concrete cosmos shape. |

No SDK changes needed — the SDK already had `getChainAddress`, `deriveQbtcAddress`, `getQbtcChainSpecific`, and `qbtcRestUrl` wired.

## Behavior on a vault without MLDSA

The `Enable MLDSA` toggle in Developer Options gates MLDSA keygen at vault creation. Vaults created with the toggle off have no `publicKeyMldsa`. For those vaults:

- `window.vultisig.qbtc.request({ method: 'request_accounts' })` → `EIP1193Error(4100, 'QBTC requires an MLDSA-enabled vault. Enable MLDSA in Vultisig Developer Options and create a new vault.')`
- `window.vultisig.qbtc.request({ method: 'get_accounts' })` → `[]`
- Same error for `send_transaction`
- `window.keplr.enable('qbtc-testnet')` opens grant-access; if the user picks a vault without MLDSA, downstream `getAccounts` / `signDirect` surface the same error path.

## Test plan

- [ ] **Static checks**: `yarn check:all` green locally (typecheck + lint + 134/134 tests + knip).
- [ ] On a vault **with** MLDSA enabled, from a regular https page:
  - [ ] `window.vultisig.qbtc.request({ method: 'request_accounts' })` opens grant-access popup, returns the `qbtc1...` address.
  - [ ] `window.vultisig.qbtc.request({ method: 'send_transaction', params: [{ from, to, value, memo: '' }] })` opens the keysign overview, signs via MLDSA, broadcasts, and returns the tx hash.
  - [ ] `window.keplr.enable('qbtc-testnet')` succeeds (no `UnrecognizedChain`).
  - [ ] `window.keplr.getKey('qbtc-testnet')` returns the QBTC bech32 address; `pubKey` is the MLDSA-44 hex bytes.
  - [ ] `window.keplr.getOfflineSigner('qbtc-testnet').getAccounts()` returns the same.
  - [ ] A Keplr-shape send via `signDirect` (or via cosmjs's `StargateClient` using the offline signer) signs and broadcasts a QBTC `MsgSend` end-to-end.
- [ ] On a vault **without** MLDSA (toggle off):
  - [ ] `request_accounts` rejects with code 4100 and the MLDSA-required message.
  - [ ] `get_accounts` returns `[]`.
- [ ] User cancels the grant-access popup → `request_accounts` rejects with code 4001.
- [ ] Regression: `window.vultisig.ethereum`, `window.vultisig.solana`, and the existing Keplr-proxy Cosmos chains (cosmoshub-4, osmosis-1, ...) still work end-to-end.

## Out of scope

- WalletConnect / Wallet Standard registration for QBTC.
- iOS/Android mirror of the dApp surface.
- ADR-036 `signArbitrary` for QBTC (not implemented for any chain in the Keplr proxy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added QBTC support: connect, account/transaction flows, Keplr-compatible route, and QBTC-specific signing/fee handling in the wallet UI.
  * Wallet now surfaces richer error text for certain flows.

* **Documentation**
  * Comprehensive QBTC integration guide with examples, supported-chain entry, QBTC provider details, ML‑DSA vault requirement, and public-key format notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-windows/pull/3933?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->