### PR TITLE
fix(extension): compute on-chain TxRaw hash for cosmos signAmino/signDirect

### DIFF
--- a/core/ui/mpc/keysign/action/mutations/useKeysignMutation.ts
+++ b/core/ui/mpc/keysign/action/mutations/useKeysignMutation.ts
@@ -9,7 +9,7 @@ import { constructPolkadotSigningPayload } from '@core/ui/polkadot/dapp/construc
 import { PolkadotSignerPayloadJSON } from '@core/ui/polkadot/dapp/PolkadotSignerPayload'
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { useMutation } from '@tanstack/react-query'
-import { OtherChain } from '@vultisig/core-chain/Chain'
+import { Chain, OtherChain } from '@vultisig/core-chain/Chain'
 import { getChainKind } from '@vultisig/core-chain/ChainKind'
 import { getCoinType } from '@vultisig/core-chain/coin/coinType'
 import { getPublicKey } from '@vultisig/core-chain/publicKey/getPublicKey'
@@ -42,6 +42,7 @@ import { chainPromises } from '@vultisig/lib-utils/promise/chainPromises'
 import { recordFromItems } from '@vultisig/lib-utils/record/recordFromItems'
 
 import { getCustomMessageHex } from '../../customMessage/getCustomMessageHex'
+import { getCosmosKeplrBridgeTxHash } from '../../tx/getCosmosKeplrBridgeTxHash'
 
 export const useKeysignMutation = (payload: KeysignMessagePayload) => {
   const walletCore = useAssertWalletCore()
@@ -191,14 +192,36 @@ export const useKeysignMutation = (payload: KeysignMessagePayload) => {
               })
             )
 
+            const isCosmosDAppSignFlow =
+              (payload.signData.case === 'signAmino' ||
+                payload.signData.case === 'signDirect') &&
+              payload.blockchainSpecific.case === 'cosmosSpecific'
+
             const txs: Tx[] = await Promise.all(
               compiledTxs.map(async compiledTx => {
                 const data = decodeSigningOutput(chain, compiledTx)
-                const hash = await getTxHash({ chain, tx: data })
+
+                if (isCosmosDAppSignFlow) {
+                  const cosmosOutput = decodeSigningOutput(
+                    Chain.Cosmos,
+                    compiledTx
+                  )
+                  const signature = cosmosOutput.signature
+                  return {
+                    data,
+                    hash: getCosmosKeplrBridgeTxHash({
+                      keysignPayload: payload,
+                      signedAminoJson: cosmosOutput.json ?? undefined,
+                      signatureBytes: signature
+                        ? new Uint8Array(signature)
+                        : undefined,
+                    }),
+                  }
+                }
 
                 return {
                   data,
-                  hash,
+                  hash: await getTxHash({ chain, tx: data }),
                 }
               })
             )

