### PR TITLE
fix(extension/keplr): override ping() so cosmos-kit dApps can connect

### DIFF
--- a/clients/extension/src/inpage/providers/xdefiKeplr.ts
+++ b/clients/extension/src/inpage/providers/xdefiKeplr.ts
@@ -452,15 +452,28 @@ const stripEndpoints = ({
 // actually exercises (`getKeysSettled`, `getKey`, `enable`, ...) we
 // override on `XDEFIKeplrProvider`, so this requester is reached only by
 // truly unhandled paths.
+// Keplr's `SimpleMessage` exposes its route via a `type()` method (symbol-
+// backed field), not a `type` property — naive property access would
+// stringify the function source into the error message.
+const readMessageType = (msg: unknown): string | undefined => {
+  if (!msg || typeof msg !== 'object') return undefined
+  const candidate = msg as { type?: unknown; method?: unknown }
+  if (typeof candidate.type === 'function') {
+    const result = (candidate.type as () => unknown).call(msg)
+    return typeof result === 'string' ? result : undefined
+  }
+  if (typeof candidate.type === 'string') return candidate.type
+  if (typeof candidate.method === 'string') return candidate.method
+  return undefined
+}
+
 class XDEFIMessageRequester {
   constructor() {
     this.sendMessage = this.sendMessage.bind(this)
   }
   public async sendMessage(message: any, params: any): Promise<void> {
     const method =
-      (params && (params.type ?? params.method)) ??
-      (message && (message.type ?? message.method)) ??
-      'unknown'
+      readMessageType(params) ?? readMessageType(message) ?? 'unknown'
     throw new Error(`Keplr method '${method}' is not supported by Vultisig`)
   }
 }
@@ -680,6 +693,15 @@ export class XDEFIKeplrProvider extends Keplr {
     signOptions?: KeplrSignOptions
   ): Promise<OfflineAminoSigner | OfflineDirectSigner> {
     return this.getOfflineSigner(chainId, signOptions)
+  }
+
+  // Liveness probe used by cosmos-kit-based dApps (osmosis.zone, etc.)
+  // during their `Initializing Wallet Client` step. The base implementation
+  // calls `requester.sendMessage` directly via the free `sendSimpleMessage`
+  // helper — bypassing our instance-level `sendSimpleMessage` override — so
+  // without this method the requester throws and the dApp can't connect.
+  async ping(): Promise<void> {
+    return
   }
 
   async sendTx(): Promise<Uint8Array> {


### PR DESCRIPTION
## Summary
- Override `Keplr.ping()` on `XDEFIKeplrProvider` so the cosmos-kit liveness probe resolves and dApps move past "Initializing Wallet Client". The base `ping()` calls `requester.sendMessage(...)` directly via the free `sendSimpleMessage` helper, bypassing our instance-level `sendSimpleMessage` override and landing in `XDEFIMessageRequester.sendMessage` — which now throws loudly on unhandled methods.
- Fix the method-name extraction in `XDEFIMessageRequester.sendMessage`. `SimpleMessage.type` is a method (symbol-backed field), not a property, so the previous code stringified the function source into the error message; the new `readMessageType` helper invokes `.type()` when callable.

Closes #3962.

## Test plan
- [ ] `yarn check:all` passes
- [ ] Reload the extension, open a cosmos-kit-based dApp, choose Keplr → connect modal advances past "Initializing Wallet Client"
- [ ] Trigger a genuinely unsupported Keplr method and confirm the thrown error names the method (e.g. `keplr-ping`) instead of dumping function source

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wallet health check capability enabling proper liveness detection for cosmos-kit dApps during wallet initialization

* **Improvements**
  * Enhanced message type detection with robust fallback handling for improved operation recognition
  * Improved error messaging to clearly report unsupported wallet operations
  * Better compatibility with Keplr protocol specifications

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-windows/pull/3963?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->