### PR TITLE
fix(extension/ethereum): map eth_requestAccounts to specific EIP-1193 codes (closes #3973)

### DIFF
--- a/clients/extension/src/inpage/providers/core/requestAccount.ts
+++ b/clients/extension/src/inpage/providers/core/requestAccount.ts
@@ -34,9 +34,18 @@ export const requestAccount = async (
       })
     )
     if (result.data?.appSession) {
-      return callBackground({
-        getAccount: { chain, appSession: result.data.appSession },
-      })
+      // Validate the post-grant fetch: if it rejects or returns an empty
+      // address (e.g. user picked a vault without a key for this chain),
+      // surface 4100 instead of leaking a raw error or returning `['']`.
+      const accountResult = await attempt(
+        callBackground({
+          getAccount: { chain, appSession: result.data.appSession },
+        })
+      )
+      if (accountResult.data?.address) {
+        return accountResult.data
+      }
+      throw new EIP1193Error('Unauthorized')
     }
     // Window closed via X aborts to RejectedByUser. A resolved-but-empty
     // response means the popup was dismissed mid-flow — treat as a user

--- a/clients/extension/src/inpage/providers/core/requestAccount.ts
+++ b/clients/extension/src/inpage/providers/core/requestAccount.ts
@@ -21,7 +21,10 @@ export const requestAccount = async (
     return data
   }
 
