### PR TITLE
feat(extension): guard dApp transactions against network-rejected fees

### DIFF
--- a/core/inpage-provider/package.json
+++ b/core/inpage-provider/package.json
@@ -27,5 +27,8 @@
     "react-i18next": "^16.5.8",
     "styled-components": "6.3.11",
     "viem": "^2.47.4"
+  },
+  "devDependencies": {
+    "long": "^5.3.2"
   }
 }

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/build.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/build.ts
@@ -62,6 +62,7 @@ import { CustomTxData } from '../core/customTxData'
 import { ParsedTx } from '../core/parsedTx'
 import { TronMsgType } from '../interfaces'
 import { applyCosmosFeeFromSignData } from './applyCosmosFeeFromSignData'
+import { enforceMinNetworkFee } from './minNetworkFee'
 
 export type BuildSendTxKeysignPayloadInput = {
   parsedTx: ParsedTx
@@ -600,5 +601,10 @@ export const buildSendTxKeysignPayload = async ({
     })
   }
 
-  return keysignPayload
+  return enforceMinNetworkFee({
+    keysignPayload,
+    customTxData,
+    walletCore,
+    publicKey,
+  })
 }

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/index.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/index.ts
@@ -2,7 +2,7 @@ import { create } from '@bufbuild/protobuf'
 import { WalletCore } from '@trustwallet/wallet-core'
 import { PublicKey } from '@trustwallet/wallet-core/dist/src/wallet-core'
 import { UtxoChain } from '@vultisig/core-chain/Chain'
-import { getChainKind } from '@vultisig/core-chain/ChainKind'
+import { toChainKindRecordUnion } from '@vultisig/core-chain/ChainKind'
 import { getBlockchainSpecificValue } from '@vultisig/core-mpc/keysign/chainSpecific/KeysignChainSpecific'
 import { refineKeysignUtxo } from '@vultisig/core-mpc/keysign/refine/utxo'
 import { getUtxoSigningInputs } from '@vultisig/core-mpc/keysign/signingInputs/resolvers/utxo'
@@ -12,14 +12,14 @@ import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/key
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { bigIntMax } from '@vultisig/lib-utils/bigint/bigIntMax'
 import { bigIntSum } from '@vultisig/lib-utils/bigint/bigIntSum'
-import { match } from '@vultisig/lib-utils/match'
+import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
 import { Psbt } from 'bitcoinjs-lib'
 
 import { CustomTxData } from '../../core/customTxData'
 import { getPsbtFee, getPsbtMinVsize, getPsbtOutputSizes } from './psbtFee'
 import { ceilDiv, getZcashConventionalFee } from './zip317'
 
