### PR TITLE
fix(share): repair vault QR share on Linux and Telegram

### DIFF
--- a/core/ui/vault/chain/address/AddressQRCard.tsx
+++ b/core/ui/vault/chain/address/AddressQRCard.tsx
@@ -162,17 +162,32 @@ export const AddressQRCard = ({
 
     const node = qrNodeRef.current
 
-    if (node && navigator.canShare) {
-      const fileResult = await attempt(async () => {
+    if (node) {
+      const imageResult = await attempt(async () => {
         const dataUrl = await toPng(node)
         const blob = await (await fetch(dataUrl)).blob()
-        return new File([blob], `${displayName}.png`, { type: 'image/png' })
+        const file = new File([blob], `${displayName}.png`, {
+          type: 'image/png',
+        })
+        return { dataUrl, file }
       })
 
-      const file = 'data' in fileResult ? fileResult.data : undefined
+      if (imageResult.data) {
+        const { dataUrl, file } = imageResult.data
 
-      if (file && navigator.canShare({ files: [file] })) {
-        await navigator.share({ files: [file] }).catch(() => undefined)
+        if (navigator.canShare?.({ files: [file] })) {
+          await navigator.share({ files: [file] }).catch(() => undefined)
+          return
+        }
+
+        // Web Share with files is unsupported (e.g. Chrome on Linux);
+        // fall back to downloading the QR image.
+        const link = document.createElement('a')
+        link.href = dataUrl
+        link.download = `${displayName}.png`
+        document.body.appendChild(link)
+        link.click()
+        link.remove()
         return
       }
     }

--- a/core/ui/vault/chain/address/AddressQRCard.tsx
+++ b/core/ui/vault/chain/address/AddressQRCard.tsx
@@ -1,6 +1,7 @@
 import { ChainEntityIcon } from '@core/ui/chain/coin/icon/ChainEntityIcon'
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { getChainLogoSrc } from '@core/ui/chain/metadata/getChainLogoSrc'
+import { useCore } from '@core/ui/state/core'
 import { VaultAddressCopyToast } from '@core/ui/vault/page/components/VaultAddressCopyToast'
 import { useCurrentVaultAddress } from '@core/ui/vault/state/currentVaultCoins'
 import { Button } from '@lib/ui/buttons/Button'
@@ -135,6 +136,7 @@ export const AddressQRCard = ({
   onClose,
 }: AddressQRCardProps) => {
   const { t } = useTranslation()
+  const { saveFile } = useCore()
   const address = useCurrentVaultAddress(chain)
   const { addToast } = useToast()
   const qrNodeRef = useRef<HTMLDivElement | null>(null)
@@ -163,17 +165,15 @@ export const AddressQRCard = ({
     const node = qrNodeRef.current
 
     if (node) {
+      const fileName = `${displayName}.png`
       const imageResult = await attempt(async () => {
         const dataUrl = await toPng(node)
         const blob = await (await fetch(dataUrl)).blob()
-        const file = new File([blob], `${displayName}.png`, {
-          type: 'image/png',
-        })
-        return { dataUrl, file }
+        return { blob, file: new File([blob], fileName, { type: 'image/png' }) }
       })
 
       if (imageResult.data) {
-        const { dataUrl, file } = imageResult.data
+        const { blob, file } = imageResult.data
 
         if (navigator.canShare?.({ files: [file] })) {
           await navigator.share({ files: [file] }).catch(() => undefined)
@@ -182,12 +182,7 @@ export const AddressQRCard = ({
 
         // Web Share with files is unsupported (e.g. Chrome on Linux);
         // fall back to downloading the QR image.
-        const link = document.createElement('a')
-        link.href = dataUrl
-        link.download = `${displayName}.png`
-        document.body.appendChild(link)
-        link.click()
-        link.remove()
+        await saveFile({ name: fileName, blob })
         return
       }
     }
@@ -200,7 +195,7 @@ export const AddressQRCard = ({
         text: address,
       })
       .catch(() => undefined)
-  }, [address, displayName, onShare, t])
+  }, [address, displayName, onShare, saveFile, t])
 
   if (!address) return null
 

--- a/core/ui/vault/chain/address/AddressQRCard.tsx
+++ b/core/ui/vault/chain/address/AddressQRCard.tsx
@@ -185,6 +185,9 @@ export const AddressQRCard = ({
         await saveFile({ name: fileName, blob })
         return
       }
+
+      // Image generation failed — log before falling back to text-only share.
+      console.error('Error sharing image:', imageResult.error)
     }
 
     if (!navigator.share) return

--- a/core/ui/vault/share/ShareVaultPage.tsx
+++ b/core/ui/vault/share/ShareVaultPage.tsx
@@ -1,4 +1,5 @@
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
+import { useCore } from '@core/ui/state/core'
 import { ShareVaultCard } from '@core/ui/vault/share/ShareVaultCard'
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { Button } from '@lib/ui/buttons/Button'
@@ -21,6 +22,7 @@ const StyledButton = styled(Button)`
 
 export const ShareVaultPage = () => {
   const { t } = useTranslation()
+  const { saveFile } = useCore()
   const vault = useCurrentVault()
 
   const { name } = vault
@@ -32,7 +34,8 @@ export const ShareVaultPage = () => {
       try {
         const dataUrl = await toPng(node)
         const blob = await (await fetch(dataUrl)).blob()
-        const file = new File([blob], `${name}.png`, { type: 'image/png' })
+        const fileName = `${name}.png`
+        const file = new File([blob], fileName, { type: 'image/png' })
 
         // Share only the file — some targets (e.g. Telegram) drop the image
         // when title/text are also present and send just the text.
@@ -43,12 +46,7 @@ export const ShareVaultPage = () => {
         } else {
           // Web Share with files is unsupported (e.g. Chrome on Linux);
           // fall back to downloading the QR image.
-          const link = document.createElement('a')
-          link.href = dataUrl
-          link.download = `${name}.png`
-          document.body.appendChild(link)
-          link.click()
-          link.remove()
+          await saveFile({ name: fileName, blob })
         }
       } catch (error) {
         console.error('Error sharing image:', error)

--- a/core/ui/vault/share/ShareVaultPage.tsx
+++ b/core/ui/vault/share/ShareVaultPage.tsx
@@ -46,7 +46,9 @@ export const ShareVaultPage = () => {
           const link = document.createElement('a')
           link.href = dataUrl
           link.download = `${name}.png`
+          document.body.appendChild(link)
           link.click()
+          link.remove()
         }
       } catch (error) {
         console.error('Error sharing image:', error)

--- a/core/ui/vault/share/ShareVaultPage.tsx
+++ b/core/ui/vault/share/ShareVaultPage.tsx
@@ -34,14 +34,19 @@ export const ShareVaultPage = () => {
         const blob = await (await fetch(dataUrl)).blob()
         const file = new File([blob], `${name}.png`, { type: 'image/png' })
 
-        if (navigator.share) {
-          await navigator.share({
-            files: [file],
-            title: t('vault_qr_share_title'),
-            text: t('vault_qr_share_text'),
-          })
+        // Share only the file — some targets (e.g. Telegram) drop the image
+        // when title/text are also present and send just the text.
+        const shareData = { files: [file] }
+
+        if (navigator.canShare?.(shareData)) {
+          await navigator.share(shareData)
         } else {
-          alert(t('vault_qr_share_not_supported'))
+          // Web Share with files is unsupported (e.g. Chrome on Linux);
+          // fall back to downloading the QR image.
+          const link = document.createElement('a')
+          link.href = dataUrl
+          link.download = `${name}.png`
+          link.click()
         }
       } catch (error) {
         console.error('Error sharing image:', error)


### PR DESCRIPTION
Closes #4088

Two QR **Share** buttons were broken on Chrome/Linux because they relied on the Web Share API with no fallback — Chrome doesn't implement `navigator.share`/`navigator.canShare` on Linux.

## 1. Vault QR Share page (`ShareVaultPage.tsx`)
- **Linux:** showed a dead-end *"Sharing not supported on this browser"* alert (only checked `navigator.share`).
- **macOS -> Telegram:** sent only the text and **dropped the image**, because the payload bundled `files` + `title` + `text`.

**Fix:** guard with `navigator.canShare?.(shareData)`, fall back to downloading the QR PNG when file sharing is unsupported, and share **only the file** so targets like Telegram attach the image.

## 2. Receive address QR dialog (`AddressQRCard.tsx`)
- **Linux:** clicking **Share** did **nothing** — `navigator.canShare` was absent so it skipped the file branch, then `if (!navigator.share) return` bailed silently.

**Fix:** render the QR to a file, share where `canShare({files})` is supported, otherwise download the PNG. The text-only `navigator.share` is now a last resort only if the image can't be rendered.

Both fallbacks use the `useCore().saveFile` abstraction (-> `initiateFileDownload` on extension, native save dialog on desktop) for consistency with the rest of the app's download flows.

## Verification
- Built the extension; confirmed both shipped handlers match source (`canShare -> share, else saveFile`).
- Drove real Chrome 149 (Linux) via Playwright: `navigator.share`/`canShare` both absent -> handler takes the download branch and a real `download` event fires.
- Manually tested both Share buttons in the loaded extension on Linux -> both download the QR PNG.

## Notes
- `@core/ui` is `private` (not published) and this repo doesn't use changesets, so no changeset is required.
- Three i18n keys are now unused in code (`vault_qr_share_title`, `vault_qr_share_text`, `vault_qr_share_not_supported`). Left in place; can remove in a follow-up if knip flags them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QR sharing: when device supports file-based sharing, the app now shares the QR PNG directly; otherwise it automatically falls back to saving/downloading the QR image. Removed the older text-only/share-alert fallback for a more consistent QR sharing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->