-  const openGrantVaultAccess = async () => {
+  // The grant-access popup is the only recovery path. Always exit with a
+  // specific EIP-1193 code — never let a catch-all InternalError mask the
+  // common no-vault / popup-dismissed paths (#3973).
+  const grantAccessAndGetAccount = async () => {
     const result = await attempt(
       callPopup({
         grantVaultAccess: {
@@ -35,20 +38,24 @@ export const requestAccount = async (
         getAccount: { chain, appSession: result.data.appSession },
       })
     }
-    if (result.error === PopupError.RejectedByUser) {
+    // Window closed via X aborts to RejectedByUser. A resolved-but-empty
+    // response means the popup was dismissed mid-flow — treat as a user
+    // rejection so dApps can retry intelligently.
+    if (result.error === PopupError.RejectedByUser || !result.error) {
       throw new EIP1193Error('UserRejectedRequest')
     }
+    throw new EIP1193Error('InternalError')
   }
 
-  if (error === BackgroundError.Unauthorized) {
-    const account = await openGrantVaultAccess()
-    if (account) return account
-  } else if (data !== undefined) {
-    // Authorized but current vault has no account for this chain (e.g. Solana).
-    // Re-prompt so user can select a vault that supports this chain.
-    const account = await openGrantVaultAccess()
-    if (account) return account
+  // Origin not authorized for the current vault, or vault is authorized but
+  // has no account for this chain (e.g. Solana on an EVM-only import) →
+  // prompt the user to pick a vault that supports this chain.
+  if (error === BackgroundError.Unauthorized || data !== undefined) {
+    return grantAccessAndGetAccount()
   }
 
-  throw new EIP1193Error('InternalError')
+  // Any other `getAccount` failure (no vault loaded, storage failure, etc.)
+  // is an unauthorized state from the dApp's perspective. EIP-1193 §5.2
+  // reserves 4100 for "requested method/account requires authorization".
+  throw new EIP1193Error('Unauthorized')
 }

--- a/clients/extension/tests/e2e/extension.spec.ts
+++ b/clients/extension/tests/e2e/extension.spec.ts
@@ -126,7 +126,10 @@ test.describe('Provider Injection', () => {
 })
 
 test.describe('Ethereum Connect Flow', () => {
-  test('eth_requestAccounts triggers popup', async ({
+  // Regression for #3973: with no vault configured, eth_requestAccounts must
+  // reject with EIP-1193 4100 (Unauthorized), not the catch-all -32603
+  // (Internal error) that broke Privy and EVM DEX connect flows.
+  test('eth_requestAccounts with no vault rejects with code 4100', async ({
     context,
     testDappUrl,
   }) => {
@@ -137,26 +140,27 @@ test.describe('Ethereum Connect Flow', () => {
       timeout: 10_000,
     })
 
-    // Start the connection request — this should trigger a popup
-    // We can't complete the full flow without a vault, but we can verify
-    // the popup/error behavior
+    // Wrap in Promise.race with a sentinel so a dangling popup doesn't
+    // surface as a 60s Playwright timeout (same hazard as the
+    // wallet_switchEthereumChain test below).
     const result = await page.evaluate(async () => {
       try {
-        const accounts = await window.ethereum.request({
-          method: 'eth_requestAccounts',
-          params: [],
-        })
+        const accounts = await Promise.race([
+          window.ethereum.request({
+            method: 'eth_requestAccounts',
+            params: [],
+          }),
+          new Promise((_, reject) =>
+            setTimeout(() => reject(new Error('TEST_TIMEOUT')), 30_000)
+          ),
+        ])
         return { accounts }
       } catch (e: any) {
         return { error: e.message, code: e.code }
       }
     })
 
-    // Without a configured vault, we expect either:
-    // - A popup to open (which we'd need to interact with)
-    // - An error (no vault configured)
-    // Either outcome is valid — the point is the method dispatches correctly
-    expect(result).toBeDefined()
+    expect(result).toMatchObject({ code: 4100 })
   })
 
   test('eth_accounts returns empty array when not connected', async ({

--- a/clients/extension/tests/unit/requestAccount.test.ts
+++ b/clients/extension/tests/unit/requestAccount.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { EIP1193Error } from '@clients/extension/src/background/handlers/errorHandler'
 import { BackgroundError } from '@core/inpage-provider/background/error'
 import { PopupError } from '@core/inpage-provider/popup/error'
 
@@ -94,14 +93,10 @@ describe('requestAccount', () => {
     // User rejects in popup
     mockCallPopup.mockRejectedValue(PopupError.RejectedByUser)
 
-    try {
-      await requestAccount(Chain.Ethereum)
-      expect.fail('Should have thrown')
-    } catch (error) {
-      expect(error).toBeInstanceOf(EIP1193Error)
-      expect((error as EIP1193Error).code).toBe(4001)
-      expect((error as EIP1193Error).message).toBe('User rejected the request')
-    }
+    await expect(requestAccount(Chain.Ethereum)).rejects.toMatchObject({
+      code: 4001,
+      message: 'User rejected the request',
+    })
   })
 
   it('throws EIP1193Error(Unauthorized) on non-Unauthorized background errors (e.g. no vault)', async () => {
@@ -110,14 +105,10 @@ describe('requestAccount', () => {
     // Per EIP-1193, the dApp should see 4100 (Unauthorized), not -32603.
     mockCallBackground.mockRejectedValue(new Error('currentVaultId is required'))
 
-    try {
-      await requestAccount(Chain.Ethereum)
-      expect.fail('Should have thrown')
-    } catch (error) {
-      expect(error).toBeInstanceOf(EIP1193Error)
-      expect((error as EIP1193Error).code).toBe(4100)
-      expect((error as EIP1193Error).message).toBe('Unauthorized')
-    }
+    await expect(requestAccount(Chain.Ethereum)).rejects.toMatchObject({
+      code: 4100,
+      message: 'Unauthorized',
+    })
     expect(mockCallPopup).not.toHaveBeenCalled()
   })
 
@@ -128,13 +119,9 @@ describe('requestAccount', () => {
     // genuinely unexpected popup-internal failure.
     mockCallPopup.mockRejectedValue(new Error('popup crashed'))
 
-    try {
-      await requestAccount(Chain.Solana)
-      expect.fail('Should have thrown')
-    } catch (error) {
-      expect(error).toBeInstanceOf(EIP1193Error)
-      expect((error as EIP1193Error).code).toBe(-32603)
-    }
+    await expect(requestAccount(Chain.Solana)).rejects.toMatchObject({
+      code: -32603,
+    })
   })
 
   it('throws EIP1193Error(UserRejectedRequest) when popup resolves without an appSession', async () => {
@@ -142,13 +129,46 @@ describe('requestAccount', () => {
     mockCallBackground.mockRejectedValueOnce(BackgroundError.Unauthorized)
     mockCallPopup.mockResolvedValue(undefined)
 
-    try {
-      await requestAccount(Chain.Ethereum)
-      expect.fail('Should have thrown')
-    } catch (error) {
-      expect(error).toBeInstanceOf(EIP1193Error)
-      expect((error as EIP1193Error).code).toBe(4001)
+    await expect(requestAccount(Chain.Ethereum)).rejects.toMatchObject({
+      code: 4001,
+    })
+  })
+
+  it('throws EIP1193Error(Unauthorized) when post-grant getAccount returns empty address', async () => {
+    // Defensive path: popup grants a session, but the freshly-selected vault
+    // has no key for this chain. We must not return { address: '' } to dApps.
+    const appSession = {
+      vaultId: 'v1',
+      host: 'example.com',
+      url: 'https://example.com',
     }
+    mockCallBackground
+      .mockRejectedValueOnce(BackgroundError.Unauthorized)
+      .mockResolvedValueOnce({ address: '', publicKey: '' })
+    mockCallPopup.mockResolvedValue({ appSession })
+
+    await expect(requestAccount(Chain.Ethereum)).rejects.toMatchObject({
+      code: 4100,
+      message: 'Unauthorized',
+    })
+  })
+
+  it('throws EIP1193Error(Unauthorized) when post-grant getAccount rejects', async () => {
+    // Defensive path: popup grants a session, but the follow-up getAccount
+    // call fails. Surface 4100 rather than leaking the raw error.
+    const appSession = {
+      vaultId: 'v1',
+      host: 'example.com',
+      url: 'https://example.com',
+    }
+    mockCallBackground
+      .mockRejectedValueOnce(BackgroundError.Unauthorized)
+      .mockRejectedValueOnce(new Error('storage corrupt'))
+    mockCallPopup.mockResolvedValue({ appSession })
+
+    await expect(requestAccount(Chain.Ethereum)).rejects.toMatchObject({
+      code: 4100,
+    })
   })
 
   it('re-prompts via popup when vault is authorized but has no account for the chain', async () => {

--- a/clients/extension/tests/unit/requestAccount.test.ts
+++ b/clients/extension/tests/unit/requestAccount.test.ts
@@ -104,24 +104,28 @@ describe('requestAccount', () => {
     }
   })
 
-  it('throws EIP1193Error(InternalError) on other background errors', async () => {
-    // Background rejects with something other than Unauthorized
-    mockCallBackground.mockRejectedValue(new Error('Network failure'))
+  it('throws EIP1193Error(Unauthorized) on non-Unauthorized background errors (e.g. no vault)', async () => {
+    // Background rejects with something other than BackgroundError.Unauthorized
+    // — e.g. shouldBePresent('currentVaultId') throwing when no vault exists.
+    // Per EIP-1193, the dApp should see 4100 (Unauthorized), not -32603.
+    mockCallBackground.mockRejectedValue(new Error('currentVaultId is required'))
 
     try {
       await requestAccount(Chain.Ethereum)
       expect.fail('Should have thrown')
     } catch (error) {
       expect(error).toBeInstanceOf(EIP1193Error)
-      expect((error as EIP1193Error).code).toBe(-32603)
-      expect((error as EIP1193Error).message).toBe('Internal error')
+      expect((error as EIP1193Error).code).toBe(4100)
+      expect((error as EIP1193Error).message).toBe('Unauthorized')
     }
+    expect(mockCallPopup).not.toHaveBeenCalled()
   })
 
-  it('throws EIP1193Error(InternalError) when popup returns error other than RejectedByUser', async () => {
+  it('throws EIP1193Error(InternalError) when popup rejects with a non-PopupError', async () => {
     mockCallBackground.mockRejectedValueOnce(BackgroundError.Unauthorized)
 
-    // Popup rejects with something other than RejectedByUser
+    // Popup rejects with something other than RejectedByUser — this is a
+    // genuinely unexpected popup-internal failure.
     mockCallPopup.mockRejectedValue(new Error('popup crashed'))
 
     try {
@@ -131,6 +135,40 @@ describe('requestAccount', () => {
       expect(error).toBeInstanceOf(EIP1193Error)
       expect((error as EIP1193Error).code).toBe(-32603)
     }
+  })
+
+  it('throws EIP1193Error(UserRejectedRequest) when popup resolves without an appSession', async () => {
+    // Popup dismissed mid-flow (window closed without explicit reject signal).
+    mockCallBackground.mockRejectedValueOnce(BackgroundError.Unauthorized)
+    mockCallPopup.mockResolvedValue(undefined)
+
+    try {
+      await requestAccount(Chain.Ethereum)
+      expect.fail('Should have thrown')
+    } catch (error) {
+      expect(error).toBeInstanceOf(EIP1193Error)
+      expect((error as EIP1193Error).code).toBe(4001)
+    }
+  })
+
+  it('re-prompts via popup when vault is authorized but has no account for the chain', async () => {
+    // Authorized vault, but no key for this chain (e.g. mldsa chain on a vault
+    // without an mldsa key). getAccount returns { address: '' } — falsy address.
+    const appSession = {
+      vaultId: 'v1',
+      host: 'example.com',
+      url: 'https://example.com',
+    }
+    const accountData = { address: 'newAddress', publicKey: 'newKey' }
+    mockCallBackground
+      .mockResolvedValueOnce({ address: '', publicKey: '' })
+      .mockResolvedValueOnce(accountData)
+    mockCallPopup.mockResolvedValue({ appSession })
+
+    const result = await requestAccount(Chain.Solana)
+
+    expect(result).toEqual(accountData)
+    expect(mockCallPopup).toHaveBeenCalledTimes(1)
   })
 
   it('works with Solana chain', async () => {


### PR DESCRIPTION
## Summary
- `requestAccount.ts` was throwing a catch-all `EIP1193Error('InternalError')` (-32603) for three distinct failure paths. Privy and EVM DEX wallet adapters interpret that as "Connection declined — Connection can be declined if a previous request is still active", breaking connect flows on Uniswap, 1inch, and any Privy-onboarded dApp.
- Each path now maps to the correct EIP-1193 code:
  - **No vault / unexpected `getAccount` failure → `4100` Unauthorized**
  - **Popup dismissed (`RejectedByUser` *or* resolved-without-`appSession`) → `4001` UserRejectedRequest**
  - **Popup rejects with a non-`PopupError` → `-32603` InternalError** (reserved for genuinely unexpected popup-internal failures)
- `grantAccessAndGetAccount` is now the single recovery path; it always returns an account or throws a specific code, never silently returns `undefined`.

Closes #3973.

## Test plan
- [x] `yarn check` — typecheck, lint:fix, knip clean
- [x] `yarn test` — 144/144 pass, including 9 unit tests in `requestAccount.test.ts` (two updated to assert the new codes, two new cases added)
- [x] New e2e regression in `extension.spec.ts`: `eth_requestAccounts with no vault rejects with code 4100`, wrapped in `Promise.race` with a 30s sentinel to avoid dangling-evaluate timeouts
- [ ] Manual: connect Vultisig on Uniswap (loaded vault) — succeeds first-try
- [ ] Manual: connect Vultisig on a Privy-onboarded dApp — succeeds
- [ ] Manual: call `eth_requestAccounts` with no vault — dApp receives `code: 4100`
- [ ] Manual: dismiss the grant-access popup mid-flow — dApp receives `code: 4001`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Account requests now return precise EIP-1193 error codes: 4100 (Unauthorized) when authorization is missing or invalid, 4001 (UserRejectedRequest) when the popup is dismissed/denied, and -32603 for popup/internal failures. Unauthorized initial fetches now trigger a re-prompt or reject with 4100 instead of a generic internal error.

* **Tests**
  * Added regression and expanded unit tests to assert the specific error codes and popup retry behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-windows/pull/3977?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->