### PR TITLE
Share receive address as QR image (#4041)

### DIFF
--- a/core/ui/vault/chain/address/AddressQRCard.tsx
+++ b/core/ui/vault/chain/address/AddressQRCard.tsx
@@ -160,7 +160,6 @@ export const AddressQRCard = ({
 
     if (!address) return
 
-    const shareTitle = `${t('receive')} ${displayName}`
     const node = qrNodeRef.current
 
     if (node && navigator.canShare) {
@@ -175,10 +174,7 @@ export const AddressQRCard = ({
           throw new Error('File sharing not supported')
         }
 
-        await navigator.share({
-          files: [file],
-          title: shareTitle,
-        })
+        await navigator.share({ files: [file] })
       })
 
       if ('data' in result) return
@@ -188,7 +184,7 @@ export const AddressQRCard = ({
 
     void navigator
       .share({
-        title: shareTitle,
+        title: `${t('receive')} ${displayName}`,
         text: address,
       })
       .catch(() => undefined)

--- a/core/ui/vault/chain/address/AddressQRCard.tsx
+++ b/core/ui/vault/chain/address/AddressQRCard.tsx
@@ -163,21 +163,21 @@ export const AddressQRCard = ({
     const node = qrNodeRef.current
 
     if (node && navigator.canShare) {
-      const result = await attempt(async () => {
+      const fileResult = await attempt(async () => {
         const dataUrl = await toPng(node)
         const blob = await (await fetch(dataUrl)).blob()
-        const file = new File([blob], `${displayName}.png`, {
-          type: 'image/png',
-        })
-
-        if (!navigator.canShare({ files: [file] })) {
-          throw new Error('File sharing not supported')
-        }
-
-        await navigator.share({ files: [file] })
+        return new File([blob], `${displayName}.png`, { type: 'image/png' })
       })
 
-      if ('data' in result) return
+      if (
+        'data' in fileResult &&
+        navigator.canShare({ files: [fileResult.data] })
+      ) {
+        await navigator
+          .share({ files: [fileResult.data] })
+          .catch(() => undefined)
+        return
+      }
     }
 
     if (!navigator.share) return

--- a/core/ui/vault/chain/address/AddressQRCard.tsx
+++ b/core/ui/vault/chain/address/AddressQRCard.tsx
@@ -15,7 +15,9 @@ import { getColor } from '@lib/ui/theme/getters'
 import { useToast } from '@lib/ui/toast/ToastProvider'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { CoinKey, CoinMetadata } from '@vultisig/core-chain/coin/Coin'
-import { useCallback } from 'react'
+import { attempt } from '@vultisig/lib-utils/attempt'
+import { toPng } from 'html-to-image'
+import { useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import QRCode from 'react-qr-code'
 import styled from 'styled-components'
@@ -135,6 +137,7 @@ export const AddressQRCard = ({
   const { t } = useTranslation()
   const address = useCurrentVaultAddress(chain)
   const { addToast } = useToast()
+  const qrNodeRef = useRef<HTMLDivElement | null>(null)
 
   const displayName = coin?.ticker || chain
 
@@ -149,27 +152,54 @@ export const AddressQRCard = ({
     }
   }, [address, addToast, chain, onClose])
 
-  const handleShare = useCallback(() => {
+  const handleShare = useCallback(async () => {
     if (onShare) {
       onShare()
       return
     }
 
-    if (!navigator.share || !address) return
+    if (!address) return
+
+    const shareTitle = `${t('receive')} ${displayName}`
+    const node = qrNodeRef.current
+
+    if (node && navigator.canShare) {
+      const result = await attempt(async () => {
+        const dataUrl = await toPng(node)
+        const blob = await (await fetch(dataUrl)).blob()
+        const file = new File([blob], `${displayName}.png`, {
+          type: 'image/png',
+        })
+
+        if (!navigator.canShare({ files: [file] })) {
+          throw new Error('File sharing not supported')
+        }
+
+        await navigator.share({
+          files: [file],
+          title: shareTitle,
+          text: address,
+        })
+      })
+
+      if ('data' in result) return
+    }
+
+    if (!navigator.share) return
 
     void navigator
       .share({
-        title: `Receive ${chain}`,
+        title: shareTitle,
         text: address,
       })
       .catch(() => undefined)
-  }, [address, chain, onShare])
+  }, [address, displayName, onShare, t])
 
   if (!address) return null
 
   return (
     <Container>
-      <QRContainer>
+      <QRContainer ref={qrNodeRef}>
         <QRWrapper>
           <QRCode
             value={address}

--- a/core/ui/vault/chain/address/AddressQRCard.tsx
+++ b/core/ui/vault/chain/address/AddressQRCard.tsx
@@ -169,13 +169,10 @@ export const AddressQRCard = ({
         return new File([blob], `${displayName}.png`, { type: 'image/png' })
       })
 
-      if (
-        'data' in fileResult &&
-        navigator.canShare({ files: [fileResult.data] })
-      ) {
-        await navigator
-          .share({ files: [fileResult.data] })
-          .catch(() => undefined)
+      const file = 'data' in fileResult ? fileResult.data : undefined
+
+      if (file && navigator.canShare({ files: [file] })) {
+        await navigator.share({ files: [file] }).catch(() => undefined)
         return
       }
     }

--- a/core/ui/vault/chain/address/AddressQRCard.tsx
+++ b/core/ui/vault/chain/address/AddressQRCard.tsx
@@ -178,7 +178,6 @@ export const AddressQRCard = ({
         await navigator.share({
           files: [file],
           title: shareTitle,
-          text: address,
         })
       })
 


### PR DESCRIPTION
## Summary
The **Share** button on the Receive screen (the address QR modal) previously shared only the address as plain text. It now shares the **QR code as a PNG image** via the Web Share API, matching the existing "Share Vault QR" experience — so recipients can scan the code directly.

Closes #4041

## Changes
- `core/ui/vault/chain/address/AddressQRCard.tsx`
  - Added a ref to the QR card container and render it to a PNG with `toPng` (`html-to-image`)
  - Share the image via `navigator.share({ files: [file], title, text })`, guarded by `navigator.canShare({ files })`
  - Wrapped the conversion/share in `attempt()` per repo conventions
  - Graceful fallback to the existing text-only share when file sharing is unsupported

This reuses the exact pattern already proven in `ShareVaultPage.tsx`. No new dependencies were added.

## Notes
- `onShare` override prop still takes priority (currently unused by callers).
- Web Share with files works in the extension popup (Chromium). On the Wails desktop webview, if `navigator.share` is unavailable it no-ops exactly as before — no regression.

## Testing
- [x] `yarn check` passes for the changed file (two pre-existing `cowswap_order` typecheck errors on `main` are unrelated — verified via `git stash`)
- [ ] Manual: tap Share on the Receive screen in the extension → QR image is shared

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * QR cards can be shared as an image via the system share sheet when supported.
  * Falls back to sharing the address as text if image/file sharing isn’t available or fails.
  * Honors a provided onShare callback before performing the built-in share flow.
  * Uses a localized share title for shared content.

* **Bug Fixes**
  * Safely handles missing addresses and silent failures in image generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->