### PR TITLE
chore: bump @vultisig/sdk to 2.0.0 (re-enable Bittensor seed-phrase import)

### DIFF
--- a/clients/desktop/package.json
+++ b/clients/desktop/package.json
@@ -42,7 +42,7 @@
     "@vultisig/core-config": "0.9.1",
     "@vultisig/core-mpc": "1.5.0",
     "@vultisig/lib-utils": "0.10.1",
-    "@vultisig/sdk": "1.8.11",
+    "@vultisig/sdk": "2.0.0",
     "@wailsapp/runtime": "workspace:^",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/clients/extension/package.json
+++ b/clients/extension/package.json
@@ -55,7 +55,7 @@
     "@vultisig/core-chain": "2.15.0",
     "@vultisig/core-mpc": "1.5.0",
     "@vultisig/lib-utils": "0.10.1",
-    "@vultisig/sdk": "1.8.11",
+    "@vultisig/sdk": "2.0.0",
     "@wallet-standard/base": "^1.1.1",
     "@wallet-standard/features": "^1.1.1",
     "bech32": "^2.0.0",

--- a/core/ui/package.json
+++ b/core/ui/package.json
@@ -41,7 +41,7 @@
     "@vultisig/core-config": "0.9.1",
     "@vultisig/core-mpc": "1.5.0",
     "@vultisig/lib-utils": "0.10.1",
-    "@vultisig/sdk": "1.8.11",
+    "@vultisig/sdk": "2.0.0",
     "bs58": "^6.0.0",
     "cosmjs-types": "^0.11.0",
     "ethers": "^6.16.0",


### PR DESCRIPTION
## What

Bumps `@vultisig/sdk` from 1.8.11 → **2.0.0** to re-enable **Bittensor** in seed-phrase key import.

Windows sources the import chain list from the SDK's `SEEDPHRASE_IMPORT_SUPPORTED_CHAINS`, so this is data-driven — no Windows logic change. SDK 2.0.0 drops Bittensor from `SEEDPHRASE_IMPORT_UNSUPPORTED_CHAINS` (now `[Cardano, QBTC]`).

## Why it's safe now

Bittensor was excluded because seed-phrase import hung indefinitely — vultiserver misclassified it as ECDSA (ran DKLS) while clients run Schnorr. Both gates are now cleared:

- **Server fix** — vultisig/vultiserver#157 (classify Bittensor as EdDSA), merged to prod 2026-06-03.
- **SDK re-enable** — vultisig/vultisig-sdk#653, shipped in `@vultisig/sdk` 2.0.0.

## ⚠️ Lockfile pending

`yarn.lock` is **not** updated in this PR yet. SDK 2.0.0 was published 2026-06-11 03:10 UTC and is still inside Yarn's 24h `npmMinimalAgeGate` quarantine window, so `yarn install` refuses to resolve it. The lockfile will be added once it clears (~2026-06-12 03:10 UTC). **Don't merge until the lockfile commit lands and CI is green.**

## Verification (after lockfile)

- [ ] Bittensor appears in `SelectChainsStep` and `useScanChainsWithBalanceQuery` (no code change expected).
- [ ] E2E: seed-phrase import including Bittensor completes against the deployed server; address/balance resolve.

Closes #4051

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SDK dependency to version 2.0.0 across multiple packages (desktop, extension, and UI).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->