### PR TITLE
fix(send): hide memo field for Cardano (#3877)

### DIFF
--- a/core/ui/vault/send/memo/ManageMemo.tsx
+++ b/core/ui/vault/send/memo/ManageMemo.tsx
@@ -1,10 +1,12 @@
 import { useSendMemo } from '@core/ui/vault/send/state/memo'
+import { useCurrentSendCoin } from '@core/ui/vault/send/state/sendCoin'
 import { interactive } from '@lib/ui/css/interactive'
 import { useBoolean } from '@lib/ui/hooks/useBoolean'
 import { InputContainer } from '@lib/ui/inputs/InputContainer'
 import { InputLabel } from '@lib/ui/inputs/InputLabel'
 import { CollapsableStateIndicator } from '@lib/ui/layout/CollapsableStateIndicator'
 import { Text, text } from '@lib/ui/text'
+import { Chain } from '@vultisig/core-chain/Chain'
 import { motion } from 'framer-motion'
 import { AnimatePresence } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
@@ -12,10 +14,17 @@ import styled from 'styled-components'
 
 import { TextInputWithPasteAction } from '../../../components/TextInputWithPasteAction'
 
+const chainsWithoutMemoSupport: Chain[] = [Chain.Cardano]
+
 export const ManageMemo = () => {
   const [value, setValue] = useSendMemo()
   const { t } = useTranslation()
+  const { chain } = useCurrentSendCoin()
   const [isOpen, { toggle }] = useBoolean(!!value)
+
+  if (chainsWithoutMemoSupport.includes(chain)) {
+    return null
+  }
 
   return (
     <InputContainer>


### PR DESCRIPTION
## Description

Cardano direct send currently accepts a memo in the UI, but the signed transaction has null auxiliary data — the memo never lands on-chain (see issue #3877 and SDK issue vultisig/vultisig-sdk#432).

Until the SDK adds CIP-20 metadata support to its direct-send Cardano path, hide the memo input for Cardano so users do not assume the memo will be persisted on-chain.


## Implementation

- Added a `chainsWithoutMemoSupport` allowlist in `core/ui/vault/send/memo/ManageMemo.tsx`. When the current send coin's chain is in the list, the component renders `null` and the "Add MEMO" section is not shown at all.
- The allowlist is the single place to add other chains later if needed; removing Cardano from the list will be the only change required once SDK CIP-20 support lands.
- CIP-30 flow (dApp-signed transactions via `cardanoCip30.ts`) is unaffected — that path signs the dApp-provided tx body hash directly and is separate from the direct-send/deposit UI.

## Which feature is affected?

- [x] Sending — Cardano (ADA) direct send/deposit
- [ ] Create vault
- [ ] Swap
- [ ] New Chain / Chain related feature

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (lint passes; pre-existing cosmos-staking TS errors are unrelated)
- [ ] I have added tests that prove my fix is effective or that my feature works — UI gate is trivial; manual verification path described below

## Manual verification

1. Open the extension popup, pick a Cardano (ADA) coin on the send screen → no "Add MEMO" row is shown.
2. Switch to any other chain (e.g. ETH, BTC, ATOM) → "Add MEMO" row is shown as before.

## Agent Metadata

- **Agent**: Claude Code (Opus 4.7)
- **Issue**: #3877
- **Confidence**: high
- **Needs human review for**: UX choice (hide vs disable-with-message) — confirmed with reporter that full hide is preferred for now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Memo input field is now hidden for cryptocurrencies that don't support memos (such as Cardano).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-windows/pull/3955?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->