### PR TITLE
fix(defi/maya): correct block time to 6s

### DIFF
--- a/core/ui/defi/chain/constants/time.ts
+++ b/core/ui/defi/chain/constants/time.ts
@@ -8,5 +8,5 @@ export const secondsInDay = secondsInHour * hoursInDay
 
 export const daysInYear = 365.25
 export const thorchainBlockTimeSeconds = 6
-export const mayachainBlockTimeSeconds = 5
+export const mayachainBlockTimeSeconds = 6
 export const blocksPerDay = secondsInDay / thorchainBlockTimeSeconds


### PR DESCRIPTION
## Summary

- `mayachainBlockTimeSeconds` was `5` in [core/ui/defi/chain/constants/time.ts](https://github.com/vultisig/vultisig-windows/blob/main/core/ui/defi/chain/constants/time.ts); Maya's official docs state 6s on average (FAQ: *"MAYAChain produces a block every 6 seconds on average"*).
- Mimir math confirms: `CACAOPOOLDEPOSITMATURITYBLOCKS: 302400 × 6s = 21 days` (the published CACAO single-pool unbond period).
- Only affects ETA display (CACAO unstake countdown at `mayachainStake.ts:98`, Maya bond/unbond service at `mayachainBondService.ts:163`). The on-chain gate is block-count based and was already correct, so no functional change to button enable/disable behavior — only the "Unlocks in N days" copy goes from ~17.5d to a correct 21d for a fresh 21-day stake.

Surfaced while investigating #3924. Closes #3959.

## Test plan

- [ ] `yarn check` passes locally (typecheck + lint:fix + i18n + knip) — done
- [ ] CACAO unstake countdown displays a value within a few hours of `blocksRemaining × 6s` against current mimir
- [ ] Maya bond/unbond ETA display unchanged in math relative to block-count source of truth
- [ ] No change to gate behavior — Unstake button still toggles on block-count parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Mayachain block time calculations to reflect current network parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-windows/pull/3960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->