### PR TITLE
Match joined-device keysign verify screen to Send Overview design (#4028)

### DIFF
--- a/core/ui/chain/security/blockaid/tx/BlockaidTxScan.tsx
+++ b/core/ui/chain/security/blockaid/tx/BlockaidTxScan.tsx
@@ -1,0 +1,45 @@
+import { useAssertWalletCore } from '@core/ui/chain/providers/WalletCoreProvider'
+import { BlockaidTxScanStatus } from '@core/ui/chain/security/blockaid/tx/BlockaidTxScanStatus'
+import { getBlockaidTxValidationQuery } from '@core/ui/chain/security/blockaid/tx/queries/blockaidTxValidation'
+import { useIsBlockaidEnabled } from '@core/ui/storage/blockaid'
+import { usePotentialQuery } from '@lib/ui/query/hooks/usePotentialQuery'
+import { useTransformQueryData } from '@lib/ui/query/hooks/useTransformQueryData'
+import { Query } from '@lib/ui/query/Query'
+import { getBlockaidTxValidationInput } from '@vultisig/core-mpc/security/blockaid/tx/validation/input'
+import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+
+type BlockaidTxScanProps = {
+  keysignPayloadQuery: Query<KeysignPayload>
+}
+
+/**
+ * Self-contained Blockaid transaction-scan banner. Runs the validation against
+ * the resolved keysign payload and renders the scan status. Renders nothing
+ * when Blockaid is disabled. Shared by the initiator's pre-sign screen and the
+ * joiner's verify screen so both co-signers see the same security result.
+ */
+export const BlockaidTxScan = ({
+  keysignPayloadQuery,
+}: BlockaidTxScanProps) => {
+  const isBlockaidEnabled = useIsBlockaidEnabled()
+  const walletCore = useAssertWalletCore()
+
+  const txScanInput = useTransformQueryData(keysignPayloadQuery, payload => {
+    if (!isBlockaidEnabled) {
+      return null
+    }
+
+    return getBlockaidTxValidationInput({ payload, walletCore })
+  })
+
+  const txScanQuery = usePotentialQuery(
+    txScanInput.data || undefined,
+    getBlockaidTxValidationQuery
+  )
+
+  if (!isBlockaidEnabled) {
+    return null
+  }
+
+  return <BlockaidTxScanStatus value={txScanQuery} />
+}

--- a/core/ui/chain/security/blockaid/tx/BlockaidTxScanStatus.tsx
+++ b/core/ui/chain/security/blockaid/tx/BlockaidTxScanStatus.tsx
@@ -1,0 +1,26 @@
+import { BlockaidNoScanStatus } from '@core/ui/chain/security/blockaid/scan/BlockaidNoScanStatus'
+import { BlockaidScanning } from '@core/ui/chain/security/blockaid/scan/BlockaidScanning'
+import { BlockaidScanStatusContainer } from '@core/ui/chain/security/blockaid/scan/BlockaidScanStatusContainer'
+import { BlockaidTxValidationResult } from '@core/ui/chain/security/blockaid/tx/BlockaidTxValidationResult'
+import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
+import { Query } from '@lib/ui/query/Query'
+import { BlockaidValidationResult } from '@vultisig/core-chain/security/blockaid/tx/validation/core'
+
+type BlockaidTxScanStatusProps = {
+  value: Query<BlockaidValidationResult | undefined>
+}
+
+/**
+ * Presentational Blockaid scan banner — maps a tx-validation query to its scan
+ * status UI. Shared by every screen that surfaces the scan so the banner stays
+ * identical across the initiator and joiner flows.
+ */
+export const BlockaidTxScanStatus = ({ value }: BlockaidTxScanStatusProps) => (
+  <MatchQuery
+    value={value}
+    success={result => <BlockaidTxValidationResult value={result} />}
+    pending={() => <BlockaidScanning />}
+    error={() => <BlockaidNoScanStatus entity="tx" />}
+    inactive={() => <BlockaidScanStatusContainer />}
+  />
+)

--- a/core/ui/mpc/keysign/join/JoinKeysignVerifyStep.tsx
+++ b/core/ui/mpc/keysign/join/JoinKeysignVerifyStep.tsx
@@ -1,11 +1,12 @@
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { JoinKeysignCustomMessageVerify } from '@core/ui/mpc/keysign/join/JoinKeysignCustomMessageVerify'
+import { JoinKeysignButton } from '@core/ui/mpc/keysign/join/tx/JoinKeysignButton'
 import { JoinKeysignTransactionVerify } from '@core/ui/mpc/keysign/join/tx/JoinKeysignTransactionVerify'
 import { useCoreViewState } from '@core/ui/navigation/hooks/useCoreViewState'
 import { MatchRecordUnion } from '@lib/ui/base/MatchRecordUnion'
-import { Button } from '@lib/ui/buttons/Button'
 import { VStack } from '@lib/ui/layout/Stack'
 import { PageContent } from '@lib/ui/page/PageContent'
+import { PageFooter } from '@lib/ui/page/PageFooter'
 import { PageHeader } from '@lib/ui/page/PageHeader'
 import { OnFinishProp } from '@lib/ui/props'
 import { getKeysignMessagePayload } from '@vultisig/core-mpc/keysign/keysignPayload/KeysignMessagePayload'
@@ -28,20 +29,26 @@ export const JoinKeysignVerifyStep = ({ onFinish }: OnFinishProp) => {
         title={t('verify')}
         hasBorder
       />
-      <PageContent>
-        <VStack flexGrow>
-          <MatchRecordUnion
-            value={keysignPayload}
-            handlers={{
-              keysign: payload => (
-                <JoinKeysignTransactionVerify value={payload} />
-              ),
-              custom: value => <JoinKeysignCustomMessageVerify value={value} />,
-            }}
-          />
-        </VStack>
-        <Button onClick={onFinish}>{t('join_keysign')}</Button>
-      </PageContent>
+      <MatchRecordUnion
+        value={keysignPayload}
+        handlers={{
+          keysign: payload => (
+            <JoinKeysignTransactionVerify value={payload} onFinish={onFinish} />
+          ),
+          custom: value => (
+            <>
+              <PageContent scrollable>
+                <VStack flexGrow>
+                  <JoinKeysignCustomMessageVerify value={value} />
+                </VStack>
+              </PageContent>
+              <PageFooter>
+                <JoinKeysignButton onClick={onFinish} />
+              </PageFooter>
+            </>
+          ),
+        }}
+      />
     </>
   )
 }