--- a/core/ui/mpc/keysign/tx/getCosmosKeplrBridgeTxHash.ts
+++ b/core/ui/mpc/keysign/tx/getCosmosKeplrBridgeTxHash.ts
@@ -1,0 +1,151 @@
+import { StdFee } from '@cosmjs/amino'
+import { createWasmAminoConverters, wasmTypes } from '@cosmjs/cosmwasm-stargate'
+import { fromBase64, fromHex, toBase64 } from '@cosmjs/encoding'
+import { Int53 } from '@cosmjs/math'
+import {
+  encodePubkey,
+  makeAuthInfoBytes,
+  Registry,
+} from '@cosmjs/proto-signing'
+import {
+  AminoTypes,
+  createDefaultAminoConverters,
+  defaultRegistryTypes,
+} from '@cosmjs/stargate'
+import { getBlockchainSpecificValue } from '@vultisig/core-mpc/keysign/chainSpecific/KeysignChainSpecific'
+import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
+import { stripHexPrefix } from '@vultisig/lib-utils/hex/stripHexPrefix'
+import { SignMode } from 'cosmjs-types/cosmos/tx/signing/v1beta1/signing'
+import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
+import { sha256 } from 'viem'
+
+const registry = new Registry([...defaultRegistryTypes, ...wasmTypes])
+const aminoTypes = new AminoTypes({
+  ...createDefaultAminoConverters(),
+  ...createWasmAminoConverters(),
+})
+
+type AminoStdTx = {
+  msg: Array<{ type: string; value: Record<string, unknown> }>
+  fee: StdFee
+  memo: string
+  signatures: Array<{
+    pub_key: { type: string; value: string }
+    signature: string
+  }>
+}
+
+const sha256UpperHex = (bytes: Uint8Array): string =>
+  stripHexPrefix(sha256(bytes)).toUpperCase()
+
+const encodeTxRawHash = ({
+  bodyBytes,
+  authInfoBytes,
+  signature,
+}: {
+  bodyBytes: Uint8Array
+  authInfoBytes: Uint8Array
+  signature: Uint8Array
+}): string => {
+  const txRaw = TxRaw.fromPartial({
+    bodyBytes,
+    authInfoBytes,
+    signatures: [signature],
+  })
+  return sha256UpperHex(TxRaw.encode(txRaw).finish())
+}
+
+const getKeysignPayloadPubkeyBase64 = (
+  keysignPayload: KeysignPayload,
+  fallback: string
+): string => {
+  const hex = keysignPayload.coin?.hexPublicKey
+  if (!hex) return fallback
+  return toBase64(fromHex(stripHexPrefix(hex)))
+}
+
+/**
+ * Compute the sha256 of the TxRaw a Keplr-bridge dApp will broadcast after a
+ * `signAmino` / `signDirect` keysign — so the done screen polls the same hash
+ * the dApp puts on-chain.
+ *
+ * WalletCore's amino output is the StdTx JSON, not the protobuf TxRaw the
+ * dApp encodes via cosmjs. Hashing the amino JSON yields a hash that never
+ * lands on-chain and `useTxStatusQuery` sits in `pending` forever. Rebuilding
+ * the TxRaw via cosmjs's default registry + amino converters reproduces the
+ * exact bytes a cosmos-kit / cosmjs dApp broadcasts.
+ */
+export const getCosmosKeplrBridgeTxHash = ({
+  keysignPayload,
+  signedAminoJson,
+  signatureBytes,
+}: {
+  keysignPayload: KeysignPayload
+  signedAminoJson: string | undefined
+  signatureBytes: Uint8Array | undefined
+}): string => {
+  const { signData } = keysignPayload
+
+  if (signData.case === 'signDirect') {
+    return encodeTxRawHash({
+      bodyBytes: fromBase64(signData.value.bodyBytes),
+      authInfoBytes: fromBase64(signData.value.authInfoBytes),
+      signature: shouldBePresent(signatureBytes, 'cosmos signDirect signature'),
+    })
+  }
+
+  if (signData.case !== 'signAmino') {
+    throw new Error(
+      `getCosmosKeplrBridgeTxHash: unsupported signData case ${signData.case}`
+    )
+  }
+
+  const json = shouldBePresent(signedAminoJson, 'WalletCore amino JSON output')
+  const parsed = JSON.parse(json) as { tx: AminoStdTx }
+  const stdTx = parsed.tx
+
+  const [stdSignature] = stdTx.signatures
+  if (!stdSignature) {
+    throw new Error('Amino JSON output is missing signatures')
+  }
+
+  const cosmosSpecific = getBlockchainSpecificValue(
+    keysignPayload.blockchainSpecific,
+    'cosmosSpecific'
+  )
+  const pubkey = encodePubkey({
+    type: 'tendermint/PubKeySecp256k1',
+    value: getKeysignPayloadPubkeyBase64(
+      keysignPayload,
+      stdSignature.pub_key.value
+    ),
+  })
+  const sequence = Int53.fromString(
+    cosmosSpecific.sequence.toString()
+  ).toNumber()
+  const gas = Int53.fromString(stdTx.fee.gas).toNumber()
+
+  const bodyBytes = registry.encode({
+    typeUrl: '/cosmos.tx.v1beta1.TxBody',
+    value: {
+      messages: stdTx.msg.map(msg =>
+        aminoTypes.fromAmino({ type: msg.type, value: msg.value })
+      ),
+      memo: stdTx.memo ?? '',
+    },
+  })
+
+  const authInfoBytes = makeAuthInfoBytes(
+    [{ pubkey, sequence }],
+    stdTx.fee.amount,
+    gas,
+    stdTx.fee.granter,
+    stdTx.fee.payer,
+    SignMode.SIGN_MODE_LEGACY_AMINO_JSON
+  )
+
+  const signature = signatureBytes ?? fromBase64(stdSignature.signature)
+
+  return encodeTxRawHash({ bodyBytes, authInfoBytes, signature })
+}

--- a/core/ui/mpc/keysign/tx/getCosmosKeplrBridgeTxHash.ts
+++ b/core/ui/mpc/keysign/tx/getCosmosKeplrBridgeTxHash.ts
@@ -1,4 +1,3 @@
-import { StdFee } from '@cosmjs/amino'
 import { createWasmAminoConverters, wasmTypes } from '@cosmjs/cosmwasm-stargate'
 import { fromBase64, fromHex, toBase64 } from '@cosmjs/encoding'
 import { Int53 } from '@cosmjs/math'
