### PR TITLE
Add Keplr sendTx broadcast and a Cosmos min-fee floor

### DIFF
--- a/clients/extension/src/inpage/providers/cosmos/injectKeplrFeeIfMissing.ts
+++ b/clients/extension/src/inpage/providers/cosmos/injectKeplrFeeIfMissing.ts
@@ -4,7 +4,11 @@ import { attempt } from '@vultisig/lib-utils/attempt'
 import { BinaryWriter } from 'cosmjs-types/binary'
 import { AuthInfo } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
 
-import { keplrAverageGasPrice, SupportedKeplrChain } from '../keplrChainInfo'
+import {
+  keplrAverageGasPrice,
+  keplrMinInjectedFee,
+  SupportedKeplrChain,
+} from '../keplrChainInfo'
 
 // Excludes QBTC (handled separately because its fee denom isn't in
 // `cosmosFeeCoinDenom`) and narrows back down to CosmosChain so the
@@ -55,7 +59,14 @@ export const injectKeplrFeeIfMissing = ({
   // out, rounding up so the fee never falls below the chain's minimum.
   const scale = 1_000_000_000n
   const scaledPrice = BigInt(Math.ceil(gasPrice * Number(scale)))
-  const feeAmountInt = (gasLimitBigInt * scaledPrice + scale - 1n) / scale
+  const computedFee = (gasLimitBigInt * scaledPrice + scale - 1n) / scale
+
+  // Some chains require a higher minimum fee than `gasLimit * gasPrice`
+  // produces (e.g. Akash, where a staking tx's computed fee falls below the
+  // network's accepted minimum). Floor the injected amount so the broadcast
+  // isn't rejected for an insufficient fee.
+  const minFee = keplrMinInjectedFee[chain] ?? 0n
+  const feeAmountInt = computedFee > minFee ? computedFee : minFee
 
   const denom = cosmosFeeCoinDenom[chain]
 

--- a/clients/extension/src/inpage/providers/keplrChainInfo.ts
+++ b/clients/extension/src/inpage/providers/keplrChainInfo.ts
@@ -107,6 +107,19 @@ export const keplrAverageGasPrice: Record<SupportedKeplrChain, number> = {
   QBTC: 0.004,
 }
 
+// Lower bound (in the chain's fee denom base units) for a wallet-injected
+// fee. `gasLimit * gasPrice` can land below what the chain's validators
+// actually accept — Akash's chain-registry gas price (0.025 uakt/gas)
+// yields only 7500 uakt (0.0075 AKT) on a ~300k-gas delegation, which the
+// network's mempool rejects. Floor the injected amount to the minimum the
+// chain expects. Only chains that need a floor above their computed fee are
+// listed; everything else relies on `gasLimit * gasPrice` alone.
+export const keplrMinInjectedFee: Partial<Record<SupportedKeplrChain, bigint>> =
+  {
+    // 0.025 AKT — the minimum fee Akash validators accept for staking txs.
+    Akash: 25_000n,
+  }
+
 const buildBech32Config = (prefix: string) => ({
   bech32PrefixAccAddr: prefix,
   bech32PrefixAccPub: `${prefix}pub`,

--- a/clients/extension/src/inpage/providers/xdefiKeplr.ts
+++ b/clients/extension/src/inpage/providers/xdefiKeplr.ts
@@ -15,6 +15,7 @@ import {
 import {
   AccountData,
   AminoSignResponse,
+  BroadcastMode,
   ChainInfo,
   ChainInfoWithoutEndpoints,
   DirectSignResponse,
@@ -750,14 +751,31 @@ export class XDEFIKeplrProvider extends Keplr {
     return
   }
 
-  async sendTx(): Promise<Uint8Array> {
-    // Keplr's `sendTx` broadcasts a fully signed transaction via Keplr's
-    // background relay. Vultisig has no equivalent relay — dApps that
-    // need to broadcast should do so via their own RPC client after
-    // `signAmino` / `signDirect`. Throwing here (instead of resolving
-    // `undefined` from the inherited base requester) gives the dApp a
-    // deterministic signal to fall back to its own broadcast.
-    throw new Error('Keplr.sendTx is not supported by Vultisig')
+  async sendTx(
+    chainId: string,
+    tx: Uint8Array,
+    _mode: BroadcastMode
+  ): Promise<Uint8Array> {
+    // cosmos-kit dApps sign with `signDirect` / `signAmino` (which Vultisig
+    // handles with `skipBroadcast`) and then call `sendTx` with the encoded
+    // `TxRaw` bytes to publish the transaction. Broadcasting runs in the
+    // background service worker — like real Keplr — so it isn't blocked by the
+    // dApp page's CSP via the SDK's shared broadcast path. Returns the tx-hash
+    // bytes the dApp uses to track inclusion. `_mode` is ignored — the SDK
+    // broadcast resolver picks the broadcast semantics.
+    const chain = getCosmosChainByChainId(chainId)
+    if (!chain) {
+      throw new Error(`Keplr.sendTx is not supported for chain ${chainId}`)
+    }
+
+    const { txHash } = await callBackground({
+      broadcastTx: {
+        chain,
+        txBytes: Buffer.from(tx).toString('base64'),
+      },
+    })
+
+    return hexToBytes(txHash)
   }
   async sendMessage() {}
 

--- a/clients/extension/tests/unit/injectKeplrFeeIfMissing.test.ts
+++ b/clients/extension/tests/unit/injectKeplrFeeIfMissing.test.ts
@@ -1,7 +1,6 @@
+import { injectKeplrFeeIfMissing } from '@clients/extension/src/inpage/providers/cosmos/injectKeplrFeeIfMissing'
 import { AuthInfo } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
 import { describe, expect, it } from 'vitest'
-
-import { injectKeplrFeeIfMissing } from '@clients/extension/src/inpage/providers/cosmos/injectKeplrFeeIfMissing'
 
 const encodeAuthInfo = (input: Parameters<typeof AuthInfo.fromPartial>[0]) =>
   AuthInfo.encode(AuthInfo.fromPartial(input)).finish()
@@ -16,7 +15,10 @@ describe('injectKeplrFeeIfMissing', () => {
       fee: { amount: [], gasLimit: 310823n, payer: '', granter: '' },
     })
 
-    const out = injectKeplrFeeIfMissing({ authInfoBytes: input, chain: 'Osmosis' })
+    const out = injectKeplrFeeIfMissing({
+      authInfoBytes: input,
+      chain: 'Osmosis',
+    })
 
     const decoded = AuthInfo.decode(out)
     expect(decoded.fee?.amount).toEqual([{ denom: 'uosmo', amount: '12433' }])
@@ -31,10 +33,47 @@ describe('injectKeplrFeeIfMissing', () => {
       fee: { amount: [], gasLimit: 310823n, payer: '', granter: '' },
     })
 
-    const out = injectKeplrFeeIfMissing({ authInfoBytes: input, chain: 'Osmosis' })
+    const out = injectKeplrFeeIfMissing({
+      authInfoBytes: input,
+      chain: 'Osmosis',
+    })
     const decoded = AuthInfo.decode(out)
     const amount = BigInt(decoded.fee?.amount[0]?.amount ?? '0')
     expect(amount).toBeGreaterThan(9325n)
+  })
+
+  it('floors the Akash injected fee to the chain minimum (0.025 AKT)', () => {
+    // A delegation runs ~300k gas; at 0.025 uakt/gas that computes to only
+    // 7500 uakt (0.0075 AKT), below Akash's accepted minimum. The injected
+    // fee must be floored to 25000 uakt (0.025 AKT).
+    const input = encodeAuthInfo({
+      signerInfos: [],
+      fee: { amount: [], gasLimit: 300000n, payer: '', granter: '' },
+    })
+
+    const out = injectKeplrFeeIfMissing({
+      authInfoBytes: input,
+      chain: 'Akash',
+    })
+
+    const decoded = AuthInfo.decode(out)
+    expect(decoded.fee?.amount).toEqual([{ denom: 'uakt', amount: '25000' }])
+  })
+
+  it('keeps the computed Akash fee when it already exceeds the minimum', () => {
+    // 2,000,000 gas × 0.025 uakt/gas = 50000 uakt, above the 25000 floor.
+    const input = encodeAuthInfo({
+      signerInfos: [],
+      fee: { amount: [], gasLimit: 2_000_000n, payer: '', granter: '' },
+    })
+
+    const out = injectKeplrFeeIfMissing({
+      authInfoBytes: input,
+      chain: 'Akash',
+    })
+
+    const decoded = AuthInfo.decode(out)
+    expect(decoded.fee?.amount).toEqual([{ denom: 'uakt', amount: '50000' }])
   })
 
   it('leaves bytes unchanged when fee.amount is already populated', () => {
@@ -48,7 +87,10 @@ describe('injectKeplrFeeIfMissing', () => {
       },
     })
 
-    const out = injectKeplrFeeIfMissing({ authInfoBytes: input, chain: 'Osmosis' })
+    const out = injectKeplrFeeIfMissing({
+      authInfoBytes: input,
+      chain: 'Osmosis',
+    })
 
     expect(Array.from(out)).toEqual(Array.from(input))
   })
@@ -59,7 +101,10 @@ describe('injectKeplrFeeIfMissing', () => {
       fee: { amount: [], gasLimit: 0n, payer: '', granter: '' },
     })
 
-    const out = injectKeplrFeeIfMissing({ authInfoBytes: input, chain: 'Osmosis' })
+    const out = injectKeplrFeeIfMissing({
+      authInfoBytes: input,
+      chain: 'Osmosis',
+    })
 
     expect(Array.from(out)).toEqual(Array.from(input))
   })

--- a/core/inpage-provider/background/interface.ts
+++ b/core/inpage-provider/background/interface.ts
@@ -2,7 +2,7 @@ import { VaultAppSession } from '@core/extension/storage/appSessions'
 import { KeplrSuggestedChainsRecord } from '@core/extension/storage/keplrSuggestedChains'
 import { VaultExport } from '@core/ui/vault/export/core'
 import { ChainInfo } from '@keplr-wallet/types'
-import { Chain } from '@vultisig/core-chain/Chain'
+import { Chain, CosmosChain } from '@vultisig/core-chain/Chain'
 import { ChainOfKind } from '@vultisig/core-chain/ChainKind'
 import { CoinKey, CoinMetadata, Token } from '@vultisig/core-chain/coin/Coin'
 import { ChainWithTokenMetadataDiscovery } from '@vultisig/core-chain/coin/token/metadata/chains'
@@ -35,6 +35,10 @@ export type BackgroundInterface = {
   evmClientRequest: Method<{ method: string; params?: unknown[] }, unknown>
   exportVault: Method<{}, VaultExport>
   getTx: Method<{ chain: Chain; hash: string }, unknown>
+  broadcastTx: Method<
+    { chain: CosmosChain; txBytes: string },
+    { txHash: string }
+  >
   getTokenMetadata: Method<
     Token<CoinKey<ChainWithTokenMetadataDiscovery>>,
     CoinMetadata

--- a/core/inpage-provider/background/resolvers/broadcastTx.ts
+++ b/core/inpage-provider/background/resolvers/broadcastTx.ts
@@ -1,0 +1,33 @@
+import { BackgroundResolver } from '@core/inpage-provider/background/resolver'
+import { deserializeSigningOutput } from '@vultisig/core-chain/tw/signingOutput'
+import { broadcastTx as broadcastChainTx } from '@vultisig/core-chain/tx/broadcast'
+import { getTxHash } from '@vultisig/core-chain/tx/hash'
+
+/**
+ * Broadcasts a fully signed Cosmos transaction and returns its hash.
+ *
+ * This backs the Keplr `sendTx` provider method: cosmos-kit dApps sign with
+ * `signDirect` / `signAmino` (which Vultisig handles with `skipBroadcast`) and
+ * then call `sendTx` with the encoded `TxRaw` bytes to publish it. Broadcasting
+ * runs in the background service worker — like real Keplr — so it isn't blocked
+ * by the dApp page's CSP.
+ *
+ * The dApp's `TxRaw` bytes are wrapped in the Cosmos signing-output shape the
+ * SDK's broadcast/hash resolvers expect (`serialized.tx_bytes`), then handed to
+ * the shared `broadcastTx` — which swallows duplicate-broadcast errors and
+ * verifies inclusion by hash — and `getTxHash`. Broadcast rejection (e.g.
+ * insufficient fee) propagates so the dApp sees the real failure.
+ */
+export const broadcastTx: BackgroundResolver<'broadcastTx'> = async ({
+  input: { chain, txBytes },
+}) => {
+  const tx = deserializeSigningOutput(chain, {
+    serialized: JSON.stringify({ tx_bytes: txBytes }),
+  })
+
+  const txHash = await getTxHash({ chain, tx })
+
+  await broadcastChainTx({ chain, tx })
+
+  return { txHash }
+}

--- a/core/inpage-provider/background/resolvers/index.ts
+++ b/core/inpage-provider/background/resolvers/index.ts
@@ -3,6 +3,7 @@ import { BackgroundMethod } from '@core/inpage-provider/background/interface'
 import { BackgroundResolver } from '@core/inpage-provider/background/resolver'
 import { getTokenMetadata } from '@vultisig/core-chain/coin/token/metadata'
 
+import { broadcastTx } from './broadcastTx'
 import { evmClientRequest } from './evmClientRequest'
 import { exportVault } from './exportVault'
 import { getAccount } from './getAccount'
@@ -32,6 +33,7 @@ export const backgroundResolvers: BackgroundResolvers = {
   evmClientRequest,
   exportVault,
   getTx,
+  broadcastTx,
   getTokenMetadata: ({ input }) => getTokenMetadata(input),
   getIsWalletPrioritized: () => getIsWalletPrioritized(),
   hasChainInVault,


### PR DESCRIPTION
## Summary

Two related fixes to the extension's Keplr provider for cosmos-kit dApp flows:

### 1. Implement `sendTx` broadcast (closes #4022)
`XDEFIKeplrProvider.sendTx` was a stub that threw `Keplr.sendTx is not supported by Vultisig`. cosmos-kit dApps sign via `signDirect` / `signAmino` (which Vultisig handles with `skipBroadcast`) and then call `window.keplr.sendTx` with the encoded `TxRaw` bytes to publish the tx — so the transaction failed **after** a successful signature.

Now `sendTx` broadcasts like real Keplr:
- A new `broadcastTx` background resolver wraps the raw `TxRaw` bytes into the SDK's signing-output shape (`deserializeSigningOutput`, no `as` casts) and delegates to the shared **`broadcastTx` + `getTxHash`** from `@vultisig/core-chain/tx/{broadcast,hash}` — the same path the keysign mutation and agent `signTx` use. This reuses the SDK's duplicate-broadcast handling and `verifyBroadcastByHash` safety net instead of reimplementing broadcast logic.
- Broadcasting runs in the **background service worker**, so it isn't blocked by the dApp page's CSP.
- Returns the tx-hash bytes; CheckTx rejections (e.g. insufficient fee) propagate to the dApp.

### 2. Floor the wallet-injected Cosmos fee (closes #3814)
`gasLimit * gasPrice` can land below what a chain's validators accept. `injectKeplrFeeIfMissing` now clamps the injected fee up to a configurable per-chain minimum (`keplrMinInjectedFee`), so wallet-filled fees clear the network floor.

Tx: https://www.mintscan.io/akash/tx/06D9D74DB293CB0BE1B4A2B060C45875AB5D2C4BF23A7323AB21AA3D35264DDB

## Changes
- `clients/extension/.../xdefiKeplr.ts` — implement `sendTx(chainId, tx, mode)`
- `core/inpage-provider/background/resolvers/broadcastTx.ts` — new resolver reusing the SDK
- `core/inpage-provider/background/{interface.ts,resolvers/index.ts}` — wire up `broadcastTx`
- `clients/extension/.../cosmos/injectKeplrFeeIfMissing.ts` — per-chain min-fee floor
- `clients/extension/.../keplrChainInfo.ts` — `keplrMinInjectedFee` map
- `clients/extension/tests/unit/injectKeplrFeeIfMissing.test.ts` — floor tests

## Testing
- `yarn typecheck` ✅
- Extension test suite: 425/425 ✅ (incl. 2 new fee-floor tests)
- `yarn knip` ✅ / ESLint clean

Closes #3814
Closes #4022

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled transaction broadcasting support for XDEFI Keplr provider integration.
  * Added automatic fee validation to ensure Cosmos transactions meet chain-specific minimum fee requirements, preventing validator rejection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-windows/pull/4025?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->