### PR TITLE
Fix deposit form revalidating when selected coin changes

### DIFF
--- a/core/ui/vault/deposit/DepositForm/index.tsx
+++ b/core/ui/vault/deposit/DepositForm/index.tsx
@@ -27,7 +27,7 @@ import { PageHeader } from '@lib/ui/page/PageHeader'
 import { Text } from '@lib/ui/text'
 import { TronResourceType } from '@vultisig/core-chain/chains/tron/resources'
 import { isOneOf } from '@vultisig/lib-utils/array/isOneOf'
-import { FC, useState } from 'react'
+import { FC, useEffect, useState } from 'react'
 import { FieldValues, useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 
@@ -76,6 +76,7 @@ export const DepositForm: FC<DepositFormProps> = ({ onSubmit }) => {
     setValue,
     getValues,
     control,
+    trigger,
     formState: { errors, isValid, touchedFields, dirtyFields },
   } = useForm<FormData>({
     resolver: zodResolver(schema as any),
@@ -86,6 +87,14 @@ export const DepositForm: FC<DepositFormProps> = ({ onSubmit }) => {
       ...(formDefaults ?? {}),
     },
   })
+
+  // Re-validate when the selected coin or its balance changes — the resolver
+  // schema rebuilds with the new max, but react-hook-form only re-runs
+  // validation on field changes, so switching coins would otherwise leave
+  // a stale "valid" amount that exceeds the new balance.
+  useEffect(() => {
+    trigger()
+  }, [coin.id, balance, trigger])
 
   const handleFormSubmit = (data: FieldValues) => {
     onSubmit(data)


### PR DESCRIPTION
## Summary
- Trigger react-hook-form validation in `DepositForm` whenever the selected coin or its balance changes, so the `amount` field is re-checked against the new max.
- Fixes the case where a previously valid amount stays "valid" (and Continue stays enabled) after the user switches to a coin with a lower balance — most visible in THORChain → Functions → Custom Action.

Closes #4023

## Root cause
The Zod schema in `core/ui/vault/deposit/DepositForm/index.tsx` already rebuilds with the new balance every render (via `useDepositFormConfig`). But `useForm({ mode: 'onChange' })` only re-runs validation when a field changes, so switching the coin updated the resolver but did not re-validate — leaving the stale "valid" state.

## Fix
Extract `trigger` from `useForm` and call it from a `useEffect` keyed on `coin.id` and `balance`.

## Test plan
- [ ] Open a vault holding RUNE and another THORChain asset (e.g. ETH) with RUNE balance > ETH balance.
- [ ] Navigate to THORChain → Functions → Custom Action.
- [ ] Enter an amount that is valid for RUNE but greater than the ETH balance.
- [ ] Switch the token selector from RUNE to ETH → `Amount exceeded` error appears, Continue is disabled.
- [ ] Switch back to RUNE → error clears, Continue re-enables.
- [ ] Other actions with an amount field (mint, redeem, bond, stake, etc.) still validate correctly on amount changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deposit form validation so it refreshes immediately when users change the selected coin or when the available balance updates, preventing stale or out-of-date validation states and reducing validation errors during deposit entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->