### PR TITLE
[Fix] Use medium (500) weight in Positions row

### DIFF
--- a/core/ui/vault/chain/positions/WithdrawablePositions.tsx
+++ b/core/ui/vault/chain/positions/WithdrawablePositions.tsx
@@ -76,20 +76,20 @@ export const WithdrawablePositions = ({ value }: ValueProp<AccountCoin>) => {
                 <HStack alignItems="center" justifyContent="space-between">
                   <HStack alignItems="center" gap={12}>
                     <CoinIcon style={{ fontSize: 32 }} coin={value} />
-                    <Text weight="700" color="contrast" size={20}>
+                    <Text weight={500} color="contrast" size={20}>
                       {value.ticker} ({t('merged')})
                     </Text>
                   </HStack>
                   <Text
                     size={20}
-                    weight="700"
+                    weight={500}
                     color="contrast"
                     centerVertically
                   >
                     {formatFiatAmount(rujiFiat)}
                   </Text>
                 </HStack>
-                <Text size={20} weight="700" color="contrast" centerVertically>
+                <Text size={20} weight={500} color="contrast" centerVertically>
                   {totalSharesFormatted}
                 </Text>
               </VStack>


### PR DESCRIPTION
## Summary
The merged "Positions" row at the bottom of a chain's token list (e.g. RUJI (Merged) on THORChain) rendered its token name, fiat value, and staked amount at `font-weight: 700` (Bold). Per the Figma design these should be `font-weight: 500` (Medium). This PR changes only the font weight — size, color, and layout are unchanged.

Closes #4049

## Changes
- `core/ui/vault/chain/positions/WithdrawablePositions.tsx`: `weight="700"` → `weight={500}` on the token name, fiat value, and staked amount `Text` elements.

##
<img width="949" height="181" alt="telegram-cloud-photo-size-4-5838969075428691572-y" src="https://github.com/user-attachments/assets/7db9b851-12cd-4df2-8989-11d74ef80676" />

## Testing
- `yarn check` (typecheck + lint) passes
- Production extension build succeeds
- Verified visually in the extension popup: Positions row text now renders at medium weight

🤖 Generated with [Claude Code](https://claude.com/claude-code)