-type MinNetworkFeeInput = {
+type EnforceMinNetworkFeeInput = {
   keysignPayload: KeysignPayload
   customTxData: CustomTxData
   walletCore: WalletCore
@@ -54,7 +54,12 @@ const getOpReturnOutputSize = (memo: string): bigint => {
   return 9n + pushOverhead + BigInt(dataSize)
 }
 
-const assertPsbtFee = (chain: UtxoChain, psbt: Psbt): void => {
+type AssertPsbtFeeInput = {
+  chain: UtxoChain
+  psbt: Psbt
+}
+
+const assertPsbtFee = ({ chain, psbt }: AssertPsbtFeeInput): void => {
   const fee = getPsbtFee(psbt)
   if (fee === null) return
 
@@ -73,15 +78,24 @@ const assertPsbtFee = (chain: UtxoChain, psbt: Psbt): void => {
   )
 }
 
-const getZcashPlannedOutputSizes = (
-  change: bigint,
+type GetZcashPlannedOutputSizesInput = {
+  change: bigint
   memo: string | undefined
-): bigint[] => {
+}
+
+const getZcashPlannedOutputSizes = ({
+  change,
+  memo,
+}: GetZcashPlannedOutputSizesInput): bigint[] => {
   const sizes = [p2pkhOutputSize]
   if (change > 0n) sizes.push(p2pkhOutputSize)
   if (memo) sizes.push(getOpReturnOutputSize(memo))
 
   return sizes
+}
+
+type EnforceZcashConventionalFeeInput = EnforceMinNetworkFeeInput & {
+  bumpsLeft?: number
 }
 
 /**
@@ -90,10 +104,10 @@ const getZcashPlannedOutputSizes = (
  * floor makes the guarantee structural, covering manual fee-settings
  * overrides and any future byte-fee reduction.
  */
-const enforceZcashConventionalFee = async (
-  input: MinNetworkFeeInput,
-  bumpsLeft = maxByteFeeBumps
-): Promise<KeysignPayload> => {
+const enforceZcashConventionalFee = async ({
+  bumpsLeft = maxByteFeeBumps,
+  ...input
+}: EnforceZcashConventionalFeeInput): Promise<KeysignPayload> => {
   const { keysignPayload, walletCore, publicKey } = input
   const [signingInput] = await getUtxoSigningInputs({
     keysignPayload,
@@ -106,10 +120,10 @@ const enforceZcashConventionalFee = async (
     shouldBePresent(plan.fee, 'UTXO signing input plan fee').toString()
   )
   const inputCount = plan.utxos?.length ?? 0
-  const outputSizes = getZcashPlannedOutputSizes(
-    BigInt(plan.change?.toString() ?? '0'),
-    keysignPayload.memo
-  )
+  const outputSizes = getZcashPlannedOutputSizes({
+    change: BigInt(plan.change?.toString() ?? '0'),
+    memo: keysignPayload.memo,
+  })
   const conventionalFee = getZcashConventionalFee({ inputCount, outputSizes })
   if (planFee >= conventionalFee) return keysignPayload
 
@@ -128,37 +142,44 @@ const enforceZcashConventionalFee = async (
     BigInt(inputCount) * p2pkhInputSize +
     bigIntSum(outputSizes)
   const bumpedByteFee = bigIntMax(
-    ceilDiv(conventionalFee, estimatedVsize),
+    ceilDiv({ value: conventionalFee, divisor: estimatedVsize }),
     BigInt(utxoSpecific.byteFee || '0') + 1n
   )
 
-  const bumpedPayload = await refineKeysignUtxo({
-    keysignPayload: {
-      ...keysignPayload,
-      blockchainSpecific: {
-        case: 'utxoSpecific',
-        value: create(UTXOSpecificSchema, {
-          ...utxoSpecific,
-          byteFee: bumpedByteFee.toString(),
-        }),
-      },
-    } as KeysignPayload,
+  const bumpedKeysignPayload: KeysignPayload = {
+    ...keysignPayload,
+    blockchainSpecific: {
+      case: 'utxoSpecific',
+      value: create(UTXOSpecificSchema, {
+        ...utxoSpecific,
+        byteFee: bumpedByteFee.toString(),
+      }),
+    },
+  }
+
+  const refinedPayload = await refineKeysignUtxo({
+    keysignPayload: bumpedKeysignPayload,
     walletCore,
     publicKey: shouldBePresent(publicKey, 'publicKey'),
   })
 
-  return enforceZcashConventionalFee(
-    { ...input, keysignPayload: bumpedPayload },
-    bumpsLeft - 1
-  )
+  return enforceZcashConventionalFee({
+    ...input,
+    keysignPayload: refinedPayload,
+    bumpsLeft: bumpsLeft - 1,
+  })
 }
 
-const enforceMinUtxoFee = async (
-  chain: UtxoChain,
-  input: MinNetworkFeeInput
-): Promise<KeysignPayload> => {
+type EnforceMinUtxoFeeInput = EnforceMinNetworkFeeInput & {
+  chain: UtxoChain
+}
+
+const enforceMinUtxoFee = async ({
+  chain,
+  ...input
+}: EnforceMinUtxoFeeInput): Promise<KeysignPayload> => {
   if ('psbt' in input.customTxData) {
-    assertPsbtFee(chain, input.customTxData.psbt)
+    assertPsbtFee({ chain, psbt: input.customTxData.psbt })
 
     return input.keysignPayload
   }
@@ -184,13 +205,13 @@ const enforceMinUtxoFee = async (
  *  - remaining kinds: fee computed by us from chain config or network quotes
  */
 export const enforceMinNetworkFee = (
-  input: MinNetworkFeeInput
+  input: EnforceMinNetworkFeeInput
 ): Promise<KeysignPayload> => {
   const chain = getKeysignChain(input.keysignPayload)
   const noOp = async () => input.keysignPayload
 
-  return match(getChainKind(chain), {
-    utxo: () => enforceMinUtxoFee(chain as UtxoChain, input),
+  return matchRecordUnion(toChainKindRecordUnion(chain), {
+    utxo: utxoChain => enforceMinUtxoFee({ ...input, chain: utxoChain }),
     evm: noOp,
     cosmos: noOp,
     solana: noOp,

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/index.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/index.ts
@@ -1,0 +1,206 @@
+import { create } from '@bufbuild/protobuf'
+import { WalletCore } from '@trustwallet/wallet-core'
+import { PublicKey } from '@trustwallet/wallet-core/dist/src/wallet-core'
+import { UtxoChain } from '@vultisig/core-chain/Chain'
+import { getChainKind } from '@vultisig/core-chain/ChainKind'
+import { getBlockchainSpecificValue } from '@vultisig/core-mpc/keysign/chainSpecific/KeysignChainSpecific'
+import { refineKeysignUtxo } from '@vultisig/core-mpc/keysign/refine/utxo'
+import { getUtxoSigningInputs } from '@vultisig/core-mpc/keysign/signingInputs/resolvers/utxo'
+import { getKeysignChain } from '@vultisig/core-mpc/keysign/utils/getKeysignChain'
+import { UTXOSpecificSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
+import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
+import { bigIntMax } from '@vultisig/lib-utils/bigint/bigIntMax'
+import { bigIntSum } from '@vultisig/lib-utils/bigint/bigIntSum'
+import { match } from '@vultisig/lib-utils/match'
+import { Psbt } from 'bitcoinjs-lib'
+
+import { CustomTxData } from '../../core/customTxData'
+import { getPsbtFee, getPsbtMinVsize, getPsbtOutputSizes } from './psbtFee'
+import { ceilDiv, getZcashConventionalFee } from './zip317'
+
+type MinNetworkFeeInput = {
+  keysignPayload: KeysignPayload
+  customTxData: CustomTxData
+  walletCore: WalletCore
+  publicKey: PublicKey | null
+}
+
+/**
+ * Default min-relay floors (base units per vbyte). Anything below is dropped
+ * by every default-configured node, so blocking pre-sign saves a guaranteed
+ * failed keysign ceremony. Zcash uses ZIP-317 action-based fees instead.
+ */
+const relayFloorPerVbyte: Record<UtxoChain, bigint> = {
+  [UtxoChain.Bitcoin]: 1n,
+  [UtxoChain.BitcoinCash]: 1n,
+  [UtxoChain.Litecoin]: 1n,
+  [UtxoChain.Dogecoin]: 100n,
+  [UtxoChain.Dash]: 1n,
+  [UtxoChain.Zcash]: 0n,
+}
+
+const p2pkhInputSize = 148n
+const p2pkhOutputSize = 34n
+const zcashTxOverhead = 30n
+const maxByteFeeBumps = 3
+
+const memoEncoder = new TextEncoder()
+
+const getOpReturnOutputSize = (memo: string): bigint => {
+  const dataSize = memoEncoder.encode(memo).length
+  const pushOverhead = dataSize <= 75 ? 2n : 3n
+
+  return 9n + pushOverhead + BigInt(dataSize)
+}
+
+const assertPsbtFee = (chain: UtxoChain, psbt: Psbt): void => {
+  const fee = getPsbtFee(psbt)
+  if (fee === null) return
+
+  const minFee =
+    chain === UtxoChain.Zcash
+      ? getZcashConventionalFee({
+          inputCount: psbt.txInputs.length,
+          outputSizes: getPsbtOutputSizes(psbt),
+        })
+      : relayFloorPerVbyte[chain] * getPsbtMinVsize(psbt)
+
+  if (fee >= minFee) return
+
+  throw new Error(
+    `The dApp built this ${chain} transaction with a network fee of ${fee} base units, below the network minimum of ${minFee}. The network would reject it — ask the dApp to increase the fee.`
+  )
+}
+
+const getZcashPlannedOutputSizes = (
+  change: bigint,
+  memo: string | undefined
+): bigint[] => {
+  const sizes = [p2pkhOutputSize]
+  if (change > 0n) sizes.push(p2pkhOutputSize)
+  if (memo) sizes.push(getOpReturnOutputSize(memo))
+
+  return sizes
+}
+
+/**
+ * Enforce the ZIP-317 conventional fee on Zcash transactions we plan
+ * ourselves. The default 100 sats/byte clears it with room to spare; this
+ * floor makes the guarantee structural, covering manual fee-settings
+ * overrides and any future byte-fee reduction.
+ */
+const enforceZcashConventionalFee = async (
+  input: MinNetworkFeeInput,
+  bumpsLeft = maxByteFeeBumps
+): Promise<KeysignPayload> => {
+  const { keysignPayload, walletCore, publicKey } = input
+  const [signingInput] = await getUtxoSigningInputs({
+    keysignPayload,
+    walletCore,
+    publicKey: shouldBePresent(publicKey, 'publicKey'),
+  })
+  const plan = shouldBePresent(signingInput.plan, 'UTXO signing input plan')
+
+  const planFee = BigInt(
+    shouldBePresent(plan.fee, 'UTXO signing input plan fee').toString()
+  )
+  const inputCount = plan.utxos?.length ?? 0
+  const outputSizes = getZcashPlannedOutputSizes(
+    BigInt(plan.change?.toString() ?? '0'),
+    keysignPayload.memo
+  )
+  const conventionalFee = getZcashConventionalFee({ inputCount, outputSizes })
+  if (planFee >= conventionalFee) return keysignPayload
+
+  if (bumpsLeft === 0) {
+    throw new Error(
+      `Failed to meet the Zcash minimum network fee (ZIP-317): planned ${planFee} zats, required ${conventionalFee}`
+    )
+  }
+
+  const utxoSpecific = getBlockchainSpecificValue(
+    keysignPayload.blockchainSpecific,
+    'utxoSpecific'
+  )
+  const estimatedVsize =
+    zcashTxOverhead +
+    BigInt(inputCount) * p2pkhInputSize +
+    bigIntSum(outputSizes)
+  const bumpedByteFee = bigIntMax(
+    ceilDiv(conventionalFee, estimatedVsize),
+    BigInt(utxoSpecific.byteFee || '0') + 1n
+  )
+
+  const bumpedPayload = await refineKeysignUtxo({
+    keysignPayload: {
+      ...keysignPayload,
+      blockchainSpecific: {
+        case: 'utxoSpecific',
+        value: create(UTXOSpecificSchema, {
+          ...utxoSpecific,
+          byteFee: bumpedByteFee.toString(),
+        }),
+      },
+    } as KeysignPayload,
+    walletCore,
+    publicKey: shouldBePresent(publicKey, 'publicKey'),
+  })
+
+  return enforceZcashConventionalFee(
+    { ...input, keysignPayload: bumpedPayload },
+    bumpsLeft - 1
+  )
+}
+
+const enforceMinUtxoFee = async (
+  chain: UtxoChain,
+  input: MinNetworkFeeInput
+): Promise<KeysignPayload> => {
+  if ('psbt' in input.customTxData) {
+    assertPsbtFee(chain, input.customTxData.psbt)
+
+    return input.keysignPayload
+  }
+
+  // Non-Zcash plans already satisfy relay floors: byteFee is network-quoted
+  // with a 2.5x buffer and never below 1 base unit per vbyte.
+  if (chain !== UtxoChain.Zcash) return input.keysignPayload
+
+  return enforceZcashConventionalFee(input)
+}
+
+/**
+ * Guard every dApp transaction against fees the network is guaranteed to
+ * reject. Where we own the fee we raise it; where the dApp authored the
+ * transaction (PSBT) we block pre-sign with an actionable message instead
+ * of mutating outputs the user already approved.
+ *
+ * Chain kinds without a check are safe by construction:
+ *  - evm: fee quoted from the network by us; dApp gas values never enter the payload
+ *  - cosmos: fee is inside the dApp-signed doc; nodes reject underpaid txs at
+ *    CheckTx with an explicit "insufficient fees" before anything moves
+ *  - solana: base fee is protocol-fixed and network-deducted; cannot be underpaid
+ *  - remaining kinds: fee computed by us from chain config or network quotes
+ */
+export const enforceMinNetworkFee = (
+  input: MinNetworkFeeInput
+): Promise<KeysignPayload> => {
+  const chain = getKeysignChain(input.keysignPayload)
+  const noOp = async () => input.keysignPayload
+
+  return match(getChainKind(chain), {
+    utxo: () => enforceMinUtxoFee(chain as UtxoChain, input),
+    evm: noOp,
+    cosmos: noOp,
+    solana: noOp,
+    sui: noOp,
+    polkadot: noOp,
+    bittensor: noOp,
+    ton: noOp,
+    ripple: noOp,
+    tron: noOp,
+    cardano: noOp,
+    qbtc: noOp,
+  })
+}

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/index.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/index.ts
@@ -99,12 +99,10 @@ type EnforceZcashConventionalFeeInput = EnforceMinNetworkFeeInput & {
 
 /**
  * Enforce the ZIP-317 conventional fee on Zcash transactions we plan
- * ourselves. This is load-bearing for memo sends: WalletCore's planner
- * charges an OP_RETURN output as a fixed ~34 bytes regardless of memo
- * length, while ZIP-317 charges ~one action per 34 memo bytes — so any
- * dApp send with a memo of ~92 bytes or more underpays the conventional
- * fee at the default 100 sats/byte and every node rejects the broadcast.
- * It also covers manual fee-settings overrides and future byte-fee cuts.
+ * ourselves. Load-bearing for memo sends: WalletCore's planner charges an
+ * OP_RETURN output as a fixed ~34 bytes while ZIP-317 charges ~one action
+ * per 34 memo bytes, so long-memo plans fall below the conventional fee.
+ * Also covers manual fee-settings overrides and future byte-fee cuts.
  */
 const enforceZcashConventionalFee = async ({
   bumpsLeft = maxByteFeeBumps,
@@ -139,10 +137,7 @@ const enforceZcashConventionalFee = async ({
     keysignPayload.blockchainSpecific,
     'utxoSpecific'
   )
-  // The bump divisor must be the PLANNER's fee-per-byteFee ratio
-  // (planFee / byteFee), not the real serialized size: the planner
-  // under-sizes OP_RETURN outputs, so dividing by the larger real size
-  // yields a byteFee that still plans below the conventional fee.
+  // Must divide by the planner's own fee ratio, not the real serialized size.
   const currentByteFee = BigInt(utxoSpecific.byteFee || '0')
   const plannerVsize =
     currentByteFee > 0n && planFee > 0n

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/index.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/index.ts
@@ -99,9 +99,12 @@ type EnforceZcashConventionalFeeInput = EnforceMinNetworkFeeInput & {
 
 /**
  * Enforce the ZIP-317 conventional fee on Zcash transactions we plan
- * ourselves. The default 100 sats/byte clears it with room to spare; this
- * floor makes the guarantee structural, covering manual fee-settings
- * overrides and any future byte-fee reduction.
+ * ourselves. This is load-bearing for memo sends: WalletCore's planner
+ * charges an OP_RETURN output as a fixed ~34 bytes regardless of memo
+ * length, while ZIP-317 charges ~one action per 34 memo bytes — so any
+ * dApp send with a memo of ~92 bytes or more underpays the conventional
+ * fee at the default 100 sats/byte and every node rejects the broadcast.
+ * It also covers manual fee-settings overrides and future byte-fee cuts.
  */
 const enforceZcashConventionalFee = async ({
   bumpsLeft = maxByteFeeBumps,
@@ -136,13 +139,20 @@ const enforceZcashConventionalFee = async ({
     keysignPayload.blockchainSpecific,
     'utxoSpecific'
   )
-  const estimatedVsize =
-    zcashTxOverhead +
-    BigInt(inputCount) * p2pkhInputSize +
-    bigIntSum(outputSizes)
+  // The bump divisor must be the PLANNER's fee-per-byteFee ratio
+  // (planFee / byteFee), not the real serialized size: the planner
+  // under-sizes OP_RETURN outputs, so dividing by the larger real size
+  // yields a byteFee that still plans below the conventional fee.
+  const currentByteFee = BigInt(utxoSpecific.byteFee || '0')
+  const plannerVsize =
+    currentByteFee > 0n && planFee > 0n
+      ? planFee / currentByteFee
+      : zcashTxOverhead +
+        BigInt(inputCount) * p2pkhInputSize +
+        bigIntSum(outputSizes)
   const bumpedByteFee = bigIntMax(
-    ceilDiv({ value: conventionalFee, divisor: estimatedVsize }),
-    BigInt(utxoSpecific.byteFee || '0') + 1n
+    ceilDiv({ value: conventionalFee, divisor: plannerVsize }),
+    currentByteFee + 1n
   )
 
   const bumpedKeysignPayload: KeysignPayload = {

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/index.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/index.ts
@@ -17,7 +17,7 @@ import { Psbt } from 'bitcoinjs-lib'
 
 import { CustomTxData } from '../../core/customTxData'
 import { getPsbtFee, getPsbtMinVsize, getPsbtOutputSizes } from './psbtFee'
-import { ceilDiv, getZcashConventionalFee } from './zip317'
+import { ceilDiv, getZcashConventionalFee, p2pkhInputSize } from './zip317'
 
 type EnforceMinNetworkFeeInput = {
   keysignPayload: KeysignPayload
@@ -40,7 +40,6 @@ const relayFloorPerVbyte: Record<UtxoChain, bigint> = {
   [UtxoChain.Zcash]: 0n,
 }
 
-const p2pkhInputSize = 148n
 const p2pkhOutputSize = 34n
 const zcashTxOverhead = 30n
 const maxByteFeeBumps = 3

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/minNetworkFee.test.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/minNetworkFee.test.ts
@@ -1,0 +1,90 @@
+import { networks, payments, Psbt } from 'bitcoinjs-lib'
+import { describe, expect, it } from 'vitest'
+
+import { getPsbtFee, getPsbtMinVsize } from './psbtFee'
+import { getZcashConventionalFee } from './zip317'
+
+const p2pkhOutput = 34n
+
+describe('getZcashConventionalFee', () => {
+  it('returns the 10,000 zat floor for a simple 1-in 2-out send', () => {
+    expect(
+      getZcashConventionalFee({
+        inputCount: 1,
+        outputSizes: [p2pkhOutput, p2pkhOutput],
+      })
+    ).toBe(10_000n)
+  })
+
+  it('scales with input count beyond the grace window', () => {
+    expect(
+      getZcashConventionalFee({
+        inputCount: 4,
+        outputSizes: [p2pkhOutput, p2pkhOutput],
+      })
+    ).toBe(20_000n)
+  })
+
+  it('counts large OP_RETURN outputs as multiple actions', () => {
+    // 80-byte memo: 9 + 3 + 80 = 92 bytes -> with two p2pkh outputs,
+    // ceil(160 / 34) = 5 actions -> 25,000 zats
+    expect(
+      getZcashConventionalFee({
+        inputCount: 1,
+        outputSizes: [p2pkhOutput, p2pkhOutput, 92n],
+      })
+    ).toBe(25_000n)
+  })
+})
+
+const makePsbt = ({
+  inputValues,
+  outputValues,
+}: {
+  inputValues: bigint[]
+  outputValues: bigint[]
+}) => {
+  const psbt = new Psbt({ network: networks.bitcoin })
+  const keyHash = Buffer.alloc(20, 1)
+  const { output: script } = payments.p2wpkh({
+    hash: keyHash,
+    network: networks.bitcoin,
+  })
+
+  inputValues.forEach((value, index) => {
+    psbt.addInput({
+      hash: Buffer.alloc(32, index + 1),
+      index: 0,
+      witnessUtxo: { script: script!, value },
+    })
+  })
+  outputValues.forEach(value => {
+    psbt.addOutput({ script: script!, value })
+  })
+
+  return psbt
+}
+
+describe('getPsbtFee', () => {
+  it('returns input total minus output total', () => {
+    const psbt = makePsbt({
+      inputValues: [100_000n, 50_000n],
+      outputValues: [140_000n],
+    })
+
+    expect(getPsbtFee(psbt)).toBe(10_000n)
+  })
+})
+
+describe('getPsbtMinVsize', () => {
+  it('stays below the real vsize of a standard 1-in 2-out p2wpkh tx (~141 vB)', () => {
+    const psbt = makePsbt({
+      inputValues: [100_000n],
+      outputValues: [50_000n, 40_000n],
+    })
+
+    const minVsize = getPsbtMinVsize(psbt)
+    expect(minVsize).toBeGreaterThan(100n)
+    expect(minVsize).toBeLessThanOrEqual(141n)
+  })
+})

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/minNetworkFee.test.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/minNetworkFee.test.ts
@@ -25,6 +25,16 @@ describe('getZcashConventionalFee', () => {
     ).toBe(20_000n)
   })
 
+  it('charges input actions from serialized bytes, not raw count', () => {
+    // 75 P2PKH inputs: ceil(75 * 148 / 150) = 74 actions, not 75
+    expect(
+      getZcashConventionalFee({
+        inputCount: 75,
+        outputSizes: [p2pkhOutput, p2pkhOutput],
+      })
+    ).toBe(370_000n)
+  })
+
   it('counts large OP_RETURN outputs as multiple actions', () => {
     // 80-byte memo: 9 + 3 + 80 = 92 bytes -> with two p2pkh outputs,
     // ceil(160 / 34) = 5 actions -> 25,000 zats

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/psbtFee.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/psbtFee.ts
@@ -7,6 +7,7 @@ const txOverheadVsize = 11n
 /** P2TR key-path spend — the smallest standard input, so vsize stays a lower bound. */
 const minInputVsize = 57n
 
+/** Serialized size of each PSBT output in bytes (value + script length + script). */
 export const getPsbtOutputSizes = (psbt: Psbt): bigint[] =>
   psbt.txOutputs.map(({ script }) => outputBaseSize + BigInt(script.length))
 

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/psbtFee.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/psbtFee.ts
@@ -1,0 +1,52 @@
+import { bigIntSum } from '@vultisig/lib-utils/bigint/bigIntSum'
+import { Psbt, Transaction } from 'bitcoinjs-lib'
+
+/** 8-byte value + 1-byte script length varint (scripts < 253 bytes). */
+const outputBaseSize = 9n
+const txOverheadVsize = 11n
+/** P2TR key-path spend — the smallest standard input, so vsize stays a lower bound. */
+const minInputVsize = 57n
+
+export const getPsbtOutputSizes = (psbt: Psbt): bigint[] =>
+  psbt.txOutputs.map(({ script }) => outputBaseSize + BigInt(script.length))
+
+/**
+ * Total network fee a PSBT pays: sum(input values) - sum(output values).
+ * Returns null when an input lacks UTXO data, leaving validation to the
+ * signing layer which rejects such inputs anyway.
+ */
+export const getPsbtFee = (psbt: Psbt): bigint | null => {
+  let inputsTotal = 0n
+
+  for (const [index, input] of psbt.data.inputs.entries()) {
+    if (input.witnessUtxo) {
+      inputsTotal += BigInt(input.witnessUtxo.value)
+      continue
+    }
+
+    if (!input.nonWitnessUtxo) return null
+
+    const prevTx = Transaction.fromBuffer(input.nonWitnessUtxo)
+    const prevOut = prevTx.outs[psbt.txInputs[index]?.index ?? -1]
+    if (!prevOut) return null
+
+    inputsTotal += BigInt(prevOut.value)
+  }
+
+  const outputsTotal = psbt.txOutputs.reduce(
+    (sum, { value }) => sum + BigInt(value),
+    0n
+  )
+
+  return inputsTotal - outputsTotal
+}
+
+/**
+ * Lower-bound vsize of the finalized tx, assuming the cheapest standard
+ * input type. Underestimating keeps the min-fee check free of false
+ * positives: we only flag fees no input composition could justify.
+ */
+export const getPsbtMinVsize = (psbt: Psbt): bigint =>
+  txOverheadVsize +
+  BigInt(psbt.txInputs.length) * minInputVsize +
+  bigIntSum(getPsbtOutputSizes(psbt))

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/zcashMemoFee.test.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/zcashMemoFee.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Regression test for the bitfrost.xyz Zcash bridge failure: WalletCore's
+ * planner charges an OP_RETURN output as a fixed ~34 bytes regardless of
+ * memo length, while ZIP-317 charges ~one logical action per 34 memo bytes.
+ * At the default 100 sats/byte, a dApp send with a memo of ~92+ bytes plans
+ * a fee below the conventional fee and every node rejects the broadcast
+ * with "tx unpaid action limit exceeded".
+ *
+ * Exercises the real planner end-to-end and verifies the bump formula used
+ * by enforceZcashConventionalFee: the divisor must be the planner's own
+ * fee-per-byteFee ratio, not the larger real serialized size.
+ */
+import { initWasm, TW, WalletCore } from '@trustwallet/wallet-core'
+import Long from 'long'
+import { describe, expect, it } from 'vitest'
+
+import { ceilDiv, getZcashConventionalFee } from './zip317'
+
+const zcashAddress = 't1PoLLLwEcVhqMBhk53tANtSepnPXAQJkPM'
+
+type PlanZcashSendInput = {
+  walletCore: WalletCore
+  byteFee: bigint
+  memoLength: number
+}
+
+const planZcashSend = ({
+  walletCore,
+  byteFee,
+  memoLength,
+}: PlanZcashSendInput): bigint => {
+  const coinType = walletCore.CoinType.zcash
+  const lockScript = walletCore.BitcoinScript.lockScriptForAddress(
+    zcashAddress,
+    coinType
+  )
+  const input = TW.Bitcoin.Proto.SigningInput.create({
+    hashType: walletCore.BitcoinScript.hashTypeForCoin(coinType),
+    amount: Long.fromString('100000'),
+    useMaxAmount: false,
+    toAddress: zcashAddress,
+    changeAddress: zcashAddress,
+    byteFee: Long.fromString(byteFee.toString()),
+    coinType: coinType.value,
+    utxo: [
+      TW.Bitcoin.Proto.UnspentTransaction.create({
+        amount: Long.fromString('10000000'),
+        outPoint: TW.Bitcoin.Proto.OutPoint.create({
+          hash: new Uint8Array(32).fill(0xff),
+          index: 0,
+          sequence: 0xffffffff,
+        }),
+        script: lockScript.data(),
+      }),
+    ],
+  })
+  if (memoLength > 0) {
+    input.outputOpReturn = new TextEncoder().encode('m'.repeat(memoLength))
+  }
+  const encoded = TW.Bitcoin.Proto.SigningInput.encode(input).finish()
+  const plan = TW.Bitcoin.Proto.TransactionPlan.decode(
+    walletCore.AnySigner.plan(encoded, coinType)
+  )
+
+  return BigInt(plan.fee.toString())
+}
+
+const getConventionalFee = (memoLength: number): bigint =>
+  getZcashConventionalFee({
+    inputCount: 1,
+    outputSizes: [34n, 34n, 11n + 1n + BigInt(memoLength)],
+  })
+
+describe('Zcash memo sends vs ZIP-317', () => {
+  it('pins the WalletCore quirk: plan fee is flat across memo sizes', async () => {
+    const walletCore = await initWasm()
+    const fee80 = planZcashSend({ walletCore, byteFee: 100n, memoLength: 80 })
+    const fee200 = planZcashSend({ walletCore, byteFee: 100n, memoLength: 200 })
+
+    // If this ever fails, WalletCore started sizing OP_RETURN correctly —
+    // re-evaluate whether the bump in enforceZcashConventionalFee still fires.
+    expect(fee80).toBe(fee200)
+  })
+
+  it('underpays ZIP-317 at 100 sats/byte once the memo reaches ~120 bytes', async () => {
+    const walletCore = await initWasm()
+    const planFee = planZcashSend({
+      walletCore,
+      byteFee: 100n,
+      memoLength: 120,
+    })
+
+    expect(planFee).toBeLessThan(getConventionalFee(120))
+  })
+
+  it('meets the conventional fee after one planner-ratio bump', async () => {
+    const walletCore = await initWasm()
+    const byteFee = 100n
+    const memoLength = 120
+    const planFee = planZcashSend({ walletCore, byteFee, memoLength })
+    const conventionalFee = getConventionalFee(memoLength)
+
+    const plannerVsize = planFee / byteFee
+    const bumpedByteFee = ceilDiv({
+      value: conventionalFee,
+      divisor: plannerVsize,
+    })
+    const bumpedFee = planZcashSend({
+      walletCore,
+      byteFee: bumpedByteFee,
+      memoLength,
+    })
+
+    expect(bumpedFee).toBeGreaterThanOrEqual(conventionalFee)
+  })
+})

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/zcashMemoFee.test.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/zcashMemoFee.test.ts
@@ -1,18 +1,13 @@
 /**
- * Regression test for the bitfrost.xyz Zcash bridge failure: WalletCore's
- * planner charges an OP_RETURN output as a fixed ~34 bytes regardless of
- * memo length, while ZIP-317 charges ~one logical action per 34 memo bytes.
- * At the default 100 sats/byte, a dApp send with a memo of ~92+ bytes plans
- * a fee below the conventional fee and every node rejects the broadcast
- * with "tx unpaid action limit exceeded".
- *
- * Exercises the real planner end-to-end and verifies the bump formula used
- * by enforceZcashConventionalFee: the divisor must be the planner's own
- * fee-per-byteFee ratio, not the larger real serialized size.
+ * WalletCore's planner charges an OP_RETURN output as a fixed ~34 bytes
+ * regardless of memo length, while ZIP-317 charges ~one logical action per
+ * 34 memo bytes — so memo sends can plan below the conventional fee.
+ * Exercises the real planner to verify the bump formula in
+ * enforceZcashConventionalFee compensates.
  */
 import { initWasm, TW, WalletCore } from '@trustwallet/wallet-core'
 import Long from 'long'
-import { describe, expect, it } from 'vitest'
+import { beforeAll, describe, expect, it } from 'vitest'
 
 import { ceilDiv, getZcashConventionalFee } from './zip317'
 
@@ -72,8 +67,13 @@ const getConventionalFee = (memoLength: number): bigint =>
   })
 
 describe('Zcash memo sends vs ZIP-317', () => {
-  it('pins the WalletCore quirk: plan fee is flat across memo sizes', async () => {
-    const walletCore = await initWasm()
+  let walletCore: WalletCore
+
+  beforeAll(async () => {
+    walletCore = await initWasm()
+  })
+
+  it('pins the WalletCore quirk: plan fee is flat across memo sizes', () => {
     const fee80 = planZcashSend({ walletCore, byteFee: 100n, memoLength: 80 })
     const fee200 = planZcashSend({ walletCore, byteFee: 100n, memoLength: 200 })
 
@@ -82,8 +82,7 @@ describe('Zcash memo sends vs ZIP-317', () => {
     expect(fee80).toBe(fee200)
   })
 
-  it('underpays ZIP-317 at 100 sats/byte once the memo reaches ~120 bytes', async () => {
-    const walletCore = await initWasm()
+  it('underpays ZIP-317 at 100 sats/byte once the memo reaches ~120 bytes', () => {
     const planFee = planZcashSend({
       walletCore,
       byteFee: 100n,
@@ -93,8 +92,7 @@ describe('Zcash memo sends vs ZIP-317', () => {
     expect(planFee).toBeLessThan(getConventionalFee(120))
   })
 
-  it('meets the conventional fee after one planner-ratio bump', async () => {
-    const walletCore = await initWasm()
+  it('meets the conventional fee after one planner-ratio bump', () => {
     const byteFee = 100n
     const memoLength = 120
     const planFee = planZcashSend({ walletCore, byteFee, memoLength })

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/zip317.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/zip317.ts
@@ -10,7 +10,7 @@ import { bigIntSum } from '@vultisig/lib-utils/bigint/bigIntSum'
 const marginalFee = 5000n
 const graceActions = 2n
 /** Serialized size of a signed transparent P2PKH input (ZIP-317 §3.1). */
-const p2pkhInputSize = 148n
+export const p2pkhInputSize = 148n
 const inputActionSize = 150n
 const outputActionSize = 34n
 

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/zip317.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/zip317.ts
@@ -9,27 +9,45 @@ import { bigIntSum } from '@vultisig/lib-utils/bigint/bigIntSum'
  */
 const marginalFee = 5000n
 const graceActions = 2n
+/** Serialized size of a signed transparent P2PKH input (ZIP-317 §3.1). */
+const p2pkhInputSize = 148n
+const inputActionSize = 150n
 const outputActionSize = 34n
 
-export const ceilDiv = (value: bigint, divisor: bigint): bigint =>
+type CeilDivInput = {
+  value: bigint
+  divisor: bigint
+}
+
+/** Ceiling division for bigints: smallest n such that n * divisor >= value. */
+export const ceilDiv = ({ value, divisor }: CeilDivInput): bigint =>
   (value + divisor - 1n) / divisor
 
-type ZcashTxShape = {
-  /**
-   * Transparent P2PKH inputs (148 bytes serialized) map 1:1 to logical
-   * actions — ceil(148n / 150) equals n for any realistic input count (< 75).
-   */
+type GetZcashConventionalFeeInput = {
+  /** Transparent P2PKH inputs; sized at 148 bytes each per ZIP-317. */
   inputCount: number
   /** Serialized size of each tx_out in bytes (value + script length + script). */
   outputSizes: bigint[]
 }
 
+/**
+ * Minimum fee the Zcash network relays for a transparent tx of the given
+ * shape: 5,000 zats per logical action with a two-action grace window, where
+ * logical actions = max(ceil(tx_in bytes / 150), ceil(tx_out bytes / 34)).
+ */
 export const getZcashConventionalFee = ({
   inputCount,
   outputSizes,
-}: ZcashTxShape): bigint => {
-  const outputActions = ceilDiv(bigIntSum(outputSizes), outputActionSize)
-  const logicalActions = bigIntMax(BigInt(inputCount), outputActions)
+}: GetZcashConventionalFeeInput): bigint => {
+  const inputActions = ceilDiv({
+    value: BigInt(inputCount) * p2pkhInputSize,
+    divisor: inputActionSize,
+  })
+  const outputActions = ceilDiv({
+    value: bigIntSum(outputSizes),
+    divisor: outputActionSize,
+  })
+  const logicalActions = bigIntMax(inputActions, outputActions)
 
   return marginalFee * bigIntMax(graceActions, logicalActions)
 }

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/zip317.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/minNetworkFee/zip317.ts
@@ -1,0 +1,35 @@
+import { bigIntMax } from '@vultisig/lib-utils/bigint/bigIntMax'
+import { bigIntSum } from '@vultisig/lib-utils/bigint/bigIntSum'
+
+/**
+ * ZIP-317 conventional fee for a transparent-only Zcash transaction.
+ * Nodes relay zero "unpaid actions" by default, so any tx paying less is
+ * rejected at broadcast with "tx unpaid action limit exceeded".
+ * https://zips.z.cash/zip-0317
+ */
+const marginalFee = 5000n
+const graceActions = 2n
+const outputActionSize = 34n
+
+export const ceilDiv = (value: bigint, divisor: bigint): bigint =>
+  (value + divisor - 1n) / divisor
+
+type ZcashTxShape = {
+  /**
+   * Transparent P2PKH inputs (148 bytes serialized) map 1:1 to logical
+   * actions — ceil(148n / 150) equals n for any realistic input count (< 75).
+   */
+  inputCount: number
+  /** Serialized size of each tx_out in bytes (value + script length + script). */
+  outputSizes: bigint[]
+}
+
+export const getZcashConventionalFee = ({
+  inputCount,
+  outputSizes,
+}: ZcashTxShape): bigint => {
+  const outputActions = ceilDiv(bigIntSum(outputSizes), outputActionSize)
+  const logicalActions = bigIntMax(BigInt(inputCount), outputActions)
+
+  return marginalFee * bigIntMax(graceActions, logicalActions)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -887,6 +887,7 @@ __metadata:
     cosmjs-types: "npm:^0.11.0"
     ethers: "npm:^6.16.0"
     framer-motion: "npm:^12.40.0"
+    long: "npm:^5.3.2"
     react: "npm:19.2.4"
     react-dom: "npm:19.2.4"
     react-i18next: "npm:^16.5.8"


### PR DESCRIPTION
## Summary
- Adds `enforceMinNetworkFee` as the final step of the extension's dApp `sendTx` keysign-payload build, so transactions whose fee the network is guaranteed to reject never reach a keysign ceremony
- dApp-authored PSBTs that underpay are **blocked pre-sign** with an actionable message (we never mutate outputs the user approved); wallet-planned Zcash transactions get a structural ZIP-317 floor (bump byte fee + re-plan)
- All 12 chain kinds are dispatched exhaustively — EVM/Cosmos/Solana/etc. are documented no-ops (fees are network-quoted by us, inside dApp-signed bytes, or protocol-fixed), and any future chain kind fails typecheck until a rule is chosen

## Changes
| File | Change |
|------|--------|
| `.../keysignPayload/minNetworkFee/index.ts` | Guard entry: per-chain-kind dispatch, PSBT fee assertion, ZIP-317 floor with bounded byte-fee bump |
| `.../keysignPayload/minNetworkFee/zip317.ts` | ZIP-317 conventional-fee formula (5,000 zats × max(2, logical actions)) |
| `.../keysignPayload/minNetworkFee/psbtFee.ts` | PSBT fee extraction (inputs − outputs) and conservative lower-bound vsize |
| `.../keysignPayload/minNetworkFee/minNetworkFee.test.ts` | Unit tests for the ZIP-317 math, PSBT fee, and vsize bound |
| `.../keysignPayload/build.ts` | Wire the guard in before returning the payload |

## Context
A user reported dApp-connection Zcash sends failing on bitfrost.xyz's ZEC→Hyperliquid bridge. The broadcast was rejected by the network with `tx unpaid action limit exceeded: 1 action(s) exceeds limit of 0` — a ZIP-317 rejection meaning the signed fee was below the conventional fee (10,000 zat minimum). The failure surfaced as raw Blockchair JSON **after** a full (wasted) keysign ceremony. Our own `transfer` path pays 100 sats/byte (safe); the dApp-authored path had no floor at all. This guard makes underpaid dApp transactions fail fast, pre-sign, with a message that tells the dApp exactly what to fix.

## Test plan
- [x] Unit tests for ZIP-317 conventional fee (floor, input scaling, OP_RETURN actions), PSBT fee extraction, vsize lower bound
- [x] Full repo suite (205 tests), `tsgo` typecheck, eslint
- [ ] Manual repro on bitfrost.xyz with a dev vault (in progress on a separate track)

## receipts
```
$ yarn vitest run .../minNetworkFee --reporter=verbose
✓ getZcashConventionalFee > returns the 10,000 zat floor for a simple 1-in 2-out send
✓ getZcashConventionalFee > scales with input count beyond the grace window
✓ getZcashConventionalFee > counts large OP_RETURN outputs as multiple actions
✓ getPsbtFee > returns input total minus output total
✓ getPsbtMinVsize > stays below the real vsize of a standard 1-in 2-out p2wpkh tx (~141 vB)
Test Files  1 passed (1) | Tests  5 passed (5)

$ yarn test
Test Files  43 passed (43) | Tests  205 passed (205)

$ yarn typecheck && yarn lint
(clean)
```

Heads up — AI-assisted change on signing-adjacent code; review the PSBT fee math and the ZIP-317 constants against https://zips.z.cash/zip-0317.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added network-fee enforcement that adjusts planned transactions to meet chain minimums, including ZIP-317 handling for Zcash.
  * Added PSBT fee sizing helpers and conventional-fee calculation utilities.

* **Bug Fixes**
  * Prevents signing transactions with fees that would be rejected by the network.

* **Tests**
  * New unit and regression tests covering PSBT fee calculations and Zcash memo/ZIP-317 scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->