--- a/core/ui/mpc/keysign/join/tx/JoinKeysignButton.tsx
+++ b/core/ui/mpc/keysign/join/tx/JoinKeysignButton.tsx
@@ -1,0 +1,25 @@
+import { Button } from '@lib/ui/buttons/Button'
+import { OnClickProp } from '@lib/ui/props'
+import { useTranslation } from 'react-i18next'
+
+type JoinKeysignButtonProps = OnClickProp & {
+  /** When a string, the button is disabled and the value is shown as a tooltip. */
+  disabled?: boolean | string
+}
+
+/**
+ * Shared "Join Keysign" action used by every joiner verify view so the footer
+ * label and styling stay consistent across transfer, swap, LP and custom flows.
+ */
+export const JoinKeysignButton = ({
+  onClick,
+  disabled,
+}: JoinKeysignButtonProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <Button onClick={onClick} disabled={disabled}>
+      {t('join_keysign')}
+    </Button>
+  )
+}

--- a/core/ui/mpc/keysign/join/tx/JoinKeysignTransactionVerify.tsx
+++ b/core/ui/mpc/keysign/join/tx/JoinKeysignTransactionVerify.tsx
@@ -1,34 +1,90 @@
-import { TxOverviewPanel } from '@core/ui/chain/tx/TxOverviewPanel'
-import { ValueProp } from '@lib/ui/props'
+import { verticalPadding } from '@lib/ui/css/verticalPadding'
+import { Checkbox } from '@lib/ui/inputs/checkbox/Checkbox'
+import { VStack } from '@lib/ui/layout/Stack'
+import { PageContent } from '@lib/ui/page/PageContent'
+import { PageFooter } from '@lib/ui/page/PageFooter'
+import { OnFinishProp, ValueProp } from '@lib/ui/props'
+import { Text } from '@lib/ui/text'
 import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { updateAtIndex } from '@vultisig/lib-utils/array/updateAtIndex'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
 
