### PR TITLE
fix(extension/build): use relative icon import in brand config

### DIFF
--- a/clients/extension/src/brand/extensionBrandConfig.ts
+++ b/clients/extension/src/brand/extensionBrandConfig.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
-import vultisigIconDataUri from '@clients/extension/src/inpage/icon'
+import vultisigIconDataUri from '../inpage/icon'
 
 export type ExtensionProductBrand = 'vultisig' | 'station'
 


### PR DESCRIPTION
## Summary
- `vite.config.ts` imports `src/brand/extensionBrandConfig.ts`, which used a workspace self-import (`@clients/extension/src/inpage/icon`). esbuild externalizes that bare specifier when bundling the Vite config; Node then resolves through the `@clients/extension` workspace link (no `exports`, `type: "module"`) and tries to load `icon.ts` directly, failing with `ERR_UNKNOWN_FILE_EXTENSION` and aborting the extension build before `build:app` runs. Regression from #3967.
- Use a relative import (`../inpage/icon`) so esbuild inlines the icon into the bundled config. No runtime change — both specifiers resolve to the same file.

Closes #3996

## Test plan
- [x] `yarn build:extension` succeeds end-to-end locally
- [ ] CI green
- [ ] Vultisig brand assertion still passes (`Extension brand assertion passed for vultisig.`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated import paths for improved code organization in the browser extension.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-windows/pull/3997?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->