### PR TITLE
Add Station migration review shell

### DIFF
--- a/clients/extension/src/components/settings/StationMigrationSettingsEntry.tsx
+++ b/clients/extension/src/components/settings/StationMigrationSettingsEntry.tsx
@@ -1,0 +1,40 @@
+import { currentProductBrand } from '@core/ui/product/brand'
+import { ListItem } from '@lib/ui/list/item'
+import { useNavigate } from '@lib/ui/navigation/hooks/useNavigate'
+import { useTranslation } from 'react-i18next'
+
+import { AppView } from '../../navigation/AppView'
+import { shouldShowStationLegacyMigration } from '../../pages/station-migration/stationLegacyMigrationGate'
+import { StationMigrationListItemIcon } from '../../pages/station-migration/StationMigrationListItemIcon'
+import { useStationLegacyWalletStorageClassification } from '../../storage/useStationLegacyWalletStorageClassification'
+
+export const StationMigrationSettingsEntry = () => {
+  const { t } = useTranslation()
+  const navigate = useNavigate<AppView>()
+  const isStationBrand = currentProductBrand === 'station'
+  const classification = useStationLegacyWalletStorageClassification({
+    enabled: isStationBrand,
+  })
+
+  if (
+    !shouldShowStationLegacyMigration({
+      classification,
+      productBrand: currentProductBrand,
+    })
+  ) {
+    return null
+  }
+
+  return (
+    <ListItem
+      data-testid="station-migration-settings-link"
+      icon={<StationMigrationListItemIcon />}
+      onClick={() =>
+        navigate({ id: 'stationMigration', state: { source: 'settings' } })
+      }
+      title={t('station_migration_settings_title')}
+      description={t('station_migration_settings_description')}
+      showArrow
+    />
+  )
+}

--- a/clients/extension/src/navigation/AppView.ts
+++ b/clients/extension/src/navigation/AppView.ts
@@ -1,5 +1,9 @@
 import { CoreView } from '@core/ui/navigation/CoreView'
 
-export type AppView = CoreView | { id: 'onboarding' } | { id: 'connectedDapps' }
+export type AppView =
+  | CoreView
+  | { id: 'onboarding' }
+  | { id: 'connectedDapps' }
+  | { id: 'stationMigration'; state?: { source?: 'setup' | 'settings' } }
 
 export type AppViewId = AppView['id']

--- a/clients/extension/src/navigation/views.tsx
+++ b/clients/extension/src/navigation/views.tsx
@@ -7,6 +7,7 @@ import { ReshareFastVault } from '@clients/extension/src/components/settings/res
 import { ReshareSecureVault } from '@clients/extension/src/components/settings/reshare/ReshareSecureVault'
 import { SingleKeygenFastVault } from '@clients/extension/src/components/settings/singleKeygen/SingleKeygenFastVault'
 import { SingleKeygenSecureVault } from '@clients/extension/src/components/settings/singleKeygen/SingleKeygenSecureVault'
+import { StationMigrationSettingsEntry } from '@clients/extension/src/components/settings/StationMigrationSettingsEntry'
 import { SetupFastVaultPage } from '@clients/extension/src/components/setup/SetupFastVaultPage'
 import { SetupSecureVaultPage } from '@clients/extension/src/components/setup/SetupSecureVaultPage'
 import { JoinKeygenPage } from '@clients/extension/src/mpc/keygen/join/JoinKeygenPage'
@@ -14,6 +15,7 @@ import { JoinKeysignPage } from '@clients/extension/src/mpc/keysign/join/JoinKey
 import { AppViewId } from '@clients/extension/src/navigation/AppView'
 import { ConnectedDappsPage } from '@clients/extension/src/pages/connected-dapps'
 import { SetupVaultPageController } from '@clients/extension/src/pages/setup-vault/SetupVaultPageController'
+import { StationMigrationPage } from '@clients/extension/src/pages/station-migration/StationMigrationPage'
 import { StartKeysignView } from '@core/extension/keysign/start/StartKeysignView'
 import { SharedViewId, sharedViews } from '@core/ui/navigation/sharedViews'
 import { OnboardingPage } from '@core/ui/onboarding/components/OnboardingPage'
@@ -25,6 +27,7 @@ import { ImportVaultPage } from '@core/ui/vault/import/components/ImportVaultPag
 import { ImportSeedphrasePage } from '@core/ui/vault/import/seedphrase/ImportSeedphrasePage'
 import { VaultPage } from '@core/ui/vault/page/components/VaultPage'
 import { useNavigate } from '@lib/ui/navigation/hooks/useNavigate'
+import { useViewState } from '@lib/ui/navigation/hooks/useViewState'
 import { Views } from '@lib/ui/navigation/Views'
 import { useEffect } from 'react'
 
@@ -53,6 +56,12 @@ const ExtensionVaultPage = () => {
   )
 }
 
