### PR TITLE
chore(mldsa): hide toggle and force MLDSA off in extension and desktop

### DIFF
--- a/clients/desktop/src/components/manage-mpc-lib/index.tsx
+++ b/clients/desktop/src/components/manage-mpc-lib/index.tsx
@@ -1,10 +1,6 @@
 import { useVaultCreationMpcLib } from '@clients/desktop/src/mpc/state/vaultCreationMpcLib'
 import { useCore } from '@core/ui/state/core'
 import {
-  useIsMLDSAEnabled,
-  useSetIsMLDSAEnabledMutation,
-} from '@core/ui/storage/mldsaEnabled'
-import {
   useIsTssBatchingEnabled,
   useSetIsTssBatchingEnabledMutation,
 } from '@core/ui/storage/tssBatchingEnabled'
@@ -24,8 +20,6 @@ export const ManageMpcLib = () => {
   const gate = useClickGate()
   const isDKLS = value === 'DKLS'
 
-  const isMLDSAEnabled = useIsMLDSAEnabled()
-  const { mutate: setIsMLDSAEnabled } = useSetIsMLDSAEnabledMutation()
   const isTssBatchingEnabled = useIsTssBatchingEnabled()
   const { mutate: setIsTssBatchingEnabled } =
     useSetIsTssBatchingEnabledMutation()
@@ -48,11 +42,6 @@ export const ManageMpcLib = () => {
               checked={isDKLS}
               label={t('enable_dkls')}
               onChange={() => setValue(isDKLS ? 'GG20' : 'DKLS')}
-            />
-            <Switch
-              checked={isMLDSAEnabled}
-              label={t('enable_mldsa')}
-              onChange={() => setIsMLDSAEnabled(!isMLDSAEnabled)}
             />
             <Switch
               checked={isTssBatchingEnabled}

--- a/clients/desktop/src/storage/mldsaEnabled.ts
+++ b/clients/desktop/src/storage/mldsaEnabled.ts
@@ -1,22 +1,5 @@
-import {
-  isMLDSAInitiallyEnabled,
-  MLDSAEnabledStorage,
-} from '@core/ui/storage/mldsaEnabled'
-import { StorageKey } from '@core/ui/storage/StorageKey'
-
-import { persistentStorage } from '../state/persistentState'
+import { MLDSAEnabledStorage } from '@core/ui/storage/mldsaEnabled'
 
 export const mldsaEnabledStorage: MLDSAEnabledStorage = {
-  getIsMLDSAEnabled: async () => {
-    const value = persistentStorage.getItem<boolean>(StorageKey.isMLDSAEnabled)
-
-    if (value === undefined) {
-      return isMLDSAInitiallyEnabled
-    }
-
-    return value
-  },
-  setIsMLDSAEnabled: async isMLDSAEnabled => {
-    persistentStorage.setItem(StorageKey.isMLDSAEnabled, isMLDSAEnabled)
-  },
+  getIsMLDSAEnabled: async () => false,
 }

--- a/clients/extension/src/components/developer-options/index.tsx
+++ b/clients/extension/src/components/developer-options/index.tsx
@@ -4,10 +4,6 @@ import {
   setDeveloperOptions,
 } from '@core/extension/storage/developerOptions'
 import { useCore } from '@core/ui/state/core'
-import {
-  useIsMLDSAEnabled,
-  useSetIsMLDSAEnabledMutation,
-} from '@core/ui/storage/mldsaEnabled'
 import { StorageKey } from '@core/ui/storage/StorageKey'
 import {
   useIsTssBatchingEnabled,
@@ -48,8 +44,6 @@ export const ExtensionDeveloperOptions = () => {
   const { version } = useCore()
   const clickCount = useRef(0)
   const refetchQueries = useRefetchQueries()
-  const isMLDSAEnabled = useIsMLDSAEnabled()
-  const { mutate: setIsMLDSAEnabled } = useSetIsMLDSAEnabledMutation()
   const isTssBatchingEnabled = useIsTssBatchingEnabled()
   const { mutate: setIsTssBatchingEnabled } =
     useSetIsTssBatchingEnabledMutation()
@@ -99,11 +93,6 @@ export const ExtensionDeveloperOptions = () => {
       {visible && (
         <Modal onClose={() => setVisible(false)} title={t('developer_options')}>
           <VStack gap={16} fullHeight>
-            <Switch
-              checked={isMLDSAEnabled}
-              label={t('enable_mldsa')}
-              onChange={() => setIsMLDSAEnabled(!isMLDSAEnabled)}
-            />
             <Switch
               checked={isTssBatchingEnabled}
               label={t('enable_tss_batching')}

--- a/core/extension/storage/mldsaEnabled.ts
+++ b/core/extension/storage/mldsaEnabled.ts
@@ -1,16 +1,5 @@
-import {
-  isMLDSAInitiallyEnabled,
-  MLDSAEnabledStorage,
-} from '@core/ui/storage/mldsaEnabled'
-import { StorageKey } from '@core/ui/storage/StorageKey'
-import { getStorageValue } from '@lib/extension/storage/get'
-import { setStorageValue } from '@lib/extension/storage/set'
+import { MLDSAEnabledStorage } from '@core/ui/storage/mldsaEnabled'
 
 export const mldsaEnabledStorage: MLDSAEnabledStorage = {
-  getIsMLDSAEnabled: async () => {
-    return getStorageValue(StorageKey.isMLDSAEnabled, isMLDSAInitiallyEnabled)
-  },
-  setIsMLDSAEnabled: async isMLDSAEnabled => {
-    await setStorageValue(StorageKey.isMLDSAEnabled, isMLDSAEnabled)
-  },
+  getIsMLDSAEnabled: async () => false,
 }

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -299,7 +299,6 @@ export const en = {
   enable: 'Enable',
   enable_all: 'Enable all',
   enable_dkls: 'Enable DKLS',
-  enable_mldsa: 'Enable MLDSA',
   enable_tss_batching: 'Enable TSS Batching',
   post_quantum_keygen: 'Post-Quantum Key Generation',
   post_quantum_keygen_description:

--- a/core/ui/storage/mldsaEnabled.tsx
+++ b/core/ui/storage/mldsaEnabled.tsx
@@ -1,20 +1,14 @@
-import { useRefetchQueries } from '@lib/ui/query/hooks/useRefetchQueries'
 import { noRefetchQueryOptions } from '@lib/ui/query/utils/options'
-import { useMutation, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { shouldBeDefined } from '@vultisig/lib-utils/assert/shouldBeDefined'
 
 import { useCore } from '../state/core'
 import { StorageKey } from './StorageKey'
 
-export const isMLDSAInitiallyEnabled = false
-
-type SetIsMLDSAEnabledFunction = (isMLDSAEnabled: boolean) => Promise<void>
-
 type GetIsMLDSAEnabledFunction = () => Promise<boolean>
 
 export type MLDSAEnabledStorage = {
   getIsMLDSAEnabled: GetIsMLDSAEnabledFunction
-  setIsMLDSAEnabled: SetIsMLDSAEnabledFunction
 }
 
 export const useIsMLDSAEnabledQuery = () => {
@@ -31,18 +25,4 @@ export const useIsMLDSAEnabled = () => {
   const { data } = useIsMLDSAEnabledQuery()
 
   return shouldBeDefined(data)
-}
-
-export const useSetIsMLDSAEnabledMutation = () => {
-  const { setIsMLDSAEnabled } = useCore()
-  const refetchQueries = useRefetchQueries()
-
-  const mutationFn: SetIsMLDSAEnabledFunction = async input => {
-    await setIsMLDSAEnabled(input)
-    await refetchQueries([StorageKey.isMLDSAEnabled])
-  }
-
-  return useMutation({
-    mutationFn,
-  })
 }


### PR DESCRIPTION
## Summary

- Removes the MLDSA switch from the extension's developer-options modal and the desktop's Advanced modal.
- Hard-wires `getIsMLDSAEnabled` to `false` in both client storage implementations so any persisted `true` value from earlier builds is ignored.
- Drops the now-dead `setIsMLDSAEnabled` from `MLDSAEnabledStorage`, plus `useSetIsMLDSAEnabledMutation`, `isMLDSAInitiallyEnabled`, and the orphaned `enable_mldsa` key in `en.ts`. `useIsMLDSAEnabled` stays for the keygen action providers — it will always read `false` until QBTC ships.

Closes #3936.

## Test plan

- [ ] `yarn check:all` passes.
- [ ] Extension: triple-click the version label in settings — developer modal opens with the **TSS Batching** switch and the URL/timeout inputs, **no MLDSA switch**.
- [ ] Desktop: open Advanced (version click) — modal shows **Enable DKLS** and **Enable TSS Batching** only, **no MLDSA switch**.
- [ ] Upgrade path: with `chrome.storage.local.isMLDSAEnabled = true` set before the upgrade, confirm `useIsMLDSAEnabled()` reads `false` after upgrade (i.e. keygen no longer enters MLDSA-gated branches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed ML-DSA enablement toggle from advanced settings and developer options
  * DKLS is now the default MPC library configuration option
  * TSS batching settings remain available and unchanged

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-windows/pull/3937?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->