### PR TITLE
Fill keysign progress bar during signing

### DIFF
--- a/core/ui/mpc/keysign/flow/KeysignSigningState.tsx
+++ b/core/ui/mpc/keysign/flow/KeysignSigningState.tsx
@@ -1,8 +1,17 @@
+import { useEffect, useState } from 'react'
 import styled from 'styled-components'
 
 import { useKeysignMessagePayload } from '../state/keysignMessagePayload'
 import { KeysignLoadingAnimation } from './KeysignLoadingAnimation'
 import { getKeysignPayloadLogoSrc } from './utils/getKeysignPayloadLogoSrc'
+
+// The core keysign is a single TSS signing operation that exposes no
+// per-round progress, so the bar is driven by a simulated ramp that eases
+// toward a ceiling while signing is in progress. The component unmounts when
+// the keysign mutation resolves, flipping the screen to the success state.
+const signingProgressCeiling = 90
+const signingDurationMs = 12000
+const signingTickMs = 200
 
 /**
  * Full-screen signing state shown while an MPC keysign is in progress.
@@ -12,10 +21,26 @@ import { getKeysignPayloadLogoSrc } from './utils/getKeysignPayloadLogoSrc'
 export const KeysignSigningState = () => {
   const payload = useKeysignMessagePayload()
   const logoSrc = getKeysignPayloadLogoSrc(payload)
+  const [progress, setProgress] = useState(0)
+
+  useEffect(() => {
+    const start = Date.now()
+    const interval = setInterval(() => {
+      const ratio = Math.min((Date.now() - start) / signingDurationMs, 1)
+      // Ease-out: advances quickly at first, then slows as it nears the ceiling
+      setProgress(Math.round(signingProgressCeiling * (1 - (1 - ratio) ** 2)))
+    }, signingTickMs)
+
+    return () => clearInterval(interval)
+  }, [])
 
   return (
     <Container>
-      <KeysignLoadingAnimation isConnected logoSrc={logoSrc} />
+      <KeysignLoadingAnimation
+        isConnected
+        progress={progress}
+        logoSrc={logoSrc}
+      />
     </Container>
   )
 }


### PR DESCRIPTION
## Summary

Fixes #4019 — during keysign, the progress bar under the "Signing" label stayed empty and never filled.

**Root cause:** the Rive animation's progress bar is driven by `KeysignLoadingAnimation`'s `progress` prop (0–100), but `KeysignSigningState` rendered it without passing `progress`, so it defaulted to `0`.

**Why not mirror keygen?** Keygen maps discrete protocol steps (`prepareVault → ecdsa → eddsa → …`) to percentages, but the core `keysign()` is a single TSS signing operation that exposes no per-round/step callbacks. So there's no real step signal to map.

**Fix:** drive a self-contained simulated ramp in `KeysignSigningState`. It eases out toward a 90% ceiling over ~12s while signing is in progress. The component only mounts while the keysign mutation is pending and unmounts on success/error, so the screen naturally flips to the "Done" view — no need to force the bar to 100%.

##
<img width="366" height="247" alt="telegram-cloud-photo-size-4-5834879536418459011-x" src="https://github.com/user-attachments/assets/840ac7e4-60f2-40b5-8261-5f894ee76026" />

## Test plan

- [x] `yarn eslint` clean on the changed file
- [x] Typecheck: the 2 remaining errors (`cowswap_order` in `SwapKeysignTxOverview.tsx` / `useSwapFeesQuery.ts`) pre-exist on `main` and are unrelated to this change
- [x] Extension built successfully (all 4 vite chunks)
- [ ] Manual: run Send/Swap/Deposit keysign and confirm the bar fills progressively instead of staying empty

## Notes

`signingDurationMs = 12000` is a heuristic for typical signing time. In a Fast Vault that signs faster, the bar may only reach partway before flipping to "Done" (expected); in a Secure Vault awaiting a co-signer it sits near the 90% ceiling until the peer signs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)