### PR TITLE
fix(swap): don't crash verify screen when a fee coin isn't in the portfolio

### DIFF
--- a/core/ui/vault/swap/queries/useSwapFiatFeesQuery.ts
+++ b/core/ui/vault/swap/queries/useSwapFiatFeesQuery.ts
@@ -7,7 +7,6 @@ import { areEqualCoins, coinKeyToString } from '@vultisig/core-chain/coin/Coin'
 import { SwapFee } from '@vultisig/core-chain/swap/SwapFee'
 import { sum } from '@vultisig/lib-utils/array/sum'
 import { withoutDuplicates } from '@vultisig/lib-utils/array/withoutDuplicates'
-import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { useCallback, useMemo } from 'react'
 
 export const useSwapFiatFeesQuery = (value: SwapFee[]) => {
@@ -15,12 +14,9 @@ export const useSwapFiatFeesQuery = (value: SwapFee[]) => {
   const coins = useMemo(
     () =>
       withoutDuplicates(
-        value.map(key => {
-          const coin = shouldBePresent(
-            vaultCoins.find(coin => areEqualCoins(coin, key))
-          )
-
-          return coin
+        value.flatMap(key => {
+          const coin = vaultCoins.find(coin => areEqualCoins(coin, key))
+          return coin ? [coin] : []
         }),
         areEqualCoins
       ),
@@ -36,7 +32,7 @@ export const useSwapFiatFeesQuery = (value: SwapFee[]) => {
         const total = sum(
           value.map(({ amount, decimals, ...coinKey }) => {
             const key = coinKeyToString(coinKey)
-            const price = prices[key]
+            const price = prices[key] ?? 0
 
             return price * fromChainAmount(amount, decimals)
           })


### PR DESCRIPTION
## Summary

- `useSwapFiatFeesQuery` threaded each `SwapFee` through an unlabeled `shouldBePresent`. When a provider returns a fee in a coin the user doesn't currently hold in their portfolio, the lookup missed and the swap verify screen crashed with the unhelpful **`value is required`** error.
- Concrete trigger: KyberSwap's affiliate fee on native destinations sets `id: evmNativeCoinAddress` (the API placeholder), which doesn't match the vault's native coin record (`id: undefined`). Fixed at the source in vultisig/vultisig-sdk#509 — this PR is the defense-in-depth fix on our side so a future provider quirk degrades gracefully instead of blowing up the flow.
- Skip fee coins not in the portfolio (via `flatMap`) and treat their fiat contribution as 0.

Closes #3951
Pairs with vultisig/vultisig-sdk#509

## Test plan

- [ ] With SDK #509 picked up: USDC → ETH on Ethereum via KyberSwap reaches the verify screen and proceeds to keysign
- [ ] AAVE → BNB on BSC via KyberSwap reaches the verify screen and proceeds to keysign
- [ ] LiFi-routed swaps (e.g. USDC → ETH that previously selected LiFi) still render fees correctly — no regression in the happy path
- [ ] THORChain native swap (e.g. ETH → BTC) still renders the swap fee on the verify screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of swap fiat fee calculations by enhancing the handling of missing coin and pricing data to ensure more reliable and stable fee computations during swap transactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-windows/pull/3958?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->