### PR TITLE
fix(sign-message): wrap long typed-data values to prevent horizontal scroll

### DIFF
--- a/core/inpage-provider/popup/view/resolvers/signMessage/components/Eip712PermitDisplay.tsx
+++ b/core/inpage-provider/popup/view/resolvers/signMessage/components/Eip712PermitDisplay.tsx
@@ -11,6 +11,7 @@ import { EvmChain } from '@vultisig/core-chain/Chain'
 import { TypedDataDomain } from 'ethers'
 import { FC, Fragment } from 'react'
 import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
 
 type Eip712PermitDisplayProps = {
   chain: EvmChain
@@ -177,6 +178,15 @@ const formatPrimitive = (value: unknown): string => {
   return String(value)
 }
 
+// Long, unbroken values (keys, hashes) are flex items inside a nowrap row.
+// `min-width: 0` lets the cell shrink below its content so `break-word` can
+// wrap instead of widening the row and forcing horizontal scroll.
+const RowValue = styled(Text)`
+  min-width: 0;
+  flex: 1;
+  text-align: right;
+`
+
 const Row: FC<{ label: string; value: React.ReactNode }> = ({
   label,
   value,
@@ -191,9 +201,9 @@ const Row: FC<{ label: string; value: React.ReactNode }> = ({
       {label}
     </Text>
     {typeof value === 'string' ? (
-      <Text as="span" size={14} weight={500}>
+      <RowValue as="span" size={14} weight={500}>
         {value}
-      </Text>
+      </RowValue>
     ) : (
       value
     )}


### PR DESCRIPTION
## Problem

On the **Sign message** screen for `eth_signTypedData_v4` requests, each message field renders as a label/value row. When a value is long and unbroken (e.g. an Orderly `AddOrderlyKey` payload's `orderlyKey`, `ed25519:4wLN…`), the value overflows its row and pushes the whole popup wider, making it horizontally scrollable. Any long value (keys, hashes, long strings) is affected.

## Root cause

In `Eip712PermitDisplay`'s `Row`, the value is a flex item inside an `HStack` with `wrap="nowrap"`. Flex items default to `min-width: auto`, so the cell never shrinks below its content width — and although `Text` already sets `overflow-wrap: break-word`, `break-word` does not reduce the flex item's intrinsic min-content size, so the long token keeps the row wide.

## Fix

Constrain the string value cell with `min-width: 0` (plus `flex: 1` and right alignment). `min-width: 0` lets the flex item shrink below its content size, so `overflow-wrap: break-word` can finally wrap the long token. Applied generically to every value row in the fallback path, not just `orderlyKey`.

## Verification

- `yarn check` passes (typecheck + lint + knip + i18n).
- Trigger an `eth_signTypedData_v4` request with a long field value (e.g. Orderly `AddOrderlyKey`) and confirm the value wraps within the popup width with no horizontal scroll.

Closes #4089

🤖 Generated with [Claude Code](https://claude.com/claude-code)