### PR TITLE
Show non-native Cosmos dApp fees in approvals

### DIFF
--- a/core/inpage-provider/popup/view/resolvers/sendTx/components/NetworkFeeSection.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/components/NetworkFeeSection.tsx
@@ -1,3 +1,4 @@
+import { getNonNativeDappCosmosFeeDisplay } from '@core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/dappCosmosFee'
 import { ManageEvmFee } from '@core/inpage-provider/popup/view/resolvers/sendTx/ManageEvmFee'
 import { usePopupInput } from '@core/inpage-provider/popup/view/state/input'
 import { useAssertWalletCore } from '@core/ui/chain/providers/WalletCoreProvider'
@@ -5,6 +6,7 @@ import { useCurrentVaultNullablePublicKey } from '@core/ui/vault/state/currentVa
 import { MatchRecordUnion } from '@lib/ui/base/MatchRecordUnion'
 import { List } from '@lib/ui/list'
 import { ListItem } from '@lib/ui/list/item'
+import { getColor } from '@lib/ui/theme/getters'
 import { PublicKey } from '@trustwallet/wallet-core/dist/src/wallet-core'
 import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
 import { Chain } from '@vultisig/core-chain/Chain'
@@ -17,6 +19,15 @@ import { getFeeAmount } from '@vultisig/core-mpc/keysign/fee'
 import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
 import { formatAmount } from '@vultisig/lib-utils/formatAmount'
 import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+
