### PR TITLE
ci(extension): add Firefox build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,41 @@ jobs:
           name: extension-dist-${{ github.sha }}
           path: clients/extension/dist
 
+  extension-firefox:
+    needs: lint
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Prepare vultisig-sdk from main (patch package.json)
+        uses: ./.github/actions/prepare-vultisig-sdk-from-main
+        with:
+          yarn-version: ${{ env.YARN_VERSION }}
+
+      - name: Setup and install
+        uses: ./.github/actions/setup-yarn-monorepo
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          immutable-install: 'false'
+
+      - name: Build extension (Firefox)
+        run: yarn workspace @clients/extension build:firefox
+
+      - name: Upload dist to artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: extension-firefox-dist-${{ github.sha }}
+          path: clients/extension/dist
+
   build:
     needs: lint
     strategy:


### PR DESCRIPTION
## Summary
- Adds an `extension-firefox` job to `.github/workflows/build.yml`, parallel to the existing `extension` job (both `needs: lint`).
- The new job runs `yarn workspace @clients/extension build:firefox`, which sets `VULTISIG_EXTENSION_TARGET=firefox`, runs the standard build (vite branches on this flag), then patches `dist/manifest.json` via `scripts/prepare-firefox-build.mjs` for Gecko.
- Uploads the resulting `clients/extension/dist` as `extension-firefox-dist-<sha>` so it stays distinct from the Chrome/Brave artifact.

## Test plan
- [ ] CI: `extension-firefox` job goes green on this PR
- [ ] Download `extension-firefox-dist-<sha>` from the workflow run
- [ ] `manifest.json` in the artifact contains `browser_specific_settings.gecko` and uses `background.scripts` (not `service_worker`)
- [ ] Existing `extension` job still passes and produces `extension-dist-<sha>` unchanged

Closes #3934

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Firefox browser extension is now available for download and installation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-windows/pull/3935?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->