+const StationMigrationRoute = () => {
+  const [state] = useViewState<{ source?: 'setup' | 'settings' } | undefined>()
+
+  return <StationMigrationPage source={state?.source} />
+}
+
 const appCustomViews: Views<Exclude<AppViewId, SharedViewId>> = {
   connectedDapps: ConnectedDappsPage,
   importSeedphrase: ImportSeedphrasePage,
@@ -79,6 +88,7 @@ const appCustomViews: Views<Exclude<AppViewId, SharedViewId>> = {
     <SettingsPage
       insiderOptions={<ExtensionDeveloperOptions />}
       prioritize={<Prioritize />}
+      stationMigration={<StationMigrationSettingsEntry />}
       expandView={<ExpandView />}
       sidePanel={<ManageSidePanel />}
     />
@@ -92,6 +102,7 @@ const appCustomViews: Views<Exclude<AppViewId, SharedViewId>> = {
       </ResponsivenessProvider>
     </ExpandViewGuard>
   ),
+  stationMigration: StationMigrationRoute,
 }
 
 const extensionSharedViewOverrides: Pick<

--- a/clients/extension/src/pages/setup-vault/SetupVaultPageController.tsx
+++ b/clients/extension/src/pages/setup-vault/SetupVaultPageController.tsx
@@ -1,3 +1,34 @@
+import { shouldShowStationLegacyMigration } from '@clients/extension/src/pages/station-migration/stationLegacyMigrationGate'
+import { StationMigrationPage } from '@clients/extension/src/pages/station-migration/StationMigrationPage'
+import { useStationLegacyWalletStorageClassification } from '@clients/extension/src/storage/useStationLegacyWalletStorageClassification'
+import { useCoreViewState } from '@core/ui/navigation/hooks/useCoreViewState'
+import { currentProductBrand } from '@core/ui/product/brand'
 import { SetupVaultPage } from '@core/ui/vault/create/setup-vault'
+import { useState } from 'react'
 
-export const SetupVaultPageController = () => <SetupVaultPage />
+export const SetupVaultPageController = () => {
+  const [state] = useCoreViewState<'setupVault'>()
+  const [hasSkippedMigration, setHasSkippedMigration] = useState(false)
+  const isStationBrand = currentProductBrand === 'station'
+  const classification = useStationLegacyWalletStorageClassification({
+    enabled: isStationBrand,
+  })
+  const skipMigration = hasSkippedMigration || state?.skipStationMigration
+
+  if (
+    shouldShowStationLegacyMigration({
+      classification,
+      productBrand: currentProductBrand,
+      skip: skipMigration,
+    })
+  ) {
+    return (
+      <StationMigrationPage
+        source="setup"
+        onSkip={() => setHasSkippedMigration(true)}
+      />
+    )
+  }
+
+  return <SetupVaultPage />
+}

--- a/clients/extension/src/pages/station-migration/StationMigrationListItemIcon.tsx
+++ b/clients/extension/src/pages/station-migration/StationMigrationListItemIcon.tsx
@@ -1,0 +1,15 @@
+import { IconWrapper } from '@lib/ui/icons/IconWrapper'
+import { WalletIcon } from '@lib/ui/icons/WalletIcon'
+import { getColor } from '@lib/ui/theme/getters'
+import styled from 'styled-components'
+
+export const StationMigrationListItemIcon = () => (
+  <ListItemIconWrapper>
+    <WalletIcon />
+  </ListItemIconWrapper>
+)
+
+const ListItemIconWrapper = styled(IconWrapper)`
+  font-size: 20px;
+  color: ${getColor('primaryAlt')};
+`

--- a/clients/extension/src/pages/station-migration/StationMigrationPage.tsx
+++ b/clients/extension/src/pages/station-migration/StationMigrationPage.tsx
@@ -1,0 +1,348 @@
+import {
+  StationLegacyWalletClassification,
+  StationLegacyWalletStatus,
+} from '@clients/extension/src/storage/stationLegacyWalletClassifier'
+import { useStationLegacyWalletStorageClassification } from '@clients/extension/src/storage/useStationLegacyWalletStorageClassification'
+import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
+import { currentProductBrand } from '@core/ui/product/brand'
+import { Button } from '@lib/ui/buttons/Button'
+import { HStack, VStack } from '@lib/ui/layout/Stack'
+import { ListItem } from '@lib/ui/list/item'
+import { useNavigate } from '@lib/ui/navigation/hooks/useNavigate'
+import { useNavigateBack } from '@lib/ui/navigation/hooks/useNavigateBack'
+import { PageContent } from '@lib/ui/page/PageContent'
+import { PageFooter } from '@lib/ui/page/PageFooter'
+import { PageHeader } from '@lib/ui/page/PageHeader'
+import { Panel } from '@lib/ui/panel/Panel'
+import { Text, TextColor } from '@lib/ui/text'
+import { getColor } from '@lib/ui/theme/getters'
+import { TFunction } from 'i18next'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+
+import { AppView } from '../../navigation/AppView'
+import { shouldShowStationLegacyMigration } from './stationLegacyMigrationGate'
+
+type StationMigrationPageSource = 'setup' | 'settings'
+
+type Props = {
+  onSkip?: () => void
+  source?: StationMigrationPageSource
+}
+
+const walletStatusColor: Record<StationLegacyWalletStatus, TextColor> = {
+  supported: 'success',
+  reconnect: 'warning',
+  unsupported: 'shy',
+  corrupt: 'danger',
+}
+
+export const StationMigrationPage = ({ onSkip, source = 'setup' }: Props) => {
+  const { t } = useTranslation()
+  const navigate = useNavigate<AppView>()
+  const goBack = useNavigateBack()
+  const isStationBrand = currentProductBrand === 'station'
+  const classification = useStationLegacyWalletStorageClassification({
+    enabled: isStationBrand,
+  })
+  const wallets = classification.wallets
+
+  const shouldShowMigration = shouldShowStationLegacyMigration({
+    classification,
+    productBrand: currentProductBrand,
+  })
+
+  const handleSkip = () => {
+    if (onSkip) {
+      onSkip()
+      return
+    }
+
+    navigate(
+      source === 'settings'
+        ? { id: 'settings' }
+        : { id: 'setupVault', state: { skipStationMigration: true } },
+      { replace: true }
+    )
+  }
+
+  const skipLabel =
+    source === 'settings'
+      ? t('skip_for_now')
+      : t('station_migration_set_up_without_migrating')
+
+  return (
+    <VStack fullHeight>
+      <PageHeader
+        primaryControls={<PageHeaderBackButton onClick={goBack} />}
+        title={t('station_migration_title')}
+        hasBorder
+      />
+      <PageContent gap={20} flexGrow scrollable>
+        <VStack gap={8}>
+          <Text color="contrast" weight={600} size={22} height={1.2}>
+            {t('station_migration_review_title')}
+          </Text>
+          <Text color="shy" size={14} height={1.5}>
+            {t('station_migration_review_description')}
+          </Text>
+        </VStack>
+
+        {shouldShowMigration ? (
+          <>
+            <MigrationSummary wallets={wallets} />
+            <Panel withSections data-testid="station-migration-wallet-list">
+              {wallets.map(wallet => (
+                <StationMigrationWalletItem
+                  key={`${wallet.storageKey}-${wallet.storageIndex ?? 'storage'}`}
+                  wallet={wallet}
+                />
+              ))}
+            </Panel>
+          </>
+        ) : (
+          <Panel data-testid="station-migration-empty-state">
+            <Text color="shy" size={14} height={1.5}>
+              {t('station_migration_no_wallets_found')}
+            </Text>
+          </Panel>
+        )}
+      </PageContent>
+      <PageFooter>
+        <Button kind="secondary" onClick={handleSkip}>
+          {skipLabel}
+        </Button>
+      </PageFooter>
+    </VStack>
+  )
+}
+
+const MigrationSummary = ({
+  wallets,
+}: {
+  wallets: StationLegacyWalletClassification[]
+}) => {
+  const { t } = useTranslation()
+  const supportedCount = wallets.filter(
+    wallet => wallet.status === 'supported'
+  ).length
+  const reconnectCount = wallets.filter(
+    wallet => wallet.status === 'reconnect'
+  ).length
+  const unsupportedCount = wallets.filter(
+    wallet => wallet.status === 'unsupported'
+  ).length
+  const corruptCount = wallets.filter(
+    wallet => wallet.status === 'corrupt'
+  ).length
+
+  return (
+    <SummaryGrid data-testid="station-migration-summary">
+      <SummaryItem
+        label={t('station_migration_summary_total', {
+          count: wallets.length,
+        })}
+        value={wallets.length}
+      />
+      <SummaryItem
+        label={t('station_migration_status_supported')}
+        value={supportedCount}
+      />
+      <SummaryItem
+        label={t('station_migration_status_reconnect')}
+        value={reconnectCount}
+      />
+      <SummaryItem
+        label={t('station_migration_status_needs_review')}
+        value={unsupportedCount + corruptCount}
+      />
+    </SummaryGrid>
+  )
+}
+
+const SummaryItem = ({ label, value }: { label: string; value: number }) => (
+  <SummaryCell>
+    <Text color="contrast" weight={600} size={18} height={1}>
+      {value}
+    </Text>
+    <Text color="shy" size={11} height={1.2} nowrap>
+      {label}
+    </Text>
+  </SummaryCell>
+)
+
+const StationMigrationWalletItem = ({
+  wallet,
+}: {
+  wallet: StationLegacyWalletClassification
+}) => {
+  const { t } = useTranslation()
+  const reason = getWalletReason({ t, wallet })
+
+  return (
+    <ListItem
+      data-testid="station-migration-wallet-item"
+      hoverable={false}
+      title={
+        <WalletTitleRow>
+          <Text color="contrast" size={14} weight={600} height={1.3}>
+            {wallet.walletName}
+          </Text>
+          <StatusBadge>
+            <Text
+              color={walletStatusColor[wallet.status]}
+              size={11}
+              weight={600}
+              height={1}
+              nowrap
+            >
+              {getWalletStatusLabel({ t, status: wallet.status })}
+            </Text>
+          </StatusBadge>
+        </WalletTitleRow>
+      }
+      description={
+        <VStack gap={4}>
+          <Text color="shy" size={12} height={1.35}>
+            {getWalletTypeLabel({ t, wallet })}
+          </Text>
+          <Text color="shy" size={12} height={1.35}>
+            {reason}
+          </Text>
+        </VStack>
+      }
+      status={wallet.status === 'corrupt' ? 'error' : 'default'}
+    />
+  )
+}
+
+type TranslationInput = {
+  t: TFunction
+}
+
+const getWalletStatusLabel = ({
+  status,
+  t,
+}: TranslationInput & { status: StationLegacyWalletStatus }) => {
+  switch (status) {
+    case 'supported':
+      return t('station_migration_status_supported')
+    case 'reconnect':
+      return t('station_migration_status_reconnect')
+    case 'unsupported':
+      return t('station_migration_status_unsupported')
+    case 'corrupt':
+      return t('station_migration_status_corrupt')
+  }
+}
+
+const getWalletTypeLabel = ({
+  t,
+  wallet,
+}: TranslationInput & { wallet: StationLegacyWalletClassification }) => {
+  switch (wallet.walletType) {
+    case 'mnemonic':
+      return t('station_migration_wallet_type_mnemonic')
+    case 'seed':
+      return t('station_migration_wallet_type_seed')
+    case 'privateKey':
+      return t('station_migration_wallet_type_private_key')
+    case 'interchainPrivateKey':
+      return t('station_migration_wallet_type_interchain_private_key')
+    case 'legacyPrivateKey':
+      return t('station_migration_wallet_type_legacy_private_key')
+    case 'ledger':
+      return t('station_migration_wallet_type_ledger')
+    case 'multisig':
+      return t('station_migration_wallet_type_multisig')
+    case 'unknown':
+      return t('station_migration_wallet_type_unknown')
+    case 'corruptStorage':
+      return t('station_migration_wallet_type_corrupt_storage')
+    case 'corruptWallet':
+      return t('station_migration_wallet_type_corrupt_wallet')
+  }
+}
+
+const getWalletReason = ({
+  t,
+  wallet,
+}: TranslationInput & { wallet: StationLegacyWalletClassification }) => {
+  switch (wallet.reasonCode) {
+    case 'ledgerReconnectRequired':
+      return t('station_migration_reason_ledger_reconnect')
+    case 'multisigPublicMetadataOnly':
+      return t('station_migration_reason_multisig')
+    case 'encryptedSeedNotString':
+      return t('station_migration_reason_encrypted_seed_not_string')
+    case 'encryptedInvalidShape':
+      return t('station_migration_reason_encrypted_invalid_shape')
+    case 'encryptedPrivateKeyMissing330':
+      return t('station_migration_reason_encrypted_private_key_missing_330')
+    case 'legacyWalletBlobNotString':
+      return t('station_migration_reason_legacy_wallet_blob_not_string')
+    case 'unknownWalletShape':
+      return t('station_migration_reason_unknown_wallet_shape')
+    case 'malformedJson':
+      return t('station_migration_reason_malformed_json', {
+        storageKey: wallet.storageKey,
+      })
+    case 'storageNotArray':
+      return t('station_migration_reason_storage_not_array', {
+        storageKey: wallet.storageKey,
+      })
+    case 'walletEntryNotObject':
+      return t('station_migration_reason_wallet_entry_not_object')
+    default:
+      break
+  }
+
+  switch (wallet.walletType) {
+    case 'mnemonic':
+      return t('station_migration_reason_supported_mnemonic')
+    case 'seed':
+      return t('station_migration_reason_supported_seed')
+    case 'privateKey':
+      return t('station_migration_reason_supported_private_key')
+    case 'interchainPrivateKey':
+      return t('station_migration_reason_supported_interchain_private_key')
+    case 'legacyPrivateKey':
+      return t('station_migration_reason_supported_legacy_private_key')
+    default:
+      return t('station_migration_reason_unsupported_fallback')
+  }
+}
+
+const SummaryGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1px;
+  overflow: hidden;
+  border-radius: 8px;
+  background: ${getColor('mistExtra')};
+`
+
+const SummaryCell = styled(VStack).attrs({
+  alignItems: 'center',
+  gap: 6,
+})`
+  min-width: 0;
+  padding: 12px 6px;
+  background: ${getColor('foreground')};
+`
+
+const WalletTitleRow = styled(HStack).attrs({
+  alignItems: 'center',
+  gap: 8,
+  justifyContent: 'space-between',
+})`
+  width: 100%;
+  min-width: 0;
+`
+
+const StatusBadge = styled.span`
+  flex: 0 0 auto;
+  padding: 5px 8px;
+  border-radius: 999px;
+  background: ${getColor('foregroundExtra')};
+`

--- a/clients/extension/src/pages/station-migration/stationLegacyMigrationGate.ts
+++ b/clients/extension/src/pages/station-migration/stationLegacyMigrationGate.ts
@@ -1,0 +1,16 @@
+import { ProductBrand } from '@core/ui/product/brand'
+
+import { StationLegacyStorageClassification } from '../../storage/stationLegacyWalletClassifier'
+
+type ShouldShowStationLegacyMigrationInput = {
+  classification: StationLegacyStorageClassification
+  productBrand: ProductBrand
+  skip?: boolean
+}
+
+export const shouldShowStationLegacyMigration = ({
+  classification,
+  productBrand,
+  skip = false,
+}: ShouldShowStationLegacyMigrationInput) =>
+  productBrand === 'station' && !skip && classification.wallets.length > 0

--- a/clients/extension/src/storage/stationLegacyWalletClassifier.ts
+++ b/clients/extension/src/storage/stationLegacyWalletClassifier.ts
@@ -1,4 +1,4 @@
-const stationLegacyStorageKeys: {
+export const stationLegacyStorageKeys: {
   wallets: 'wallets'
   keys: 'keys'
   passwordChallenge: 'passwordChallenge'
@@ -12,13 +12,16 @@ const stationLegacyStorageKeys: {
   isMigrationDone: 'isMigrationDone',
 }
 
-type StationLegacyWalletStorageKey =
+export type StationLegacyWalletStorageKey =
   | typeof stationLegacyStorageKeys.wallets
   | typeof stationLegacyStorageKeys.keys
 
-type StationLegacyStorageSnapshot = Record<string, string | null | undefined>
+export type StationLegacyStorageSnapshot = Record<
+  string,
+  string | null | undefined
+>
 
-type StationLegacyWalletType =
+export type StationLegacyWalletType =
   | 'mnemonic'
   | 'seed'
   | 'privateKey'
@@ -30,9 +33,25 @@ type StationLegacyWalletType =
   | 'corruptStorage'
   | 'corruptWallet'
 
-type StationLegacyWalletStatus = 'supported' | 'unsupported' | 'corrupt'
+export type StationLegacyWalletStatus =
+  | 'supported'
+  | 'reconnect'
+  | 'unsupported'
+  | 'corrupt'
 
-type StationLegacyWalletMetadata = {
+export type StationLegacyWalletReasonCode =
+  | 'ledgerReconnectRequired'
+  | 'multisigPublicMetadataOnly'
+  | 'encryptedSeedNotString'
+  | 'encryptedInvalidShape'
+  | 'encryptedPrivateKeyMissing330'
+  | 'legacyWalletBlobNotString'
+  | 'unknownWalletShape'
+  | 'malformedJson'
+  | 'storageNotArray'
+  | 'walletEntryNotObject'
+
+export type StationLegacyWalletMetadata = {
   address?: string
   bluetooth?: boolean
   encrypted?: string | Record<string, string>
@@ -50,18 +69,19 @@ type StationLegacyWalletMetadata = {
   words?: Record<string, string>
 }
 
-type StationLegacyWalletClassification = {
+export type StationLegacyWalletClassification = {
   walletName: string
   source: 'localStorage'
   storageKey: StationLegacyWalletStorageKey
   storageIndex?: number
   walletType: StationLegacyWalletType
   status: StationLegacyWalletStatus
+  reasonCode?: StationLegacyWalletReasonCode
   reason?: string
   metadata: StationLegacyWalletMetadata
 }
 
-type StationLegacyStorageClassification = {
+export type StationLegacyStorageClassification = {
   wallets: StationLegacyWalletClassification[]
   metadata: {
     connectedWallet?: string
@@ -72,10 +92,10 @@ type StationLegacyStorageClassification = {
 }
 
 const ledgerUnsupportedReason =
-  'Station only stores public account details for Ledger wallets, not keys Vultisig can convert into a vault.'
+  'Station stores public account details for this Ledger wallet. Reconnect the hardware device later to use it in Station.'
 
 const multisigUnsupportedReason =
-  'Station only stores public multisig metadata, not key material Vultisig can convert into a vault.'
+  'Station only stores public multisig metadata. It does not store private keys that can be converted into a Vultisig vault.'
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -192,6 +212,7 @@ const getCommonMetadata = (
 const createClassification = ({
   record,
   reason,
+  reasonCode,
   status,
   storageIndex,
   storageKey,
@@ -199,6 +220,7 @@ const createClassification = ({
 }: {
   record: Record<string, unknown>
   reason?: string
+  reasonCode?: StationLegacyWalletReasonCode
   status: StationLegacyWalletStatus
   storageIndex: number
   storageKey: StationLegacyWalletStorageKey
@@ -210,15 +232,18 @@ const createClassification = ({
   storageIndex,
   walletType,
   status,
+  reasonCode,
   reason,
   metadata: getCommonMetadata(record),
 })
 
 const createStorageCorruptionResult = ({
   reason,
+  reasonCode,
   storageKey,
 }: {
   reason: string
+  reasonCode: StationLegacyWalletReasonCode
   storageKey: StationLegacyWalletStorageKey
 }): StationLegacyWalletClassification => ({
   walletName: storageKey,
@@ -226,6 +251,7 @@ const createStorageCorruptionResult = ({
   storageKey,
   walletType: 'corruptStorage',
   status: 'corrupt',
+  reasonCode,
   reason,
   metadata: {},
 })
@@ -243,7 +269,8 @@ const classifyWalletRecord = ({
     return createClassification({
       record,
       reason: ledgerUnsupportedReason,
-      status: 'unsupported',
+      reasonCode: 'ledgerReconnectRequired',
+      status: 'reconnect',
       storageIndex,
       storageKey,
       walletType: 'ledger',
@@ -254,6 +281,7 @@ const classifyWalletRecord = ({
     return createClassification({
       record,
       reason: multisigUnsupportedReason,
+      reasonCode: 'multisigPublicMetadataOnly',
       status: 'unsupported',
       storageIndex,
       storageKey,
@@ -266,6 +294,7 @@ const classifyWalletRecord = ({
       return createClassification({
         record,
         reason: 'encryptedSeed is present but is not a string.',
+        reasonCode: 'encryptedSeedNotString',
         status: 'corrupt',
         storageIndex,
         storageKey,
@@ -298,6 +327,7 @@ const classifyWalletRecord = ({
       return createClassification({
         record,
         reason: 'encrypted is present but is neither a string nor an object.',
+        reasonCode: 'encryptedInvalidShape',
         status: 'corrupt',
         storageIndex,
         storageKey,
@@ -309,6 +339,7 @@ const classifyWalletRecord = ({
       return createClassification({
         record,
         reason: 'encrypted private-key object is missing coin type 330.',
+        reasonCode: 'encryptedPrivateKeyMissing330',
         status: 'corrupt',
         storageIndex,
         storageKey,
@@ -330,6 +361,7 @@ const classifyWalletRecord = ({
       return createClassification({
         record,
         reason: 'legacy wallet blob is present but is not a string.',
+        reasonCode: 'legacyWalletBlobNotString',
         status: 'corrupt',
         storageIndex,
         storageKey,
@@ -349,6 +381,7 @@ const classifyWalletRecord = ({
   return createClassification({
     record,
     reason: 'Wallet entry does not match any known Station storage shape.',
+    reasonCode: 'unknownWalletShape',
     status: 'unsupported',
     storageIndex,
     storageKey,
@@ -373,6 +406,7 @@ const parseWallets = ({
     return [
       createStorageCorruptionResult({
         reason: `${storageKey} contains malformed JSON.`,
+        reasonCode: 'malformedJson',
         storageKey,
       }),
     ]
@@ -382,6 +416,7 @@ const parseWallets = ({
     return [
       createStorageCorruptionResult({
         reason: `${storageKey} must be a JSON array.`,
+        reasonCode: 'storageNotArray',
         storageKey,
       }),
     ]
@@ -396,6 +431,7 @@ const parseWallets = ({
         storageIndex,
         walletType: 'corruptWallet',
         status: 'corrupt',
+        reasonCode: 'walletEntryNotObject',
         reason: 'Wallet entry is not an object.',
         metadata: {},
       }

--- a/clients/extension/src/storage/stationLegacyWalletStorageSnapshot.ts
+++ b/clients/extension/src/storage/stationLegacyWalletStorageSnapshot.ts
@@ -7,13 +7,14 @@ import {
 
 export type StationLegacyStorageReader = Pick<Storage, 'getItem'>
 
-export const stationLegacyLocalStorageKeys = [
-  stationLegacyStorageKeys.wallets,
-  stationLegacyStorageKeys.keys,
-  stationLegacyStorageKeys.passwordChallenge,
-  stationLegacyStorageKeys.connectedWallet,
-  stationLegacyStorageKeys.isMigrationDone,
-]
+export const stationLegacyLocalStorageKeys: ReadonlyArray<string> =
+  Object.freeze([
+    stationLegacyStorageKeys.wallets,
+    stationLegacyStorageKeys.keys,
+    stationLegacyStorageKeys.passwordChallenge,
+    stationLegacyStorageKeys.connectedWallet,
+    stationLegacyStorageKeys.isMigrationDone,
+  ])
 
 const getBrowserLocalStorage = (): StationLegacyStorageReader | undefined => {
   if (typeof window === 'undefined') return undefined

--- a/clients/extension/src/storage/stationLegacyWalletStorageSnapshot.ts
+++ b/clients/extension/src/storage/stationLegacyWalletStorageSnapshot.ts
@@ -1,0 +1,50 @@
+import {
+  classifyStationLegacyWalletStorage,
+  StationLegacyStorageClassification,
+  stationLegacyStorageKeys,
+  StationLegacyStorageSnapshot,
+} from './stationLegacyWalletClassifier'
+
+export type StationLegacyStorageReader = Pick<Storage, 'getItem'>
+
+export const stationLegacyLocalStorageKeys = [
+  stationLegacyStorageKeys.wallets,
+  stationLegacyStorageKeys.keys,
+  stationLegacyStorageKeys.passwordChallenge,
+  stationLegacyStorageKeys.connectedWallet,
+  stationLegacyStorageKeys.isMigrationDone,
+]
+
+const getBrowserLocalStorage = (): StationLegacyStorageReader | undefined => {
+  if (typeof window === 'undefined') return undefined
+
+  return window.localStorage
+}
+
+export const getStationLegacyWalletStorageSnapshot = (
+  storage: StationLegacyStorageReader
+): StationLegacyStorageSnapshot => {
+  const snapshot: StationLegacyStorageSnapshot = {}
+
+  stationLegacyLocalStorageKeys.forEach(key => {
+    snapshot[key] = storage.getItem(key)
+  })
+
+  return snapshot
+}
+
+export const getEmptyStationLegacyWalletStorageClassification =
+  (): StationLegacyStorageClassification =>
+    classifyStationLegacyWalletStorage({})
+
+export const getStationLegacyWalletStorageClassification = (
+  storage = getBrowserLocalStorage()
+): StationLegacyStorageClassification => {
+  if (!storage) {
+    return getEmptyStationLegacyWalletStorageClassification()
+  }
+
+  return classifyStationLegacyWalletStorage(
+    getStationLegacyWalletStorageSnapshot(storage)
+  )
+}

--- a/clients/extension/src/storage/useStationLegacyWalletStorageClassification.ts
+++ b/clients/extension/src/storage/useStationLegacyWalletStorageClassification.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react'
+
+import {
+  getEmptyStationLegacyWalletStorageClassification,
+  getStationLegacyWalletStorageClassification,
+} from './stationLegacyWalletStorageSnapshot'
+
+type UseStationLegacyWalletStorageClassificationInput = {
+  enabled: boolean
+}
+
+export const useStationLegacyWalletStorageClassification = ({
+  enabled,
+}: UseStationLegacyWalletStorageClassificationInput) => {
+  const [classification, setClassification] = useState(() =>
+    enabled
+      ? getStationLegacyWalletStorageClassification()
+      : getEmptyStationLegacyWalletStorageClassification()
+  )
+
+  useEffect(() => {
+    if (!enabled) {
+      setClassification(getEmptyStationLegacyWalletStorageClassification())
+      return
+    }
+
+    setClassification(getStationLegacyWalletStorageClassification())
+
+    const refreshClassification = () => {
+      setClassification(getStationLegacyWalletStorageClassification())
+    }
+
+    window.addEventListener('storage', refreshClassification)
+
+    return () => {
+      window.removeEventListener('storage', refreshClassification)
+    }
+  }, [enabled])
+
+  return classification
+}

--- a/clients/extension/tests/unit/stationLegacyMigrationGate.test.ts
+++ b/clients/extension/tests/unit/stationLegacyMigrationGate.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldShowStationLegacyMigration } from '@clients/extension/src/pages/station-migration/stationLegacyMigrationGate'
+import { StationLegacyStorageClassification } from '@clients/extension/src/storage/stationLegacyWalletClassifier'
+
+const classificationWithWallets: StationLegacyStorageClassification = {
+  wallets: [
+    {
+      walletName: 'Station Wallet',
+      source: 'localStorage',
+      storageKey: 'wallets',
+      storageIndex: 0,
+      walletType: 'seed',
+      status: 'supported',
+      metadata: {
+        encryptedSeed: 'encrypted-seed',
+      },
+    },
+  ],
+  metadata: {
+    hasPasswordChallenge: false,
+    isMigrationDone: false,
+    storageKeysDetected: ['wallets'],
+  },
+}
+
+const emptyClassification: StationLegacyStorageClassification = {
+  wallets: [],
+  metadata: {
+    hasPasswordChallenge: false,
+    isMigrationDone: false,
+    storageKeysDetected: [],
+  },
+}
+
+describe('shouldShowStationLegacyMigration', () => {
+  it('shows the migration entry only for Station builds with detected legacy wallets', () => {
+    expect(
+      shouldShowStationLegacyMigration({
+        classification: classificationWithWallets,
+        productBrand: 'station',
+      })
+    ).toBe(true)
+
+    expect(
+      shouldShowStationLegacyMigration({
+        classification: classificationWithWallets,
+        productBrand: 'vultisig',
+      })
+    ).toBe(false)
+
+    expect(
+      shouldShowStationLegacyMigration({
+        classification: emptyClassification,
+        productBrand: 'station',
+      })
+    ).toBe(false)
+  })
+
+  it('lets users continue normal setup after skipping the shell', () => {
+    expect(
+      shouldShowStationLegacyMigration({
+        classification: classificationWithWallets,
+        productBrand: 'station',
+        skip: true,
+      })
+    ).toBe(false)
+  })
+})

--- a/clients/extension/tests/unit/stationLegacyWalletClassifier.test.ts
+++ b/clients/extension/tests/unit/stationLegacyWalletClassifier.test.ts
@@ -164,7 +164,7 @@ describe('classifyStationLegacyWalletStorage', () => {
     })
   })
 
-  it('classifies Ledger wallets as unsupported reconnect-only entries', () => {
+  it('classifies Ledger wallets as reconnect-only entries', () => {
     const result = classifyStationLegacyWalletStorage({
       wallets: JSON.stringify([
         {
@@ -182,9 +182,10 @@ describe('classifyStationLegacyWalletStorage', () => {
     expect(result.wallets[0]).toMatchObject({
       walletName: 'Ledger Wallet',
       walletType: 'ledger',
-      status: 'unsupported',
+      status: 'reconnect',
+      reasonCode: 'ledgerReconnectRequired',
       reason:
-        'Station only stores public account details for Ledger wallets, not keys Vultisig can convert into a vault.',
+        'Station stores public account details for this Ledger wallet. Reconnect the hardware device later to use it in Station.',
       metadata: {
         index: 4,
         pubkey: { '330': 'ledger-pubkey' },
@@ -209,8 +210,9 @@ describe('classifyStationLegacyWalletStorage', () => {
       walletName: 'Multisig Wallet',
       walletType: 'multisig',
       status: 'unsupported',
+      reasonCode: 'multisigPublicMetadataOnly',
       reason:
-        'Station only stores public multisig metadata, not key material Vultisig can convert into a vault.',
+        'Station only stores public multisig metadata. It does not store private keys that can be converted into a Vultisig vault.',
       metadata: {
         threshold: 2,
       },
@@ -229,6 +231,7 @@ describe('classifyStationLegacyWalletStorage', () => {
         storageKey: 'wallets',
         walletType: 'corruptStorage',
         status: 'corrupt',
+        reasonCode: 'malformedJson',
         reason: 'wallets contains malformed JSON.',
         metadata: {},
       },
@@ -251,6 +254,7 @@ describe('classifyStationLegacyWalletStorage', () => {
       walletType: 'unknown',
       status: 'unsupported',
       reason: 'Wallet entry does not match any known Station storage shape.',
+      reasonCode: 'unknownWalletShape',
     })
   })
 
@@ -280,6 +284,7 @@ describe('classifyStationLegacyWalletStorage', () => {
         storageIndex: 0,
         walletType: 'corruptWallet',
         status: 'corrupt',
+        reasonCode: 'walletEntryNotObject',
         reason: 'Wallet entry is not an object.',
         metadata: {},
       },
@@ -290,6 +295,7 @@ describe('classifyStationLegacyWalletStorage', () => {
         storageIndex: 1,
         walletType: 'corruptWallet',
         status: 'corrupt',
+        reasonCode: 'encryptedPrivateKeyMissing330',
         reason: 'encrypted private-key object is missing coin type 330.',
         metadata: {
           encrypted: {

--- a/clients/extension/tests/unit/stationLegacyWalletStorageSnapshot.test.ts
+++ b/clients/extension/tests/unit/stationLegacyWalletStorageSnapshot.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getStationLegacyWalletStorageClassification,
+  getStationLegacyWalletStorageSnapshot,
+  stationLegacyLocalStorageKeys,
+  StationLegacyStorageReader,
+} from '@clients/extension/src/storage/stationLegacyWalletStorageSnapshot'
+
+const createStorage = (
+  values: Record<string, string | null>
+): StationLegacyStorageReader => ({
+  getItem: key => values[key] ?? null,
+})
+
+describe('getStationLegacyWalletStorageSnapshot', () => {
+  it('reads only the legacy Station localStorage keys needed by the classifier', () => {
+    const readKeys: string[] = []
+    const storage: StationLegacyStorageReader = {
+      getItem: key => {
+        readKeys.push(key)
+        return key === 'wallets' ? '[]' : null
+      },
+    }
+
+    expect(getStationLegacyWalletStorageSnapshot(storage)).toEqual({
+      wallets: '[]',
+      keys: null,
+      passwordChallenge: null,
+      connectedWallet: null,
+      isMigrationDone: null,
+    })
+    expect(readKeys).toEqual(stationLegacyLocalStorageKeys)
+  })
+
+  it('classifies the read-only snapshot without writing migration state', () => {
+    const result = getStationLegacyWalletStorageClassification(
+      createStorage({
+        wallets: JSON.stringify([
+          {
+            name: 'Station Seed',
+            encryptedSeed: 'encrypted-seed',
+          },
+        ]),
+        isMigrationDone: 'true',
+      })
+    )
+
+    expect(result.metadata.isMigrationDone).toBe(true)
+    expect(result.wallets).toHaveLength(1)
+    expect(result.wallets[0]).toMatchObject({
+      walletName: 'Station Seed',
+      walletType: 'seed',
+      status: 'supported',
+    })
+  })
+})

--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -1581,4 +1581,67 @@ export const de = {
   raw_message: 'Rohdaten',
   token: 'Token',
   token_approval: 'Token-Genehmigung',
+  skip_for_now: 'Überspringen Sie vorerst',
+  station_migration_title: 'Station Wallets migrieren',
+  station_migration_review_title: 'Alte Station-Wallets überprüfen',
+  station_migration_review_description:
+    'Hierbei wird lediglich der Speicher der alten Station-Erweiterung gelesen. Bisher wurden keine Wallets migriert, neu verbunden, gelöscht oder als abgeschlossen markiert.',
+  station_migration_settings_title: 'Station Wallets migrieren',
+  station_migration_settings_description:
+    'Überprüfen Sie die auf diesem Gerät erkannten alten Station Wallets.',
+  station_migration_set_up_without_migrating: 'Einrichtung ohne Migration',
+  station_migration_no_wallets_found:
+    'In diesem Erweiterungsspeicher wurden keine älteren Station-Wallets gefunden.',
+  station_migration_summary_total_one: '{{count}} Wallet',
+  station_migration_summary_total_other: '{{count}} Wallets',
+  station_migration_status_supported: 'Unterstützt',
+  station_migration_status_reconnect: 'Wiederverbinden',
+  station_migration_status_unsupported: 'Nicht unterstützt',
+  station_migration_status_corrupt: 'Ungültig',
+  station_migration_status_needs_review: 'Überprüfung erforderlich',
+  station_migration_wallet_type_mnemonic: 'Verschlüsselter Seed und Mnemonik',
+  station_migration_wallet_type_seed: 'Verschlüsselter Seed',
+  station_migration_wallet_type_private_key:
+    'Verschlüsselter privater Schlüssel',
+  station_migration_wallet_type_interchain_private_key:
+    'Verschlüsselte private Terra-Schlüssel',
+  station_migration_wallet_type_legacy_private_key:
+    'Legacy-verschlüsselter privater Schlüssel-Blob',
+  station_migration_wallet_type_ledger: 'Ledger-Hardware-Wallet',
+  station_migration_wallet_type_multisig: 'Multisig-Wallet',
+  station_migration_wallet_type_unknown: 'Unbekanntes Wallet-Format Station',
+  station_migration_wallet_type_corrupt_storage: 'Ungültiger Speicher',
+  station_migration_wallet_type_corrupt_wallet: 'Ungültiger Wallet-Eintrag',
+  station_migration_reason_supported_mnemonic:
+    'Die verschlüsselten Wallet-Daten sind für eine zukünftige Migration vorhanden, bei der das Passwort Station abgefragt wird.',
+  station_migration_reason_supported_seed:
+    'Verschlüsselte Seed-Bytes sind für eine zukünftige Migration vorhanden, die nach dem Passwort Station fragt.',
+  station_migration_reason_supported_private_key:
+    'Verschlüsselte private Schlüsseldaten sind für einen zukünftigen Import in die Terra-Familie vorhanden.',
+  station_migration_reason_supported_interchain_private_key:
+    'Verschlüsselte Terra-Privatschlüsseldaten sind für einen späteren Import vorhanden.',
+  station_migration_reason_supported_legacy_private_key:
+    'Für einen späteren Import sind verschlüsselte Legacy-Daten des privaten Schlüssels vorhanden.',
+  station_migration_reason_ledger_reconnect:
+    'Station speichert die öffentlichen Kontodaten für diese Ledger-Wallet. Verbinden Sie das Hardwaregerät später erneut, um es in Station zu verwenden.',
+  station_migration_reason_multisig:
+    'Station speichert ausschließlich öffentliche Multisig-Metadaten. Es speichert keine privaten Schlüssel, die in einen Vultisig-Tresor konvertiert werden können.',
+  station_migration_reason_encrypted_seed_not_string:
+    'encryptedSeed ist vorhanden, aber keine Zeichenkette.',
+  station_migration_reason_encrypted_invalid_shape:
+    'Der Wert von encrypted ist vorhanden, aber er ist weder eine Zeichenkette noch ein Objekt.',
+  station_migration_reason_encrypted_private_key_missing_330:
+    'Dem verschlüsselten privaten Schlüsselobjekt fehlt der Münztyp 330.',
+  station_migration_reason_legacy_wallet_blob_not_string:
+    'Der Legacy-Wallet-Blob ist vorhanden, stellt aber keine Zeichenkette dar.',
+  station_migration_reason_unknown_wallet_shape:
+    'Der Wallet-Eintrag entspricht keinem bekannten Station-Speicherformat.',
+  station_migration_reason_malformed_json:
+    '{{storageKey}} enthält fehlerhaftes JSON.',
+  station_migration_reason_storage_not_array:
+    '{{storageKey}} muss ein JSON-Array sein.',
+  station_migration_reason_wallet_entry_not_object:
+    'Der Wallet-Eintrag ist kein Objekt.',
+  station_migration_reason_unsupported_fallback:
+    'Diese Wallet muss vor der Migration überprüft werden.',
 }

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -1512,4 +1512,66 @@ export const en = {
   agent_reauth_description:
     'For security, authorization expires periodically.\nPlease confirm to continue using Vulti Agent.',
   authorize: 'Authorize',
+  skip_for_now: 'Skip for now',
+  station_migration_title: 'Migrate Station wallets',
+  station_migration_review_title: 'Review old Station wallets',
+  station_migration_review_description:
+    'This only reads legacy Station extension storage. No wallets are migrated, reconnected, deleted, or marked complete yet.',
+  station_migration_settings_title: 'Migrate Station wallets',
+  station_migration_settings_description:
+    'Review old Station wallets detected on this device.',
+  station_migration_set_up_without_migrating: 'Set up without migrating',
+  station_migration_no_wallets_found:
+    'No legacy Station wallets were found in this extension storage.',
+  station_migration_summary_total_one: '{{count}} wallet',
+  station_migration_summary_total_other: '{{count}} wallets',
+  station_migration_status_supported: 'Supported',
+  station_migration_status_reconnect: 'Reconnect',
+  station_migration_status_unsupported: 'Unsupported',
+  station_migration_status_corrupt: 'Invalid',
+  station_migration_status_needs_review: 'Needs review',
+  station_migration_wallet_type_mnemonic: 'Encrypted seed and mnemonic',
+  station_migration_wallet_type_seed: 'Encrypted seed',
+  station_migration_wallet_type_private_key: 'Encrypted private key',
+  station_migration_wallet_type_interchain_private_key:
+    'Encrypted Terra private keys',
+  station_migration_wallet_type_legacy_private_key:
+    'Legacy encrypted private-key blob',
+  station_migration_wallet_type_ledger: 'Ledger hardware wallet',
+  station_migration_wallet_type_multisig: 'Multisig wallet',
+  station_migration_wallet_type_unknown: 'Unknown Station wallet format',
+  station_migration_wallet_type_corrupt_storage: 'Invalid storage',
+  station_migration_wallet_type_corrupt_wallet: 'Invalid wallet entry',
+  station_migration_reason_supported_mnemonic:
+    'Encrypted wallet data is present for a future migration that asks for the Station password.',
+  station_migration_reason_supported_seed:
+    'Encrypted seed bytes are present for a future migration that asks for the Station password.',
+  station_migration_reason_supported_private_key:
+    'Encrypted private-key data is present for a future Terra-family import.',
+  station_migration_reason_supported_interchain_private_key:
+    'Encrypted Terra private-key data is present for a future import.',
+  station_migration_reason_supported_legacy_private_key:
+    'Legacy encrypted private-key data is present for a future import.',
+  station_migration_reason_ledger_reconnect:
+    'Station stores public account details for this Ledger wallet. Reconnect the hardware device later to use it in Station.',
+  station_migration_reason_multisig:
+    'Station only stores public multisig metadata. It does not store private keys that can be converted into a Vultisig vault.',
+  station_migration_reason_encrypted_seed_not_string:
+    'encryptedSeed is present but is not a string.',
+  station_migration_reason_encrypted_invalid_shape:
+    'encrypted is present but is neither a string nor an object.',
+  station_migration_reason_encrypted_private_key_missing_330:
+    'Encrypted private-key object is missing coin type 330.',
+  station_migration_reason_legacy_wallet_blob_not_string:
+    'Legacy wallet blob is present but is not a string.',
+  station_migration_reason_unknown_wallet_shape:
+    'Wallet entry does not match any known Station storage format.',
+  station_migration_reason_malformed_json:
+    '{{storageKey}} contains malformed JSON.',
+  station_migration_reason_storage_not_array:
+    '{{storageKey}} must be a JSON array.',
+  station_migration_reason_wallet_entry_not_object:
+    'Wallet entry is not an object.',
+  station_migration_reason_unsupported_fallback:
+    'This wallet needs review before it can be migrated.',
 }

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -1565,4 +1565,68 @@ export const es = {
   raw_message: 'Mensaje sin formato',
   token: 'Simbólico',
   token_approval: 'Aprobación de tokens',
+  skip_for_now: 'Saltar por ahora',
+  station_migration_title: 'Migrar las carteras Station',
+  station_migration_review_title: 'Revisar las antiguas carteras Station',
+  station_migration_review_description:
+    'Esto solo lee el almacenamiento de la extensión heredada Station. Aún no se han migrado, reconectado, eliminado ni marcado como completadas las carteras.',
+  station_migration_settings_title: 'Migrar las carteras Station',
+  station_migration_settings_description:
+    'Revisar las carteras antiguas Station detectadas en este dispositivo.',
+  station_migration_set_up_without_migrating: 'Configurar sin migrar',
+  station_migration_no_wallets_found:
+    'No se encontraron carteras antiguas Station en este almacenamiento de extensión.',
+  station_migration_summary_total_one: 'Cartera {{count}}',
+  station_migration_summary_total_other: 'Carteras {{count}}',
+  station_migration_status_supported: 'Compatible',
+  station_migration_status_reconnect: 'Reconectar',
+  station_migration_status_unsupported: 'Sin soporte',
+  station_migration_status_corrupt: 'Inválido',
+  station_migration_status_needs_review: 'Necesita revisión',
+  station_migration_wallet_type_mnemonic: 'Semilla encriptada y mnemotécnica',
+  station_migration_wallet_type_seed: 'Semilla cifrada',
+  station_migration_wallet_type_private_key: 'Clave privada cifrada',
+  station_migration_wallet_type_interchain_private_key:
+    'Claves privadas cifradas de Terra',
+  station_migration_wallet_type_legacy_private_key:
+    'Bloque de clave privada cifrada heredada',
+  station_migration_wallet_type_ledger: 'Cartera de hardware Ledger',
+  station_migration_wallet_type_multisig: 'Cartera multifirma',
+  station_migration_wallet_type_unknown:
+    'Formato de billetera Station desconocido',
+  station_migration_wallet_type_corrupt_storage: 'Almacenamiento no válido',
+  station_migration_wallet_type_corrupt_wallet:
+    'Entrada de billetera no válida',
+  station_migration_reason_supported_mnemonic:
+    'Los datos cifrados de la cartera están disponibles para una futura migración que solicitará la contraseña Station.',
+  station_migration_reason_supported_seed:
+    'Se incluyen bytes de semilla cifrados para una futura migración que solicitará la contraseña Station.',
+  station_migration_reason_supported_private_key:
+    'Los datos de clave privada cifrados están disponibles para una futura importación a la familia Terra.',
+  station_migration_reason_supported_interchain_private_key:
+    'Los datos de clave privada de Terra, cifrados, están disponibles para una futura importación.',
+  station_migration_reason_supported_legacy_private_key:
+    'Los datos de clave privada cifrados heredados están disponibles para una futura importación.',
+  station_migration_reason_ledger_reconnect:
+    'Station almacena los detalles de la cuenta pública para esta billetera Ledger. Vuelva a conectar el dispositivo de hardware más tarde para usarlo en Station.',
+  station_migration_reason_multisig:
+    'Station solo almacena metadatos multifirma públicos. No almacena claves privadas que puedan convertirse en una bóveda Vultisig.',
+  station_migration_reason_encrypted_seed_not_string:
+    'La clave encryptedSeed está presente, pero no es una cadena de texto.',
+  station_migration_reason_encrypted_invalid_shape:
+    'La expresión &quot;encriptado&quot; está presente, pero no es ni una cadena de texto ni un objeto.',
+  station_migration_reason_encrypted_private_key_missing_330:
+    'Al objeto de clave privada cifrado le falta el tipo de moneda 330.',
+  station_migration_reason_legacy_wallet_blob_not_string:
+    'El blob de la billetera heredada está presente, pero no es una cadena de texto.',
+  station_migration_reason_unknown_wallet_shape:
+    'La entrada de la cartera no coincide con ningún formato de almacenamiento Station conocido.',
+  station_migration_reason_malformed_json:
+    '{{storageKey}} contiene JSON con formato incorrecto.',
+  station_migration_reason_storage_not_array:
+    '{{storageKey}} debe ser una matriz JSON.',
+  station_migration_reason_wallet_entry_not_object:
+    'La entrada de la cartera no es un objeto.',
+  station_migration_reason_unsupported_fallback:
+    'Esta billetera necesita ser revisada antes de poder ser migrada.',
 }

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -1614,7 +1614,7 @@ export const es = {
   station_migration_reason_encrypted_seed_not_string:
     'La clave encryptedSeed está presente, pero no es una cadena de texto.',
   station_migration_reason_encrypted_invalid_shape:
-    'La expresión &quot;encriptado&quot; está presente, pero no es ni una cadena de texto ni un objeto.',
+    'La clave "encrypted" está presente, pero no es ni una cadena de texto ni un objeto.',
   station_migration_reason_encrypted_private_key_missing_330:
     'Al objeto de clave privada cifrado le falta el tipo de moneda 330.',
   station_migration_reason_legacy_wallet_blob_not_string:

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -1541,4 +1541,66 @@ export const hr = {
   raw_message: 'Sirova poruka',
   token: 'Znak',
   token_approval: 'Odobrenje tokena',
+  skip_for_now: 'Preskoči za sada',
+  station_migration_title: 'Migrirajte Station novčanike',
+  station_migration_review_title: 'Pregledajte stare Station novčanike',
+  station_migration_review_description:
+    'Ovo čita samo naslijeđenu pohranu proširenja Station. Nijedan novčanik još nije migriran, ponovno povezan, izbrisan ili označen kao dovršen.',
+  station_migration_settings_title: 'Migrirajte Station novčanike',
+  station_migration_settings_description:
+    'Pregledajte stare Station novčanike otkrivene na ovom uređaju.',
+  station_migration_set_up_without_migrating: 'Postavljanje bez migracije',
+  station_migration_no_wallets_found:
+    'U ovom proširenom skladištu nisu pronađeni naslijeđeni Station novčanici.',
+  station_migration_summary_total_one: 'Novčanik {{count}}',
+  station_migration_summary_total_other: 'Novčanici {{count}}',
+  station_migration_status_supported: 'Podržano',
+  station_migration_status_reconnect: 'Ponovno se poveži',
+  station_migration_status_unsupported: 'Nepodržano',
+  station_migration_status_corrupt: 'Nevažeće',
+  station_migration_status_needs_review: 'Potreban je pregled',
+  station_migration_wallet_type_mnemonic: 'Šifrirano sjeme i mnemotehnika',
+  station_migration_wallet_type_seed: 'Šifrirano sjeme',
+  station_migration_wallet_type_private_key: 'Šifrirani privatni ključ',
+  station_migration_wallet_type_interchain_private_key:
+    'Šifrirani privatni ključevi Terre',
+  station_migration_wallet_type_legacy_private_key:
+    'Zastarjeli šifrirani blob s privatnim ključem',
+  station_migration_wallet_type_ledger: 'Ledger hardverski novčanik',
+  station_migration_wallet_type_multisig: 'Višestruki potpisni novčanik',
+  station_migration_wallet_type_unknown: 'Nepoznati format novčanika Station',
+  station_migration_wallet_type_corrupt_storage: 'Nevažeća pohrana',
+  station_migration_wallet_type_corrupt_wallet: 'Nevažeći unos u novčanik',
+  station_migration_reason_supported_mnemonic:
+    'Šifrirani podaci novčanika prisutni su za buduću migraciju koja traži lozinku Station.',
+  station_migration_reason_supported_seed:
+    'Šifrirani početni bajtovi prisutni su za buduću migraciju koja traži lozinku Station.',
+  station_migration_reason_supported_private_key:
+    'Šifrirani podaci privatnog ključa prisutni su za budući uvoz Terra-family.',
+  station_migration_reason_supported_interchain_private_key:
+    'Šifrirani podaci privatnog ključa Terra dostupni su za budući uvoz.',
+  station_migration_reason_supported_legacy_private_key:
+    'Za budući uvoz prisutni su naslijeđeni šifrirani podaci privatnog ključa.',
+  station_migration_reason_ledger_reconnect:
+    'Station pohranjuje podatke javnog računa za ovaj Ledger novčanik. Kasnije ponovno spojite hardverski uređaj da biste ga koristili u Station.',
+  station_migration_reason_multisig:
+    'Station pohranjuje samo javne metapodatke s višestrukim potpisom. Ne pohranjuje privatne ključeve koji se mogu pretvoriti u Vultisig trezor.',
+  station_migration_reason_encrypted_seed_not_string:
+    'encryptedSeed je prisutan, ali nije niz znakova.',
+  station_migration_reason_encrypted_invalid_shape:
+    'Vrijednost &quot;encrypted&quot; je prisutna, ali nije ni niz znakova ni objekt.',
+  station_migration_reason_encrypted_private_key_missing_330:
+    'Kriptiranom objektu privatnog ključa nedostaje tip kovanice 330.',
+  station_migration_reason_legacy_wallet_blob_not_string:
+    'Prisutan je stari blob novčanika, ali nije niz znakova.',
+  station_migration_reason_unknown_wallet_shape:
+    'Unos u novčanik ne odgovara nijednom poznatom formatu pohrane Station.',
+  station_migration_reason_malformed_json:
+    '{{storageKey}} sadrži oštećeni JSON.',
+  station_migration_reason_storage_not_array:
+    '{{storageKey}} mora biti JSON niz.',
+  station_migration_reason_wallet_entry_not_object:
+    'Unos u novčanik nije objekt.',
+  station_migration_reason_unsupported_fallback:
+    'Ovaj novčanik treba pregledati prije nego što se može migrirati.',
 }

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -1569,4 +1569,68 @@ export const it = {
   raw_message: 'Messaggio grezzo',
   token: 'Token',
   token_approval: 'Approvazione del token',
+  skip_for_now: 'Per ora saltate.',
+  station_migration_title: 'Migrare i wallet Station',
+  station_migration_review_title: 'Revisione dei vecchi portafogli Station',
+  station_migration_review_description:
+    'Questa operazione legge solo la memoria di archiviazione legacy dell&#39;estensione Station. Nessun portafoglio è stato ancora migrato, riconnesso, eliminato o contrassegnato come completato.',
+  station_migration_settings_title: 'Migrare i wallet Station',
+  station_migration_settings_description:
+    'Esamina i vecchi portafogli Station rilevati su questo dispositivo.',
+  station_migration_set_up_without_migrating: 'Configurazione senza migrazione',
+  station_migration_no_wallets_found:
+    'In questa estensione di archiviazione non è stato trovato alcun portafoglio legacy Station.',
+  station_migration_summary_total_one: 'Portafoglio {{count}}',
+  station_migration_summary_total_other: 'portafogli {{count}}',
+  station_migration_status_supported: 'Supportato',
+  station_migration_status_reconnect: 'Ricollega',
+  station_migration_status_unsupported: 'Non supportato',
+  station_migration_status_corrupt: 'Non valido',
+  station_migration_status_needs_review: 'Necessita di revisione',
+  station_migration_wallet_type_mnemonic: 'Seed crittografato e mnemonico',
+  station_migration_wallet_type_seed: 'Seed crittografato',
+  station_migration_wallet_type_private_key: 'Chiave privata crittografata',
+  station_migration_wallet_type_interchain_private_key:
+    'Chiavi private Terra crittografate',
+  station_migration_wallet_type_legacy_private_key:
+    'Blob di chiave privata crittografata legacy',
+  station_migration_wallet_type_ledger: 'Portafoglio hardware Ledger',
+  station_migration_wallet_type_multisig: 'Portafoglio multisig',
+  station_migration_wallet_type_unknown:
+    'Formato del portafoglio sconosciuto Station',
+  station_migration_wallet_type_corrupt_storage: 'Memoria non valida',
+  station_migration_wallet_type_corrupt_wallet:
+    'Inserimento del portafoglio non valido',
+  station_migration_reason_supported_mnemonic:
+    'I dati del portafoglio crittografati sono presenti per una futura migrazione che richiede la password Station.',
+  station_migration_reason_supported_seed:
+    'Sono presenti byte di seeding crittografati per una futura migrazione che richiederà la password Station.',
+  station_migration_reason_supported_private_key:
+    'I dati della chiave privata crittografata sono presenti per una futura importazione nella famiglia Terra.',
+  station_migration_reason_supported_interchain_private_key:
+    'I dati crittografati della chiave privata di Terra sono presenti per una futura importazione.',
+  station_migration_reason_supported_legacy_private_key:
+    'I dati della chiave privata crittografata preesistente sono presenti per una futura importazione.',
+  station_migration_reason_ledger_reconnect:
+    'Station memorizza i dettagli dell&#39;account pubblico per questo portafoglio Ledger. Ricollega il dispositivo hardware in seguito per utilizzarlo in Station.',
+  station_migration_reason_multisig:
+    'Station memorizza solo i metadati pubblici multisig. Non memorizza le chiavi private che possono essere convertite in un vault Vultisig.',
+  station_migration_reason_encrypted_seed_not_string:
+    'encryptedSeed è presente ma non è una stringa.',
+  station_migration_reason_encrypted_invalid_shape:
+    'La parola chiave `encrypted` è presente ma non è né una stringa né un oggetto.',
+  station_migration_reason_encrypted_private_key_missing_330:
+    'L&#39;oggetto chiave privata crittografata non supporta il tipo di moneta 330.',
+  station_migration_reason_legacy_wallet_blob_not_string:
+    'Il blob del portafoglio legacy è presente ma non è una stringa.',
+  station_migration_reason_unknown_wallet_shape:
+    'La voce del portafoglio non corrisponde ad alcun formato di archiviazione Station conosciuto.',
+  station_migration_reason_malformed_json:
+    '{{storageKey}} contiene JSON non valido.',
+  station_migration_reason_storage_not_array:
+    '{{storageKey}} deve essere un array JSON.',
+  station_migration_reason_wallet_entry_not_object:
+    'La voce del portafoglio non è un oggetto.',
+  station_migration_reason_unsupported_fallback:
+    'Questo portafoglio necessita di revisione prima di poter essere migrato.',
 }

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -1569,7 +1569,7 @@ export const it = {
   raw_message: 'Messaggio grezzo',
   token: 'Token',
   token_approval: 'Approvazione del token',
-  skip_for_now: 'Per ora saltate.',
+  skip_for_now: 'Salta per ora',
   station_migration_title: 'Migrare i wallet Station',
   station_migration_review_title: 'Revisione dei vecchi portafogli Station',
   station_migration_review_description:

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -1526,4 +1526,66 @@ export const ko = {
   raw_message: '원본 메시지',
   token: '토큰',
   token_approval: '토큰 승인',
+  skip_for_now: '지금은 건너뛰세요',
+  station_migration_title: 'Station 지갑을 마이그레이션하세요',
+  station_migration_review_title: '기존 Station 지갑을 검토하세요',
+  station_migration_review_description:
+    '이 작업은 기존 Station 확장 저장소만 읽습니다. 아직 어떤 지갑도 마이그레이션, 재연결, 삭제 또는 완료로 표시되지 않았습니다.',
+  station_migration_settings_title: 'Station 지갑을 마이그레이션하세요',
+  station_migration_settings_description:
+    '이 기기에서 감지된 이전 Station 지갑을 검토하세요.',
+  station_migration_set_up_without_migrating: '마이그레이션 없이 설정',
+  station_migration_no_wallets_found:
+    '이 확장 저장소에서 기존 Station 지갑이 발견되지 않았습니다.',
+  station_migration_summary_total_one: '{{count}} 지갑',
+  station_migration_summary_total_other: '{{count}} 지갑',
+  station_migration_status_supported: '지원됨',
+  station_migration_status_reconnect: '다시 연결',
+  station_migration_status_unsupported: '지원되지 않음',
+  station_migration_status_corrupt: '유효하지 않은',
+  station_migration_status_needs_review: '검토 필요',
+  station_migration_wallet_type_mnemonic: '암호화된 시드와 니모닉',
+  station_migration_wallet_type_seed: '암호화된 시드',
+  station_migration_wallet_type_private_key: '암호화된 개인 키',
+  station_migration_wallet_type_interchain_private_key:
+    '암호화된 Terra 개인 키',
+  station_migration_wallet_type_legacy_private_key:
+    '기존 암호화된 개인 키 블롭',
+  station_migration_wallet_type_ledger: '레저 하드웨어 지갑',
+  station_migration_wallet_type_multisig: '멀티시그 지갑',
+  station_migration_wallet_type_unknown: '알 수 없는 Station 지갑 형식',
+  station_migration_wallet_type_corrupt_storage: '잘못된 저장소',
+  station_migration_wallet_type_corrupt_wallet: '잘못된 지갑 입력입니다',
+  station_migration_reason_supported_mnemonic:
+    '암호화된 지갑 데이터는 향후 마이그레이션을 위해 존재하며, 해당 마이그레이션에서 Station 암호를 요구합니다.',
+  station_migration_reason_supported_seed:
+    '암호화된 시드 바이트는 향후 마이그레이션에서 Station 암호를 요청할 때 사용됩니다.',
+  station_migration_reason_supported_private_key:
+    '암호화된 개인 키 데이터가 향후 Terra 제품군 가져오기를 위해 존재합니다.',
+  station_migration_reason_supported_interchain_private_key:
+    '암호화된 Terra 개인 키 데이터가 향후 가져오기를 위해 준비되어 있습니다.',
+  station_migration_reason_supported_legacy_private_key:
+    '기존에 암호화된 개인 키 데이터가 향후 가져오기를 위해 존재합니다.',
+  station_migration_reason_ledger_reconnect:
+    'Station에는 이 Ledger 지갑의 공개 계정 정보가 저장됩니다. 나중에 하드웨어 장치를 다시 연결하여 Station에서 사용하세요.',
+  station_migration_reason_multisig:
+    'Station는 공개 멀티시그 메타데이터만 저장합니다. Vultisig 볼트로 변환할 수 있는 개인 키는 저장하지 않습니다.',
+  station_migration_reason_encrypted_seed_not_string:
+    'encryptedSeed는 존재하지만 문자열이 아닙니다.',
+  station_migration_reason_encrypted_invalid_shape:
+    'encrypted는 존재하지만 문자열도 아니고 객체도 아닙니다.',
+  station_migration_reason_encrypted_private_key_missing_330:
+    '암호화된 개인 키 객체에 코인 유형 330이 누락되었습니다.',
+  station_migration_reason_legacy_wallet_blob_not_string:
+    '기존 지갑의 블롭이 존재하지만 문자열은 아닙니다.',
+  station_migration_reason_unknown_wallet_shape:
+    '지갑 항목이 알려진 Station 저장 형식과 일치하지 않습니다.',
+  station_migration_reason_malformed_json:
+    '{{storageKey}}에 잘못된 형식의 JSON이 포함되어 있습니다.',
+  station_migration_reason_storage_not_array:
+    '{{storageKey}}는 JSON 배열이어야 합니다.',
+  station_migration_reason_wallet_entry_not_object:
+    '지갑 항목은 객체가 아닙니다.',
+  station_migration_reason_unsupported_fallback:
+    '이 지갑은 이전하기 전에 검토가 필요합니다.',
 }

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -1545,4 +1545,66 @@ export const nl = {
   raw_message: 'Onbewerkt bericht',
   token: 'Token',
   token_approval: 'Tokengoedkeuring',
+  skip_for_now: 'Sla dit voorlopig over.',
+  station_migration_title: 'Migreer Station wallets',
+  station_migration_review_title: 'Bekijk oude Station wallets',
+  station_migration_review_description:
+    'Dit leest alleen de oude Station-extensieopslag. Er zijn nog geen wallets gemigreerd, opnieuw verbonden, verwijderd of als voltooid gemarkeerd.',
+  station_migration_settings_title: 'Migreer Station wallets',
+  station_migration_settings_description:
+    'Controleer de oude Station wallets die op dit apparaat zijn gedetecteerd.',
+  station_migration_set_up_without_migrating: 'Instellen zonder migratie',
+  station_migration_no_wallets_found:
+    'Er zijn geen oudere Station wallets gevonden in deze extensieopslag.',
+  station_migration_summary_total_one: '{{count}} portemonnee',
+  station_migration_summary_total_other: '{{count}} wallets',
+  station_migration_status_supported: 'Ondersteund',
+  station_migration_status_reconnect: 'Opnieuw verbinding maken',
+  station_migration_status_unsupported: 'Niet ondersteund',
+  station_migration_status_corrupt: 'Ongeldig',
+  station_migration_status_needs_review: 'Moet beoordeeld worden',
+  station_migration_wallet_type_mnemonic: 'Versleutelde seed en mnemonic',
+  station_migration_wallet_type_seed: 'Versleutelde seed',
+  station_migration_wallet_type_private_key: 'Versleutelde privésleutel',
+  station_migration_wallet_type_interchain_private_key:
+    'Versleutelde Terra privésleutels',
+  station_migration_wallet_type_legacy_private_key:
+    'Legacy versleutelde privésleutelblob',
+  station_migration_wallet_type_ledger: 'Ledger hardware wallet',
+  station_migration_wallet_type_multisig: 'Multisig-wallet',
+  station_migration_wallet_type_unknown: 'Onbekend Station-walletformaat',
+  station_migration_wallet_type_corrupt_storage: 'Ongeldige opslag',
+  station_migration_wallet_type_corrupt_wallet: 'Ongeldige portemonnee-invoer',
+  station_migration_reason_supported_mnemonic:
+    'Versleutelde portemonneegegevens zijn aanwezig voor een toekomstige migratie waarbij het wachtwoord Station nodig is.',
+  station_migration_reason_supported_seed:
+    'Versleutelde seed-bytes zijn aanwezig voor een toekomstige migratie waarbij het wachtwoord Station wordt opgevraagd.',
+  station_migration_reason_supported_private_key:
+    'Versleutelde privé-sleutelgegevens zijn aanwezig voor een toekomstige import binnen de Terra-familie.',
+  station_migration_reason_supported_interchain_private_key:
+    'Versleutelde Terra-privésleutelgegevens zijn aanwezig voor een toekomstige import.',
+  station_migration_reason_supported_legacy_private_key:
+    'Versleutelde privé-sleutelgegevens uit het verleden zijn aanwezig voor een toekomstige import.',
+  station_migration_reason_ledger_reconnect:
+    'Station slaat de openbare accountgegevens voor deze Ledger-wallet op. Sluit het hardwareapparaat later opnieuw aan om het in Station te gebruiken.',
+  station_migration_reason_multisig:
+    'Station slaat alleen openbare multisig-metadata op. Het slaat geen privésleutels op die kunnen worden omgezet in een Vultisig-kluis.',
+  station_migration_reason_encrypted_seed_not_string:
+    'encryptedSeed is aanwezig, maar is geen tekenreeks.',
+  station_migration_reason_encrypted_invalid_shape:
+    'De versleutelde waarde is aanwezig, maar het is noch een tekenreeks, noch een object.',
+  station_migration_reason_encrypted_private_key_missing_330:
+    'Het versleutelde object met de privésleutel mist munttype 330.',
+  station_migration_reason_legacy_wallet_blob_not_string:
+    'De legacy wallet-blob is aanwezig, maar is geen tekenreeks.',
+  station_migration_reason_unknown_wallet_shape:
+    'De wallet-invoer komt niet overeen met een bekend Station-opslagformaat.',
+  station_migration_reason_malformed_json:
+    '{{storageKey}} bevat onjuist opgemaakte JSON.',
+  station_migration_reason_storage_not_array:
+    '{{storageKey}} moet een JSON-array zijn.',
+  station_migration_reason_wallet_entry_not_object:
+    'De portemonnee-ingang is geen object.',
+  station_migration_reason_unsupported_fallback:
+    'Deze portemonnee moet eerst gecontroleerd worden voordat deze gemigreerd kan worden.',
 }

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -1610,7 +1610,7 @@ export const pt = {
   station_migration_reason_ledger_reconnect:
     'Station armazena os detalhes da conta pública desta carteira Ledger. Reconecte o dispositivo de hardware posteriormente para usá-lo em Station.',
   station_migration_reason_multisig:
-    'O token Station armazena apenas metadados multisig públicos. Ele não armazena chaves privadas que possam ser convertidas em um cofre Vultisig.',
+    'A Station armazena apenas metadados multisig públicos. Ela não armazena chaves privadas que possam ser convertidas em um cofre Vultisig.',
   station_migration_reason_encrypted_seed_not_string:
     'O encryptedSeed está presente, mas não é uma string.',
   station_migration_reason_encrypted_invalid_shape:

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -1566,4 +1566,67 @@ export const pt = {
   raw_message: 'Mensagem bruta',
   token: 'Token',
   token_approval: 'Aprovação de token',
+  skip_for_now: 'Por enquanto, pule esta etapa.',
+  station_migration_title: 'Migrar carteiras Station',
+  station_migration_review_title: 'Analisar carteiras antigas Station',
+  station_migration_review_description:
+    'Esta operação lê apenas o armazenamento da extensão legada Station. Nenhuma carteira foi migrada, reconectada, excluída ou marcada como concluída ainda.',
+  station_migration_settings_title: 'Migrar carteiras Station',
+  station_migration_settings_description:
+    'Analisar carteiras antigas Station detectadas neste dispositivo.',
+  station_migration_set_up_without_migrating: 'Configurar sem migrar',
+  station_migration_no_wallets_found:
+    'Nenhuma carteira Station legada foi encontrada neste armazenamento de extensão.',
+  station_migration_summary_total_one: 'Carteira {{count}}',
+  station_migration_summary_total_other: 'Carteiras {{count}}',
+  station_migration_status_supported: 'Apoiado',
+  station_migration_status_reconnect: 'Reconectar',
+  station_migration_status_unsupported: 'Sem suporte',
+  station_migration_status_corrupt: 'Inválido',
+  station_migration_status_needs_review: 'Precisa de revisão',
+  station_migration_wallet_type_mnemonic: 'Semente criptografada e mnemônica',
+  station_migration_wallet_type_seed: 'Semente criptografada',
+  station_migration_wallet_type_private_key: 'Chave privada criptografada',
+  station_migration_wallet_type_interchain_private_key:
+    'Chaves privadas Terra criptografadas',
+  station_migration_wallet_type_legacy_private_key:
+    'Blob de chave privada criptografada legado',
+  station_migration_wallet_type_ledger: 'Carteira de hardware Ledger',
+  station_migration_wallet_type_multisig: 'Carteira multisig',
+  station_migration_wallet_type_unknown:
+    'Formato de carteira Station desconhecido',
+  station_migration_wallet_type_corrupt_storage: 'Armazenamento inválido',
+  station_migration_wallet_type_corrupt_wallet: 'Entrada de carteira inválida',
+  station_migration_reason_supported_mnemonic:
+    'Os dados criptografados da carteira estão presentes para uma futura migração que solicitará a senha Station.',
+  station_migration_reason_supported_seed:
+    'Os bytes de semente criptografados estão presentes para uma futura migração que solicitará a senha Station.',
+  station_migration_reason_supported_private_key:
+    'Os dados criptografados da chave privada estão presentes para uma futura importação da família Terra.',
+  station_migration_reason_supported_interchain_private_key:
+    'Os dados criptografados da chave privada do Terra estão presentes para uma futura importação.',
+  station_migration_reason_supported_legacy_private_key:
+    'Os dados legados criptografados da chave privada estão presentes para uma futura importação.',
+  station_migration_reason_ledger_reconnect:
+    'Station armazena os detalhes da conta pública desta carteira Ledger. Reconecte o dispositivo de hardware posteriormente para usá-lo em Station.',
+  station_migration_reason_multisig:
+    'O token Station armazena apenas metadados multisig públicos. Ele não armazena chaves privadas que possam ser convertidas em um cofre Vultisig.',
+  station_migration_reason_encrypted_seed_not_string:
+    'O encryptedSeed está presente, mas não é uma string.',
+  station_migration_reason_encrypted_invalid_shape:
+    'O valor criptografado está presente, mas não é uma string nem um objeto.',
+  station_migration_reason_encrypted_private_key_missing_330:
+    'O objeto de chave privada criptografada não possui o tipo de moeda 330.',
+  station_migration_reason_legacy_wallet_blob_not_string:
+    'O blob da carteira legada está presente, mas não é uma string.',
+  station_migration_reason_unknown_wallet_shape:
+    'A entrada da carteira não corresponde a nenhum formato de armazenamento Station conhecido.',
+  station_migration_reason_malformed_json:
+    '{{storageKey}} contém JSON malformado.',
+  station_migration_reason_storage_not_array:
+    '{{storageKey}} deve ser uma matriz JSON.',
+  station_migration_reason_wallet_entry_not_object:
+    'A entrada da carteira não é um objeto.',
+  station_migration_reason_unsupported_fallback:
+    'Esta carteira precisa ser analisada antes de ser migrada.',
 }

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -1543,7 +1543,7 @@ export const ru = {
   station_migration_title: 'Перенести кошельки Station',
   station_migration_review_title: 'Проверка старых кошельков Station',
   station_migration_review_description:
-    'Это только чтение устаревшего хранилища расширения Station. Пока ни один кошельк не был перенесен, переподключен, удален или помечен как завершенный.',
+    'Это только чтение устаревшего хранилища расширения Station. Пока ни один кошелёк не был перенесён, переподключён, удалён или помечен как завершённый.',
   station_migration_settings_title: 'Перенести кошельки Station',
   station_migration_settings_description:
     'Просмотрите старые кошельки Station, обнаруженные на этом устройстве.',

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -1539,4 +1539,67 @@ export const ru = {
   raw_message: 'Исходное сообщение',
   token: 'Токен',
   token_approval: 'Подтверждение токена',
+  skip_for_now: 'Пропустите пока что',
+  station_migration_title: 'Перенести кошельки Station',
+  station_migration_review_title: 'Проверка старых кошельков Station',
+  station_migration_review_description:
+    'Это только чтение устаревшего хранилища расширения Station. Пока ни один кошельк не был перенесен, переподключен, удален или помечен как завершенный.',
+  station_migration_settings_title: 'Перенести кошельки Station',
+  station_migration_settings_description:
+    'Просмотрите старые кошельки Station, обнаруженные на этом устройстве.',
+  station_migration_set_up_without_migrating: 'Настройка без миграции.',
+  station_migration_no_wallets_found:
+    'В хранилище этого расширения не обнаружено устаревших кошельков Station.',
+  station_migration_summary_total_one: 'Кошелек {{count}}',
+  station_migration_summary_total_other: 'Кошельки {{count}}',
+  station_migration_status_supported: 'Поддерживается',
+  station_migration_status_reconnect: 'Восстановить соединение',
+  station_migration_status_unsupported: 'Неподдерживаемый',
+  station_migration_status_corrupt: 'Неверный',
+  station_migration_status_needs_review: 'Требуется пересмотр',
+  station_migration_wallet_type_mnemonic:
+    'Зашифрованное начальное значение и мнемоническое правило',
+  station_migration_wallet_type_seed: 'Зашифрованное начальное значение',
+  station_migration_wallet_type_private_key: 'Зашифрованный закрытый ключ',
+  station_migration_wallet_type_interchain_private_key:
+    'Зашифрованные закрытые ключи Terra',
+  station_migration_wallet_type_legacy_private_key:
+    'Устаревший зашифрованный блок закрытого ключа',
+  station_migration_wallet_type_ledger: 'Аппаратный кошелек Ledger',
+  station_migration_wallet_type_multisig: 'Кошелек с мультиподписью',
+  station_migration_wallet_type_unknown: 'Неизвестный формат кошелька Station',
+  station_migration_wallet_type_corrupt_storage: 'Недопустимое хранилище',
+  station_migration_wallet_type_corrupt_wallet: 'Неверная запись в кошельке',
+  station_migration_reason_supported_mnemonic:
+    'Зашифрованные данные кошелька присутствуют для будущей миграции, при которой потребуется пароль Station.',
+  station_migration_reason_supported_seed:
+    'Зашифрованные начальные байты присутствуют для будущей миграции, при которой будет запрошен пароль Station.',
+  station_migration_reason_supported_private_key:
+    'Зашифрованные данные закрытого ключа доступны для будущего импорта в семейство Terra.',
+  station_migration_reason_supported_interchain_private_key:
+    'Зашифрованные данные закрытого ключа Terra доступны для импорта в будущем.',
+  station_migration_reason_supported_legacy_private_key:
+    'Устаревшие зашифрованные данные закрытого ключа доступны для импорта в будущем.',
+  station_migration_reason_ledger_reconnect:
+    'В Station хранятся общедоступные данные учетной записи для этого кошелька Ledger. Подключите аппаратное устройство позже, чтобы использовать его в Station.',
+  station_migration_reason_multisig:
+    'Station хранит только открытые метаданные мультиподписи. Он не хранит закрытые ключи, которые можно преобразовать в хранилище Vultisig.',
+  station_migration_reason_encrypted_seed_not_string:
+    'Параметр encryptedSeed присутствует, но не является строкой.',
+  station_migration_reason_encrypted_invalid_shape:
+    'Зашифрованное значение присутствует, но не является ни строкой, ни объектом.',
+  station_migration_reason_encrypted_private_key_missing_330:
+    'В зашифрованном объекте закрытого ключа отсутствует тип монеты 330.',
+  station_migration_reason_legacy_wallet_blob_not_string:
+    'Устаревший объект Wallet Blob присутствует, но не является строкой.',
+  station_migration_reason_unknown_wallet_shape:
+    'Запись в кошельке не соответствует ни одному известному формату хранения Station.',
+  station_migration_reason_malformed_json:
+    '{{storageKey}} содержит некорректный JSON.',
+  station_migration_reason_storage_not_array:
+    '{{storageKey}} должен быть массивом JSON.',
+  station_migration_reason_wallet_entry_not_object:
+    'Запись в кошельке не является объектом.',
+  station_migration_reason_unsupported_fallback:
+    'Перед переносом данных из этого кошелька требуется его проверка.',
 }

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -1448,4 +1448,61 @@ export const zh = {
   raw_message: '原始信息',
   token: '令牌',
   token_approval: '代币批准',
+  skip_for_now: '暂时跳过',
+  station_migration_title: '迁移 Station 钱包',
+  station_migration_review_title: '查看旧的 Station 钱包',
+  station_migration_review_description:
+    '此功能仅读取旧版 Station 扩展存储。目前尚未迁移、重新连接、删除或标记为已完成任何钱包。',
+  station_migration_settings_title: '迁移 Station 钱包',
+  station_migration_settings_description:
+    '查看此设备上检测到的旧版 Station 钱包。',
+  station_migration_set_up_without_migrating: '无需迁移即可设置',
+  station_migration_no_wallets_found: '在此扩展存储中未找到旧版 Station 钱包。',
+  station_migration_summary_total_one: '{{count}} 钱包',
+  station_migration_summary_total_other: '{{count}} 钱包',
+  station_migration_status_supported: '支持',
+  station_migration_status_reconnect: '重新连接',
+  station_migration_status_unsupported: '不支持',
+  station_migration_status_corrupt: '无效的',
+  station_migration_status_needs_review: '需要审查',
+  station_migration_wallet_type_mnemonic: '加密种子和助记词',
+  station_migration_wallet_type_seed: '加密种子',
+  station_migration_wallet_type_private_key: '加密私钥',
+  station_migration_wallet_type_interchain_private_key: '加密的 Terra 私钥',
+  station_migration_wallet_type_legacy_private_key: '遗留的加密私钥块',
+  station_migration_wallet_type_ledger: 'Ledger硬件钱包',
+  station_migration_wallet_type_multisig: '多重签名钱包',
+  station_migration_wallet_type_unknown: '未知 Station 钱包格式',
+  station_migration_wallet_type_corrupt_storage: '无效存储',
+  station_migration_wallet_type_corrupt_wallet: '无效的钱包条目',
+  station_migration_reason_supported_mnemonic:
+    '加密钱包数据已保存，以便将来迁移时需要输入 Station 密码。',
+  station_migration_reason_supported_seed:
+    '已加密种子字节，以备将来迁移时需要输入 Station 密码。',
+  station_migration_reason_supported_private_key:
+    '已为将来导入 Terra 系列产品准备加密的私钥数据。',
+  station_migration_reason_supported_interchain_private_key:
+    '已加密的 Terra 私钥数据已准备就绪，可供将来导入。',
+  station_migration_reason_supported_legacy_private_key:
+    '已保存旧版加密私钥数据，以备将来导入。',
+  station_migration_reason_ledger_reconnect:
+    'Station 存储此 Ledger 钱包的公共账户详细信息。稍后重新连接硬件设备，即可在 Station 中使用它。',
+  station_migration_reason_multisig:
+    'Station 仅存储公共多重签名元数据。它不存储可以转换为 Vultisig 保险库的私钥。',
+  station_migration_reason_encrypted_seed_not_string:
+    'encryptedSeed 存在，但它不是字符串。',
+  station_migration_reason_encrypted_invalid_shape:
+    '加密内容存在，但既不是字符串也不是对象。',
+  station_migration_reason_encrypted_private_key_missing_330:
+    '加密的私钥对象缺少币种类型 330。',
+  station_migration_reason_legacy_wallet_blob_not_string:
+    '旧版钱包数据块存在，但它不是字符串。',
+  station_migration_reason_unknown_wallet_shape:
+    '钱包条目与任何已知的 Station 存储格式都不匹配。',
+  station_migration_reason_malformed_json:
+    '{{storageKey}} 包含格式错误的 JSON。',
+  station_migration_reason_storage_not_array:
+    '{{storageKey}} 必须是一个 JSON 数组。',
+  station_migration_reason_wallet_entry_not_object: '钱包条目不是一种对象。',
+  station_migration_reason_unsupported_fallback: '该钱包需要审核后才能迁移。',
 }

--- a/core/ui/i18n/utils/i18nGlossary.ts
+++ b/core/ui/i18n/utils/i18nGlossary.ts
@@ -27,6 +27,11 @@ export const i18nGlossary = [
     note: 'Brand name; keep exactly as written.',
   },
   {
+    term: 'Station',
+    preserve: true,
+    note: 'Brand name; keep exactly as written.',
+  },
+  {
     term: 'Vultiserver',
     preserve: true,
     note: 'Service name; keep exactly as written.',

--- a/core/ui/navigation/CoreView.ts
+++ b/core/ui/navigation/CoreView.ts
@@ -100,7 +100,11 @@ export type CoreView =
     }
   | {
       id: 'setupVault'
-      state: { type?: VaultSecurityType; keyImportInput?: KeyImportInput }
+      state: {
+        type?: VaultSecurityType
+        keyImportInput?: KeyImportInput
+        skipStationMigration?: boolean
+      }
     }
   | {
       id: 'setupVaultOverview'

--- a/core/ui/settings/index.tsx
+++ b/core/ui/settings/index.tsx
@@ -59,6 +59,7 @@ type Props = {
   insiderOptions?: ReactNode
   prioritize?: ReactNode
   sidePanel?: ReactNode
+  stationMigration?: ReactNode
   checkUpdate?: ReactNode
 }
 
@@ -120,6 +121,7 @@ export const SettingsPage: FC<Props> = props => {
                 showArrow
               />
             )}
+            {client === 'extension' && props.stationMigration}
           </SettingsSection>
 
           <SettingsSection title={t('general')}>


### PR DESCRIPTION
![screenshot-1](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/station-migration-shell/screenshot-1-1779856167751.png)
![screenshot-2](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/station-migration-shell/screenshot-2-1779856167751.png)
![screenshot-3](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/station-migration-shell/screenshot-3-1779856167751.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Station Wallet Migration: review and migrate legacy Station wallets from Settings or during setup, with a “skip for now” option and detailed per-wallet status/reason labels.
* **UI**
  * New settings entry, page layout, summary counts and a wallet icon for the migration flow.
* **Localization**
  * Added translations for Station migration in EN, DE, ES, IT, NL, PT, KO, HR, RU, ZH.
* **Tests**
  * Unit tests added to validate migration gating and classification logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-windows/pull/4002?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->