### PR TITLE
feat(qbtc/dapp): add sign_and_broadcast for arbitrary Cosmos messages

### DIFF
--- a/clients/extension/src/inpage/providers/qbtc.ts
+++ b/clients/extension/src/inpage/providers/qbtc.ts
@@ -6,6 +6,10 @@ import EventEmitter from 'events'
 import { EIP1193Error } from '../../background/handlers/errorHandler'
 import { Callback } from '../constants'
 import { getSharedHandlers } from './core/sharedHandlers'
+import {
+  handleQbtcSignAndBroadcast,
+  parseSignAndBroadcastParams,
+} from './qbtcSignAndBroadcast'
 
 const mldsaRequiredMessage =
   'QBTC requires an MLDSA-enabled vault. Enable MLDSA in Vultisig Developer Options and create a new vault.'
@@ -31,8 +35,13 @@ const parseSendTransactionParams = (
  * QBTC is a post-quantum Cosmos SDK chain that signs with MLDSA-44 rather
  * than secp256k1/ed25519. This provider is the QBTC-native surface
  * (`get_accounts`, `request_accounts`, `send_transaction`,
- * `get_transaction_by_hash`) with explicit MLDSA semantics — no `algo`
- * spoofing, no Keplr signature-shape compromises.
+ * `sign_and_broadcast`, `get_transaction_by_hash`) with explicit MLDSA
+ * semantics — no `algo` spoofing, no Keplr signature-shape compromises.
+ *
+ * `send_transaction` is the legacy bank-send shortcut; new dApp flows that
+ * need to sign arbitrary Cosmos SDK messages (`MsgVote`, `MsgDelegate`,
+ * `MsgWithdrawDelegatorReward`, etc.) should use `sign_and_broadcast` —
+ * see {@link handleQbtcSignAndBroadcast} for the accepted shape.
  *
  * QBTC is also reachable via the Keplr compatibility route at chainId
  * `qbtc-testnet` for dApps that can't be modified; see `xdefiKeplr.ts`.