+import { JoinKeysignButton } from './JoinKeysignButton'
 import { JoinKeysignLpVerify } from './JoinKeysignLpVerify'
 import { JoinKeysignSwapVerify } from './JoinKeysignSwapVerify'
-import { JoinKeysignTxPrimaryInfo } from './JoinKeysignTxPrimaryInfo'
+import { JoinKeysignTxOverview } from './JoinKeysignTxOverview'
 import { parseThorLpMemo } from './parseThorLpMemo'
 
+const sendTerms = ['send_terms_1', 'send_terms_0'] as const
+
+const TermItem = styled(Checkbox)`
+  ${verticalPadding(10)}
+  font-family: inherit;
+  font-size: 14px;
+`
+
 /**
- * Routes a join keysign payload to the correct verify view. THORChain LP
- * add/remove is detected via memo first so iOS-initiated LP deposits (which
- * carry a synthesized `thorchainSwapPayload` for the EVM router signing path)
- * still render as deposits. Falls back to swap, then to a generic transfer.
+ * Routes a join keysign payload to the correct verify view and owns the shared
+ * footer. THORChain LP add/remove is detected via memo first so iOS-initiated
+ * LP deposits (which carry a synthesized `thorchainSwapPayload` for the EVM
+ * router signing path) still render as deposits. Falls back to swap, then to a
+ * generic transfer.
+ *
+ * The generic transfer renders the updated "Send Overview" card and the same
+ * confirmation checkboxes the initiator shows, keeping both devices in sync.
  */
 export const JoinKeysignTransactionVerify = ({
   value,
-}: ValueProp<KeysignPayload>) => {
+  onFinish,
+}: ValueProp<KeysignPayload> & OnFinishProp) => {
+  const { t } = useTranslation()
+
   const lp = value.memo ? parseThorLpMemo(value.memo) : null
+  const isSwap = !lp && !!value.swapPayload?.value
 
-  if (lp) {
-    return <JoinKeysignLpVerify value={value} lp={lp} />
-  }
+  const terms = lp || isSwap ? [] : sendTerms.map(term => t(term))
+  const [termsAccepted, setTermsAccepted] = useState<boolean[]>(
+    new Array(terms.length).fill(false)
+  )
 
-  if (value.swapPayload?.value) {
-    return <JoinKeysignSwapVerify value={value} />
-  }
+  const content = lp ? (
+    <JoinKeysignLpVerify value={value} lp={lp} />
+  ) : isSwap ? (
+    <JoinKeysignSwapVerify value={value} />
+  ) : (
+    <JoinKeysignTxOverview value={value} />
+  )
+
+  const disabled = termsAccepted.some(term => !term)
 
   return (
-    <TxOverviewPanel>
-      <JoinKeysignTxPrimaryInfo value={value} />
-    </TxOverviewPanel>
+    <>
+      <PageContent gap={12} scrollable>
+        {content}
+        {terms.length > 0 && (
+          <VStack>
+            {terms.map((term, index) => (
+              <TermItem
+                key={index}
+                data-testid={`terms-checkbox-${index}`}
+                label={<Text size={14}>{term}</Text>}
+                value={termsAccepted[index]}
+                onChange={v =>
+                  setTermsAccepted(prev => updateAtIndex(prev, index, () => v))
+                }
+              />
+            ))}
+          </VStack>
+        )}
+      </PageContent>
+      <PageFooter>
+        <JoinKeysignButton
+          onClick={onFinish}
+          disabled={disabled ? t('terms_required') : undefined}
+        />
+      </PageFooter>
+    </>
   )
 }

