### PR TITLE
fix(qbtc/dapp): show real amount in sign_and_broadcast approval popup

### DIFF
--- a/clients/extension/src/inpage/providers/qbtcSignAndBroadcast.ts
+++ b/clients/extension/src/inpage/providers/qbtcSignAndBroadcast.ts
@@ -11,6 +11,7 @@ import {
   QbtcDappMessage,
   UnsupportedQbtcMessageTypeError,
 } from '@core/ui/qbtc/dapp/encodeAnyMessage'
+import { getQbtcDappAmount } from '@core/ui/qbtc/dapp/getQbtcDappAmount'
 import { qbtcChainId } from '@core/ui/qbtc/dapp/qbtcDirectConstants'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { getQbtcAccountInfo } from '@vultisig/core-chain/chains/cosmos/qbtc/getQbtcAccountInfo'
@@ -151,6 +152,7 @@ export const handleQbtcSignAndBroadcast = async (
     asset: { ticker: 'QBTC' },
     from,
     memo,
+    amount: getQbtcDappAmount(messages),
     directPayload: {
       bodyBytes,
       authInfoBytes,

--- a/core/ui/qbtc/dapp/getQbtcDappAmount.ts
+++ b/core/ui/qbtc/dapp/getQbtcDappAmount.ts
@@ -1,0 +1,56 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
+
+import { QbtcDappMessage } from './encodeAnyMessage'
+import { qbtcFeeDenom } from './qbtcDirectConstants'
+
+type QbtcDisplayAmount = { amount: string; decimals: number }
+
+type RawCoin = { denom: string; amount: string }
+
+const isRawCoin = (value: unknown): value is RawCoin =>
+  !!value &&
+  typeof value === 'object' &&
+  typeof (value as RawCoin).denom === 'string' &&
+  typeof (value as RawCoin).amount === 'string'
+
+/**
+ * Pulls the native-denom coin out of a Cosmos message value. Most messages
+ * (MsgSend, MsgDelegate, MsgDeposit, ...) carry it under `amount` as either a
+ * single `Coin` or a `Coin[]`; IBC `MsgTransfer` uses `token`.
+ */
+const extractNativeCoins = (value: Record<string, unknown>): RawCoin[] => {
+  const candidates = [value.amount, value.token].flatMap(field =>
+    Array.isArray(field) ? field : [field]
+  )
+
+  return candidates
+    .filter(isRawCoin)
+    .filter(coin => coin.denom === qbtcFeeDenom)
+}
+
+/**
+ * Derives the human-readable amount shown in the QBTC `sign_and_broadcast`
+ * approval popup by summing the native-denom coins across every message. The
+ * signed transaction always carries the exact amounts inside `bodyBytes`; this
+ * is purely for the approval UI, which reads `transactionDetails.amount`.
+ *
+ * Returns `undefined` when no message carries a native coin (e.g. votes or
+ * reward withdrawals), leaving the amount field empty rather than showing `0`.
+ */
+export const getQbtcDappAmount = (
+  messages: QbtcDappMessage[]
+): QbtcDisplayAmount | undefined => {
+  const total = messages
+    .flatMap(message => extractNativeCoins(message.value))
+    .reduce((sum, coin) => sum + BigInt(coin.amount), 0n)
+
+  if (total === 0n) {
+    return undefined
+  }
+
+  return {
+    amount: total.toString(),
+    decimals: chainFeeCoin[Chain.QBTC].decimals,
+  }
+}

--- a/core/ui/qbtc/dapp/getQbtcDappAmount.ts
+++ b/core/ui/qbtc/dapp/getQbtcDappAmount.ts
@@ -8,11 +8,16 @@ type QbtcDisplayAmount = { amount: string; decimals: number }
 
 type RawCoin = { denom: string; amount: string }
 
+const isIntegerString = (value: string): boolean => /^[+-]?\d+$/.test(value)
+
 const isRawCoin = (value: unknown): value is RawCoin =>
-  !!value &&
+  value != null &&
   typeof value === 'object' &&
-  typeof (value as RawCoin).denom === 'string' &&
-  typeof (value as RawCoin).amount === 'string'
+  'denom' in value &&
+  'amount' in value &&
+  typeof value.denom === 'string' &&
+  typeof value.amount === 'string' &&
+  isIntegerString(value.amount)
 
 /**
  * Pulls the native-denom coin out of a Cosmos message value. Most messages


### PR DESCRIPTION
## Problem

When a dApp (e.g. qBTC Explorer) calls `vultisig.qbtc.request({ method: 'sign_and_broadcast' })` — for example a `MsgDelegate` of `100000` — the Vultisig "Sign Transaction" approval popup displayed **`0.0 QBTC`** instead of the real amount.

The signed transaction itself was always correct (the amount is encoded inside `bodyBytes`); only the human-readable amount shown to the user for approval was wrong, which is misleading and a signing-safety concern.

| Field | Before | After |
|-------|--------|-------|
| Delegate `100000` (base units) | `0.0 QBTC` | `0.001 QBTC` |

## Root cause

`handleQbtcSignAndBroadcast` built `transactionDetails` with only `directPayload` and never set `transactionDetails.amount`. The popup derives the displayed amount via `getTxAmount`, which falls back to `BigInt(transactionDetails.amount?.amount ?? 0)` → `0`. The Cosmos messages were never decoded to surface a displayable amount.

## Fix

- New `core/ui/qbtc/dapp/getQbtcDappAmount.ts` — sums the native-denom (`qbtc`) coins across the dApp messages (`amount` as `Coin`/`Coin[]`, plus IBC `token`) and returns `{ amount, decimals }` using `chainFeeCoin[Chain.QBTC]` (8 decimals). Returns `undefined` when no message carries a native amount (votes, reward withdrawals), leaving the field empty rather than showing `0`.
- `handleQbtcSignAndBroadcast` now sets `transactionDetails.amount = getQbtcDappAmount(messages)`.

Display-only change — the SignDoc / `bodyBytes` / `authInfoBytes` and the MLDSA keysign flow are untouched.

## Testing

- `yarn typecheck` ✅
- `yarn build:extension` ✅

Closes #4075

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds QBTC approval amount calculation for sign-and-broadcast popups so DApp approvals show summed native QBTC amounts.
  * Transaction details now populate with accurate QBTC amounts using chain decimals for proper formatting.
  * Improved visibility of transaction amounts and fee contexts during QBTC approval flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->