### PR TITLE
Preserve vault storage child rows

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -104,9 +104,19 @@ func (s *Store) SaveVault(vault *Vault) error {
 		"chain_key_shares",
 		"public_key_mldsa",
 	}
-	query := fmt.Sprintf(`INSERT OR REPLACE INTO vaults (%s) VALUES (%s)`,
+	updates := make([]string, 0, len(columns)-1)
+	for _, column := range columns {
+		if column == "public_key_ecdsa" {
+			continue
+		}
+		updates = append(updates, fmt.Sprintf("%s = excluded.%s", column, column))
+	}
+	query := fmt.Sprintf(
+		`INSERT INTO vaults (%s) VALUES (%s) ON CONFLICT(public_key_ecdsa) DO UPDATE SET %s`,
 		strings.Join(columns, ", "),
-		generatePlaceholders(len(columns)))
+		generatePlaceholders(len(columns)),
+		strings.Join(updates, ", "),
+	)
 
 	var chainPublicKeys interface{}
 	if vault.ChainPublicKeys != nil {

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -1,0 +1,125 @@
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSaveVaultUpdatePreservesChildRows(t *testing.T) {
+	store := newTestStore(t)
+
+	vault := testVault()
+	if err := store.SaveVault(vault); err != nil {
+		t.Fatal(err)
+	}
+
+	coin := Coin{
+		ID:              "coin-1",
+		Chain:           "Bitcoin",
+		Address:         "bc1qtest",
+		Ticker:          "BTC",
+		IsNativeToken:   true,
+		Logo:            "btc.png",
+		PriceProviderID: "bitcoin",
+		Decimals:        8,
+	}
+	if _, err := store.SaveCoin(vault.PublicKeyECDSA, coin); err != nil {
+		t.Fatal(err)
+	}
+
+	record := TransactionRecord{
+		ID:          "tx-1",
+		VaultID:     vault.PublicKeyECDSA,
+		Type:        "send",
+		Status:      "pending",
+		Chain:       "Bitcoin",
+		Timestamp:   "2026-06-14T00:00:00Z",
+		TxHash:      "tx-hash-1",
+		ExplorerURL: "https://example.com/tx/tx-hash-1",
+		FiatValue:   "1.00",
+		Data:        "{}",
+	}
+	if err := store.SaveTransactionRecord(record); err != nil {
+		t.Fatal(err)
+	}
+
+	update := *vault
+	update.Name = "Renamed Vault"
+	update.KeyShares = nil
+	update.Coins = nil
+	if err := store.SaveVault(&update); err != nil {
+		t.Fatal(err)
+	}
+
+	savedVault, err := store.GetVault(vault.PublicKeyECDSA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if savedVault.Name != update.Name {
+		t.Fatalf("expected vault name %q, got %q", update.Name, savedVault.Name)
+	}
+	if len(savedVault.KeyShares) != len(vault.KeyShares) {
+		t.Fatalf("expected %d keyshares, got %d", len(vault.KeyShares), len(savedVault.KeyShares))
+	}
+
+	coins, err := store.GetVaultCoins(vault.PublicKeyECDSA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(coins) != 1 || coins[0].ID != coin.ID {
+		t.Fatalf("expected saved coin %q to survive vault update, got %#v", coin.ID, coins)
+	}
+
+	records, err := store.GetTransactionRecords(vault.PublicKeyECDSA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 || records[0].ID != record.ID {
+		t.Fatalf("expected transaction record %q to survive vault update, got %#v", record.ID, records)
+	}
+}
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+
+	t.Setenv("VULTISIG_DB_PATH", filepath.Join(t.TempDir(), "test.db"))
+	store, err := NewStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if err := store.Migrate(); err != nil {
+		t.Fatal(err)
+	}
+
+	return store
+}
+
+func testVault() *Vault {
+	return &Vault{
+		Name:           "Test Vault",
+		PublicKeyECDSA: "test-public-key-ecdsa",
+		PublicKeyEdDSA: "test-public-key-eddsa",
+		Signers:        []string{"test-signer"},
+		CreatedAt:      time.Unix(1, 0).UTC(),
+		HexChainCode:   "test-chain-code",
+		KeyShares: []KeyShare{
+			{
+				PublicKey: "test-public-key-ecdsa",
+				KeyShare:  "ecdsa-share",
+			},
+			{
+				PublicKey: "test-public-key-eddsa",
+				KeyShare:  "eddsa-share",
+			},
+		},
+		LocalPartyID: "test-party",
+		LibType:      "DKLS",
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where updating vault information would inadvertently remove associated transaction and coin records. Vault updates now preserve previously saved related data while only updating the vault details themselves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->