### PR TITLE
feat(swap): Advanced Settings link + Advanced swap sheet (phase 1)

### DIFF
--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -39,6 +39,8 @@ export const en = {
   adjust_search_query: 'Try adjusting your search criteria',
   advanced: 'Advanced',
   advanced_gas_fee: 'Advanced gas fee',
+  advanced_settings: 'Advanced Settings',
+  advanced_swap: 'Advanced swap',
   all_vaults: 'All Vaults',
   amount: 'Amount',
   amount_must_be_non_negative: 'Amount must be non-negative',
@@ -62,6 +64,7 @@ export const en = {
   at_least_one_device: 'At least one device',
   at_least_one_device_subtitle:
     'Any device that can run {{productName}} will work.',
+  auto: 'Auto',
   available: 'Available',
   back: 'Back',
   before_you_start: 'Before you start...',
@@ -908,6 +911,7 @@ export const en = {
   site_has_risk: 'Malicious site detected by <provider></provider>',
   skip: 'Skip',
   slippage: 'Slippage',
+  slippage_tolerance: 'Slippage Tolerance',
   something_went_wrong: 'Something went wrong',
   somethings_wrong: "Something's wrong",
   soon: 'Soon',
@@ -1082,6 +1086,7 @@ export const en = {
   upload_qr_code_image: 'Upload QR Code',
   upload_qr_code_to_join_keysign: 'Upload QR Code to join Keysign',
   upload_qr_code_with_address: 'Upload QR code with address',
+  use_external_recipient: 'Use External Recipient',
   use_referral_code: 'Use referral Code',
   used_referral_error:
     'Used referral code can not be the same as your referral code',

--- a/core/ui/vault/swap/form/MarketSwapForm.tsx
+++ b/core/ui/vault/swap/form/MarketSwapForm.tsx
@@ -18,6 +18,7 @@ import styled from 'styled-components'
 import { useCoreViewState } from '../../../navigation/hooks/useCoreViewState'
 import { useSwapQuoteQuery } from '../queries/useSwapQuoteQuery'
 import { useSwapValidationQuery } from '../queries/useSwapValidationQuery'
+import { AdvancedSwapSettings } from './advanced/AdvancedSwapSettings'
 
 export const MarketSwapForm: FC<OnFinishProp<SwapQuote>> = ({ onFinish }) => {
   const {
@@ -114,13 +115,16 @@ export const MarketSwapForm: FC<OnFinishProp<SwapQuote>> = ({ onFinish }) => {
           <SwapInfo />
         </VStack>
       </VStack>
-      <Button
-        disabled={!!errorMessage}
-        type="submit"
-        data-testid="swap-continue"
-      >
-        {t('continue')}
-      </Button>
+      <VStack gap={20}>
+        <AdvancedSwapSettings />
+        <Button
+          disabled={!!errorMessage}
+          type="submit"
+          data-testid="swap-continue"
+        >
+          {t('continue')}
+        </Button>
+      </VStack>
     </PageContent>
   )
 }

--- a/core/ui/vault/swap/form/advanced/AdvancedSwapSettings.tsx
+++ b/core/ui/vault/swap/form/advanced/AdvancedSwapSettings.tsx
@@ -1,0 +1,33 @@
+import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { useBoolean } from '@lib/ui/hooks/useBoolean'
+import { Text } from '@lib/ui/text'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+
+import { AdvancedSwapSettingsSheet } from './AdvancedSwapSettingsSheet'
+
+export const AdvancedSwapSettings = () => {
+  const { t } = useTranslation()
+  const [isOpen, { set: open, unset: close }] = useBoolean(false)
+
+  return (
+    <>
+      <Trigger onClick={open}>
+        <Text size={14} color="shy" centerHorizontally>
+          {t('advanced_settings')}
+        </Text>
+      </Trigger>
+      {isOpen && <AdvancedSwapSettingsSheet onClose={close} />}
+    </>
+  )
+}
+
+const Trigger = styled(UnstyledButton)`
+  align-self: center;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+
+  &:hover {
+    opacity: 0.8;
+  }
+`

--- a/core/ui/vault/swap/form/advanced/AdvancedSwapSettingsSheet.tsx
+++ b/core/ui/vault/swap/form/advanced/AdvancedSwapSettingsSheet.tsx
@@ -1,0 +1,116 @@
+import { IconButton } from '@lib/ui/buttons/IconButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
+import { CheckIcon } from '@lib/ui/icons/CheckIcon'
+import { ChevronRightIcon } from '@lib/ui/icons/ChevronRightIcon'
+import { CrossIcon } from '@lib/ui/icons/CrossIcon'
+import { IconWrapper } from '@lib/ui/icons/IconWrapper'
+import { HStack, VStack } from '@lib/ui/layout/Stack'
+import { List } from '@lib/ui/list'
+import { ListItem } from '@lib/ui/list/item'
+import { ResponsiveModal } from '@lib/ui/modal/ResponsiveModal'
+import { OnCloseProp } from '@lib/ui/props'
+import { mediaQuery } from '@lib/ui/responsive/mediaQuery'
+import { Text } from '@lib/ui/text'
+import { getColor } from '@lib/ui/theme/getters'
+import { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+
+import { ExternalRecipientIcon } from './icons/ExternalRecipientIcon'
+import { GasLimitIcon } from './icons/GasLimitIcon'
+import { SlippageIcon } from './icons/SlippageIcon'
+
+type SettingRow = {
+  key: string
+  icon: ReactNode
+  title: string
+  value: string
+}
+
+export const AdvancedSwapSettingsSheet = ({ onClose }: OnCloseProp) => {
+  const { t } = useTranslation()
+
+  const rows: SettingRow[] = [
+    {
+      key: 'slippage',
+      icon: <SlippageIcon />,
+      title: t('slippage_tolerance'),
+      value: t('auto'),
+    },
+    {
+      key: 'gasLimit',
+      icon: <GasLimitIcon />,
+      title: t('gas_limit'),
+      value: t('auto'),
+    },
+    {
+      key: 'externalRecipient',
+      icon: <ExternalRecipientIcon />,
+      title: t('use_external_recipient'),
+      value: t('off'),
+    },
+  ]
+
+  return (
+    <ResponsiveModal
+      isOpen
+      onClose={onClose}
+      modalProps={{ withDefaultStructure: false }}
+    >
+      <Wrapper gap={20}>
+        <HStack alignItems="center" justifyContent="space-between" gap={12}>
+          <IconButton kind="secondary" size="lg" onClick={onClose}>
+            <CrossIcon />
+          </IconButton>
+          <Text
+            size={16}
+            weight={500}
+            color="contrast"
+            style={{ flex: 1, textAlign: 'center' }}
+          >
+            {t('advanced_swap')}
+          </Text>
+          <IconButton kind="primary" size="lg" onClick={onClose}>
+            <CheckIcon />
+          </IconButton>
+        </HStack>
+        <List border="solid">
+          {rows.map(({ key, icon, title, value }) => (
+            <ListItem
+              key={key}
+              hoverable={false}
+              icon={
+                <IconWrapper size={20} color="textShyExtra">
+                  {icon}
+                </IconWrapper>
+              }
+              title={title}
+              styles={{ title: { color: 'textShyExtra', fontSize: 14 } }}
+              extra={
+                <HStack alignItems="center" gap={8}>
+                  <Text size={14} color="regular">
+                    {value}
+                  </Text>
+                  <IconWrapper size={16} color="text">
+                    <ChevronRightIcon />
+                  </IconWrapper>
+                </HStack>
+              }
+            />
+          ))}
+        </List>
+      </Wrapper>
+    </ResponsiveModal>
+  )
+}
+
+const Wrapper = styled(VStack)`
+  width: 100%;
+  background: ${getColor('background')};
+  ${borderRadius.m};
+  padding: 20px;
+
+  @media ${mediaQuery.tabletDeviceAndUp} {
+    width: min(420px, 100% - 32px);
+  }
+`

--- a/core/ui/vault/swap/form/advanced/icons/ExternalRecipientIcon.tsx
+++ b/core/ui/vault/swap/form/advanced/icons/ExternalRecipientIcon.tsx
@@ -1,0 +1,28 @@
+import { SvgProps } from '@lib/ui/props'
+import { FC } from 'react'
+
+export const ExternalRecipientIcon: FC<SvgProps> = props => (
+  <svg
+    width="1em"
+    height="1em"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      d="M5.83203 5.83203H3.16536C2.42898 5.83203 1.83203 6.42898 1.83203 7.16536V12.832C1.83203 13.5684 2.42898 14.1654 3.16536 14.1654H8.83203C9.56843 14.1654 10.1654 13.5684 10.1654 12.832V10.1654"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M5.83203 5.83203V6.66536V8.66536V8.83203C5.83203 9.56843 6.42898 10.1654 7.16536 10.1654H7.33203H9.33203H10.1654M5.83203 3.33203V3.16536C5.83203 2.42898 6.42898 1.83203 7.16536 1.83203H7.33203M12.6654 1.83203H12.832C13.5684 1.83203 14.1654 2.42898 14.1654 3.16536V3.33203M9.33203 1.83203H10.6654M14.1654 5.33203V6.66536M14.1654 8.66536V8.83203C14.1654 9.56843 13.5684 10.1654 12.832 10.1654H12.6654"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+)

--- a/core/ui/vault/swap/form/advanced/icons/GasLimitIcon.tsx
+++ b/core/ui/vault/swap/form/advanced/icons/GasLimitIcon.tsx
@@ -1,0 +1,21 @@
+import { SvgProps } from '@lib/ui/props'
+import { FC } from 'react'
+
+export const GasLimitIcon: FC<SvgProps> = props => (
+  <svg
+    width="1em"
+    height="1em"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      d="M9.4987 13.5H10.1654M9.4987 13.5V6.5M9.4987 13.5H2.4987M9.4987 6.5V3.83333C9.4987 3.09695 8.90176 2.5 8.16536 2.5H3.83203C3.09565 2.5 2.4987 3.09695 2.4987 3.83333V13.5M9.4987 6.5H10.4987C11.2351 6.5 11.832 7.09693 11.832 7.83333V10.3333C11.832 10.9777 12.3544 11.5 12.9987 11.5C13.643 11.5 14.1654 10.9777 14.1654 10.3333V5.92715C14.1654 5.54917 14.005 5.18895 13.724 4.93609L12.4987 3.83333M2.4987 13.5H1.83203M7.4987 6.5H4.4987"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+)

--- a/core/ui/vault/swap/form/advanced/icons/SlippageIcon.tsx
+++ b/core/ui/vault/swap/form/advanced/icons/SlippageIcon.tsx
@@ -1,0 +1,20 @@
+import { SvgProps } from '@lib/ui/props'
+import { FC } from 'react'
+
+export const SlippageIcon: FC<SvgProps> = props => (
+  <svg
+    width="1em"
+    height="1em"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      d="M12.2042 6.903H9.25249C8.83357 6.903 8.53834 6.48899 8.6723 6.08939L10.0626 1.94236C10.274 1.31182 9.48018 0.838085 9.03212 1.32738L2.89771 8.02634C2.53601 8.42136 2.81431 9.06071 3.34795 9.06071H6.29961C6.71393 9.06071 7.00861 9.46618 6.88327 9.86371L5.55719 14.0684C5.35812 14.6996 6.15286 15.1597 6.59458 14.6689L12.6579 7.93345C13.0146 7.53721 12.7353 6.903 12.2042 6.903Z"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinejoin="round"
+    />
+  </svg>
+)


### PR DESCRIPTION
## Summary

Phase 1 of the **Advanced Swap** work (#4099). Adds the **Advanced Settings** entry and the **Advanced swap** sheet.

- A centered **Advanced Settings** link sits above the Swap button (spacing matches the design), opening the sheet.
- The sheet reuses the shared `ResponsiveModal` animation (slide-up bottom sheet on mobile / centered modal on desktop) — no custom animation.
- Header: circular **X** (close, secondary) on the left, centered title, circular **✓** (confirm, primary) on the right. Confirm currently closes; its real behavior is wired in a later phase.
- Three rows — **Slippage Tolerance** (`Auto`), **Gas Limit** (`Auto`), **Use External Recipient** (`Off`) — inside a bordered, rounded `List`. Row sub-sheets are added in phases 2–4.

## Design fidelity (from Figma node `218-72211`)

- Icons are the **exact Figma SVGs** (`IconThunder` / `IconGas` / copy), converted to `currentColor` stroke, all rendered at equal size. Hidden Figma leftover layers (`IconVault`, `visible=false`) were ignored.
- Colors taken from Figma and mapped to theme tokens (no hardcoded hex):
  - left icon + title `#C9D6E8` → `textShyExtra`
  - right value + chevron `#F0F4FC` → `text`/`regular`
  - header title `contrast`

## Files

- `form/advanced/AdvancedSwapSettings.tsx` — trigger link + open/close state
- `form/advanced/AdvancedSwapSettingsSheet.tsx` — the sheet
- `form/advanced/icons/{SlippageIcon,GasLimitIcon,ExternalRecipientIcon}.tsx` — Figma icons
- `form/MarketSwapForm.tsx` — link placement above the button
- `i18n/locales/en.ts` — new keys

## Notes

- Base is the phase 0 branch (`feat/swap-market-limit-tabs`) so the diff stays scoped to phase 1; will retarget to `main` after phase 0 merges.
- `yarn typecheck` ✅, `yarn eslint --fix` ✅, extension build ✅

Relates to #4099

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added advanced swap settings panel accessible from the swap form, enabling users to configure slippage tolerance, gas limits, and external recipient settings. Settings are presented in a modal interface with clear labeling and default values for convenient access and customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->