### PR TITLE
fix(qbtc/history): label Cosmos staking txs by message type, not "Send"

### DIFF
--- a/core/inpage-provider/popup/view/resolvers/sendTx/SendTxOverview.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/SendTxOverview.tsx
@@ -1,6 +1,7 @@
 import { BlockaidSimulationContent } from '@core/inpage-provider/popup/view/resolvers/sendTx/blockaid/BlockaidSimulationContent'
 import { BlockaidSimulationError } from '@core/inpage-provider/popup/view/resolvers/sendTx/blockaid/BlockaidSimulationError'
 import { useBlockaidSimulationQuery } from '@core/inpage-provider/popup/view/resolvers/sendTx/blockaid/useBlockaidSimulationQuery'
+import { CosmosTxTypeRow } from '@core/inpage-provider/popup/view/resolvers/sendTx/components/CosmosTxTypeRow'
 import { DappRequestHeader } from '@core/inpage-provider/popup/view/resolvers/sendTx/components/DappRequestHeader'
 import {
   DappRequestDivider,
@@ -420,6 +421,7 @@ export const SendTxOverview = ({
                   ) : (
                     <>
                       <List>
+                        <CosmosTxTypeRow keysignPayload={keysignPayload} />
                         <ListItem description={address} title={t('from')} />
                         {keysignPayload.toAddress && (
                           <ListItem

--- a/core/inpage-provider/popup/view/resolvers/sendTx/components/CosmosTxTypeRow.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/components/CosmosTxTypeRow.tsx
@@ -1,0 +1,34 @@
+import { getSignDataTxAction } from '@core/ui/mpc/keysign/tx/utils/getSignDataTxAction'
+import { ListItem } from '@lib/ui/list/item'
+import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { isOneOf } from '@vultisig/lib-utils/array/isOneOf'
+import { useTranslation } from 'react-i18next'
+
+const labeledCosmosActions = [
+  'delegate',
+  'undelegate',
+  'redelegate',
+  'vote',
+  'claim_rewards',
+] as const
+
+type CosmosTxTypeRowProps = {
+  keysignPayload: KeysignPayload
+}
+
+/**
+ * Renders a "Type" row (e.g. "Delegate") in the approval popup for Cosmos
+ * staking/gov transactions so the user can tell a delegate/vote/claim apart
+ * from a plain send. Renders nothing for sends and non-Cosmos txs, where the
+ * existing amount/address rows already convey the action.
+ */
+export const CosmosTxTypeRow = ({ keysignPayload }: CosmosTxTypeRowProps) => {
+  const { t } = useTranslation()
+  const action = getSignDataTxAction(keysignPayload, 0)
+
+  if (!action || !isOneOf(action.action, labeledCosmosActions)) {
+    return null
+  }
+
+  return <ListItem title={t('type')} description={t(action.labelKey)} />
+}

--- a/core/ui/mpc/keysign/tx/TxOverviewAmount.tsx
+++ b/core/ui/mpc/keysign/tx/TxOverviewAmount.tsx
@@ -16,6 +16,11 @@ type TxActionLabelKey =
   | 'contract_execution'
   | 'deposited'
   | 'transferred'
+  | 'delegate'
+  | 'undelegate'
+  | 'redelegate'
+  | 'vote'
+  | 'claim_rewards'
 
 type TxOverviewAmountProps = ValueProp<Coin> & {
   amount: number

--- a/core/ui/mpc/keysign/tx/utils/getSignDataTxAction.test.ts
+++ b/core/ui/mpc/keysign/tx/utils/getSignDataTxAction.test.ts
@@ -1,0 +1,170 @@
+import { create } from '@bufbuild/protobuf'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { CoinSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/coin_pb'
+import { KeysignPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { SignDirectSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/wasm_execute_contract_payload_pb'
+import { MsgSend } from 'cosmjs-types/cosmos/bank/v1beta1/tx'
+import { MsgWithdrawDelegatorReward } from 'cosmjs-types/cosmos/distribution/v1beta1/tx'
+import { MsgVote } from 'cosmjs-types/cosmos/gov/v1/tx'
+import {
+  MsgBeginRedelegate,
+  MsgDelegate,
+  MsgUndelegate,
+} from 'cosmjs-types/cosmos/staking/v1beta1/tx'
+import { TxBody } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
+import { describe, expect, it } from 'vitest'
+
+import { getSignDataTxAction } from './getSignDataTxAction'
+
+const bodyBytesBase64 = (
+  messages: { typeUrl: string; value: Uint8Array }[]
+): string =>
+  Buffer.from(
+    TxBody.encode(TxBody.fromPartial({ messages, memo: '' })).finish()
+  ).toString('base64')
+
+const qbtcSignDirectPayload = (
+  messages: { typeUrl: string; value: Uint8Array }[]
+) =>
+  create(KeysignPayloadSchema, {
+    coin: create(CoinSchema, {
+      chain: Chain.QBTC,
+      ticker: 'QBTC',
+      decimals: 8,
+    }),
+    signData: {
+      case: 'signDirect',
+      value: create(SignDirectSchema, {
+        bodyBytes: bodyBytesBase64(messages),
+      }),
+    },
+  })
+
+const delegateMsg = {
+  typeUrl: '/cosmos.staking.v1beta1.MsgDelegate',
+  value: MsgDelegate.encode({
+    delegatorAddress: 'qbtc1aaa',
+    validatorAddress: 'qbtcvaloper1xyz',
+    amount: { denom: 'qbtc', amount: '1000' },
+  }).finish(),
+}
+
+describe('getSignDataTxAction — Cosmos staking/gov signDirect', () => {
+  it('labels MsgDelegate as a delegate action', () => {
+    const action = getSignDataTxAction(qbtcSignDirectPayload([delegateMsg]), 0)
+    expect(action).toMatchObject({ action: 'delegate', labelKey: 'delegate' })
+  })
+
+  it('labels MsgUndelegate as an undelegate action', () => {
+    const action = getSignDataTxAction(
+      qbtcSignDirectPayload([
+        {
+          typeUrl: '/cosmos.staking.v1beta1.MsgUndelegate',
+          value: MsgUndelegate.encode({
+            delegatorAddress: 'qbtc1aaa',
+            validatorAddress: 'qbtcvaloper1xyz',
+            amount: { denom: 'qbtc', amount: '1000' },
+          }).finish(),
+        },
+      ]),
+      0
+    )
+    expect(action).toMatchObject({
+      action: 'undelegate',
+      labelKey: 'undelegate',
+    })
+  })
+
+  it('labels MsgBeginRedelegate as a redelegate action', () => {
+    const action = getSignDataTxAction(
+      qbtcSignDirectPayload([
+        {
+          typeUrl: '/cosmos.staking.v1beta1.MsgBeginRedelegate',
+          value: MsgBeginRedelegate.encode({
+            delegatorAddress: 'qbtc1aaa',
+            validatorSrcAddress: 'qbtcvaloper1src',
+            validatorDstAddress: 'qbtcvaloper1dst',
+            amount: { denom: 'qbtc', amount: '1000' },
+          }).finish(),
+        },
+      ]),
+      0
+    )
+    expect(action).toMatchObject({
+      action: 'redelegate',
+      labelKey: 'redelegate',
+    })
+  })
+
+  it('labels MsgVote as a vote action with no amount', () => {
+    const action = getSignDataTxAction(
+      qbtcSignDirectPayload([
+        {
+          typeUrl: '/cosmos.gov.v1.MsgVote',
+          value: MsgVote.encode({
+            proposalId: 1n,
+            voter: 'qbtc1aaa',
+            option: 1,
+            metadata: '',
+          }).finish(),
+        },
+      ]),
+      0
+    )
+    expect(action).toEqual({ action: 'vote', labelKey: 'vote' })
+  })
+
+  it('labels MsgWithdrawDelegatorReward as a claim_rewards action', () => {
+    const action = getSignDataTxAction(
+      qbtcSignDirectPayload([
+        {
+          typeUrl: '/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward',
+          value: MsgWithdrawDelegatorReward.encode({
+            delegatorAddress: 'qbtc1aaa',
+            validatorAddress: 'qbtcvaloper1xyz',
+          }).finish(),
+        },
+      ]),
+      0
+    )
+    expect(action).toEqual({
+      action: 'claim_rewards',
+      labelKey: 'claim_rewards',
+    })
+  })
+
+  it('still labels MsgSend as a send action', () => {
+    const action = getSignDataTxAction(
+      qbtcSignDirectPayload([
+        {
+          typeUrl: '/cosmos.bank.v1beta1.MsgSend',
+          value: MsgSend.encode({
+            fromAddress: 'qbtc1aaa',
+            toAddress: 'qbtc1bbb',
+            amount: [{ denom: 'qbtc', amount: '1000' }],
+          }).finish(),
+        },
+      ]),
+      0
+    )
+    expect(action?.action).toBe('send')
+  })
+
+  it('uses the first staking message in a multi-message tx', () => {
+    const action = getSignDataTxAction(
+      qbtcSignDirectPayload([
+        delegateMsg,
+        {
+          typeUrl: '/cosmos.bank.v1beta1.MsgSend',
+          value: MsgSend.encode({
+            fromAddress: 'qbtc1aaa',
+            toAddress: 'qbtc1bbb',
+            amount: [{ denom: 'qbtc', amount: '1' }],
+          }).finish(),
+        },
+      ]),
+      0
+    )
+    expect(action).toMatchObject({ action: 'delegate' })
+  })
+})

--- a/core/ui/mpc/keysign/tx/utils/getSignDataTxAction.ts
+++ b/core/ui/mpc/keysign/tx/utils/getSignDataTxAction.ts
@@ -9,6 +9,11 @@ import { getKeysignChain } from '@vultisig/core-mpc/keysign/utils/getKeysignChai
 import type { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
 import { attempt } from '@vultisig/lib-utils/attempt'
 import { MsgSend } from 'cosmjs-types/cosmos/bank/v1beta1/tx'
+import {
+  MsgBeginRedelegate,
+  MsgDelegate,
+  MsgUndelegate,
+} from 'cosmjs-types/cosmos/staking/v1beta1/tx'
 import { TxBody } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
 import { MsgExecuteContract } from 'cosmjs-types/cosmwasm/wasm/v1/tx'
 import { MsgTransfer } from 'cosmjs-types/ibc/applications/transfer/v1/tx'
@@ -24,6 +29,11 @@ type SignDataTxAction =
     }
   | { action: 'deposit'; labelKey: 'deposited'; amount: number }
   | { action: 'transfer'; labelKey: 'transferred'; amount: number }
+  | { action: 'delegate'; labelKey: 'delegate'; amount?: number }
+  | { action: 'undelegate'; labelKey: 'undelegate'; amount?: number }
+  | { action: 'redelegate'; labelKey: 'redelegate'; amount?: number }
+  | { action: 'vote'; labelKey: 'vote' }
+  | { action: 'claim_rewards'; labelKey: 'claim_rewards' }
 
 const sumAmountForDenom = (
   amounts: readonly { denom: string; amount: string }[],
@@ -175,6 +185,49 @@ const parseSignDirectMessage = (
     return { action: 'leave_pool', labelKey: 'left_pool' }
   }
 
+  if (typeUrl === CosmosMsgType.MSG_DELEGATE_URL) {
+    const result = attempt(() => MsgDelegate.decode(value))
+    if ('error' in result) return null
+    const coin = result.data.amount
+    const amount = coin
+      ? sumAmountForDenom([coin], chainFeeDenom, decimals)
+      : undefined
+    return { action: 'delegate', labelKey: 'delegate', amount }
+  }
+
+  if (typeUrl === CosmosMsgType.MSG_UNDELEGATE_URL) {
+    const result = attempt(() => MsgUndelegate.decode(value))
+    if ('error' in result) return null
+    const coin = result.data.amount
+    const amount = coin
+      ? sumAmountForDenom([coin], chainFeeDenom, decimals)
+      : undefined
+    return { action: 'undelegate', labelKey: 'undelegate', amount }
+  }
+
+  if (typeUrl === CosmosMsgType.MSG_BEGIN_REDELEGATE_URL) {
+    const result = attempt(() => MsgBeginRedelegate.decode(value))
+    if ('error' in result) return null
+    const coin = result.data.amount
+    const amount = coin
+      ? sumAmountForDenom([coin], chainFeeDenom, decimals)
+      : undefined
+    return { action: 'redelegate', labelKey: 'redelegate', amount }
+  }
+
+  if (typeUrl === CosmosMsgType.MSG_WITHDRAW_DELEGATOR_REWARD_URL) {
+    return { action: 'claim_rewards', labelKey: 'claim_rewards' }
+  }
+
+  // Gov vote (v1 and v1beta1) carries no transferable amount — surface the
+  // action label only.
+  if (
+    typeUrl === '/cosmos.gov.v1.MsgVote' ||
+    typeUrl === '/cosmos.gov.v1beta1.MsgVote'
+  ) {
+    return { action: 'vote', labelKey: 'vote' }
+  }
+
   return null
 }
 
@@ -284,6 +337,33 @@ export const getSignDataTxAction = (
       }
       if (result.action === 'leave_pool') {
         return { action: 'leave_pool', labelKey: 'left_pool' }
+      }
+      if (result.action === 'delegate') {
+        return {
+          action: 'delegate',
+          labelKey: 'delegate',
+          amount: result.amount,
+        }
+      }
+      if (result.action === 'undelegate') {
+        return {
+          action: 'undelegate',
+          labelKey: 'undelegate',
+          amount: result.amount,
+        }
+      }
+      if (result.action === 'redelegate') {
+        return {
+          action: 'redelegate',
+          labelKey: 'redelegate',
+          amount: result.amount,
+        }
+      }
+      if (result.action === 'vote') {
+        return { action: 'vote', labelKey: 'vote' }
+      }
+      if (result.action === 'claim_rewards') {
+        return { action: 'claim_rewards', labelKey: 'claim_rewards' }
       }
     }
 

--- a/core/ui/mpc/keysign/tx/utils/getSignDataTxAction.ts
+++ b/core/ui/mpc/keysign/tx/utils/getSignDataTxAction.ts
@@ -101,7 +101,7 @@ const parseSignDirectMessage = (
   chain: CosmosChain,
   chainFeeDenom: string,
   decimals: number
-): Partial<SignDataTxAction> | null => {
+): SignDataTxAction | null => {
   if (
     typeUrl === CosmosMsgType.MSG_SEND_URL ||
     typeUrl === CosmosMsgType.THORCHAIN_MSG_SEND_URL
@@ -310,61 +310,14 @@ export const getSignDataTxAction = (
       )
       if (!result) continue
 
-      if (result.action === 'send' && result.amount !== undefined) {
+      // Accumulate the first send amount but keep scanning: a later non-send
+      // message (e.g. a staking action in a multi-message tx) takes priority.
+      if (result.action === 'send') {
         if (firstSendAmount === undefined) firstSendAmount = result.amount
         continue
       }
 
-      if (
-        result.action === 'contract_execution' &&
-        'contractAddress' in result
-      ) {
-        return result as SignDataTxAction
-      }
-      if (result.action === 'deposit' && result.amount !== undefined) {
-        return {
-          action: 'deposit',
-          labelKey: 'deposited',
-          amount: result.amount,
-        }
-      }
-      if (result.action === 'transfer' && result.amount !== undefined) {
-        return {
-          action: 'transfer',
-          labelKey: 'transferred',
-          amount: result.amount,
-        }
-      }
-      if (result.action === 'leave_pool') {
-        return { action: 'leave_pool', labelKey: 'left_pool' }
-      }
-      if (result.action === 'delegate') {
-        return {
-          action: 'delegate',
-          labelKey: 'delegate',
-          amount: result.amount,
-        }
-      }
-      if (result.action === 'undelegate') {
-        return {
-          action: 'undelegate',
-          labelKey: 'undelegate',
-          amount: result.amount,
-        }
-      }
-      if (result.action === 'redelegate') {
-        return {
-          action: 'redelegate',
-          labelKey: 'redelegate',
-          amount: result.amount,
-        }
-      }
-      if (result.action === 'vote') {
-        return { action: 'vote', labelKey: 'vote' }
-      }
-      if (result.action === 'claim_rewards') {
-        return { action: 'claim_rewards', labelKey: 'claim_rewards' }
-      }
+      return result
     }
 
     return {

--- a/core/ui/transaction-history/TransactionHistoryCard/TransactionHistoryCard.tsx
+++ b/core/ui/transaction-history/TransactionHistoryCard/TransactionHistoryCard.tsx
@@ -51,6 +51,8 @@ export type TransactionHistoryCardPill =
 export type TransactionHistoryCardProps = {
   /** Transaction type shown in the tag (send, receive, swap, approve). */
   tagType: TransactionHistoryTagType
+  /** Optional pre-resolved tag label override (e.g. "Delegate" for staking). */
+  tagLabel?: string
   /** Card state: successful (green), pending (neutral), or error (red). */
   status: TransactionHistoryCardStatus
   /** USD amount, e.g. "$1,000.54". */
@@ -74,6 +76,7 @@ export type TransactionHistoryCardProps = {
 
 export const TransactionHistoryCard = ({
   tagType,
+  tagLabel,
   status,
   amountUsd,
   amountCrypto,
@@ -99,7 +102,7 @@ export const TransactionHistoryCard = ({
   return (
     <Card>
       <TopRow>
-        <TransactionHistoryTag type={tagType} />
+        <TransactionHistoryTag type={tagType} label={tagLabel} />
         <StatusLabel $status={status}>{statusLabel}</StatusLabel>
       </TopRow>
 

--- a/core/ui/transaction-history/TransactionHistoryTag/TransactionHistoryTag.tsx
+++ b/core/ui/transaction-history/TransactionHistoryTag/TransactionHistoryTag.tsx
@@ -33,9 +33,18 @@ const labelKeyMap = {
 
 export type TransactionHistoryTagProps = {
   type: TransactionHistoryTagType
+  /**
+   * Pre-resolved label override. When provided it replaces the default
+   * `type`-derived label (the icon still follows `type`) — used to surface
+   * Cosmos message actions like "Delegate"/"Vote" on otherwise-send records.
+   */
+  label?: string
 }
 
-export const TransactionHistoryTag = ({ type }: TransactionHistoryTagProps) => {
+export const TransactionHistoryTag = ({
+  type,
+  label,
+}: TransactionHistoryTagProps) => {
   const { t } = useTranslation()
   const Icon = iconMap[type]
   const labelKey = labelKeyMap[type]
@@ -44,7 +53,7 @@ export const TransactionHistoryTag = ({ type }: TransactionHistoryTagProps) => {
     <TagPill>
       <Icon style={{ fontSize: 12 }} aria-hidden />
       <Text variant="caption" color="info">
-        {t(labelKey)}
+        {label ?? t(labelKey)}
       </Text>
     </TagPill>
   )

--- a/core/ui/transaction-history/core.ts
+++ b/core/ui/transaction-history/core.ts
@@ -33,6 +33,14 @@ export type SendTransactionData = {
   decimals: number
   feeEstimate?: string
   memo?: string
+  /**
+   * For Cosmos SDK chains (QBTC dApp txs and in-wallet staking), the typeUrl of
+   * the primary (first) message in the signed `TxBody`, e.g.
+   * `/cosmos.staking.v1beta1.MsgDelegate`. Drives the history tag label so a
+   * delegate/vote/claim tx isn't mislabeled as a plain "Send". Undefined for
+   * non-Cosmos sends, which keep the default "Send" label.
+   */
+  messageTypeUrl?: string
 }
 
 export type SwapTransactionData = {

--- a/core/ui/transaction-history/cosmosMessageLabel.test.ts
+++ b/core/ui/transaction-history/cosmosMessageLabel.test.ts
@@ -1,4 +1,4 @@
-import { TFunction } from 'i18next'
+import { createInstance } from 'i18next'
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -7,9 +7,12 @@ import {
   getTransactionTagLabel,
 } from './cosmosMessageLabel'
 
-// Identity translator: returns the key it's given so assertions can check which
-// translation key was selected without loading the real i18n resources.
-const identityT = ((key: string) => key) as unknown as TFunction
+// A real i18next instance with no resources: t(key) returns the key verbatim,
+// giving an identity translator with a genuine TFunction type (no casts), so
+// assertions can check which translation key was selected.
+const i18n = createInstance()
+void i18n.init({ lng: 'en', resources: {} })
+const identityT = i18n.t
 
 describe('getCosmosMessageLabelKey', () => {
   it('maps known staking/gov/distribution typeUrls to translation keys', () => {

--- a/core/ui/transaction-history/cosmosMessageLabel.test.ts
+++ b/core/ui/transaction-history/cosmosMessageLabel.test.ts
@@ -1,0 +1,77 @@
+import { TFunction } from 'i18next'
+import { describe, expect, it } from 'vitest'
+
+import {
+  deriveCosmosMessageLabel,
+  getCosmosMessageLabelKey,
+  getTransactionTagLabel,
+} from './cosmosMessageLabel'
+
+// Identity translator: returns the key it's given so assertions can check which
+// translation key was selected without loading the real i18n resources.
+const identityT = ((key: string) => key) as unknown as TFunction
+
+describe('getCosmosMessageLabelKey', () => {
+  it('maps known staking/gov/distribution typeUrls to translation keys', () => {
+    expect(
+      getCosmosMessageLabelKey('/cosmos.staking.v1beta1.MsgDelegate')
+    ).toBe('delegate')
+    expect(
+      getCosmosMessageLabelKey('/cosmos.staking.v1beta1.MsgUndelegate')
+    ).toBe('undelegate')
+    expect(
+      getCosmosMessageLabelKey('/cosmos.staking.v1beta1.MsgBeginRedelegate')
+    ).toBe('redelegate')
+    expect(
+      getCosmosMessageLabelKey(
+        '/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward'
+      )
+    ).toBe('claim_rewards')
+    expect(getCosmosMessageLabelKey('/cosmos.gov.v1.MsgVote')).toBe('vote')
+    expect(getCosmosMessageLabelKey('/cosmos.gov.v1beta1.MsgVote')).toBe('vote')
+    expect(getCosmosMessageLabelKey('/cosmos.bank.v1beta1.MsgSend')).toBe(
+      'send'
+    )
+  })
+
+  it('returns undefined for unmapped typeUrls', () => {
+    expect(
+      getCosmosMessageLabelKey('/cosmos.foo.v1.MsgSomethingNew')
+    ).toBeUndefined()
+  })
+})
+
+describe('deriveCosmosMessageLabel', () => {
+  it('uses the last dotted segment with the Msg prefix stripped', () => {
+    expect(deriveCosmosMessageLabel('/cosmos.foo.v1.MsgClaim')).toBe('Claim')
+    expect(deriveCosmosMessageLabel('/some.module.v2.MsgFancyAction')).toBe(
+      'FancyAction'
+    )
+  })
+})
+
+describe('getTransactionTagLabel', () => {
+  it('returns undefined when there is no message typeUrl (non-Cosmos send)', () => {
+    expect(
+      getTransactionTagLabel({ messageTypeUrl: undefined, t: identityT })
+    ).toBeUndefined()
+  })
+
+  it('resolves a known typeUrl through the translator', () => {
+    expect(
+      getTransactionTagLabel({
+        messageTypeUrl: '/cosmos.staking.v1beta1.MsgDelegate',
+        t: identityT,
+      })
+    ).toBe('delegate')
+  })
+
+  it('falls back to the derived label for an unmapped typeUrl', () => {
+    expect(
+      getTransactionTagLabel({
+        messageTypeUrl: '/cosmos.foo.v1.MsgClaim',
+        t: identityT,
+      })
+    ).toBe('Claim')
+  })
+})

--- a/core/ui/transaction-history/cosmosMessageLabel.ts
+++ b/core/ui/transaction-history/cosmosMessageLabel.ts
@@ -1,0 +1,62 @@
+import { CosmosMsgType } from '@vultisig/core-chain/chains/cosmos/cosmosMsgTypes'
+import { TFunction } from 'i18next'
+
+/** Translation keys in `en.ts` used for Cosmos message tag labels. */
+type CosmosMessageLabelKey =
+  | 'send'
+  | 'delegate'
+  | 'undelegate'
+  | 'redelegate'
+  | 'claim_rewards'
+  | 'vote'
+
+/**
+ * Maps a Cosmos message typeUrl to a translation key in `en.ts`. Covers the
+ * staking/gov/distribution actions a tx may carry so the history tag reads
+ * "Delegate"/"Vote"/… instead of a generic "Send". Add an entry (and the
+ * matching `en.ts` key) when a new message type needs a dedicated label.
+ */
+const labelKeyByTypeUrl: Record<string, CosmosMessageLabelKey> = {
+  [CosmosMsgType.MSG_SEND_URL]: 'send',
+  [CosmosMsgType.MSG_DELEGATE_URL]: 'delegate',
+  [CosmosMsgType.MSG_UNDELEGATE_URL]: 'undelegate',
+  [CosmosMsgType.MSG_BEGIN_REDELEGATE_URL]: 'redelegate',
+  [CosmosMsgType.MSG_WITHDRAW_DELEGATOR_REWARD_URL]: 'claim_rewards',
+  '/cosmos.gov.v1.MsgVote': 'vote',
+  '/cosmos.gov.v1beta1.MsgVote': 'vote',
+}
+
+/** Translation key for a known Cosmos message typeUrl, or undefined. */
+export const getCosmosMessageLabelKey = (
+  typeUrl: string
+): CosmosMessageLabelKey | undefined => labelKeyByTypeUrl[typeUrl]
+
+/**
+ * Human label for an unmapped typeUrl: the last dotted segment with the `Msg`
+ * prefix stripped, e.g. `/cosmos.foo.v1.MsgClaim` → "Claim". Not translated —
+ * known types should go through {@link getCosmosMessageLabelKey} instead.
+ */
+export const deriveCosmosMessageLabel = (typeUrl: string): string => {
+  const lastSegment = typeUrl.split('.').pop() ?? typeUrl
+  return lastSegment.replace(/^Msg/, '') || typeUrl
+}
+
+type GetTransactionTagLabelInput = {
+  messageTypeUrl: string | undefined
+  t: TFunction
+}
+
+/**
+ * Resolves the history tag label for a Cosmos send record. Returns undefined
+ * when there is no message typeUrl (non-Cosmos sends) so the caller keeps the
+ * default "Send" tag.
+ */
+export const getTransactionTagLabel = ({
+  messageTypeUrl,
+  t,
+}: GetTransactionTagLabelInput): string | undefined => {
+  if (!messageTypeUrl) return undefined
+
+  const labelKey = getCosmosMessageLabelKey(messageTypeUrl)
+  return labelKey ? t(labelKey) : deriveCosmosMessageLabel(messageTypeUrl)
+}

--- a/core/ui/transaction-history/list/TransactionRecordCard.tsx
+++ b/core/ui/transaction-history/list/TransactionRecordCard.tsx
@@ -13,8 +13,10 @@ import {
 } from '@vultisig/core-chain/coin/Coin'
 import { isOneOf } from '@vultisig/lib-utils/array/isOneOf'
 import { formatAmount } from '@vultisig/lib-utils/formatAmount'
+import { useTranslation } from 'react-i18next'
 
 import { TransactionRecord, TransactionRecordStatus } from '../core'
+import { getTransactionTagLabel } from '../cosmosMessageLabel'
 import {
   TransactionHistoryCard,
   TransactionHistoryCardPill,
@@ -39,6 +41,8 @@ type TransactionDisplayData = {
   symbol: string
   pill: TransactionHistoryCardPill
   coin: (CoinKey & { logo: string }) | undefined
+  /** Cosmos message typeUrl driving the tag label, when present. */
+  messageTypeUrl?: string
 }
 
 const formatCryptoAmount = (amount: number): string =>
@@ -117,6 +121,7 @@ const getDisplayData = (record: TransactionRecord): TransactionDisplayData => {
           logo: record.data.tokenLogo,
         }
       : undefined,
+    messageTypeUrl: record.data.messageTypeUrl,
   }
 }
 
@@ -168,9 +173,14 @@ const useFiatDisplay = (record: TransactionRecord, cryptoAmount: number) => {
 export const TransactionRecordCard = ({
   record,
 }: TransactionRecordCardProps) => {
+  const { t } = useTranslation()
   const navigate = useCoreNavigate()
   const display = getDisplayData(record)
   const amountUsd = useFiatDisplay(record, display.cryptoAmount)
+  const tagLabel = getTransactionTagLabel({
+    messageTypeUrl: display.messageTypeUrl,
+    t,
+  })
 
   const handleClick = () =>
     navigate({ id: 'transactionDetail', state: { id: record.id } })
@@ -190,6 +200,7 @@ export const TransactionRecordCard = ({
     >
       <TransactionHistoryCard
         tagType={display.tagType}
+        tagLabel={tagLabel}
         status={statusToCardStatus[record.status]}
         amountUsd={amountUsd}
         amountCrypto={display.amountCrypto}

--- a/core/ui/transaction-history/record/createTransactionRecord.ts
+++ b/core/ui/transaction-history/record/createTransactionRecord.ts
@@ -19,6 +19,7 @@ import {
   SwapTransactionRecord,
   TransactionRecord,
 } from '../core'
+import { getPrimaryCosmosMessageTypeUrl } from './getPrimaryCosmosMessageTypeUrl'
 
 type CreateTransactionRecordInput = {
   payload: KeysignPayload
@@ -40,6 +41,7 @@ const createSendData = (payload: KeysignPayload): SendTransactionData => {
     tokenId: coin.id,
     decimals: coin.decimals,
     memo: payload.memo || undefined,
+    messageTypeUrl: getPrimaryCosmosMessageTypeUrl(payload),
   }
 }
 

--- a/core/ui/transaction-history/record/getPrimaryCosmosMessageTypeUrl.test.ts
+++ b/core/ui/transaction-history/record/getPrimaryCosmosMessageTypeUrl.test.ts
@@ -1,0 +1,82 @@
+import { create } from '@bufbuild/protobuf'
+import { KeysignPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { SignDirectSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/wasm_execute_contract_payload_pb'
+import { MsgSend } from 'cosmjs-types/cosmos/bank/v1beta1/tx'
+import {
+  MsgDelegate,
+  MsgUndelegate,
+} from 'cosmjs-types/cosmos/staking/v1beta1/tx'
+import { TxBody } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
+import { describe, expect, it } from 'vitest'
+
+import { getPrimaryCosmosMessageTypeUrl } from './getPrimaryCosmosMessageTypeUrl'
+
+const toBodyBytesBase64 = (
+  messages: { typeUrl: string; value: Uint8Array }[]
+): string =>
+  Buffer.from(
+    TxBody.encode(TxBody.fromPartial({ messages, memo: '' })).finish()
+  ).toString('base64')
+
+const signDirectPayload = (bodyBytes: string) =>
+  create(KeysignPayloadSchema, {
+    signData: {
+      case: 'signDirect',
+      value: create(SignDirectSchema, { bodyBytes }),
+    },
+  })
+
+describe('getPrimaryCosmosMessageTypeUrl', () => {
+  it('extracts the typeUrl of a single staking message', () => {
+    const bodyBytes = toBodyBytesBase64([
+      {
+        typeUrl: '/cosmos.staking.v1beta1.MsgDelegate',
+        value: MsgDelegate.encode({
+          delegatorAddress: 'qbtc1aaa',
+          validatorAddress: 'qbtcvaloper1xyz',
+          amount: { denom: 'uqbtc', amount: '1000000' },
+        }).finish(),
+      },
+    ])
+
+    expect(getPrimaryCosmosMessageTypeUrl(signDirectPayload(bodyBytes))).toBe(
+      '/cosmos.staking.v1beta1.MsgDelegate'
+    )
+  })
+
+  it('uses the primary (first) message for a multi-message tx', () => {
+    const bodyBytes = toBodyBytesBase64([
+      {
+        typeUrl: '/cosmos.staking.v1beta1.MsgUndelegate',
+        value: MsgUndelegate.encode({
+          delegatorAddress: 'qbtc1aaa',
+          validatorAddress: 'qbtcvaloper1xyz',
+          amount: { denom: 'uqbtc', amount: '5' },
+        }).finish(),
+      },
+      {
+        typeUrl: '/cosmos.bank.v1beta1.MsgSend',
+        value: MsgSend.encode({
+          fromAddress: 'qbtc1aaa',
+          toAddress: 'qbtc1bbb',
+          amount: [{ denom: 'uqbtc', amount: '1' }],
+        }).finish(),
+      },
+    ])
+
+    expect(getPrimaryCosmosMessageTypeUrl(signDirectPayload(bodyBytes))).toBe(
+      '/cosmos.staking.v1beta1.MsgUndelegate'
+    )
+  })
+
+  it('returns undefined when signData is not signDirect', () => {
+    const payload = create(KeysignPayloadSchema, {})
+    expect(getPrimaryCosmosMessageTypeUrl(payload)).toBeUndefined()
+  })
+
+  it('returns undefined when bodyBytes cannot be decoded', () => {
+    expect(
+      getPrimaryCosmosMessageTypeUrl(signDirectPayload('not-valid-base64-$$$'))
+    ).toBeUndefined()
+  })
+})

--- a/core/ui/transaction-history/record/getPrimaryCosmosMessageTypeUrl.ts
+++ b/core/ui/transaction-history/record/getPrimaryCosmosMessageTypeUrl.ts
@@ -1,0 +1,29 @@
+import { fromBase64 } from '@cosmjs/encoding'
+import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { attempt } from '@vultisig/lib-utils/attempt'
+import { TxBody } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
+
+/**
+ * Extracts the typeUrl of the first message in a Cosmos `signDirect` payload.
+ *
+ * Both QBTC dApp `sign_and_broadcast` txs and in-wallet Cosmos staking txs sign
+ * over a proto `TxBody` carried in `signData.signDirect.bodyBytes`, so decoding
+ * that body recovers the message typeUrl(s) for transaction-history labeling.
+ * Multi-message txs are labeled by their primary (first) message.
+ *
+ * Returns undefined when the payload isn't `signDirect`, fails to decode, or
+ * carries no messages — the caller then falls back to the default "Send" label.
+ */
+export const getPrimaryCosmosMessageTypeUrl = (
+  payload: KeysignPayload
+): string | undefined => {
+  const { signData } = payload
+  if (signData.case !== 'signDirect') return undefined
+
+  const decoded = attempt(() =>
+    TxBody.decode(fromBase64(signData.value.bodyBytes))
+  )
+  if ('error' in decoded) return undefined
+
+  return decoded.data.messages[0]?.typeUrl || undefined
+}


### PR DESCRIPTION
## Problem

In the browser extension's **Transaction History** (Overview tab), a QBTC
staking tx submitted via `window.vultisig.qbtc` → `sign_and_broadcast` with a
`/cosmos.staking.v1beta1.MsgDelegate` message is rendered with the title
**"Send"** instead of **"Delegate"**. The tx confirms correctly on-chain; only
the history label is wrong. The same applied to the other Cosmos
staking/gov/distribution messages.

| Message | Before | After |
|---------|--------|-------|
| `MsgDelegate` | Send | Delegate |
| `MsgUndelegate` | Send | Undelegate |
| `MsgBeginRedelegate` | Send | Redelegate |
| `MsgVote` | Send | Vote |
| `MsgWithdrawDelegatorReward` | Send | Claim Rewards |
| `MsgSend` | Send | Send |
| unmapped `/x.y.MsgFoo` | Send | Foo (derived) |

## Root cause

The history never inspects the Cosmos message typeUrl. `createTransactionRecord`
classifies every non-swap tx as `type: 'send'`, and `getDisplayData` in
`TransactionRecordCard.tsx` always returns `tagType: 'send'` → rendered as
`t('send')` = "Send".

Both QBTC dApp txs and in-wallet Cosmos staking txs sign over a proto `TxBody`
in `signData.signDirect.bodyBytes`, so the typeUrl is recoverable by decoding
those bytes — covering both paths with one renderer.

## Fix

- **`getPrimaryCosmosMessageTypeUrl.ts`** (new) — decodes `signDirect.bodyBytes`
  and returns the first message's typeUrl (multi-msg → primary). Returns
  `undefined` for non-`signDirect` / undecodable payloads.
- **`core.ts`** — adds optional `messageTypeUrl` to `SendTransactionData`.
- **`createTransactionRecord.ts`** — persists `messageTypeUrl` on send records.
- **`cosmosMessageLabel.ts`** (new) — maps typeUrl → existing `en.ts`
  translation key, with a last-path-segment fallback (`Msg` prefix stripped)
  for unmapped types.
- **`TransactionHistoryTag` / `TransactionHistoryCard` / `TransactionRecordCard`**
  — thread an optional resolved `label` override through to the tag (icon
  unchanged).

Display-only — the SignDoc / `bodyBytes` / `authInfoBytes` and the MLDSA
keysign flow are untouched. All label strings reuse translation keys that
already exist in `en.ts` (`delegate`, `undelegate`, `redelegate`,
`claim_rewards`, `vote`, `send`), so no i18n changes were needed.

## Testing

- `yarn typecheck` ✅ (0 errors)
- New unit tests: `cosmosMessageLabel.test.ts` (label mapping + fallback) and
  `getPrimaryCosmosMessageTypeUrl.test.ts` (proto decode, multi-msg primary,
  non-signDirect, undecodable) — 10 new tests, all green.
- `yarn build:extension` ✅

Closes #4083

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — also adds the staking type label to the Sign Transaction popup

Follow-up in this same PR (per review request): the **approval popup** for a
QBTC `sign_and_broadcast` `MsgDelegate` previously showed only generic
From/To/Amount/Network rows and the raw `SignDirectDisplay` JSON, with no
indication it was a staking action — a delegate looked like a send.

- **`getSignDataTxAction.ts`** — now recognizes `MsgDelegate`, `MsgUndelegate`,
  `MsgBeginRedelegate`, `MsgVote`, `MsgWithdrawDelegatorReward` (signDirect),
  returning `delegate`/`undelegate`/`redelegate`/`vote`/`claim_rewards` actions
  (delegate-family also surface the staked amount). `MsgSend` and the existing
  THORChain/wasm/IBC actions are unchanged.
- **`CosmosTxTypeRow.tsx`** (new) — renders a **"Type"** row (e.g. "Delegate")
  in `SendTxOverview` for those actions; renders nothing for plain sends.
- **`TxOverviewAmount.tsx`** — widens `TxActionLabelKey` so the in-app
  `KeysignTxOverview` / `TxSuccess` staking display benefits too.

Display-only; the SignDoc / `bodyBytes` / MLDSA keysign flow are untouched.
Reuses existing `en.ts` keys (no i18n changes). Adds 7 unit tests in
`getSignDataTxAction.test.ts`. `yarn check` ✅, `yarn build:extension` ✅.

> Note: the amount **number** shown for QBTC dApp delegate (`0.0`) is fixed
> separately in #4076; this PR adds the **type label**, not the amount value.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transaction history displays overrideable, more accurate tag labels for Cosmos actions (delegate/undelegate/redelegate/vote/claim rewards).
  * Send approval overview now shows the Cosmos action type for applicable transactions.

* **Bug Fixes**
  * Improved detection of primary Cosmos message in multi-message transactions to surface correct action labels.

* **Tests**
  * Added tests for Cosmos message-type extraction, label derivation, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->