### PR TITLE
Add Keplr isEnabled handler for Cosmos dApp adapters

### DIFF
--- a/clients/extension/src/inpage/providers/xdefiKeplr.ts
+++ b/clients/extension/src/inpage/providers/xdefiKeplr.ts
@@ -671,6 +671,21 @@ export class XDEFIKeplrProvider extends Keplr {
   }
 
   /**
+   * Reports whether the host has an active vault grant. cosmos-kit / graz
+   * adapters call this on hydration to decide between auto-reconnect and
+   * showing the connect button; the inherited base routes through our
+   * requester and throws, which surfaces an unhandled rejection in the
+   * dApp console and confuses some adapters.
+   *
+   * Vultisig's `appSession` is host-keyed (not host+chain-keyed), so the
+   * `chainIds` argument is accepted for API compatibility but ignored:
+   * either the host holds a grant for everything it can query, or nothing.
+   */
+  async isEnabled(_chainIds: string | string[]): Promise<boolean> {
+    return callBackground({ hasAppSession: {} })
+  }
+
+  /**
    * Keplr-shaped chain list for every Cosmos chain Vultisig exposes natively
    * plus any chains a dApp has registered via `experimentalSuggestChain`.
    * cosmos-kit dApps probe this BEFORE showing their

--- a/core/inpage-provider/background/interface.ts
+++ b/core/inpage-provider/background/interface.ts
@@ -32,6 +32,7 @@ export type BackgroundInterface = {
   setVaultChain: Method<SetAppChainInput>
   getAccount: Method<GetAccountInput, { address: string; publicKey: string }>
   signOut: Method<{}>
+  hasAppSession: Method<{}, boolean>
   evmClientRequest: Method<{ method: string; params?: unknown[] }, unknown>
   exportVault: Method<{}, VaultExport>
   getTx: Method<{ chain: Chain; hash: string }, unknown>

--- a/core/inpage-provider/background/resolvers/hasAppSession.ts
+++ b/core/inpage-provider/background/resolvers/hasAppSession.ts
@@ -1,0 +1,18 @@
+import { getAppSession } from '@core/inpage-provider/background/core/appSession'
+import { BackgroundResolver } from '@core/inpage-provider/background/resolver'
+
+/**
+ * Reports whether the requesting origin holds an active `appSession` against
+ * the current vault. Backs `Keplr.isEnabled` (and any future analogue) so
+ * cosmos-kit / graz adapters can probe connection state without rounding
+ * through `getKey`.
+ *
+ * Host-keyed: chain selection is ignored here because Vultisig's sessions
+ * grant per-host, not per-chain.
+ */
+export const hasAppSession: BackgroundResolver<'hasAppSession'> = async ({
+  context: { requestOrigin },
+}) => {
+  const appSession = await getAppSession(requestOrigin)
+  return !!appSession
+}

--- a/core/inpage-provider/background/resolvers/index.ts
+++ b/core/inpage-provider/background/resolvers/index.ts
@@ -9,6 +9,7 @@ import { getAccount } from './getAccount'
 import { getAppChain } from './getAppChain'
 import { getAppChainId } from './getAppChainId'
 import { getTx } from './getTx'
+import { hasAppSession } from './hasAppSession'
 import { hasChainInVault } from './hasChainInVault'
 import {
   addKeplrSuggestedChain,
@@ -29,6 +30,7 @@ export const backgroundResolvers: BackgroundResolvers = {
   setVaultChain,
   getAccount,
   signOut,
+  hasAppSession,
   evmClientRequest,
   exportVault,
   getTx,


### PR DESCRIPTION
## Summary
- Override `Keplr.isEnabled` on `XDEFIKeplrProvider` so it doesn't fall through to `XDEFIMessageRequester` and throw `"Keplr method 'is-enabled' is not supported by Vultisig"` — Keplr-shaped dApp adapters probe this on hydration to decide between auto-reconnect and showing the connect button.
- Back it with a new host-keyed `hasAppSession` background resolver that reuses the existing `getAppSession(requestOrigin)` helper.
- `chainIds` is accepted for API compatibility but ignored; Vultisig grants are host-keyed, not host+chain-keyed (same semantics as the existing `disable`).

Closes #4020

## Test plan
- [ ] `yarn check:all` succeeds
- [ ] `yarn build:extension` succeeds
- [ ] In a connected Keplr-shaped dApp's devtools, `window.keplr.isEnabled(['cosmoshub-4'])` resolves to `true` while the host has an active vault grant
- [ ] After `window.keplr.disable()` (or revoking via Connected Sites), `isEnabled` resolves to `false` — does NOT throw
- [ ] Loading a Cosmos dApp no longer logs `"Keplr method 'is-enabled' is not supported"` on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session detection capability to the wallet extension, allowing applications to query whether an active vault session exists for authenticated access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-windows/pull/4021?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->