### PR TITLE
Document SDK-main local dev flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,16 @@ This project depends on multiple packages from the [`vultisig-sdk`](https://gith
 - `@vultisig/core-mpc` — multi-party computation
 - `@vultisig/lib-utils` — shared utilities
 
-CI also runs a non-blocking compatibility check against the SDK `main` branch to catch integration issues early.
+CI builds against packed tarballs from the SDK `main` branch before installing dependencies. A plain local checkout uses the npm-published SDK versions from `yarn.lock`, so local builds can fail when Windows has merged code that depends on SDK changes that are versioned but not published yet.
+
+To make a local checkout match CI, run:
+
+```bash
+yarn sdk:use-main
+yarn dev:desktop
+```
+
+The command clones fresh SDK `main`, builds and packs the shared `@vultisig/*` packages, adds local tarball `resolutions` to `package.json`, and runs `yarn install`.
 
 ### Developing with the latest SDK (unreleased)
 
@@ -107,6 +116,8 @@ Since vultisig-sdk is a monorepo, `yarn link` won't work due to peer dependency 
 ```bash
 ./scripts/use-local-sdk.sh /path/to/vultisig-sdk
 ```
+
+Make sure `/path/to/vultisig-sdk` is on the branch you want to test. For the CI-equivalent setup, prefer `yarn sdk:use-main` so the SDK checkout is cloned from fresh `main`.
 
 This will build the SDK, pack all shared packages, add `resolutions` to `package.json`, and run `yarn install`.
 
@@ -119,7 +130,7 @@ yarn install
 
 ### Releasing
 
-Production builds always use npm-published SDK versions. Before releasing, ensure all `@vultisig/*` dependencies in `package.json` point to stable npm versions, not git references or local links.
+Release builds should use npm-published SDK versions. Before releasing, ensure all `@vultisig/*` dependencies in `package.json` point to stable npm versions, not git references or local links.
 
 ## Development Guidelines
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint:fix": "eslint --cache --cache-location node_modules/.cache/eslint/ 'clients/desktop/src/**/*.{js,jsx,ts,tsx}' 'clients/extension/src/**/*.{js,jsx,ts,tsx}' 'clients/desktop/vite.config.mts' 'clients/extension/vite.config.ts' 'core/**/*.{js,jsx,ts,tsx}' 'lib/**/*.{js,jsx,ts,tsx}' --fix",
     "dev:desktop": "wails dev -s -skipbindings -m -nosyncgomod",
     "dev:desktop:full": "wails dev",
+    "sdk:use-main": "bash scripts/use-sdk-main.sh",
     "build:desktop": "NODE_OPTIONS=--max-old-space-size=8192 yarn workspace @clients/desktop build",
     "build:extension": "yarn workspace @clients/extension build",
     "build:extension:firefox": "yarn workspace @clients/extension build:firefox",

--- a/scripts/use-sdk-main.sh
+++ b/scripts/use-sdk-main.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Clone vultisig-sdk main and apply the same local tarball override used by CI.
+set -euo pipefail
+
+WINDOWS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SDK_REPO_URL="${SDK_REPO_URL:-https://github.com/vultisig/vultisig-sdk.git}"
+SDK_REF="${SDK_REF:-main}"
+SDK_CLONE_DIR="${SDK_CLONE_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/vultisig-sdk-main.XXXXXX")}"
+
+if [ -d "$SDK_CLONE_DIR/.git" ]; then
+  echo "==> Using existing SDK checkout at $SDK_CLONE_DIR"
+  git -C "$SDK_CLONE_DIR" fetch --depth 1 origin "$SDK_REF"
+  git -C "$SDK_CLONE_DIR" checkout --detach FETCH_HEAD
+else
+  echo "==> Cloning SDK $SDK_REF from $SDK_REPO_URL"
+  git clone --depth 1 --branch "$SDK_REF" "$SDK_REPO_URL" "$SDK_CLONE_DIR"
+fi
+
+bash "$WINDOWS_DIR/scripts/use-local-sdk.sh" "$SDK_CLONE_DIR"
+
+echo ""
+echo "Local dependencies now match CI's SDK-main override."
+echo "Run: yarn dev:desktop"


### PR DESCRIPTION
## Summary\n- add a local `yarn sdk:use-main` command that clones SDK main and applies the same tarball override CI uses\n- document why plain local installs can differ from CI while SDK packages are versioned but not published\n\n## Investigation\n- reproduced the local failure on main with `yarn workspace @clients/desktop build`: published `@vultisig/core-chain@2.0.0` lacks the Cosmos staking validator/gas exports\n- confirmed CI patches dependencies from SDK main before install; SDK main has `@vultisig/core-chain@2.1.0`, but npm latest is still `2.0.0`\n\n## Verification\n- `yarn sdk:use-main`\n- `yarn workspace @clients/desktop build` passes after SDK-main override\n- restored published lockfile state and verified `yarn install --immutable`\n- `bash -n scripts/use-sdk-main.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SDK development guidance clarifying CI build processes and local SDK checkout setup requirements

* **Chores**
  * Added `yarn sdk:use-main` convenience command to automatically configure the latest SDK main branch for local development

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-windows/pull/3954?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->