### PR TITLE
Add reusable DeFi UI QA harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build:extension:station": "yarn workspace @clients/extension build:station",
     "build:extension:firefox": "yarn workspace @clients/extension build:firefox",
     "dev:extension": "yarn workspace @clients/extension dev",
+    "qa:defi-ui-harness": "yarn workspace @scripts/defi-ui-harness dev",
     "build": "NODE_OPTIONS=--max-old-space-size=8192 yarn workspace @clients/desktop build",
     "typecheck": "tsgo --noEmit",
     "test": "vitest run",

--- a/scripts/qa/defi-ui-harness/README.md
+++ b/scripts/qa/defi-ui-harness/README.md
@@ -1,0 +1,27 @@
+# DeFi UI QA harness
+
+Render DeFi screens with deterministic local fixture data instead of wiring a
+temporary app by hand.
+
+```bash
+yarn qa:defi-ui-harness
+```
+
+Open <http://127.0.0.1:5177>. The default scenario renders Circle with a funded
+protocol account. Use Playwright or the in-app browser to capture the important
+states:
+
+1. Home state: the Circle deposited panel shows the funded USDC balance and no
+   deposit action.
+2. Withdraw path: click **Withdraw** and capture the withdraw form.
+
+The fixture helpers in `fixture.tsx` seed React Query through production query
+key helpers:
+
+- `seedCircleAccount` uses `getCircleAccountQueryKey`.
+- `seedCoinBalance` uses `getBalanceQueryKey`.
+- `seedCoinPrices` uses `getCoinPricesQueryKeys`.
+
+Keep this harness fake-data only. It is useful for layout, copy, visibility, and
+navigation checks, but it does not replace real wallet QA for signing or
+broadcast flows.

--- a/scripts/qa/defi-ui-harness/README.md
+++ b/scripts/qa/defi-ui-harness/README.md
@@ -7,7 +7,7 @@ temporary app by hand.
 yarn qa:defi-ui-harness
 ```
 
-Open <http://127.0.0.1:5177>. The default scenario renders Circle with a funded
+Open `http://127.0.0.1:5177`. The default scenario renders Circle with a funded
 protocol account. Use Playwright or the in-app browser to capture the important
 states:
 

--- a/scripts/qa/defi-ui-harness/fixture.tsx
+++ b/scripts/qa/defi-ui-harness/fixture.tsx
@@ -32,18 +32,21 @@ type CreateQaVaultInput = {
 }
 
 type SeedStoredSettingsInput = {
+  queryClient: QueryClient
   fiatCurrency?: FiatCurrency
   language?: string
   isBalanceVisible?: boolean
 }
 
 type SeedCircleAccountInput = {
+  queryClient: QueryClient
   ownerAddress: string
   accountAddress: string
   accountId?: string
 }
 
 type SeedCoinBalanceInput = {
+  queryClient: QueryClient
   coin: AccountCoin
   balance: bigint
 }
@@ -54,6 +57,7 @@ type SeedCoinPrice = {
 }
 
 type SeedCoinPricesInput = {
+  queryClient: QueryClient
   fiatCurrency?: FiatCurrency
   prices: SeedCoinPrice[]
 }
@@ -76,6 +80,12 @@ export const qaEthCoin: AccountCoin = {
   decimals: 18,
 }
 
