### PR TITLE
Fix deposit option text overflowing its box

### DIFF
--- a/core/ui/vault/deposit/DepositForm/DepositActionOption.tsx
+++ b/core/ui/vault/deposit/DepositForm/DepositActionOption.tsx
@@ -1,5 +1,4 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
-import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { panel } from '@lib/ui/panel/Panel'
 import { IsActiveProp, OnClickProp, ValueProp } from '@lib/ui/props'
 import { Text } from '@lib/ui/text'
@@ -10,6 +9,8 @@ const Container = styled(UnstyledButton)<IsActiveProp>`
   ${panel()};
 
   position: relative;
+  width: 100%;
+  text-align: left;
 
   border: 2px solid
     ${matchColor('isActive', { true: 'primary', false: 'transparent' })};
@@ -19,6 +20,10 @@ const Container = styled(UnstyledButton)<IsActiveProp>`
   }
 `
 
+const Value = styled(Text)`
+  overflow-wrap: anywhere;
+`
+
 export const DepositActionOption = ({
   value,
   onClick,
@@ -26,13 +31,9 @@ export const DepositActionOption = ({
 }: ValueProp<string> & OnClickProp & IsActiveProp) => {
   return (
     <Container isActive={isActive} onClick={onClick}>
-      <HStack fullWidth alignItems="center" gap={12}>
-        <VStack alignItems="start">
-          <Text color="contrast" size={16} weight="500">
-            {value}
-          </Text>
-        </VStack>
-      </HStack>
+      <Value color="contrast" size={16} weight="500">
+        {value}
+      </Value>
     </Container>
   )
 }


### PR DESCRIPTION
Closes #4008

## Summary
- Long deposit option values (e.g. THORChain LP pool addresses like `AVAX.SOL-0X...`) overflowed the option box in the **Select pool** / token explorers.
- Root cause: the native `<button>` centered the text, and the nested `HStack`/`VStack` wrappers' default `min-width: auto` prevented the long unbroken address from wrapping.
- Fix: render the value full-width and left-aligned, with `overflow-wrap: anywhere` so long addresses break cleanly inside the box.
- `DepositActionOption` is shared across all deposit explorers (pool, token, asset), so this improves every list.

##
<img width="483" height="604" alt="image" src="https://github.com/user-attachments/assets/d9907c8e-bc16-4aef-8c9e-2cc8fd8977cc" />


## Test plan
- [ ] Open the extension popup → Deposit → THORChain LP → **Select pool**
- [ ] Confirm long pool entries (e.g. `AVAX.USDC-0X...`) wrap inside the box, left-aligned, with no horizontal overflow
- [ ] Confirm short entries (`AVAX.AVAX`, `BASE.ETH`) still render correctly
- [ ] Spot-check other explorers (token / asset / stake) for unchanged behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)