--- a/core/ui/mpc/keysign/join/tx/JoinKeysignTxOverview.tsx
+++ b/core/ui/mpc/keysign/join/tx/JoinKeysignTxOverview.tsx
@@ -1,0 +1,177 @@
+import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
+import { useGetCoin } from '@core/ui/chain/coin/useGetCoin'
+import { BlockaidTxScan } from '@core/ui/chain/security/blockaid/tx/BlockaidTxScan'
+import { TxOverviewMemo } from '@core/ui/chain/tx/TxOverviewMemo'
+import { extractTokenAndAmount } from '@core/ui/chain/tx/utils/extractTokenAndAmount'
+import { formatTokenAmount } from '@core/ui/chain/tx/utils/formatTokenAmount'
+import { useEvmContractCallInfoQuery } from '@core/ui/chain/tx/utils/useEvmContractCallInfoQuery'
+import { VerifyTransactionOverview } from '@core/ui/mpc/keysign/verify/VerifyTransactionOverview'
+import { useAddressBookNameForAddress } from '@core/ui/vault/hooks/useAddressBookNameForAddress'
+import { useVaultNameForAddress } from '@core/ui/vault/hooks/useVaultNameForAddress'
+import { useCurrentVault } from '@core/ui/vault/state/currentVault'
+import { FuelIcon } from '@lib/ui/icons/FuelIcon'
+import { IconWrapper } from '@lib/ui/icons/IconWrapper'
+import { TriangleAlertIcon } from '@lib/ui/icons/TriangleAlertIcon'
+import { HStack } from '@lib/ui/layout/Stack'
+import { ListItem } from '@lib/ui/list/item'
+import { ValueProp } from '@lib/ui/props'
+import { getResolvedQuery } from '@lib/ui/query/Query'
+import { Text } from '@lib/ui/text'
+import { useQuery } from '@tanstack/react-query'
+import { isChainOfKind } from '@vultisig/core-chain/ChainKind'
+import { feeSettingsChains } from '@vultisig/core-mpc/keysign/chainSpecific/FeeSettings'
+import { fromCommCoin } from '@vultisig/core-mpc/types/utils/commCoin'
+import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { isOneOf } from '@vultisig/lib-utils/array/isOneOf'
+import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
+import { capitalizeFirstLetter } from '@vultisig/lib-utils/capitalizeFirstLetter'
+import { assertField } from '@vultisig/lib-utils/record/assertField'
+import { useTranslation } from 'react-i18next'
+
+import { SignAminoDisplay } from '../../tx/components/SignAminoDisplay'
+import { SignDirectDisplay } from '../../tx/components/SignDirectDisplay'
+
+/**
+ * Joiner verify view for a regular transfer. Renders the same card-based
+ * "Send Overview" design the initiator shows (`VerifyTransactionOverview`) so
+ * both devices in a keysign session display matching transaction details.
+ *
+ * The keysign payload is already resolved on the joiner, so it is wrapped with
+ * `getResolvedQuery` to satisfy the shared overview's query-driven API. EVM
+ * contract-call decoding (e.g. `Approve / amount TICKER`) and Cosmos sign
+ * displays are preserved as extra rows below the standard fields.
+ */
+export const JoinKeysignTxOverview = ({ value }: ValueProp<KeysignPayload>) => {
+  const { t } = useTranslation()
+  const { toAddress, memo } = value
+
+  const coin = shouldBePresent(fromCommCoin(assertField(value, 'coin')))
+
+  const { name } = useCurrentVault()
+
+  const receiverVaultName = useVaultNameForAddress({
+    address: toAddress,
+    chain: coin.chain,
+  })
+  const receiverAddressBookName = useAddressBookNameForAddress({
+    address: toAddress,
+    chain: coin.chain,
+  })
+
+  // Match the initiator's fee row, which shows a fuel icon on fee-settings
+  // chains (EVM/UTXO). On the joiner the fee is fixed by the initiator's
+  // payload, so the icon is a non-interactive indicator rather than the
+  // editable ManageFee control.
+  const showFeeIcon = isOneOf(coin.chain, feeSettingsChains)
+
+  // Decode the EVM calldata so the joiner sees the same `[icon] Approve / amount TICKER`
+  // (and the unlimited-approval warning) the initiator shows on its pre-sign popup.
+  // The query shares its memo-keyed react-query cache with the initiator's path,
+  // so we don't refetch the 4byte signature.
+  const getCoin = useGetCoin()
+  const contractCallQuery = useEvmContractCallInfoQuery({
+    memo,
+    enabled: isChainOfKind(coin.chain, 'evm'),
+  })
+  const tokenPair = contractCallQuery.data
+    ? extractTokenAndAmount(
+        contractCallQuery.data.functionSignature,
+        contractCallQuery.data.functionArguments,
+        toAddress
+      )
+    : null
+  const tokenQuery = useQuery({
+    queryKey: ['resolveToken', tokenPair?.tokenAddress, coin.chain],
+    queryFn: () => getCoin({ id: tokenPair!.tokenAddress, chain: coin.chain }),
+    enabled: !!tokenPair,
+    staleTime: Infinity,
+  })
+  const rawFunctionName =
+    contractCallQuery.data?.functionSignature.split('(')[0]
+  const decodedCall =
+    tokenQuery.data && tokenPair && rawFunctionName
+      ? (() => {
+          const fmt = formatTokenAmount({
+            rawAmount: BigInt(tokenPair.rawAmount),
+            decimals: tokenQuery.data.decimals,
+            functionName: rawFunctionName,
+          })
+          // MAX_UINT256 in a non-approval (withdraw/repay) — exact amount
+          // depends on on-chain state, so skip the row entirely.
+          if (!fmt.display) return null
+          const amountLabel = fmt.isSentinel ? t('unlimited') : fmt.display
+          return {
+            coin: tokenQuery.data,
+            functionName: capitalizeFirstLetter(rawFunctionName),
+            display: `${amountLabel} ${tokenQuery.data.ticker}`,
+            isUnlimited: fmt.isSentinel,
+          }
+        })()
+      : null
+
+  const keysignPayloadQuery = getResolvedQuery(value)
+
+  return (
+    <>
+      <BlockaidTxScan keysignPayloadQuery={keysignPayloadQuery} />
+      <VerifyTransactionOverview
+        coin={coin}
+        amount={BigInt(value.toAmount)}
+        senderName={name}
+        senderAddress={coin.address}
+        receiver={toAddress}
+        receiverVaultName={receiverVaultName ?? undefined}
+        receiverAddressBookName={receiverAddressBookName ?? undefined}
+        chain={coin.chain}
+        keysignPayloadQuery={keysignPayloadQuery}
+        renderFeeExtra={
+          showFeeIcon
+            ? () => (
+                <IconWrapper style={{ fontSize: 16 }}>
+                  <FuelIcon />
+                </IconWrapper>
+              )
+            : undefined
+        }
+      >
+        {decodedCall && (
+          <ListItem
+            title={
+              <HStack alignItems="center" gap={8}>
+                <CoinIcon coin={decodedCall.coin} style={{ fontSize: 24 }} />
+                <Text size={14} weight={500}>
+                  {decodedCall.functionName}
+                </Text>
+              </HStack>
+            }
+            extra={
+              decodedCall.isUnlimited ? (
+                <HStack alignItems="center" gap={6}>
+                  <Text as={TriangleAlertIcon} color="warning" size={16} />
+                  <Text color="warning" weight={500}>
+                    {decodedCall.display}
+                  </Text>
+                </HStack>
+              ) : (
+                <Text size={14} weight={500}>
+                  {decodedCall.display}
+                </Text>
+              )
+            }
+          />
+        )}
+        {memo && (
+          <ListItem
+            title={<TxOverviewMemo value={memo} chain={coin.chain} />}
+          />
+        )}
+      </VerifyTransactionOverview>
+      {value.signData.case === 'signAmino' && (
+        <SignAminoDisplay signAmino={value.signData.value} />
+      )}
+      {value.signData.case === 'signDirect' && (
+        <SignDirectDisplay signDirect={value.signData.value} />
+      )}
+    </>
+  )
+}