+/**
+ * Creates a deterministic fake vault with valid key shapes for DeFi UI QA.
+ *
+ * @param input - Vault name and account coins to expose through storage.
+ * @returns A QA vault object compatible with core vault providers.
+ */
 export const createQaVault = ({ name, coins }: CreateQaVaultInput): QaVault => ({
   name,
   publicKeys: {
@@ -99,6 +109,11 @@ export const createQaVault = ({ name, coins }: CreateQaVaultInput): QaVault => (
   coins,
 })
 
+/**
+ * Creates a React Query client configured for deterministic harness fixtures.
+ *
+ * @returns A query client with app defaults and infinite stale time.
+ */
 export const createDefiQaQueryClient = () =>
   new QueryClient({
     defaultOptions: {
@@ -109,37 +124,52 @@ export const createDefiQaQueryClient = () =>
     },
   })
 
-export const seedStoredSettings = (
-  queryClient: QueryClient,
-  {
-    fiatCurrency = 'usd',
-    language = 'en',
-    isBalanceVisible = true,
-  }: SeedStoredSettingsInput = {}
-) => {
+/**
+ * Seeds storage-backed UI settings that DeFi screens expect to be loaded.
+ *
+ * @param input - Query client plus optional fiat currency, language, and balance visibility values.
+ * @returns Nothing; values are written into the query cache.
+ */
+export const seedStoredSettings = ({
+  queryClient,
+  fiatCurrency = 'usd',
+  language = 'en',
+  isBalanceVisible = true,
+}: SeedStoredSettingsInput) => {
   queryClient.setQueryData([StorageKey.fiatCurrency], fiatCurrency)
   queryClient.setQueryData([StorageKey.language], language)
   queryClient.setQueryData([StorageKey.isBalanceVisible], isBalanceVisible)
 }
 
-export const seedCircleAccount = (
-  queryClient: QueryClient,
-  {
-    ownerAddress,
-    accountAddress,
-    accountId = 'qa-circle-account',
-  }: SeedCircleAccountInput
-) => {
+/**
+ * Seeds the Circle protocol account lookup for a vault owner address.
+ *
+ * @param input - Query client, owner address, protocol account address, and optional account id.
+ * @returns Nothing; the Circle account response is written into the query cache.
+ */
+export const seedCircleAccount = ({
+  queryClient,
+  ownerAddress,
+  accountAddress,
+  accountId = 'qa-circle-account',
+}: SeedCircleAccountInput) => {
   queryClient.setQueryData(getCircleAccountQueryKey({ ownerAddress }), {
     id: accountId,
     address: accountAddress,
   })
 }
 
-export const seedCoinBalance = (
-  queryClient: QueryClient,
-  { coin, balance }: SeedCoinBalanceInput
-) => {
+/**
+ * Seeds a coin balance using the same query key shape as production balance hooks.
+ *
+ * @param input - Query client, account coin, and chain-unit balance.
+ * @returns Nothing; the balance record is written into the query cache.
+ */
+export const seedCoinBalance = ({
+  queryClient,
+  coin,
+  balance,
+}: SeedCoinBalanceInput) => {
   const coinKey = extractAccountCoinKey(coin)
 
   queryClient.setQueryData(getBalanceQueryKey(coinKey), {
@@ -147,10 +177,17 @@ export const seedCoinBalance = (
   })
 }
 
-export const seedCoinPrices = (
-  queryClient: QueryClient,
-  { fiatCurrency = 'usd', prices }: SeedCoinPricesInput
-) => {
+/**
+ * Seeds fiat prices using the normalized query key shape used by production price hooks.
+ *
+ * @param input - Query client, optional fiat currency, and coin price records.
+ * @returns Nothing; the price record is written into the query cache.
+ */
+export const seedCoinPrices = ({
+  queryClient,
+  fiatCurrency = 'usd',
+  prices,
+}: SeedCoinPricesInput) => {
   const coins = prices.map(({ coin: { chain, id, priceProviderId } }) => ({
     chain,
     id,
@@ -248,6 +285,12 @@ const createQaCoreState = (vault: QaVault): CoreState => {
   }
 }
 
+/**
+ * Wraps a DeFi screen with the providers needed to render against QA fixtures.
+ *
+ * @param props - Children, query client, and fake vault for the harness tree.
+ * @returns The provider tree used by DeFi UI harness scenarios.
+ */
 export const DefiQaProviders = ({
   queryClient,
   vault,

--- a/scripts/qa/defi-ui-harness/fixture.tsx
+++ b/scripts/qa/defi-ui-harness/fixture.tsx
@@ -1,0 +1,282 @@
+import { getBalanceQueryKey } from '@core/ui/chain/coin/queries/useBalancesQuery'
+import { getCoinPricesQueryKeys } from '@core/ui/chain/coin/price/queries/useCoinPricesQuery'
+import { WalletCoreProvider } from '@core/ui/chain/providers/WalletCoreProvider'
+import { getCircleAccountQueryKey } from '@core/ui/defi/protocols/circle/queries/circleAccount'
+import { CoreProvider, CoreState } from '@core/ui/state/core'
+import { CurrentVaultIdProvider } from '@core/ui/storage/currentVaultId'
+import { StorageKey } from '@core/ui/storage/StorageKey'
+import { VaultsProvider } from '@core/ui/storage/vaults'
+import { CurrentVaultProvider } from '@core/ui/vault/state/currentVault'
+import { GlobalStyle } from '@lib/ui/css/GlobalStyle'
+import { NavigationProvider } from '@lib/ui/navigation/state'
+import { ChildrenProp } from '@lib/ui/props'
+import { queryClientDefaultOptions } from '@lib/ui/query/queryClientDefaultOptions'
+import { darkTheme } from '@lib/ui/theme/darkTheme'
+import { ThemeProvider } from '@lib/ui/theme/ThemeProvider'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Chain } from '@vultisig/core-chain/Chain'
+import {
+  AccountCoin,
+  accountCoinKeyToString,
+  extractAccountCoinKey,
+} from '@vultisig/core-chain/coin/AccountCoin'
+import { CoinKey, coinKeyToString } from '@vultisig/core-chain/coin/Coin'
+import { FiatCurrency } from '@vultisig/core-config/FiatCurrency'
+import { getVaultId, Vault } from '@vultisig/core-mpc/vault/Vault'
+
+type QaVault = Vault & { coins: AccountCoin[] }
+
+type CreateQaVaultInput = {
+  name: string
+  coins: AccountCoin[]
+}
+
+type SeedStoredSettingsInput = {
+  fiatCurrency?: FiatCurrency
+  language?: string
+  isBalanceVisible?: boolean
+}
+
+type SeedCircleAccountInput = {
+  ownerAddress: string
+  accountAddress: string
+  accountId?: string
+}
+
+type SeedCoinBalanceInput = {
+  coin: AccountCoin
+  balance: bigint
+}
+
+type SeedCoinPrice = {
+  coin: CoinKey & { priceProviderId?: string }
+  price: number
+}
+
+type SeedCoinPricesInput = {
+  fiatCurrency?: FiatCurrency
+  prices: SeedCoinPrice[]
+}
+
+type DefiQaProvidersProps = ChildrenProp & {
+  queryClient: QueryClient
+  vault: QaVault
+}
+
+const noop = async () => {}
+
+export const qaOwnerAddress = '0x0000000000000000000000000000000000000001'
+export const qaCircleAccountAddress =
+  '0x0000000000000000000000000000000000000002'
+
+export const qaEthCoin: AccountCoin = {
+  chain: Chain.Ethereum,
+  address: qaOwnerAddress,
+  ticker: 'ETH',
+  decimals: 18,
+}
+
+export const createQaVault = ({ name, coins }: CreateQaVaultInput): QaVault => ({
+  name,
+  publicKeys: {
+    ecdsa:
+      '02acb4bc267db7774614bf6011c59929b006c2554386a3090baff0b3fc418ec044',
+    eddsa:
+      'a60409ef95ab55eb22d69b7f7504415358fee3657e665052780dce532409ef56',
+  },
+  signers: ['qa-device'],
+  createdAt: 1_700_000_000_000,
+  hexChainCode:
+    '0000000000000000000000000000000000000000000000000000000000000000',
+  keyShares: {
+    ecdsa: '',
+    eddsa: '',
+  },
+  localPartyId: 'qa-device',
+  libType: 'DKLS',
+  order: 0,
+  isBackedUp: true,
+  coins,
+})
+
+export const createDefiQaQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        ...(queryClientDefaultOptions?.queries ?? {}),
+        staleTime: Infinity,
+      },
+    },
+  })
+
+export const seedStoredSettings = (
+  queryClient: QueryClient,
+  {
+    fiatCurrency = 'usd',
+    language = 'en',
+    isBalanceVisible = true,
+  }: SeedStoredSettingsInput = {}
+) => {
+  queryClient.setQueryData([StorageKey.fiatCurrency], fiatCurrency)
+  queryClient.setQueryData([StorageKey.language], language)
+  queryClient.setQueryData([StorageKey.isBalanceVisible], isBalanceVisible)
+}
+
+export const seedCircleAccount = (
+  queryClient: QueryClient,
+  {
+    ownerAddress,
+    accountAddress,
+    accountId = 'qa-circle-account',
+  }: SeedCircleAccountInput
+) => {
+  queryClient.setQueryData(getCircleAccountQueryKey({ ownerAddress }), {
+    id: accountId,
+    address: accountAddress,
+  })
+}
+
+export const seedCoinBalance = (
+  queryClient: QueryClient,
+  { coin, balance }: SeedCoinBalanceInput
+) => {
+  const coinKey = extractAccountCoinKey(coin)
+
+  queryClient.setQueryData(getBalanceQueryKey(coinKey), {
+    [accountCoinKeyToString(coinKey)]: balance,
+  })
+}
+
+export const seedCoinPrices = (
+  queryClient: QueryClient,
+  { fiatCurrency = 'usd', prices }: SeedCoinPricesInput
+) => {
+  const coins = prices.map(({ coin: { chain, id, priceProviderId } }) => ({
+    chain,
+    id,
+    priceProviderId,
+  }))
+  const data = Object.fromEntries(
+    prices.map(({ coin, price }) => [coinKeyToString(coin), price])
+  )
+
+  queryClient.setQueryData(
+    getCoinPricesQueryKeys({
+      coins,
+      fiatCurrency,
+    }),
+    data
+  )
+}
+
+const createQaCoreState = (vault: QaVault): CoreState => {
+  const vaultId = getVaultId(vault)
+
+  return {
+    client: 'desktop',
+    openUrl: () => {},
+    saveFile: noop,
+    mpcDevice: 'windows',
+    vaultCreationMpcLib: 'DKLS',
+    getClipboardText: async () => '',
+    version: 'qa',
+    isLocalModeAvailable: true,
+    getMpcServerUrl: async () => '',
+    goBack: () => {},
+    popNavigationHistory: () => {},
+    goHome: () => {},
+    getVaults: async () => [vault],
+    createVault: async input => input,
+    updateVault: async () => vault,
+    deleteVault: noop,
+    updateVaultsKeyShares: noop,
+    getCoins: async () => ({ [vaultId]: vault.coins }),
+    createCoins: noop,
+    createCoin: noop,
+    deleteCoin: noop,
+    getCurrentVaultId: async () => vaultId,
+    setCurrentVaultId: noop,
+    getFiatCurrency: async () => 'usd',
+    setFiatCurrency: noop,
+    getLanguage: async () => 'en',
+    setLanguage: noop,
+    getIsBalanceVisible: async () => true,
+    setIsBalanceVisible: noop,
+    getIsBlockaidEnabled: async () => false,
+    setIsBlockaidEnabled: noop,
+    getHasFinishedOnboarding: async () => true,
+    setHasFinishedOnboarding: noop,
+    getHasSeenNotificationPrompt: async () => true,
+    setHasSeenNotificationPrompt: noop,
+    getHasFinishedReferralsOnboarding: async () => true,
+    setHasFinishedReferralsOnboarding: noop,
+    getCoinFinderIgnore: async () => [],
+    addToCoinFinderIgnore: noop,
+    removeFromCoinFinderIgnore: noop,
+    getVaultFolders: async () => [],
+    createVaultFolder: noop,
+    updateVaultFolder: noop,
+    deleteVaultFolder: noop,
+    getAddressBookItems: async () => [],
+    createAddressBookItem: noop,
+    updateAddressBookItem: noop,
+    deleteAddressBookItem: noop,
+    getPasscodeEncryption: async () => null,
+    setPasscodeEncryption: noop,
+    getPasscodeAutoLock: async () => null,
+    setPasscodeAutoLock: noop,
+    canPersistPasscodeUnlockSession: false,
+    getPasscodeUnlockSession: async () => null,
+    setPasscodeUnlockSession: noop,
+    clearPasscodeUnlockSession: noop,
+    getFriendReferral: async () => null,
+    setFriendReferral: noop,
+    getDismissedBanners: async () => [],
+    setDismissedBanners: noop,
+    getIsCircleVisible: async () => true,
+    setIsCircleVisible: noop,
+    getIsMLDSAEnabled: async () => false,
+    getIsTssBatchingEnabled: async () => false,
+    setIsTssBatchingEnabled: noop,
+    getTransactionRecords: async () => [],
+    saveTransactionRecord: noop,
+    updateTransactionRecord: noop,
+    getDefiChains: async () => [],
+    setDefiChains: noop,
+    getDefiPositions: async () => ({}),
+    setDefiPositions: noop,
+  }
+}
+
+export const DefiQaProviders = ({
+  queryClient,
+  vault,
+  children,
+}: DefiQaProvidersProps) => {
+  const vaultId = getVaultId(vault)
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={darkTheme}>
+        <GlobalStyle />
+        <CoreProvider value={createQaCoreState(vault)}>
+          <WalletCoreProvider>
+            <VaultsProvider value={[vault]}>
+              <CurrentVaultIdProvider value={vaultId}>
+                <CurrentVaultProvider value={vault}>
+                  <NavigationProvider
+                    initialValue={{
+                      history: [{ id: 'defi', state: { protocol: 'circle' } }],
+                    }}
+                  >
+                    {children}
+                  </NavigationProvider>
+                </CurrentVaultProvider>
+              </CurrentVaultIdProvider>
+            </VaultsProvider>
+          </WalletCoreProvider>
+        </CoreProvider>
+      </ThemeProvider>
+    </QueryClientProvider>
+  )
+}

--- a/scripts/qa/defi-ui-harness/index.html
+++ b/scripts/qa/defi-ui-harness/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DeFi UI QA Harness</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/scripts/qa/defi-ui-harness/main.tsx
+++ b/scripts/qa/defi-ui-harness/main.tsx
@@ -35,16 +35,19 @@ const vault = createQaVault({
 
 const queryClient = createDefiQaQueryClient()
 
-seedStoredSettings(queryClient)
-seedCircleAccount(queryClient, {
+seedStoredSettings({ queryClient })
+seedCircleAccount({
+  queryClient,
   ownerAddress: qaOwnerAddress,
   accountAddress: qaCircleAccountAddress,
 })
-seedCoinBalance(queryClient, {
+seedCoinBalance({
+  queryClient,
   coin: circleAccountUsdc,
   balance: 125_000_000n,
 })
-seedCoinPrices(queryClient, {
+seedCoinPrices({
+  queryClient,
   prices: [
     {
       coin: usdc,

--- a/scripts/qa/defi-ui-harness/main.tsx
+++ b/scripts/qa/defi-ui-harness/main.tsx
@@ -1,0 +1,76 @@
+import { CircleView } from '@core/ui/defi/protocols/circle/CircleView'
+import '@core/ui/i18n/config'
+import { usdc } from '@vultisig/core-chain/coin/knownTokens'
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import styled from 'styled-components'
+
+import {
+  createDefiQaQueryClient,
+  createQaVault,
+  DefiQaProviders,
+  qaCircleAccountAddress,
+  qaEthCoin,
+  qaOwnerAddress,
+  seedCircleAccount,
+  seedCoinBalance,
+  seedCoinPrices,
+  seedStoredSettings,
+} from './fixture'
+
+const vaultUsdc = {
+  ...usdc,
+  address: qaOwnerAddress,
+}
+
+const circleAccountUsdc = {
+  ...usdc,
+  address: qaCircleAccountAddress,
+}
+
+const vault = createQaVault({
+  name: 'QA Circle Vault',
+  coins: [qaEthCoin, vaultUsdc],
+})
+
+const queryClient = createDefiQaQueryClient()
+
+seedStoredSettings(queryClient)
+seedCircleAccount(queryClient, {
+  ownerAddress: qaOwnerAddress,
+  accountAddress: qaCircleAccountAddress,
+})
+seedCoinBalance(queryClient, {
+  coin: circleAccountUsdc,
+  balance: 125_000_000n,
+})
+seedCoinPrices(queryClient, {
+  prices: [
+    {
+      coin: usdc,
+      price: 1,
+    },
+  ],
+})
+
+const Page = styled.div`
+  width: 430px;
+  min-height: 720px;
+  margin: 0 auto;
+`
+
+const rootElement = document.getElementById('root')
+
+if (rootElement === null) {
+  throw new Error('Missing root element')
+}
+
+createRoot(rootElement).render(
+  <StrictMode>
+    <DefiQaProviders queryClient={queryClient} vault={vault}>
+      <Page>
+        <CircleView />
+      </Page>
+    </DefiQaProviders>
+  </StrictMode>
+)

--- a/scripts/qa/defi-ui-harness/package.json
+++ b/scripts/qa/defi-ui-harness/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@scripts/defi-ui-harness",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite --config vite.config.mts",
+    "build": "vite build --config vite.config.mts"
+  },
+  "dependencies": {
+    "@core/ui": "workspace:^",
+    "@lib/ui": "workspace:^",
+    "@tanstack/react-query": "^5.90.21",
+    "@vultisig/core-chain": "2.12.0",
+    "@vultisig/core-config": "0.9.1",
+    "@vultisig/core-mpc": "1.3.13",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "styled-components": "^6.3.11"
+  },
+  "devDependencies": {
+    "vite": "^7.3.1",
+    "vite-plugin-static-copy": "^3.3.0",
+    "vite-tsconfig-paths": "^6.1.1"
+  }
+}

--- a/scripts/qa/defi-ui-harness/vite.config.mts
+++ b/scripts/qa/defi-ui-harness/vite.config.mts
@@ -1,0 +1,44 @@
+import path from 'path'
+import { defineConfig, loadEnv } from 'vite'
+import { viteStaticCopy } from 'vite-plugin-static-copy'
+import tsconfigPaths from 'vite-tsconfig-paths'
+
+import { getFeatureFlagDefines } from '../../../core/ui/vite/featureFlagDefines'
+import { getCommonPlugins } from '../../../core/ui/vite/plugins'
+import { getStaticCopyTargets } from '../../../core/ui/vite/staticCopy'
+
+const rootDir = path.resolve(import.meta.dirname, '../../..')
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, rootDir, '')
+
+  return {
+    root: import.meta.dirname,
+    define: {
+      ...getFeatureFlagDefines(env),
+      __APP_VERSION__: JSON.stringify('qa'),
+      __APP_BUILD__: JSON.stringify('qa'),
+      __AGENT_BACKEND_URL__: JSON.stringify(
+        env.AGENT_BACKEND_URL || 'https://agent.vultisig.com'
+      ),
+      __VULTISIG_VERIFIER_URL__: JSON.stringify(
+        env.VULTISIG_VERIFIER_URL || 'https://verifier.vultisig.com'
+      ),
+      __VULTISIG_STATION_KYBER_SOURCE__: JSON.stringify(''),
+      __FAST_VAULT_URL__: JSON.stringify(''),
+      __RELAY_URL__: JSON.stringify(''),
+    },
+    plugins: [
+      tsconfigPaths({ root: rootDir }),
+      ...getCommonPlugins(),
+      viteStaticCopy({
+        targets: getStaticCopyTargets(),
+      }),
+    ],
+    server: {
+      host: '127.0.0.1',
+      port: 5177,
+      strictPort: true,
+    },
+  }
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -4708,6 +4708,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@scripts/defi-ui-harness@workspace:scripts/qa/defi-ui-harness":
+  version: 0.0.0-use.local
+  resolution: "@scripts/defi-ui-harness@workspace:scripts/qa/defi-ui-harness"
+  dependencies:
+    "@core/ui": "workspace:^"
+    "@lib/ui": "workspace:^"
+    "@tanstack/react-query": "npm:^5.90.21"
+    "@vultisig/core-chain": "npm:2.12.0"
+    "@vultisig/core-config": "npm:0.9.1"
+    "@vultisig/core-mpc": "npm:1.3.13"
+    react: "npm:^19.2.4"
+    react-dom: "npm:^19.2.4"
+    styled-components: "npm:^6.3.11"
+    vite: "npm:^7.3.1"
+    vite-plugin-static-copy: "npm:^3.3.0"
+    vite-tsconfig-paths: "npm:^6.1.1"
+  languageName: unknown
+  linkType: soft
+
 "@scure/base@npm:2.0.0, @scure/base@npm:^2.0.0":
   version: 2.0.0
   resolution: "@scure/base@npm:2.0.0"


### PR DESCRIPTION
![screenshot-1](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/defi-ui-qa-harness/screenshot-1-1780993488433.png)
![screenshot-2](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/defi-ui-qa-harness/screenshot-2-1780993488433.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a local DeFi UI QA harness for deterministic layout/navigation/visibility checks (home and withdraw paths), including a dev server entrypoint and package scripts to run/build it.
  * Harness seeds UI state (accounts, coin balances, prices, and settings) so views render reproducibly without real wallet flows.

* **Documentation**
  * Added instructions for running the harness, local URL, scenarios to capture, and fixture seeding helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->