### PR TITLE
feat(swap): Market/Limit tab row above the swap form (phase 0)

### DIFF
--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -177,6 +177,7 @@ export const en = {
     '{{action, select, add {Add liquidity} remove {Remove liquidity} other {Manage liquidity}}}',
   manage_tokens: 'Manage tokens',
   collected_rewards: 'Collected rewards',
+  coming_soon: 'Coming soon',
   complete: 'Complete',
   congrats: 'Congrats!',
   confirm: 'Confirm',
@@ -979,6 +980,9 @@ export const en = {
   swap: 'Swap',
   swaps: 'Swaps',
   swap_fee: 'Swap Fee',
+  swap_limit_orders: 'Limit orders',
+  swap_mode_limit: 'Limit',
+  swap_mode_market: 'Market',
   swap_overview: 'Swap overview',
   swap_same_asset: 'Cannot swap between the same asset',
   swap_trading_halted:

--- a/core/ui/vault/swap/form/LimitSwapForm.tsx
+++ b/core/ui/vault/swap/form/LimitSwapForm.tsx
@@ -1,0 +1,21 @@
+import { VStack } from '@lib/ui/layout/Stack'
+import { PageContent } from '@lib/ui/page/PageContent'
+import { Text } from '@lib/ui/text'
+import { useTranslation } from 'react-i18next'
+
+export const LimitSwapForm = () => {
+  const { t } = useTranslation()
+
+  return (
+    <PageContent alignItems="center" justifyContent="center" flexGrow>
+      <VStack gap={8} alignItems="center">
+        <Text size={16} weight={500} color="contrast">
+          {t('swap_limit_orders')}
+        </Text>
+        <Text size={14} color="supporting">
+          {t('coming_soon')}
+        </Text>
+      </VStack>
+    </PageContent>
+  )
+}

--- a/core/ui/vault/swap/form/MarketSwapForm.tsx
+++ b/core/ui/vault/swap/form/MarketSwapForm.tsx
@@ -1,0 +1,131 @@
+import { SwapInfo } from '@core/ui/vault/swap/form/info/SwapInfo'
+import { ManageFromCoin } from '@core/ui/vault/swap/form/ManageFromCoin'
+import { ManageToCoin } from '@core/ui/vault/swap/form/ManageToCoin'
+import { ReverseSwap } from '@core/ui/vault/swap/form/ReverseSwap'
+import { Button } from '@lib/ui/buttons/Button'
+import { getFormProps } from '@lib/ui/form/utils/getFormProps'
+import { VStack, vStack } from '@lib/ui/layout/Stack'
+import { PageContent } from '@lib/ui/page/PageContent'
+import { OnFinishProp } from '@lib/ui/props'
+import { SwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
+import { SwapError, SwapErrorCode } from '@vultisig/core-chain/swap/SwapError'
+import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
+import { extractErrorMsg } from '@vultisig/lib-utils/error/extractErrorMsg'
+import { FC, useEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+
+import { useCoreViewState } from '../../../navigation/hooks/useCoreViewState'
+import { useSwapQuoteQuery } from '../queries/useSwapQuoteQuery'
+import { useSwapValidationQuery } from '../queries/useSwapValidationQuery'
+
+export const MarketSwapForm: FC<OnFinishProp<SwapQuote>> = ({ onFinish }) => {
+  const {
+    error,
+    data: validationErrorMessage,
+    isPending,
+  } = useSwapValidationQuery()
+  const swapQuoteQuery = useSwapQuoteQuery()
+  const [{ autoSubmit }, setViewState] = useCoreViewState<'swap'>()
+  const autoSubmittedRef = useRef(false)
+
+  const { t } = useTranslation()
+
+  // The SDK classifies a provider trading halt as a typed error, so key off the
+  // code rather than string-matching the (English) message.
+  const resolveErrorMessage = (err: unknown) =>
+    err instanceof SwapError && err.code === SwapErrorCode.TradingHalted
+      ? t('swap_trading_halted')
+      : extractErrorMsg(err)
+
+  const errorMessage = (() => {
+    if (isPending) {
+      return t('loading')
+    }
+
+    if (error) {
+      return resolveErrorMessage(error)
+    }
+
+    if (validationErrorMessage === undefined) {
+      return t('fill_the_form')
+    }
+
+    return validationErrorMessage
+  })()
+
+  useEffect(() => {
+    if (
+      autoSubmit &&
+      !autoSubmittedRef.current &&
+      !errorMessage &&
+      !swapQuoteQuery.isPlaceholderData &&
+      swapQuoteQuery.data
+    ) {
+      autoSubmittedRef.current = true
+      setViewState(prev => ({ ...prev, autoSubmit: undefined }))
+      onFinish(swapQuoteQuery.data)
+    }
+  }, [
+    autoSubmit,
+    errorMessage,
+    swapQuoteQuery.data,
+    swapQuoteQuery.isPlaceholderData,
+    onFinish,
+    setViewState,
+  ])
+
+  // Display error for ReverseSwap button (excludes non-error states like loading/fill_the_form)
+  const displayErrorMessage = (() => {
+    if (isPending) return null
+    if (error) return resolveErrorMessage(error)
+    if (validationErrorMessage === undefined) return null
+    return validationErrorMessage
+  })()
+
+  const handleSubmit = () => {
+    if (!errorMessage && !swapQuoteQuery.isPlaceholderData) {
+      const swapQuote = shouldBePresent(swapQuoteQuery.data, 'swap quote')
+      onFinish(swapQuote)
+    }
+  }
+
+  return (
+    <PageContent
+      as="form"
+      gap={40}
+      data-testid="swap-form"
+      {...getFormProps({
+        onSubmit: handleSubmit,
+        isDisabled: !!errorMessage,
+      })}
+      justifyContent="space-between"
+      scrollable
+    >
+      <VStack gap={16}>
+        <VStack gap={8}>
+          <ManageFromCoin />
+          <ReverseSwapWrapper>
+            <ReverseSwap errorMessage={displayErrorMessage} />
+          </ReverseSwapWrapper>
+          <ManageToCoin />
+        </VStack>
+        <VStack gap={10}>
+          <SwapInfo />
+        </VStack>
+      </VStack>
+      <Button
+        disabled={!!errorMessage}
+        type="submit"
+        data-testid="swap-continue"
+      >
+        {t('continue')}
+      </Button>
+    </PageContent>
+  )
+}
+
+const ReverseSwapWrapper = styled.div`
+  ${vStack({ gap: 8 })}
+  position: relative;
+`

--- a/core/ui/vault/swap/form/SwapForm.tsx
+++ b/core/ui/vault/swap/form/SwapForm.tsx
@@ -1,5 +1,6 @@
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { Tab, Tabs } from '@lib/ui/base/Tabs'
+import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
 import { hStack } from '@lib/ui/layout/Stack'
 import { PageHeader } from '@lib/ui/page/PageHeader'
 import { ChildrenProp, IsActiveProp, OnFinishProp } from '@lib/ui/props'
@@ -45,8 +46,8 @@ export const SwapForm: FC<OnFinishProp<SwapQuote>> = ({ onFinish }) => {
         value={swapMode}
         onValueChange={setSwapMode}
         triggersContainer={SwapModeTabsHeader}
-        triggerSlot={({ tab: { label }, isActive }) => (
-          <TriggerItem isActive={isActive}>
+        triggerSlot={({ tab: { label }, isActive, ...triggerProps }) => (
+          <TriggerItem {...triggerProps} isActive={isActive}>
             <Text
               size={14}
               as="span"
@@ -70,7 +71,7 @@ const Header = styled.div`
   padding: 16px 16px 0;
 `
 
-const TriggerItem = styled.div<IsActiveProp>`
+const TriggerItem = styled(UnstyledButton)<IsActiveProp>`
   width: fit-content;
   padding-bottom: 6px;
   cursor: pointer;

--- a/core/ui/vault/swap/form/SwapForm.tsx
+++ b/core/ui/vault/swap/form/SwapForm.tsx
@@ -1,97 +1,36 @@
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
-import { SwapInfo } from '@core/ui/vault/swap/form/info/SwapInfo'
-import { ManageFromCoin } from '@core/ui/vault/swap/form/ManageFromCoin'
-import { ManageToCoin } from '@core/ui/vault/swap/form/ManageToCoin'
-import { ReverseSwap } from '@core/ui/vault/swap/form/ReverseSwap'
-import { Button } from '@lib/ui/buttons/Button'
-import { getFormProps } from '@lib/ui/form/utils/getFormProps'
-import { VStack, vStack } from '@lib/ui/layout/Stack'
-import { PageContent } from '@lib/ui/page/PageContent'
+import { Tab, Tabs } from '@lib/ui/base/Tabs'
+import { hStack } from '@lib/ui/layout/Stack'
 import { PageHeader } from '@lib/ui/page/PageHeader'
-import { OnFinishProp } from '@lib/ui/props'
+import { ChildrenProp, IsActiveProp, OnFinishProp } from '@lib/ui/props'
+import { Text } from '@lib/ui/text'
 import { SwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
-import { SwapError, SwapErrorCode } from '@vultisig/core-chain/swap/SwapError'
-import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
-import { extractErrorMsg } from '@vultisig/lib-utils/error/extractErrorMsg'
-import { FC, useEffect, useRef } from 'react'
+import { FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
-import { useCoreViewState } from '../../../navigation/hooks/useCoreViewState'
 import { RefreshSwap } from '../components/RefreshSwap'
-import { useSwapQuoteQuery } from '../queries/useSwapQuoteQuery'
-import { useSwapValidationQuery } from '../queries/useSwapValidationQuery'
+import { LimitSwapForm } from './LimitSwapForm'
+import { MarketSwapForm } from './MarketSwapForm'
+
+type SwapMode = 'market' | 'limit'
 
 export const SwapForm: FC<OnFinishProp<SwapQuote>> = ({ onFinish }) => {
-  const {
-    error,
-    data: validationErrorMessage,
-    isPending,
-  } = useSwapValidationQuery()
-  const swapQuoteQuery = useSwapQuoteQuery()
-  const [{ autoSubmit }, setViewState] = useCoreViewState<'swap'>()
-  const autoSubmittedRef = useRef(false)
-
   const { t } = useTranslation()
+  const [swapMode, setSwapMode] = useState<SwapMode>('market')
 
-  // The SDK classifies a provider trading halt as a typed error, so key off the
-  // code rather than string-matching the (English) message.
-  const resolveErrorMessage = (err: unknown) =>
-    err instanceof SwapError && err.code === SwapErrorCode.TradingHalted
-      ? t('swap_trading_halted')
-      : extractErrorMsg(err)
-
-  const errorMessage = (() => {
-    if (isPending) {
-      return t('loading')
-    }
-
-    if (error) {
-      return resolveErrorMessage(error)
-    }
-
-    if (validationErrorMessage === undefined) {
-      return t('fill_the_form')
-    }
-
-    return validationErrorMessage
-  })()
-
-  useEffect(() => {
-    if (
-      autoSubmit &&
-      !autoSubmittedRef.current &&
-      !errorMessage &&
-      !swapQuoteQuery.isPlaceholderData &&
-      swapQuoteQuery.data
-    ) {
-      autoSubmittedRef.current = true
-      setViewState(prev => ({ ...prev, autoSubmit: undefined }))
-      onFinish(swapQuoteQuery.data)
-    }
-  }, [
-    autoSubmit,
-    errorMessage,
-    swapQuoteQuery.data,
-    swapQuoteQuery.isPlaceholderData,
-    onFinish,
-    setViewState,
-  ])
-
-  // Display error for ReverseSwap button (excludes non-error states like loading/fill_the_form)
-  const displayErrorMessage = (() => {
-    if (isPending) return null
-    if (error) return resolveErrorMessage(error)
-    if (validationErrorMessage === undefined) return null
-    return validationErrorMessage
-  })()
-
-  const handleSubmit = () => {
-    if (!errorMessage && !swapQuoteQuery.isPlaceholderData) {
-      const swapQuote = shouldBePresent(swapQuoteQuery.data, 'swap quote')
-      onFinish(swapQuote)
-    }
-  }
+  const tabs: Tab<SwapMode>[] = [
+    {
+      value: 'market',
+      label: t('swap_mode_market'),
+      renderContent: () => <MarketSwapForm onFinish={onFinish} />,
+    },
+    {
+      value: 'limit',
+      label: t('swap_mode_limit'),
+      renderContent: LimitSwapForm,
+    },
+  ]
 
   return (
     <>
@@ -101,42 +40,44 @@ export const SwapForm: FC<OnFinishProp<SwapQuote>> = ({ onFinish }) => {
         title={t('swap')}
         hasBorder
       />
-      <PageContent
-        as="form"
-        gap={40}
-        data-testid="swap-form"
-        {...getFormProps({
-          onSubmit: handleSubmit,
-          isDisabled: !!errorMessage,
-        })}
-        justifyContent="space-between"
-        scrollable
-      >
-        <VStack gap={16}>
-          <VStack gap={8}>
-            <ManageFromCoin />
-            <ReverseSwapWrapper>
-              <ReverseSwap errorMessage={displayErrorMessage} />
-            </ReverseSwapWrapper>
-            <ManageToCoin />
-          </VStack>
-          <VStack gap={10}>
-            <SwapInfo />
-          </VStack>
-        </VStack>
-        <Button
-          disabled={!!errorMessage}
-          type="submit"
-          data-testid="swap-continue"
-        >
-          {t('continue')}
-        </Button>
-      </PageContent>
+      <Tabs
+        tabs={tabs}
+        value={swapMode}
+        onValueChange={setSwapMode}
+        triggersContainer={SwapModeTabsHeader}
+        triggerSlot={({ tab: { label }, isActive }) => (
+          <TriggerItem isActive={isActive}>
+            <Text
+              size={14}
+              as="span"
+              color={isActive ? 'contrast' : 'supporting'}
+            >
+              {label}
+            </Text>
+          </TriggerItem>
+        )}
+      />
     </>
   )
 }
 
-const ReverseSwapWrapper = styled.div`
-  ${vStack({ gap: 8 })}
-  position: relative;
+const SwapModeTabsHeader = ({ children }: ChildrenProp) => (
+  <Header>{children}</Header>
+)
+
+const Header = styled.div`
+  ${hStack({ gap: 24, alignItems: 'center' })};
+  padding: 16px 16px 0;
+`
+
+const TriggerItem = styled.div<IsActiveProp>`
+  width: fit-content;
+  padding-bottom: 6px;
+  cursor: pointer;
+
+  ${({ isActive, theme }) =>
+    isActive &&
+    css`
+      border-bottom: 1.5px solid ${theme.colors.buttonPrimary.toCssValue()};
+    `};
 `


### PR DESCRIPTION
## Summary

Phase 0 of the **Advanced Swap** work (#4099): introduce the swap mode tab row.

The swap screen now renders a `Market | Limit` tab row beneath the header, with each tab holding its own content:

- **Market** — the existing swap form, moved into `MarketSwapForm`. No behavioral change.
- **Limit** — independent placeholder content (`Limit orders — Coming soon`). Limit-order execution is **out of scope** for this ticket per the issue.

Shared swap state (amount, coins) lives in providers above the form, so switching tabs does not lose it.

## Changes

- `SwapForm.tsx` — now a tab container (header + `Market/Limit` tabs, active underline styling matching `VaultTabs`).
- `MarketSwapForm.tsx` — the previous swap form body (from/to, fees, Continue).
- `LimitSwapForm.tsx` — placeholder Limit tab content.
- `en.ts` — `swap_mode_market`, `swap_mode_limit`, `swap_limit_orders`, `coming_soon`.

## Scope / follow-ups

This is the first of 5 phases. Next phases: Advanced Settings sheet, Slippage, Gas Limit, External Recipient.

Open questions for review:
- Keep the simple "Coming soon" placeholder for Limit, or build the static Limit UI from Figma now?
- Should the Limit tab sit behind a feature flag until it ships?

## Validation

- `yarn typecheck` ✅
- `yarn eslint --fix` on changed files ✅
- Extension build (`yarn dev:extension`) ✅

Relates to #4099

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tabbed interface to swap form enabling users to switch between Market and Limit swap modes.
  * Market swap mode now includes validation and quote management functionality.
  * Limit Orders mode previewed with coming-soon status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->