@@ -19,6 +18,7 @@ import { stripHexPrefix } from '@vultisig/lib-utils/hex/stripHexPrefix'
 import { SignMode } from 'cosmjs-types/cosmos/tx/signing/v1beta1/signing'
 import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
 import { sha256 } from 'viem'
+import { z } from 'zod'
 
 const registry = new Registry([...defaultRegistryTypes, ...wasmTypes])
 const aminoTypes = new AminoTypes({
@@ -26,28 +26,51 @@ const aminoTypes = new AminoTypes({
   ...createWasmAminoConverters(),
 })
 
-type AminoStdTx = {
-  msg: Array<{ type: string; value: Record<string, unknown> }>
-  fee: StdFee
-  memo: string
-  signatures: Array<{
-    pub_key: { type: string; value: string }
-    signature: string
-  }>
-}
+const aminoCoinSchema = z.object({
+  denom: z.string(),
+  amount: z.string(),
+})
+
+const aminoStdTxSchema = z.object({
+  msg: z.array(
+    z.object({
+      type: z.string(),
+      value: z.record(z.string(), z.unknown()),
+    })
+  ),
+  fee: z.object({
+    amount: z.array(aminoCoinSchema),
+    gas: z.string(),
+    granter: z.string().optional(),
+    payer: z.string().optional(),
+  }),
+  memo: z.string().optional().default(''),
+  signatures: z
+    .array(
+      z.object({
+        pub_key: z.object({ type: z.string(), value: z.string() }),
+        signature: z.string(),
+      })
+    )
+    .min(1, 'Amino JSON output is missing signatures'),
+})
+
+const aminoOutputSchema = z.object({ tx: aminoStdTxSchema })
 
 const sha256UpperHex = (bytes: Uint8Array): string =>
   stripHexPrefix(sha256(bytes)).toUpperCase()
+
+type EncodeTxRawHashInput = {
+  bodyBytes: Uint8Array
+  authInfoBytes: Uint8Array
+  signature: Uint8Array
+}
 
 const encodeTxRawHash = ({
   bodyBytes,
   authInfoBytes,
   signature,
-}: {
-  bodyBytes: Uint8Array
-  authInfoBytes: Uint8Array
-  signature: Uint8Array
-}): string => {
+}: EncodeTxRawHashInput): string => {
   const txRaw = TxRaw.fromPartial({
     bodyBytes,
     authInfoBytes,
@@ -56,13 +79,24 @@ const encodeTxRawHash = ({
   return sha256UpperHex(TxRaw.encode(txRaw).finish())
 }
 
-const getKeysignPayloadPubkeyBase64 = (
-  keysignPayload: KeysignPayload,
+type GetKeysignPayloadPubkeyBase64Input = {
+  keysignPayload: KeysignPayload
   fallback: string
-): string => {
+}
+
+const getKeysignPayloadPubkeyBase64 = ({
+  keysignPayload,
+  fallback,
+}: GetKeysignPayloadPubkeyBase64Input): string => {
   const hex = keysignPayload.coin?.hexPublicKey
   if (!hex) return fallback
   return toBase64(fromHex(stripHexPrefix(hex)))
+}
+
+type GetCosmosKeplrBridgeTxHashInput = {
+  keysignPayload: KeysignPayload
+  signedAminoJson: string | undefined
+  signatureBytes: Uint8Array | undefined
 }
 
 /**
@@ -80,11 +114,7 @@ export const getCosmosKeplrBridgeTxHash = ({
   keysignPayload,
   signedAminoJson,
   signatureBytes,
-}: {
-  keysignPayload: KeysignPayload
-  signedAminoJson: string | undefined
-  signatureBytes: Uint8Array | undefined
-}): string => {
+}: GetCosmosKeplrBridgeTxHashInput): string => {
   const { signData } = keysignPayload
 
   if (signData.case === 'signDirect') {
@@ -102,13 +132,8 @@ export const getCosmosKeplrBridgeTxHash = ({
   }
 
   const json = shouldBePresent(signedAminoJson, 'WalletCore amino JSON output')
-  const parsed = JSON.parse(json) as { tx: AminoStdTx }
-  const stdTx = parsed.tx
-
+  const stdTx = aminoOutputSchema.parse(JSON.parse(json)).tx
   const [stdSignature] = stdTx.signatures
-  if (!stdSignature) {
-    throw new Error('Amino JSON output is missing signatures')
-  }
 
   const cosmosSpecific = getBlockchainSpecificValue(
     keysignPayload.blockchainSpecific,
@@ -116,10 +141,10 @@ export const getCosmosKeplrBridgeTxHash = ({
   )
   const pubkey = encodePubkey({
     type: 'tendermint/PubKeySecp256k1',
-    value: getKeysignPayloadPubkeyBase64(
+    value: getKeysignPayloadPubkeyBase64({
       keysignPayload,
-      stdSignature.pub_key.value
-    ),
+      fallback: stdSignature.pub_key.value,
+    }),
   })
   const sequence = Int53.fromString(
     cosmosSpecific.sequence.toString()
@@ -132,7 +157,7 @@ export const getCosmosKeplrBridgeTxHash = ({
       messages: stdTx.msg.map(msg =>
         aminoTypes.fromAmino({ type: msg.type, value: msg.value })
       ),
-      memo: stdTx.memo ?? '',
+      memo: stdTx.memo,
     },
   })
 

--- a/core/ui/package.json
+++ b/core/ui/package.json
@@ -12,7 +12,12 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0",
+    "@cosmjs/amino": "^0.38.1",
+    "@cosmjs/cosmwasm-stargate": "^0.38.1",
     "@cosmjs/encoding": "^0.38.1",
+    "@cosmjs/math": "^0.38.1",
+    "@cosmjs/proto-signing": "^0.38.1",
+    "@cosmjs/stargate": "^0.38.1",
     "@floating-ui/react": "^0.27.19",
     "@hookform/resolvers": "^5.2.2",
     "@lib/codegen": "workspace:^",

--- a/core/ui/package.json
+++ b/core/ui/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0",
-    "@cosmjs/amino": "^0.38.1",
     "@cosmjs/cosmwasm-stargate": "^0.38.1",
     "@cosmjs/encoding": "^0.38.1",
     "@cosmjs/math": "^0.38.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -758,7 +758,6 @@ __metadata:
   resolution: "@core/ui@workspace:core/ui"
   dependencies:
     "@bufbuild/protobuf": "npm:^2.11.0"
-    "@cosmjs/amino": "npm:^0.38.1"
     "@cosmjs/cosmwasm-stargate": "npm:^0.38.1"
     "@cosmjs/encoding": "npm:^0.38.1"
     "@cosmjs/math": "npm:^0.38.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -758,7 +758,12 @@ __metadata:
   resolution: "@core/ui@workspace:core/ui"
   dependencies:
     "@bufbuild/protobuf": "npm:^2.11.0"
+    "@cosmjs/amino": "npm:^0.38.1"
+    "@cosmjs/cosmwasm-stargate": "npm:^0.38.1"
     "@cosmjs/encoding": "npm:^0.38.1"
+    "@cosmjs/math": "npm:^0.38.1"
+    "@cosmjs/proto-signing": "npm:^0.38.1"
+    "@cosmjs/stargate": "npm:^0.38.1"
     "@floating-ui/react": "npm:^0.27.19"
     "@hookform/resolvers": "npm:^5.2.2"
     "@lib/codegen": "workspace:^"


### PR DESCRIPTION
## Summary
- Keplr-bridge done screen sat in `pending` forever after a Cosmos dApp signed via `signAmino` / `signDirect` (Terra, etc.) because we hashed WalletCore's amino JSON instead of the protobuf TxRaw the dApp actually broadcasts.
- New helper [`getCosmosKeplrBridgeTxHash`](https://github.com/vultisig/vultisig-windows/blob/fix/keplr-bridge-tx-hash-3906/core/ui/mpc/keysign/tx/getCosmosKeplrBridgeTxHash.ts) rebuilds the same TxRaw cosmjs / cosmos-kit dApps produce — default cosmos + wasm registry, `SIGN_MODE_LEGACY_AMINO_JSON` AuthInfo for amino — and returns its sha256.
- Wired into `useKeysignMutation` only when `signData.case` is `signAmino` / `signDirect` *and* `blockchainSpecific.case === 'cosmosSpecific'`. All other flows (in-app sends, dApp Solana/Polkadot/etc.) keep the existing `getTxHash` path.

Closes #3906

## Test plan
- [x] `yarn check:all` passes (typecheck, lint, 134 unit tests, knip)
- [ ] Manual: connect the extension to a Terra cosmos-kit dApp via the Keplr provider, send a `MsgSend` (`signAmino`) — done screen shows the on-chain hash and transitions to `success` after broadcast
- [ ] Manual: repeat with a `signDirect` flow on another cosmos chain (e.g. Osmosis / Cosmos Hub) — same expectation
- [ ] Manual: regular in-app cosmos send (where the extension broadcasts) still polls and resolves to `success`/`error` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction-hash computation for Cosmos operations when using dApp signing flows, covering both direct and Amino signing modes to ensure correct broadcasted tx hashes.

* **Chores**
  * Added/updated Cosmos JS libraries to support the enhanced transaction processing and signing compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-windows/pull/3943?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->