+const DappCosmosFeeDescription = styled.span`
+  color: ${getColor('textShy')};
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 16px;
+  overflow-wrap: anywhere;
+`
 
 export type NetworkFeeSectionProps = {
   keysignPayload: KeysignPayload
@@ -52,6 +63,12 @@ export const NetworkFeeSection = ({
             walletCore,
             publicKey: publicKey as PublicKey,
           })
+          const nonNativeDappCosmosFeeDisplay = isChainOfKind(chain, 'cosmos')
+            ? getNonNativeDappCosmosFeeDisplay({
+                keysignPayload,
+                chain,
+              })
+            : null
 
           const getEvmValues = () => {
             if (!isChainOfKind(chain, 'evm')) {
@@ -81,10 +98,18 @@ export const NetworkFeeSection = ({
           return (
             <List>
               <ListItem
-                description={formatAmount(
-                  fromChainAmount(feeAmount, chainFeeCoin[chain].decimals),
-                  chainFeeCoin[chain]
-                )}
+                description={
+                  nonNativeDappCosmosFeeDisplay ? (
+                    <DappCosmosFeeDescription>
+                      {nonNativeDappCosmosFeeDisplay}
+                    </DappCosmosFeeDescription>
+                  ) : (
+                    formatAmount(
+                      fromChainAmount(feeAmount, chainFeeCoin[chain].decimals),
+                      chainFeeCoin[chain]
+                    )
+                  )
+                }
                 extra={
                   isChainOfKind(chain, 'evm') && evmValues ? (
                     <ManageEvmFee
@@ -95,7 +120,11 @@ export const NetworkFeeSection = ({
                     />
                   ) : null
                 }
-                title={t('est_network_fee')}
+                title={t(
+                  nonNativeDappCosmosFeeDisplay
+                    ? 'network_fee'
+                    : 'est_network_fee'
+                )}
                 hoverable={false}
               />
               {transactionPayload.transactionDetails.msgPayload?.case ===

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/applyCosmosFeeFromSignData.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/applyCosmosFeeFromSignData.ts
@@ -1,53 +1,11 @@
-import { fromBase64 } from '@cosmjs/encoding'
 import { CosmosChain } from '@vultisig/core-chain/Chain'
-import { CosmosMsgType } from '@vultisig/core-chain/chains/cosmos/cosmosMsgTypes'
 import { sumFeeAmountForCosmosChainFeeDenom } from '@vultisig/core-chain/chains/cosmos/sumFeeAmountForCosmosChainFeeDenom'
 import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
-import { attempt } from '@vultisig/lib-utils/attempt'
-import { AuthInfo, TxBody } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
 
-type FeeAmount = { denom: string; amount: string }
-
-const getDappFeeAmounts = (
-  signData: KeysignPayload['signData']
-): readonly FeeAmount[] | undefined => {
-  if (signData.case === 'signAmino') {
-    return signData.value.fee?.amount
-  }
-  if (signData.case === 'signDirect') {
-    const result = attempt(() =>
-      AuthInfo.decode(fromBase64(signData.value.authInfoBytes))
-    )
-    if ('error' in result) return undefined
-    return result.data.fee?.amount
-  }
-  return undefined
-}
-
-const executeContractMsgTypes: ReadonlySet<string> = new Set([
-  CosmosMsgType.MSG_EXECUTE_CONTRACT,
-  CosmosMsgType.MSG_EXECUTE_CONTRACT_URL,
-])
-
-const isExecuteContractSignData = (
-  signData: KeysignPayload['signData']
-): boolean => {
-  if (signData.case === 'signAmino') {
-    return signData.value.msgs.some(msg =>
-      executeContractMsgTypes.has(msg.type)
-    )
-  }
-  if (signData.case === 'signDirect') {
-    const result = attempt(() =>
-      TxBody.decode(fromBase64(signData.value.bodyBytes))
-    )
-    if ('error' in result) return false
-    return result.data.messages.some(msg =>
-      executeContractMsgTypes.has(msg.typeUrl)
-    )
-  }
-  return false
-}
+import {
+  getDappCosmosFeeAmounts,
+  isExecuteContractSignData,
+} from './dappCosmosFee'
 
 type ApplyCosmosFeeFromSignDataInput = {
   keysignPayload: KeysignPayload
@@ -73,8 +31,8 @@ type ApplyCosmosFeeFromSignDataInput = {
  * No-op when:
  *   - the chain isn't cosmos-routed (caller guards on `isChainOfKind('cosmos')`)
  *   - no dapp signData is present (e.g., native sends Vultisig built itself)
- *   - the dapp paid in a non-native fee denom (we can't collapse a multi-denom
- *     fee into the proto's single `uint64`; leaves the estimate in place)
+ *   - the dapp paid only in non-native fee denoms. This function can't collapse
+ *     those into the proto's single `uint64`; the display layer shows them raw.
  *   - `blockchainSpecific.case` is `mayachainSpecific` (no `fee` field on that
  *     schema — safe to skip; MAYA uses a hardcoded fallback elsewhere)
  */
@@ -82,7 +40,7 @@ export const applyCosmosFeeFromSignData = ({
   keysignPayload,
   chain,
 }: ApplyCosmosFeeFromSignDataInput): void => {
-  const feeAmounts = getDappFeeAmounts(keysignPayload.signData)
+  const feeAmounts = getDappCosmosFeeAmounts(keysignPayload.signData)
   if (!feeAmounts) return
 
   const signedFee = sumFeeAmountForCosmosChainFeeDenom({

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/dappCosmosFee.test.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/dappCosmosFee.test.ts
@@ -1,0 +1,116 @@
+import { create } from '@bufbuild/protobuf'
+import { toBase64 } from '@cosmjs/encoding'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { CosmosMsgType } from '@vultisig/core-chain/chains/cosmos/cosmosMsgTypes'
+import { KeysignPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import {
+  SignAminoSchema,
+  SignDirectSchema,
+} from '@vultisig/core-mpc/types/vultisig/keysign/v1/wasm_execute_contract_payload_pb'
+import { AuthInfo } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
+import { describe, expect, it } from 'vitest'
+
+import { getNonNativeDappCosmosFeeDisplay } from './dappCosmosFee'
+
+const payloadWithSignAminoFee = (amount: { denom: string; amount: string }[]) =>
+  create(KeysignPayloadSchema, {
+    signData: {
+      case: 'signAmino',
+      value: create(SignAminoSchema, {
+        fee: { amount, gas: '200000' },
+      }),
+    },
+  })
+
+const payloadWithSignAminoExecuteFee = (
+  amount: { denom: string; amount: string }[]
+) =>
+  create(KeysignPayloadSchema, {
+    signData: {
+      case: 'signAmino',
+      value: create(SignAminoSchema, {
+        fee: { amount, gas: '200000' },
+        msgs: [{ type: CosmosMsgType.MSG_EXECUTE_CONTRACT, value: '{}' }],
+      }),
+    },
+  })
+
+const payloadWithSignDirectFee = (
+  amount: { denom: string; amount: string }[]
+) =>
+  create(KeysignPayloadSchema, {
+    signData: {
+      case: 'signDirect',
+      value: create(SignDirectSchema, {
+        authInfoBytes: toBase64(
+          AuthInfo.encode(
+            AuthInfo.fromPartial({
+              fee: {
+                amount,
+                gasLimit: 200000n,
+              },
+              signerInfos: [],
+            })
+          ).finish()
+        ),
+      }),
+    },
+  })
+
+describe('getNonNativeDappCosmosFeeDisplay', () => {
+  it('returns null when a Cosmos dApp fee uses only the chain native denom', () => {
+    expect(
+      getNonNativeDappCosmosFeeDisplay({
+        keysignPayload: payloadWithSignAminoFee([
+          { denom: 'uatom', amount: '1200' },
+        ]),
+        chain: Chain.Cosmos,
+      })
+    ).toBeNull()
+  })
+
+  it('surfaces the signed signAmino fee when it uses a non-native denom', () => {
+    expect(
+      getNonNativeDappCosmosFeeDisplay({
+        keysignPayload: payloadWithSignAminoFee([
+          { denom: 'ibc/ABC123', amount: '4500' },
+        ]),
+        chain: Chain.Cosmos,
+      })
+    ).toBe('4500 ibc/ABC123')
+  })
+
+  it('surfaces every signed fee entry when any denom is non-native', () => {
+    expect(
+      getNonNativeDappCosmosFeeDisplay({
+        keysignPayload: payloadWithSignDirectFee([
+          { denom: 'uatom', amount: '1200' },
+          { denom: 'ibc/ABC123', amount: '4500' },
+        ]),
+        chain: Chain.Cosmos,
+      })
+    ).toBe('1200 uatom + 4500 ibc/ABC123')
+  })
+
+  it('keeps vault-based non-contract dApp fee display on the actual chain fee', () => {
+    expect(
+      getNonNativeDappCosmosFeeDisplay({
+        keysignPayload: payloadWithSignAminoFee([
+          { denom: 'ibc/ABC123', amount: '4500' },
+        ]),
+        chain: Chain.THORChain,
+      })
+    ).toBeNull()
+  })
+
+  it('surfaces vault-based execute-contract dApp fees when they are paid by the tx', () => {
+    expect(
+      getNonNativeDappCosmosFeeDisplay({
+        keysignPayload: payloadWithSignAminoExecuteFee([
+          { denom: 'ibc/ABC123', amount: '4500' },
+        ]),
+        chain: Chain.THORChain,
+      })
+    ).toBe('4500 ibc/ABC123')
+  })
+})

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/dappCosmosFee.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/dappCosmosFee.ts
@@ -7,7 +7,7 @@ import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/key
 import { attempt } from '@vultisig/lib-utils/attempt'
 import { AuthInfo, TxBody } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
 
-export type DappCosmosFeeAmount = { denom: string; amount: string }
+type DappCosmosFeeAmount = { denom: string; amount: string }
 
 const executeContractMsgTypes: ReadonlySet<string> = new Set([
   CosmosMsgType.MSG_EXECUTE_CONTRACT,

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/dappCosmosFee.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/dappCosmosFee.ts
@@ -14,6 +14,9 @@ const executeContractMsgTypes: ReadonlySet<string> = new Set([
   CosmosMsgType.MSG_EXECUTE_CONTRACT_URL,
 ])
 
+/**
+ * Extracts dApp-signed Cosmos fee amounts from Amino or Direct sign data.
+ */
 export const getDappCosmosFeeAmounts = (
   signData: KeysignPayload['signData']
 ): readonly DappCosmosFeeAmount[] | undefined => {
@@ -30,6 +33,9 @@ export const getDappCosmosFeeAmounts = (
   return undefined
 }
 
+/**
+ * Checks whether Cosmos sign data contains an execute-contract message.
+ */
 export const isExecuteContractSignData = (
   signData: KeysignPayload['signData']
 ): boolean => {
@@ -71,13 +77,18 @@ const shouldDisplaySignedDappCosmosFee = ({
   getCosmosChainKind(chain) === 'ibcEnabled' ||
   isExecuteContractSignData(keysignPayload.signData)
 
+type GetNonNativeDappCosmosFeeDisplayInput = {
+  keysignPayload: KeysignPayload
+  chain: CosmosChain
+}
+
+/**
+ * Formats signed non-native Cosmos dApp fees when the signed fee is paid by the transaction.
+ */
 export const getNonNativeDappCosmosFeeDisplay = ({
   keysignPayload,
   chain,
-}: {
-  keysignPayload: KeysignPayload
-  chain: CosmosChain
-}): string | null => {
+}: GetNonNativeDappCosmosFeeDisplayInput): string | null => {
   if (!shouldDisplaySignedDappCosmosFee({ keysignPayload, chain })) {
     return null
   }

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/dappCosmosFee.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/dappCosmosFee.ts
@@ -1,0 +1,96 @@
+import { fromBase64 } from '@cosmjs/encoding'
+import { CosmosChain } from '@vultisig/core-chain/Chain'
+import { cosmosFeeCoinDenom } from '@vultisig/core-chain/chains/cosmos/cosmosFeeCoinDenom'
+import { CosmosMsgType } from '@vultisig/core-chain/chains/cosmos/cosmosMsgTypes'
+import { getCosmosChainKind } from '@vultisig/core-chain/chains/cosmos/utils/getCosmosChainKind'
+import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { attempt } from '@vultisig/lib-utils/attempt'
+import { AuthInfo, TxBody } from 'cosmjs-types/cosmos/tx/v1beta1/tx'
+
+export type DappCosmosFeeAmount = { denom: string; amount: string }
+
+const executeContractMsgTypes: ReadonlySet<string> = new Set([
+  CosmosMsgType.MSG_EXECUTE_CONTRACT,
+  CosmosMsgType.MSG_EXECUTE_CONTRACT_URL,
+])
+
+export const getDappCosmosFeeAmounts = (
+  signData: KeysignPayload['signData']
+): readonly DappCosmosFeeAmount[] | undefined => {
+  if (signData.case === 'signAmino') {
+    return signData.value.fee?.amount
+  }
+  if (signData.case === 'signDirect') {
+    const result = attempt(() =>
+      AuthInfo.decode(fromBase64(signData.value.authInfoBytes))
+    )
+    if ('error' in result) return undefined
+    return result.data.fee?.amount
+  }
+  return undefined
+}
+
+export const isExecuteContractSignData = (
+  signData: KeysignPayload['signData']
+): boolean => {
+  if (signData.case === 'signAmino') {
+    return signData.value.msgs.some(msg =>
+      executeContractMsgTypes.has(msg.type)
+    )
+  }
+  if (signData.case === 'signDirect') {
+    const result = attempt(() =>
+      TxBody.decode(fromBase64(signData.value.bodyBytes))
+    )
+    if ('error' in result) return false
+    return result.data.messages.some(msg =>
+      executeContractMsgTypes.has(msg.typeUrl)
+    )
+  }
+  return false
+}
+
+const isNativeCosmosFeeDenom = ({
+  denom,
+  chain,
+}: {
+  denom: string
+  chain: CosmosChain
+}) => denom.toLowerCase() === cosmosFeeCoinDenom[chain].toLowerCase()
+
+const formatDappCosmosFeeAmount = ({ amount, denom }: DappCosmosFeeAmount) =>
+  `${amount} ${denom}`
+
+const shouldDisplaySignedDappCosmosFee = ({
+  keysignPayload,
+  chain,
+}: {
+  keysignPayload: KeysignPayload
+  chain: CosmosChain
+}) =>
+  getCosmosChainKind(chain) === 'ibcEnabled' ||
+  isExecuteContractSignData(keysignPayload.signData)
+
+export const getNonNativeDappCosmosFeeDisplay = ({
+  keysignPayload,
+  chain,
+}: {
+  keysignPayload: KeysignPayload
+  chain: CosmosChain
+}): string | null => {
+  if (!shouldDisplaySignedDappCosmosFee({ keysignPayload, chain })) {
+    return null
+  }
+
+  const amounts = getDappCosmosFeeAmounts(keysignPayload.signData)?.filter(
+    ({ amount, denom }) => amount && denom
+  )
+
+  if (!amounts?.length) return null
+
+  if (amounts.every(({ denom }) => isNativeCosmosFeeDenom({ denom, chain }))) {
+    return null
+  }
+
+  return amounts.map(formatDappCosmosFeeAmount).join(' + ')
+}


### PR DESCRIPTION
Closes #4097

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced network fee display for Cosmos chains to show non-native dApp fees and switch between estimated vs exact labels when applicable.
  * Centralized extraction and detection for Cosmos dApp-provided fees to improve execute-contract fee handling.

* **Tests**
  * Added tests for non-native Cosmos fee displays, multi-denom concatenation, execute-contract scenarios, and decode-failure resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->