### PR TITLE
fix(extension): resolve Bittensor dapp chain from payload (#3985)

### DIFF
--- a/core/inpage-provider/popup/view/resolvers/sendTx/core/customTxData.test.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/core/customTxData.test.ts
@@ -1,0 +1,75 @@
+import type { WalletCore } from '@trustwallet/wallet-core'
+import { OtherChain } from '@vultisig/core-chain/Chain'
+import type { Vault } from '@vultisig/core-mpc/vault/Vault'
+import { describe, expect, it, vi } from 'vitest'
+
+import { getCustomTxData } from './customTxData'
+
+const bittensorGenesisHash =
+  '0x2f0555cc76fc2840a25a6ea3b9637146806f1f44b090c175ffde2a7e5ab36c03'
+const polkadotGenesisHash =
+  '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3'
+
+const signerPayload = {
+  address: '5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM',
+  blockHash: '0xabc',
+  blockNumber: '0x1',
+  era: '0x00',
+  method: '0x0500',
+  nonce: '0x0',
+  signedExtensions: [],
+  specVersion: '0x1',
+  tip: '0x0',
+  transactionVersion: '0x1',
+  version: 4,
+}
+
+const getSerializedSubstrateTxData = (genesisHash?: string) =>
+  getCustomTxData({
+    walletCore: null as unknown as WalletCore,
+    vault: null as unknown as Vault,
+    transactionPayload: {
+      serialized: {
+        chain: OtherChain.Polkadot,
+        data: [JSON.stringify({ ...signerPayload, genesisHash })],
+      },
+    },
+    getCoin: vi.fn(),
+    requestOrigin: 'https://taostats.io',
+  })
+
+describe('getCustomTxData Substrate dApp transactions', () => {
+  it('corrects a Bittensor payload routed through the Polkadot provider', async () => {
+    await expect(
+      getSerializedSubstrateTxData(bittensorGenesisHash)
+    ).resolves.toMatchObject({
+      polkadot: {
+        chain: OtherChain.Bittensor,
+        signerPayload: { genesisHash: bittensorGenesisHash },
+      },
+    })
+  })
+
+  it('preserves a Polkadot payload routed through the Polkadot provider', async () => {
+    await expect(
+      getSerializedSubstrateTxData(polkadotGenesisHash)
+    ).resolves.toMatchObject({
+      polkadot: {
+        chain: OtherChain.Polkadot,
+        signerPayload: { genesisHash: polkadotGenesisHash },
+      },
+    })
+  })
+
+  it('rejects unsupported Substrate networks', async () => {
+    await expect(getSerializedSubstrateTxData('0xunsupported')).rejects.toThrow(
+      'Unsupported Substrate genesis hash'
+    )
+  })
+
+  it('rejects payloads without a genesis hash', async () => {
+    await expect(getSerializedSubstrateTxData()).rejects.toThrow(
+      'Missing Substrate genesis hash'
+    )
+  })
+})

--- a/core/inpage-provider/popup/view/resolvers/sendTx/core/customTxData.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/core/customTxData.ts
@@ -27,8 +27,35 @@ type RegularTxData = IKeysignTransactionPayload & {
   coin: Coin
 }
 
+type SubstrateChain = OtherChain.Polkadot | OtherChain.Bittensor
+
+const bittensorGenesisHash =
+  '0x2f0555cc76fc2840a25a6ea3b9637146806f1f44b090c175ffde2a7e5ab36c03'
+const polkadotGenesisHash =
+  '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3'
+
+const substrateChainByGenesisHash: Record<string, SubstrateChain> = {
+  [bittensorGenesisHash]: OtherChain.Bittensor,
+  [polkadotGenesisHash]: OtherChain.Polkadot,
+}
+
+const getSubstrateChain = (genesisHash: unknown): SubstrateChain => {
+  if (typeof genesisHash !== 'string') {
+    throw new Error('Missing Substrate genesis hash')
+  }
+
+  const chain = substrateChainByGenesisHash[genesisHash.toLowerCase()]
+
+  if (!chain) {
+    throw new Error('Unsupported Substrate genesis hash')
+  }
+
+  return chain
+}
+
+/** Substrate dApp transaction data whose chain is derived from its genesis hash. */
 export type PolkadotDappTxData = {
-  chain: OtherChain.Polkadot | OtherChain.Bittensor
+  chain: SubstrateChain
   signerPayload: PolkadotSignerPayloadJSON
 }
 
@@ -124,7 +151,12 @@ export const getCustomTxData = ({
       serialized: async ({ data, chain, params }) => {
         if (chain === OtherChain.Polkadot || chain === OtherChain.Bittensor) {
           const signerPayload = JSON.parse(data[0]) as PolkadotSignerPayloadJSON
-          return { polkadot: { chain, signerPayload } }
+          return {
+            polkadot: {
+              chain: getSubstrateChain(signerPayload.genesisHash),
+              signerPayload,
+            },
+          }
         }
 
         const publicKey = getPublicKey({

--- a/core/ui/mpc/keysign/fast/FastKeysignServerStep.tsx
+++ b/core/ui/mpc/keysign/fast/FastKeysignServerStep.tsx
@@ -96,8 +96,11 @@ export const FastKeysignServerStep: React.FC<FastKeysignServerStepProps> = ({
             })
           }
 
-          // Polkadot dApp signPayload — bypass TW, send raw payload hash
-          if (chain === OtherChain.Polkadot && keysignPayload.memo) {
+          // Substrate dApp signPayload — bypass TW, send raw payload hash
+          if (
+            isOneOf(chain, [OtherChain.Polkadot, OtherChain.Bittensor]) &&
+            keysignPayload.memo
+          ) {
             const parseResult = attempt(
               () =>
                 JSON.parse(keysignPayload.memo!) as PolkadotSignerPayloadJSON


### PR DESCRIPTION
## Summary
- resolve Substrate dApp signing chain from `signerPayload.genesisHash` rather than the injected provider selected by the dApp
- preserve Polkadot handling while correcting Bittensor payloads routed through `polkadot-js`, and reject missing or unsupported genesis hashes
- route Fast Vault Bittensor dApp signing through the existing raw Substrate signing path

## Issue
Closes #3985

## Test Plan
- `yarn test` (161 tests passed)
- `yarn workspace @clients/extension test` (400 tests passed)
- `yarn workspace @clients/desktop test:ci` (20 tests passed)
- `yarn knip` (passes; existing configuration hints only)
- `yarn check` (lint and typecheck pass; existing i18n integrity failure remains: 81 missing non-English keys unrelated to this diff)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for Substrate dApp transaction behavior, verifying correct chain routing and genesis hash validation

* **Bug Fixes**
  * Enhanced chain detection accuracy for Polkadot and Bittensor transactions based on genesis hash
  * Implemented proper error handling for missing or unsupported Substrate genesis hashes

* **New Features**
  * Extended Bittensor chain support for signing operations alongside existing Polkadot functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-windows/pull/3986?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->