--- a/core/ui/mpc/keysign/start/VerifyKeysignStart.tsx
+++ b/core/ui/mpc/keysign/start/VerifyKeysignStart.tsx
@@ -7,7 +7,6 @@ import { Checkbox } from '@lib/ui/inputs/checkbox/Checkbox'
 import { VStack } from '@lib/ui/layout/Stack'
 import { PageContent } from '@lib/ui/page/PageContent'
 import { PageFooter } from '@lib/ui/page/PageFooter'
-import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
 import { usePotentialQuery } from '@lib/ui/query/hooks/usePotentialQuery'
 import { useTransformQueryData } from '@lib/ui/query/hooks/useTransformQueryData'
 import { Query } from '@lib/ui/query/Query'
@@ -24,10 +23,7 @@ import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
 import { useAssertWalletCore } from '../../../chain/providers/WalletCoreProvider'
-import { BlockaidNoScanStatus } from '../../../chain/security/blockaid/scan/BlockaidNoScanStatus'
-import { BlockaidScanning } from '../../../chain/security/blockaid/scan/BlockaidScanning'
-import { BlockaidScanStatusContainer } from '../../../chain/security/blockaid/scan/BlockaidScanStatusContainer'
-import { BlockaidTxValidationResult } from '../../../chain/security/blockaid/tx/BlockaidTxValidationResult'
+import { BlockaidTxScanStatus } from '../../../chain/security/blockaid/tx/BlockaidTxScanStatus'
 
 type VerifyKeysignStartInput = {
   children: ReactNode
@@ -154,15 +150,7 @@ export const VerifyKeysignStart = ({
   return (
     <>
       <PageContent gap={12} scrollable>
-        {isBlockaidEnabled && (
-          <MatchQuery
-            value={txScanQuery}
-            success={value => <BlockaidTxValidationResult value={value} />}
-            pending={() => <BlockaidScanning />}
-            error={() => <BlockaidNoScanStatus entity="tx" />}
-            inactive={() => <BlockaidScanStatusContainer />}
-          />
-        )}
+        {isBlockaidEnabled && <BlockaidTxScanStatus value={txScanQuery} />}
 
         {children}
 

--- a/core/ui/mpc/keysign/verify/components/TransactionOverviewAmount.tsx
+++ b/core/ui/mpc/keysign/verify/components/TransactionOverviewAmount.tsx
@@ -11,7 +11,32 @@ import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/key
 import { formatAmount } from '@vultisig/lib-utils/formatAmount'
 import { ReactNode } from 'react'
 
+import { TransactionOverviewFiatAmount } from './TransactionOverviewFiatAmount'
+
 type OverviewCoin = CoinKey & Pick<CoinMetadata, 'decimals' | 'ticker' | 'logo'>
+
+type HeroAmountProps = {
+  coin: OverviewCoin
+  amount: number
+  highPrecision?: boolean
+}
+
+const HeroAmount = ({ coin, amount, highPrecision }: HeroAmountProps) => (
+  <VStack gap={2}>
+    <HStack alignItems="center" gap={4}>
+      <Text as="span" size={17}>
+        {formatAmount(
+          amount,
+          highPrecision ? { precision: 'high' } : undefined
+        )}
+      </Text>
+      <Text as="span" color="shy" size={17}>
+        {coin.ticker}
+      </Text>
+    </HStack>
+    <TransactionOverviewFiatAmount coin={coin} amount={amount} />
+  </VStack>
+)
 
 type TransactionOverviewAmountProps = {
   label: ReactNode
@@ -48,24 +73,21 @@ export const TransactionOverviewAmount = ({
           </Text>
           <HStack alignItems="center" gap={8}>
             <CoinIcon coin={coin} style={{ fontSize: 24 }} />
-            <HStack alignItems="center" gap={4}>
-              <Text as="span" size={17}>
-                <MatchQuery
-                  value={keysignPayloadQuery}
-                  pending={() => <Spinner />}
-                  error={() => formatAmount(fallbackAmount)}
-                  success={payload =>
-                    formatAmount(
-                      fromChainAmount(getPayloadAmount(payload), coin.decimals),
-                      { precision: 'high' }
-                    )
-                  }
+            <MatchQuery
+              value={keysignPayloadQuery}
+              pending={() => <Spinner />}
+              error={() => <HeroAmount coin={coin} amount={fallbackAmount} />}
+              success={payload => (
+                <HeroAmount
+                  coin={coin}
+                  amount={fromChainAmount(
+                    getPayloadAmount(payload),
+                    coin.decimals
+                  )}
+                  highPrecision
                 />
-              </Text>
-              <Text as="span" color="shy" size={17}>
-                {coin.ticker}
-              </Text>
-            </HStack>
+              )}
+            />
           </HStack>
         </VStack>
       }

--- a/core/ui/mpc/keysign/verify/components/TransactionOverviewFiatAmount.tsx
+++ b/core/ui/mpc/keysign/verify/components/TransactionOverviewFiatAmount.tsx
@@ -1,0 +1,39 @@
+import { useCoinPriceQuery } from '@core/ui/chain/coin/price/queries/useCoinPriceQuery'
+import { useFormatFiatAmount } from '@core/ui/chain/hooks/useFormatFiatAmount'
+import { Skeleton } from '@lib/ui/loaders/Skeleton'
+import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
+import { Text } from '@lib/ui/text'
+import { CoinKey } from '@vultisig/core-chain/coin/Coin'
+
+type TransactionOverviewFiatAmountProps = {
+  coin: CoinKey
+  amount: number
+}
+
+/**
+ * Renders the fiat equivalent of a token amount in the transaction overview
+ * hero, mirroring the swap verify layout. Stays silent (renders nothing) when
+ * the coin has no price so the amount line is never left with a dangling label.
+ */
+export const TransactionOverviewFiatAmount = ({
+  coin,
+  amount,
+}: TransactionOverviewFiatAmountProps) => {
+  const query = useCoinPriceQuery({ coin })
+  const formatFiatAmount = useFormatFiatAmount()
+
+  return (
+    <MatchQuery
+      value={query}
+      error={() => null}
+      pending={() => <Skeleton width="3em" height="1em" />}
+      success={price =>
+        price ? (
+          <Text as="span" color="shy" size={13}>
+            {formatFiatAmount(amount * price)}
+          </Text>
+        ) : null
+      }
+    />
+  )
+}


### PR DESCRIPTION
## Summary

Fixes #4028. During a keysign flow, the **initiator** showed the updated "Send Overview" card while the **joined** device's "Verify" screen still used the legacy layout. This brings the joiner in line so both co-signers review the transaction with the same UI.

##
<img width="952" height="899" alt="telegram-cloud-document-4-5830112800864739841" src="https://github.com/user-attachments/assets/fba3efcf-ffdb-4fba-9b12-23e0682cd17a" />

## Changes

- **New card design on the joiner** — the regular-transfer view now renders the shared `VerifyTransactionOverview` ("You're sending" header, token amount, and `From / To / Network / Est. Network Fee / Memo` rows) instead of the old `TxOverviewPanel` + `JoinKeysignTxPrimaryInfo`. EVM contract-call decoding (e.g. `Approve / amount TICKER` with the unlimited-approval warning) and Cosmos sign displays are preserved.
- **Confirmation checkboxes** — "The amount is correct" / "I'm sending to the right address" are shown on the joiner and gate the **Join Keysign** button.
- **Fiat value under the amount** — the overview hero now shows the fiat equivalent below the token amount (matching swap), via a new reusable `TransactionOverviewFiatAmount`.
- **Network-fee fuel icon** — shown on the joiner for fee-settings chains (EVM/UTXO) as a **non-interactive** indicator. The joiner can't edit the fee (it's fixed by the initiator's payload), so it intentionally uses the icon rather than the editable `ManageFee` control.
- **Blockaid scan banner** — surfaced on the joiner too. The scan logic was extracted into a shared `BlockaidTxScan` (self-contained) + `BlockaidTxScanStatus` (presentational), and `VerifyKeysignStart` was refactored to reuse the same status component so the banner stays identical on both devices.

Swap and THORChain LP joiner views are intentionally left unchanged (out of scope; their layouts are not the outdated design from the issue).

## Validation

- `yarn check` passes (typecheck + lint + knip + i18n).
- Extension built and verified manually with a two-device send (initiator + joiner) on Ethereum: both screens now match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Blockaid transaction security scanning to keysign verification flow
  * Added transaction send terms acceptance checkboxes before confirmation
  * Added fiat amount display for transaction amounts

* **Improvements**
  * Enhanced keysign verification UI layout with improved footer organization
  * Refined transaction overview display formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->