@@ -74,6 +83,12 @@ export class Qbtc extends EventEmitter {
       if (data.method === 'send_transaction') {
         return handlers.send_transaction(
           parseSendTransactionParams(data.params)
+        )
+      }
+
+      if (data.method === 'sign_and_broadcast') {
+        return handleQbtcSignAndBroadcast(
+          parseSignAndBroadcastParams(data.params)
         )
       }
 

--- a/clients/extension/src/inpage/providers/qbtcSignAndBroadcast.ts
+++ b/clients/extension/src/inpage/providers/qbtcSignAndBroadcast.ts
@@ -1,0 +1,177 @@
+import { callBackground } from '@core/inpage-provider/background'
+import { callPopup } from '@core/inpage-provider/popup'
+import { TransactionDetails } from '@core/inpage-provider/popup/view/resolvers/sendTx/interfaces'
+import {
+  buildQBTCDirectPayload,
+  QbtcDappCoin,
+  QbtcDappFee,
+} from '@core/ui/qbtc/dapp/buildQBTCDirectPayload'
+import {
+  encodeAnyMessage,
+  QbtcDappMessage,
+  UnsupportedQbtcMessageTypeError,
+} from '@core/ui/qbtc/dapp/encodeAnyMessage'
+import { qbtcChainId } from '@core/ui/qbtc/dapp/qbtcDirectConstants'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { getQbtcAccountInfo } from '@vultisig/core-chain/chains/cosmos/qbtc/getQbtcAccountInfo'
+
+import { EIP1193Error } from '../../background/handlers/errorHandler'
+
+type QbtcSignAndBroadcastParams = {
+  from: string
+  messages: QbtcDappMessage[]
+  memo?: string
+  fee?: QbtcDappFee
+}
+
+const isCoin = (value: unknown): value is QbtcDappCoin =>
+  !!value &&
+  typeof value === 'object' &&
+  typeof (value as QbtcDappCoin).denom === 'string' &&
+  typeof (value as QbtcDappCoin).amount === 'string'
+
+const isFee = (value: unknown): value is QbtcDappFee => {
+  if (!value || typeof value !== 'object') return false
+  const candidate = value as QbtcDappFee
+  return (
+    Array.isArray(candidate.amount) &&
+    candidate.amount.every(isCoin) &&
+    typeof candidate.gas === 'string'
+  )
+}
+
+const isMessage = (value: unknown): value is QbtcDappMessage => {
+  if (!value || typeof value !== 'object') return false
+  const candidate = value as QbtcDappMessage
+  return (
+    typeof candidate.typeUrl === 'string' &&
+    !!candidate.value &&
+    typeof candidate.value === 'object'
+  )
+}
+
+/**
+ * Validates the raw `params[0]` payload sent to
+ * `vultisig.qbtc.request({ method: 'sign_and_broadcast' })`. Returns the
+ * narrowed shape or throws an `InvalidParams` EIP-1193 error.
+ */
+export const parseSignAndBroadcastParams = (
+  params: readonly unknown[]
+): QbtcSignAndBroadcastParams => {
+  const [payload] = params
+  if (!payload || typeof payload !== 'object') {
+    throw new EIP1193Error('InvalidParams')
+  }
+  const { from, messages, memo, fee } = payload as Record<string, unknown>
+  if (typeof from !== 'string' || !from) {
+    throw new EIP1193Error('InvalidParams', 'Missing `from` address')
+  }
+  if (!Array.isArray(messages) || messages.length === 0) {
+    throw new EIP1193Error(
+      'InvalidParams',
+      '`messages` must be a non-empty array'
+    )
+  }
+  if (!messages.every(isMessage)) {
+    throw new EIP1193Error(
+      'InvalidParams',
+      'Each message must be `{ typeUrl: string, value: object }`'
+    )
+  }
+  if (memo !== undefined && typeof memo !== 'string') {
+    throw new EIP1193Error('InvalidParams', '`memo` must be a string')
+  }
+  if (fee !== undefined && !isFee(fee)) {
+    throw new EIP1193Error(
+      'InvalidParams',
+      '`fee` must be `{ amount: Coin[], gas: string }`'
+    )
+  }
+  return {
+    from,
+    messages,
+    memo,
+    fee,
+  }
+}
+
+const mldsaRequiredMessage =
+  'QBTC requires an MLDSA-enabled vault. Enable MLDSA in Vultisig Developer Options and create a new vault.'
+
+/**
+ * Implements `vultisig.qbtc.request({ method: 'sign_and_broadcast' })`.
+ *
+ * Encodes the dApp-supplied Cosmos messages, fetches the live
+ * accountNumber/sequence from the QBTC REST API, builds a SignDirect-style
+ * payload (`bodyBytes` + `authInfoBytes`), and forwards it to the existing
+ * approval popup. The MLDSA keysign pipeline signs the resulting SignDoc
+ * and assembles + broadcasts the final transaction.
+ */
+export const handleQbtcSignAndBroadcast = async (
+  params: QbtcSignAndBroadcastParams
+): Promise<string> => {
+  const { from, messages, memo, fee } = params
+
+  const { address, publicKey: hexPublicKey } = await callBackground({
+    getAccount: { chain: Chain.QBTC },
+  })
+  if (!address || !hexPublicKey) {
+    throw new EIP1193Error('Unauthorized', mldsaRequiredMessage)
+  }
+  if (address !== from) {
+    throw new EIP1193Error(
+      'Unauthorized',
+      `Connected QBTC account does not match \`from\` (${from})`
+    )
+  }
+
+  // Pre-validate typeUrls so we fail fast (4200) instead of inside the popup.
+  for (const message of messages) {
+    try {
+      encodeAnyMessage(message)
+    } catch (error) {
+      if (error instanceof UnsupportedQbtcMessageTypeError) {
+        throw new EIP1193Error('UnsupportedMethod', error.message)
+      }
+      throw error
+    }
+  }
+
+  const accountInfo = await getQbtcAccountInfo({ address: from })
+
+  const { bodyBytes, authInfoBytes } = buildQBTCDirectPayload({
+    messages,
+    memo,
+    fee,
+    hexPublicKey,
+    sequence: BigInt(accountInfo.sequence),
+  })
+
+  const transactionDetails: TransactionDetails = {
+    asset: { ticker: 'QBTC' },
+    from,
+    memo,
+    directPayload: {
+      bodyBytes,
+      authInfoBytes,
+      chainId: qbtcChainId,
+      accountNumber: String(accountInfo.accountNumber),
+    },
+  }
+
+  const [{ hash }] = await callPopup(
+    {
+      sendTx: {
+        keysign: {
+          transactionDetails,
+          chain: Chain.QBTC,
+        },
+      },
+    },
+    {
+      account: from,
+    }
+  )
+
+  return hash
+}

--- a/core/ui/mpc/keysign/action/mutations/useKeysignMutation.ts
+++ b/core/ui/mpc/keysign/action/mutations/useKeysignMutation.ts
@@ -7,7 +7,13 @@ import {
 } from '@core/ui/mpc/keysign/customMessage/chains'
 import { constructPolkadotSigningPayload } from '@core/ui/polkadot/dapp/constructSigningPayload'
 import { PolkadotSignerPayloadJSON } from '@core/ui/polkadot/dapp/PolkadotSignerPayload'
+import {
+  buildQBTCSignDoc,
+  buildQBTCSignedTxFromDirect,
+} from '@core/ui/qbtc/dapp/buildQBTCSignedTxFromDirect'
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
+import { fromBase64 } from '@cosmjs/encoding'
+import { sha256 } from '@noble/hashes/sha256'
 import { useMutation } from '@tanstack/react-query'
 import { Chain, OtherChain } from '@vultisig/core-chain/Chain'
 import { getChainKind } from '@vultisig/core-chain/ChainKind'
@@ -61,6 +67,54 @@ export const useKeysignMutation = (payload: KeysignMessagePayload) => {
 
             // QBTC uses MLDSA keys — bypass WalletCore entirely
             if (chain === 'QBTC') {
+              const signatureAlgorithm = getSignatureAlgorithm(chain)
+              const coinType = getCoinType({ walletCore, chain })
+
+              // dApp signDirect path (`sign_and_broadcast`): the payload
+              // already carries proto-encoded bodyBytes + authInfoBytes that
+              // wrap arbitrary Cosmos SDK messages. Sign the SignDoc derived
+              // from those bytes directly, then re-assemble the TxRaw — no
+              // per-typeUrl branching required.
+              if (payload.signData.case === 'signDirect') {
+                const directValue = payload.signData.value
+                const bodyBytes = fromBase64(directValue.bodyBytes)
+                const authInfoBytes = fromBase64(directValue.authInfoBytes)
+                const accountNumber = BigInt(directValue.accountNumber)
+
+                const signDoc = buildQBTCSignDoc({
+                  bodyBytes,
+                  authInfoBytes,
+                  accountNumber,
+                })
+                const hashHex = Buffer.from(sha256(signDoc)).toString('hex')
+
+                const [signature] = await keysignAction({
+                  msgs: [hashHex],
+                  signatureAlgorithm,
+                  coinType,
+                  chain,
+                })
+
+                const { serialized, transactionHash } =
+                  buildQBTCSignedTxFromDirect({
+                    bodyBytes,
+                    authInfoBytes,
+                    accountNumber,
+                    derSignature: Buffer.from(signature.der_signature, 'hex'),
+                  })
+
+                const tx: Tx = {
+                  hash: transactionHash,
+                  data: deserializeSigningOutput(chain, { serialized }),
+                }
+
+                if (!payload.skipBroadcast) {
+                  await broadcastTx({ chain, tx: tx.data })
+                }
+
+                return { txs: [tx] }
+              }
+
               const cosmosSpecific = getBlockchainSpecificValue(
                 payload.blockchainSpecific,
                 'cosmosSpecific'
@@ -71,8 +125,6 @@ export const useKeysignMutation = (payload: KeysignMessagePayload) => {
                 cosmosSpecific,
               }).map(bytes => Buffer.from(bytes).toString('hex'))
 
-              const signatureAlgorithm = getSignatureAlgorithm(chain)
-              const coinType = getCoinType({ walletCore, chain })
               const signatures = await keysignAction({
                 msgs,
                 signatureAlgorithm,

--- a/core/ui/mpc/keysign/fast/FastKeysignServerStep.tsx
+++ b/core/ui/mpc/keysign/fast/FastKeysignServerStep.tsx
@@ -7,10 +7,13 @@ import { useMpcSessionId } from '@core/ui/mpc/state/mpcSession'
 import { useCoreViewState } from '@core/ui/navigation/hooks/useCoreViewState'
 import { constructPolkadotSigningPayload } from '@core/ui/polkadot/dapp/constructSigningPayload'
 import { PolkadotSignerPayloadJSON } from '@core/ui/polkadot/dapp/PolkadotSignerPayload'
+import { buildQBTCSignDoc } from '@core/ui/qbtc/dapp/buildQBTCSignedTxFromDirect'
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
+import { fromBase64 } from '@cosmjs/encoding'
 import { PageHeader } from '@lib/ui/page/PageHeader'
 import { OnFinishProp } from '@lib/ui/props'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
+import { sha256 } from '@noble/hashes/sha256'
 import { useMutation } from '@tanstack/react-query'
 import { Chain, OtherChain } from '@vultisig/core-chain/Chain'
 import { getCoinType } from '@vultisig/core-chain/coin/coinType'
@@ -72,14 +75,32 @@ export const FastKeysignServerStep: React.FC<FastKeysignServerStepProps> = ({
           // QBTC uses MLDSA — bypass WalletCore pubkey derivation and
           // build messages directly from the manual protobuf helper.
           if (chain === Chain.QBTC) {
-            const cosmosSpecific = getBlockchainSpecificValue(
-              keysignPayload.blockchainSpecific,
-              'cosmosSpecific'
-            )
-            const messages = getQBTCPreSignedImageHash({
-              keysignPayload,
-              cosmosSpecific,
-            }).map(bytes => Buffer.from(bytes).toString('hex'))
+            // dApp `sign_and_broadcast` carries arbitrary Cosmos messages via
+            // `signDirect`; the SignDoc hash must match what
+            // `useKeysignMutation` computes for the same payload, otherwise
+            // the Fast Vault server registers a different message_id and the
+            // client poll never resolves.
+            const messages =
+              keysignPayload.signData.case === 'signDirect'
+                ? (() => {
+                    const directValue = keysignPayload.signData.value
+                    const bodyBytes = fromBase64(directValue.bodyBytes)
+                    const authInfoBytes = fromBase64(directValue.authInfoBytes)
+                    const accountNumber = BigInt(directValue.accountNumber)
+                    const signDoc = buildQBTCSignDoc({
+                      bodyBytes,
+                      authInfoBytes,
+                      accountNumber,
+                    })
+                    return [Buffer.from(sha256(signDoc)).toString('hex')]
+                  })()
+                : getQBTCPreSignedImageHash({
+                    keysignPayload,
+                    cosmosSpecific: getBlockchainSpecificValue(
+                      keysignPayload.blockchainSpecific,
+                      'cosmosSpecific'
+                    ),
+                  }).map(bytes => Buffer.from(bytes).toString('hex'))
 
             return signWithServer({
               public_key: publicKeys.ecdsa,

--- a/core/ui/qbtc/dapp/buildQBTCDirectPayload.ts
+++ b/core/ui/qbtc/dapp/buildQBTCDirectPayload.ts
@@ -1,0 +1,120 @@
+import {
+  concatBytes,
+  protoBytes,
+  protoString,
+  protoVarint,
+} from '@vultisig/core-chain/chains/cosmos/protoEncoding'
+
+import { encodeAnyMessage, QbtcDappMessage } from './encodeAnyMessage'
+import {
+  qbtcDefaultFeeAmount,
+  qbtcDefaultGasLimit,
+  qbtcFeeDenom,
+  qbtcMldsaPubKeyTypeUrl,
+} from './qbtcDirectConstants'
+
+export type QbtcDappCoin = {
+  denom: string
+  amount: string
+}
+
+export type QbtcDappFee = {
+  amount: QbtcDappCoin[]
+  gas: string
+}
+
+type BuildQBTCDirectPayloadInput = {
+  messages: QbtcDappMessage[]
+  memo?: string
+  fee?: QbtcDappFee
+  /** Vault's MLDSA public key, hex-encoded (no `0x` prefix). */
+  hexPublicKey: string
+  sequence: bigint
+}
+
+type QbtcDirectPayloadBytes = {
+  /** Base64-encoded TxBody bytes used as `signDirect.bodyBytes`. */
+  bodyBytes: string
+  /** Base64-encoded AuthInfo bytes used as `signDirect.authInfoBytes`. */
+  authInfoBytes: string
+}
+
+const buildTxBody = ({
+  messages,
+  memo,
+}: {
+  messages: QbtcDappMessage[]
+  memo?: string
+}): Uint8Array =>
+  concatBytes(
+    ...messages.map(message => protoBytes(1, encodeAnyMessage(message))),
+    memo ? protoString(2, memo) : new Uint8Array(0)
+  )
+
+const buildFee = (fee?: QbtcDappFee) => {
+  const feeCoins = fee?.amount.length
+    ? fee.amount
+    : [{ denom: qbtcFeeDenom, amount: qbtcDefaultFeeAmount }]
+  const gasLimit = fee?.gas ? BigInt(fee.gas) : qbtcDefaultGasLimit
+  return {
+    feeCoins,
+    gasLimit,
+  }
+}
+
+const buildAuthInfo = ({
+  hexPublicKey,
+  sequence,
+  fee,
+}: {
+  hexPublicKey: string
+  sequence: bigint
+  fee?: QbtcDappFee
+}): Uint8Array => {
+  const pubKeyData = Buffer.from(hexPublicKey, 'hex')
+  const pubKeyMsg = protoBytes(1, pubKeyData)
+  const pubKeyAny = concatBytes(
+    protoString(1, qbtcMldsaPubKeyTypeUrl),
+    protoBytes(2, pubKeyMsg)
+  )
+
+  const singleMode = protoVarint(1, 1n)
+  const modeInfo = protoBytes(1, singleMode)
+  const signerInfo = concatBytes(
+    protoBytes(1, pubKeyAny),
+    protoBytes(2, modeInfo),
+    protoVarint(3, sequence)
+  )
+
+  const { feeCoins, gasLimit } = buildFee(fee)
+  const feeCoinBytes = feeCoins.map(coin =>
+    protoBytes(
+      1,
+      concatBytes(protoString(1, coin.denom), protoString(2, coin.amount))
+    )
+  )
+
+  const feeBytes = concatBytes(...feeCoinBytes, protoVarint(2, gasLimit))
+
+  return concatBytes(protoBytes(1, signerInfo), protoBytes(2, feeBytes))
+}
+
+/**
+ * Builds the `bodyBytes` + `authInfoBytes` used in a Cosmos `SignDoc` for QBTC.
+ * Returned as base64 strings because `SignDirect`'s proto schema stores them
+ * that way and `applyCosmosFeeFromSignData` re-decodes via `fromBase64`.
+ */
+export const buildQBTCDirectPayload = ({
+  messages,
+  memo,
+  fee,
+  hexPublicKey,
+  sequence,
+}: BuildQBTCDirectPayloadInput): QbtcDirectPayloadBytes => {
+  const bodyBytes = buildTxBody({ messages, memo })
+  const authInfoBytes = buildAuthInfo({ hexPublicKey, sequence, fee })
+  return {
+    bodyBytes: Buffer.from(bodyBytes).toString('base64'),
+    authInfoBytes: Buffer.from(authInfoBytes).toString('base64'),
+  }
+}

--- a/core/ui/qbtc/dapp/buildQBTCSignedTxFromDirect.ts
+++ b/core/ui/qbtc/dapp/buildQBTCSignedTxFromDirect.ts
@@ -1,0 +1,62 @@
+import { sha256 } from '@noble/hashes/sha256'
+import {
+  concatBytes,
+  protoBytes,
+  protoString,
+  protoVarint,
+} from '@vultisig/core-chain/chains/cosmos/protoEncoding'
+
+import { qbtcChainId } from './qbtcDirectConstants'
+
+type BuildQBTCSignDocInput = {
+  bodyBytes: Uint8Array
+  authInfoBytes: Uint8Array
+  accountNumber: bigint
+}
+
+/**
+ * Cosmos `SignDoc` for QBTC. Field layout matches the SDK's QBTCHelper.ts
+ * so cross-device cosigning produces identical hashes.
+ */
+export const buildQBTCSignDoc = ({
+  bodyBytes,
+  authInfoBytes,
+  accountNumber,
+}: BuildQBTCSignDocInput): Uint8Array =>
+  concatBytes(
+    protoBytes(1, bodyBytes),
+    protoBytes(2, authInfoBytes),
+    protoString(3, qbtcChainId),
+    protoVarint(4, accountNumber)
+  )
+
+type BuildQBTCSignedTxFromDirectInput = BuildQBTCSignDocInput & {
+  /** DER-encoded MLDSA signature returned by the keysign action. */
+  derSignature: Uint8Array
+}
+
+/**
+ * Assembles the broadcast-ready `TxRaw` and its hash for QBTC, given the
+ * pre-computed `bodyBytes` + `authInfoBytes` from the dApp's signDirect
+ * payload and the MLDSA signature produced by the keysign pipeline.
+ */
+export const buildQBTCSignedTxFromDirect = ({
+  bodyBytes,
+  authInfoBytes,
+  derSignature,
+}: BuildQBTCSignedTxFromDirectInput) => {
+  const txRaw = concatBytes(
+    protoBytes(1, bodyBytes),
+    protoBytes(2, authInfoBytes),
+    protoBytes(3, derSignature)
+  )
+  const txBytesBase64 = Buffer.from(txRaw).toString('base64')
+  const serialized = JSON.stringify({
+    tx_bytes: txBytesBase64,
+    mode: 'BROADCAST_MODE_SYNC',
+  })
+  const transactionHash = Buffer.from(sha256(txRaw))
+    .toString('hex')
+    .toUpperCase()
+  return { serialized, transactionHash }
+}

--- a/core/ui/qbtc/dapp/encodeAnyMessage.ts
+++ b/core/ui/qbtc/dapp/encodeAnyMessage.ts
@@ -1,0 +1,44 @@
+import {
+  concatBytes,
+  protoBytes,
+  protoString,
+} from '@vultisig/core-chain/chains/cosmos/protoEncoding'
+
+import { getQbtcMessageEncoder } from './messageRegistry'
+
+export type QbtcDappMessage = {
+  typeUrl: string
+  value: Record<string, unknown>
+}
+
+/**
+ * Thrown when the dApp supplies a `typeUrl` that the QBTC provider does not
+ * know how to proto-encode. Maps to the 4200 EIP-1193 error in `qbtc.ts`.
+ */
+export class UnsupportedQbtcMessageTypeError extends Error {
+  readonly typeUrl: string
+
+  constructor(typeUrl: string) {
+    super(`QBTC provider does not support message type: ${typeUrl}`)
+    this.typeUrl = typeUrl
+    this.name = 'UnsupportedQbtcMessageTypeError'
+  }
+}
+
+/**
+ * Encodes a Cosmos SDK message as a protobuf `Any` (`{ type_url, value }`).
+ * The dApp passes camelCase JSON values; `fromPartial` from `cosmjs-types`
+ * normalises them to the proto shape before `encode().finish()` serialises
+ * to canonical bytes.
+ */
+export const encodeAnyMessage = ({
+  typeUrl,
+  value,
+}: QbtcDappMessage): Uint8Array => {
+  const encoder = getQbtcMessageEncoder(typeUrl)
+  if (!encoder) {
+    throw new UnsupportedQbtcMessageTypeError(typeUrl)
+  }
+  const messageBytes = encoder(value)
+  return concatBytes(protoString(1, typeUrl), protoBytes(2, messageBytes))
+}

--- a/core/ui/qbtc/dapp/messageRegistry.ts
+++ b/core/ui/qbtc/dapp/messageRegistry.ts
@@ -1,0 +1,74 @@
+import { MsgSend } from 'cosmjs-types/cosmos/bank/v1beta1/tx'
+import {
+  MsgFundCommunityPool,
+  MsgSetWithdrawAddress,
+  MsgWithdrawDelegatorReward,
+  MsgWithdrawValidatorCommission,
+} from 'cosmjs-types/cosmos/distribution/v1beta1/tx'
+import {
+  MsgDeposit as MsgDepositV1,
+  MsgVote as MsgVoteV1,
+  MsgVoteWeighted as MsgVoteWeightedV1,
+} from 'cosmjs-types/cosmos/gov/v1/tx'
+import {
+  MsgDeposit as MsgDepositV1Beta1,
+  MsgVote as MsgVoteV1Beta1,
+  MsgVoteWeighted as MsgVoteWeightedV1Beta1,
+} from 'cosmjs-types/cosmos/gov/v1beta1/tx'
+import {
+  MsgBeginRedelegate,
+  MsgDelegate,
+  MsgUndelegate,
+} from 'cosmjs-types/cosmos/staking/v1beta1/tx'
+import { MsgTransfer } from 'cosmjs-types/ibc/applications/transfer/v1/tx'
+
+type CosmosMessageProtoEncoder = (value: Record<string, unknown>) => Uint8Array
+
+/**
+ * Shape exposed by every message constant in `cosmjs-types`. Generics are
+ * collapsed to `any` because each constant carries a different proto shape;
+ * the per-type safety lives at the dApp boundary where `fromPartial` accepts
+ * the JSON value as-is.
+ */
+type CosmjsMessageCodec<T> = {
+  fromPartial: (value: any) => T
+  encode: (message: T) => { finish: () => Uint8Array }
+}
+
+const fromCodec =
+  <T>(codec: CosmjsMessageCodec<T>): CosmosMessageProtoEncoder =>
+  value =>
+    codec.encode(codec.fromPartial(value)).finish()
+
+/**
+ * TypeUrls accepted by `vultisig.qbtc.request({ method: 'sign_and_broadcast' })`.
+ * Add new entries here as more Cosmos SDK message types are wired up by dApps.
+ */
+const qbtcMessageEncoders: Record<string, CosmosMessageProtoEncoder> = {
+  '/cosmos.bank.v1beta1.MsgSend': fromCodec(MsgSend),
+  '/cosmos.gov.v1.MsgVote': fromCodec(MsgVoteV1),
+  '/cosmos.gov.v1.MsgVoteWeighted': fromCodec(MsgVoteWeightedV1),
+  '/cosmos.gov.v1.MsgDeposit': fromCodec(MsgDepositV1),
+  '/cosmos.gov.v1beta1.MsgVote': fromCodec(MsgVoteV1Beta1),
+  '/cosmos.gov.v1beta1.MsgVoteWeighted': fromCodec(MsgVoteWeightedV1Beta1),
+  '/cosmos.gov.v1beta1.MsgDeposit': fromCodec(MsgDepositV1Beta1),
+  '/cosmos.staking.v1beta1.MsgDelegate': fromCodec(MsgDelegate),
+  '/cosmos.staking.v1beta1.MsgUndelegate': fromCodec(MsgUndelegate),
+  '/cosmos.staking.v1beta1.MsgBeginRedelegate': fromCodec(MsgBeginRedelegate),
+  '/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward': fromCodec(
+    MsgWithdrawDelegatorReward
+  ),
+  '/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission': fromCodec(
+    MsgWithdrawValidatorCommission
+  ),
+  '/cosmos.distribution.v1beta1.MsgSetWithdrawAddress': fromCodec(
+    MsgSetWithdrawAddress
+  ),
+  '/cosmos.distribution.v1beta1.MsgFundCommunityPool':
+    fromCodec(MsgFundCommunityPool),
+  '/ibc.applications.transfer.v1.MsgTransfer': fromCodec(MsgTransfer),
+}
+
+export const getQbtcMessageEncoder = (
+  typeUrl: string
+): CosmosMessageProtoEncoder | undefined => qbtcMessageEncoders[typeUrl]

--- a/core/ui/qbtc/dapp/qbtcDirectConstants.ts
+++ b/core/ui/qbtc/dapp/qbtcDirectConstants.ts
@@ -1,0 +1,21 @@
+/**
+ * QBTC chain constants used when building Cosmos transactions for the
+ * `sign_and_broadcast` dApp method. Values mirror the SDK's QBTCHelper.ts.
+ */
+
+/** Cosmos SDK chain ID used in the SignDoc. */
+export const qbtcChainId = 'qbtc-testnet'
+
+/** Native fee denom for QBTC. */
+export const qbtcFeeDenom = 'qbtc'
+
+/** Type URL for the QBTC MLDSA public-key Any. */
+export const qbtcMldsaPubKeyTypeUrl = '/cosmos.crypto.mldsa.PubKey'
+
+/**
+ * Default fee for QBTC transactions when the dApp does not supply one.
+ * QBTC enforces a flat `min_tx_fee` of 800 uqbtc; gas_limit is informational
+ * but kept at the SDK helper's default of 300_000 for parity.
+ */
+export const qbtcDefaultFeeAmount = '800'
+export const qbtcDefaultGasLimit = 300000n


### PR DESCRIPTION
## Summary

- Adds `window.vultisig.qbtc.request({ method: 'sign_and_broadcast', ... })` — a generic Cosmos message signer that accepts `Array<{ typeUrl, value }>` and broadcasts a single TxRaw via the existing ML-DSA-44 keysign pipeline.
- Unblocks the qbtc-explorer governance flows (`MsgVote`, `MsgDelegate`, `MsgWithdrawDelegatorReward`, etc.) that the legacy `send_transaction` (hardcoded to `MsgSend`) could not handle.
- Routes through `signDirect` so the approval popup, Fast Vault server, and keysign mutation all agree on the same `message_id`. `send_transaction` is untouched.

Closes #3992

## What's new

| File | Purpose |
|---|---|
| `core/ui/qbtc/dapp/qbtcDirectConstants.ts` | chain ID, fee denom, MLDSA pubkey type URL, default fee/gas |
| `core/ui/qbtc/dapp/messageRegistry.ts` | `typeUrl → cosmjs-types` encoder lookup for known Cosmos SDK messages (gov v1/v1beta1, staking, distribution, IBC transfer, bank) |
| `core/ui/qbtc/dapp/encodeAnyMessage.ts` | `{ typeUrl, value }` → protobuf `Any` bytes; throws `UnsupportedQbtcMessageTypeError` for unregistered typeUrls |
| `core/ui/qbtc/dapp/buildQBTCDirectPayload.ts` | proto-encodes `TxBody` (messages + memo) + `AuthInfo` (MLDSA signer info + fee), returns base64 for `SignDirect` |
| `core/ui/qbtc/dapp/buildQBTCSignedTxFromDirect.ts` | `buildQBTCSignDoc` + `buildQBTCSignedTxFromDirect` (TxRaw + hash) used by the keysign mutation and Fast Vault step |
| `clients/extension/src/inpage/providers/qbtcSignAndBroadcast.ts` | input validation, account/pubkey resolution, accountNumber/sequence fetch, `callPopup` with `directPayload` |

## What's modified

- `clients/extension/src/inpage/providers/qbtc.ts` — routes the new `sign_and_broadcast` method to the handler; jsdoc updated.
- `core/ui/mpc/keysign/action/mutations/useKeysignMutation.ts` — QBTC branch detects `signData.case === 'signDirect'` and derives the SignDoc + TxRaw from the dApp-supplied bytes; legacy `getQBTCPreSignedImageHash` path preserved for `send_transaction`.
- `core/ui/mpc/keysign/fast/FastKeysignServerStep.tsx` — mirrors the same `signDirect` short-circuit so the Fast Vault server receives a `message_id` matching what the client signs. Without this, the client polls indefinitely for a session the server never registered.

## API

```ts
window.vultisig.qbtc.request({
  method: 'sign_and_broadcast',
  params: [{
    from: string,
    messages: Array<{ typeUrl: string; value: Record<string, any> }>,
    memo?: string,
    fee?: { amount: { denom: string; amount: string }[]; gas: string },
  }]
}): Promise<string>
```

### Error codes (EIP-1193)

| Code | Cause |
|---|---|
| `-32602` | Invalid params shape |
| `4001` | User rejected approval |
| `4100` | Vault has no MLDSA key |
| `4200` | Unsupported message `typeUrl` (gated by registry) |

## Why `signDirect` routing

The dApp's messages get proto-encoded in the handler → bytes flow through `TransactionDetails.directPayload` → `buildSendTxKeysignPayload` routes them as `signData.case === 'signDirect'`. The existing approval popup already decodes `TxBody.messages` for `signDirect` (see `getSignDataTxAction.ts`), so the user sees the typeUrl list, memo, and fee without any new UI code. `applyCosmosFeeFromSignData` reconciles the displayed network fee with the AuthInfo we signed.

## Out of scope

- **SDK**: no changes. The feature uses already-exported helpers from `@vultisig/core-chain` (`protoEncoding`, `getQbtcAccountInfo`) and `cosmjs-types` (already a dependency).
- **iOS/Android parity**: separate native effort. The SignDoc bytes here are canonical Cosmos wire format, so a matching native impl will produce identical hashes — cross-device cosigning will work once natives ship.
- **Migrating `send_transaction`**: kept as the legacy `MsgSend` shortcut.

## Validation

- `yarn typecheck` ✓
- `yarn lint` ✓
- `yarn knip` ✓
- `yarn test` — 164/164 ✓
- Manual: voted on a proposal via `qbtc-explorer` MsgVote modal against a Fast Vault on QBTC localnet — approval popup rendered the decoded MsgVote, MLDSA Fast Sign completed, broadcast returned tx hash, voter recorded on chain.

## Test plan

- [ ] `yarn check:all` succeeds
- [ ] Build extension, load in Chrome, connect Fast Vault with MLDSA enabled
- [ ] Open qbtc-explorer (or call `window.vultisig.qbtc.request(...)` from devtools) → vote on a proposal → approval popup shows `qbtc-testnet` chain ID, accountNumber, sequence, decoded MsgVote, default 800 uqbtc fee
- [ ] Click Fast Sign → tx hash returned to dApp, tx visible on the QBTC node
- [ ] Repeat for `MsgDelegate` and `MsgWithdrawDelegatorReward` to confirm message-agnostic encoding
- [ ] `send_transaction` MsgSend regression: send native QBTC from another dApp → still works as before
- [ ] Unknown typeUrl rejects with code 4200 before popup
- [ ] Invalid params rejects with code -32602 before popup
- [ ] Vault without MLDSA key rejects with code 4100

## Cross-repo reference

The explorer-side stub waiting for this lives at `src/components/QbtcTxDialog.vue` (~155-169) in `Ehsan-saradar/qbtc-explorer`. Once merged, that stub becomes a ~5-line `provider.request(...)` call reusing the same `txHash`/success-view path that `send_transaction` already drives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `sign_and_broadcast` support for QBTC transactions, enabling direct signing and broadcasting of Cosmos SDK operations including voting, delegation, and reward withdrawal.
  * Enhanced parameter validation and comprehensive error handling to improve transaction reliability and user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-windows/pull/3993?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->