### PR TITLE
fix(send): prevent Continue button flicker when amount equals balance

### DIFF
--- a/core/ui/vault/send/queries/useSendFeeEstimateQuery.ts
+++ b/core/ui/vault/send/queries/useSendFeeEstimateQuery.ts
@@ -5,7 +5,7 @@ import {
   useCurrentVaultNullablePublicKey,
 } from '@core/ui/vault/state/currentVault'
 import { noRefetchQueryOptions } from '@lib/ui/query/utils/options'
-import { useQuery } from '@tanstack/react-query'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { extractAccountCoinKey } from '@vultisig/core-chain/coin/AccountCoin'
 import { BuildKeysignPayloadError } from '@vultisig/core-mpc/keysign/error'
 import { getSendFeeEstimate } from '@vultisig/core-mpc/keysign/send/getSendFeeEstimate'
@@ -54,6 +54,7 @@ export const useSendFeeEstimateQuery = () => {
     ],
     queryFn: () => getSendFeeEstimate(input!),
     enabled: !!receiver && balance != null && input != null,
+    placeholderData: keepPreviousData,
     ...noRefetchQueryOptions,
     retry: (failureCount, error) => {
       if (error instanceof BuildKeysignPayloadError) {

--- a/core/ui/vault/send/queries/useSendValidationQuery.ts
+++ b/core/ui/vault/send/queries/useSendValidationQuery.ts
@@ -2,6 +2,7 @@ import { useTransformQueryData } from '@lib/ui/query/hooks/useTransformQueryData
 import { extractAccountCoinKey } from '@vultisig/core-chain/coin/AccountCoin'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { isFeeCoin } from '@vultisig/core-chain/coin/utils/isFeeCoin'
+import { isRecordEmpty } from '@vultisig/lib-utils/record/isRecordEmpty'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -30,7 +31,7 @@ export const useSendValidationQuery = () => {
     })
   )
 
-  return useTransformQueryData(
+  const validationQuery = useTransformQueryData(
     balanceQuery,
     useCallback(
       balance =>
@@ -62,4 +63,24 @@ export const useSendValidationQuery = () => {
       ]
     )
   )
+
+  // A fee-coin send can't be validated until its fee is known. While the fee
+  // estimate is still loading, keep the form pending instead of reporting it
+  // as valid — otherwise Continue briefly enables (e.g. amount === balance,
+  // where the verdict flips once the fee arrives and amount + fee exceeds
+  // balance).
+  const isFeeRequiredButUnknown =
+    isFeeCoin(coin) &&
+    feeEstimateQuery.data == null &&
+    feeEstimateQuery.error == null
+
+  if (
+    isFeeRequiredButUnknown &&
+    validationQuery.data != null &&
+    isRecordEmpty(validationQuery.data)
+  ) {
+    return { ...validationQuery, data: undefined, isPending: true }
+  }
+
+  return validationQuery
 }


### PR DESCRIPTION
## Summary

Fixes the Send-form bug where the **Continue** button briefly enables when the amount is set to exactly the full available balance and the user edits the MEMO field — then flips back to "Insufficient balance" and disables again.

Reproducible whenever the amount falls in the `[balance - fee, balance]` range. Observed on QBTC but the logic lives in shared `@core/ui`, so it affects all fee-coin sends.

## Root cause

`useSendFeeEstimateQuery` includes `memo` in its `queryKey`, so each memo keystroke triggers a refetch and `feeEstimateQuery.data` momentarily becomes `undefined`. In `validateSendForm`, when `fee == null` validation falls back to the `amount > balance` branch — which is **false** for an exactly-equal amount — so the form transiently reports "valid" and Continue enables. Once the new fee resolves, `amount + fee > balance` is true again and the error returns.

## Changes

- **`useSendFeeEstimateQuery`** — add `placeholderData: keepPreviousData` so the last known fee is retained during refetches (memo edits) instead of dropping to `undefined`. Matches the existing pattern in `useSwapQuoteQuery`.
- **`useSendValidationQuery`** — keep the form in a `pending` state while a fee coin's fee estimate is still unknown, so Continue stays disabled (not falsely valid) on first load before any fee has resolved.

## Testing

- `yarn typecheck` and `yarn lint` pass.
- Built the extension and manually verified on the QBTC Send form: with amount == balance, editing MEMO no longer momentarily enables Continue; it still enables normally when amount <= balance - fee.

Closes #4085

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved fee data display during send transactions by maintaining previous estimates while new data loads, reducing UI flicker.
  * Enhanced send form validation to remain pending until all required fee information is available before processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->