### PR TITLE
fix(swap): improve fee rows visual hierarchy

### DIFF
--- a/core/ui/vault/swap/form/info/SwapFees.tsx
+++ b/core/ui/vault/swap/form/info/SwapFees.tsx
@@ -47,7 +47,7 @@ export const SwapFees: FC<SwapFeesProps> = ({ RowComponent, swapQuote }) => {
           error={() => <Text color="danger">{t('failed_to_load')}</Text>}
           success={value => (
             <HStack alignItems="center" gap={4}>
-              <Text color="shy">
+              <Text color="supporting">
                 <SwapFeeFiatValue value={Object.values(value)} />
               </Text>
               <UnstyledButton onClick={toggle}>
@@ -91,19 +91,23 @@ export const SwapFees: FC<SwapFeesProps> = ({ RowComponent, swapQuote }) => {
                     <>
                       <RowComponent>
                         <span>{t('network_fee')}</span>
-                        <Text color="shy">
-                          {formatAmount(
-                            fromChainAmount(network.amount, decimals),
-                            { ticker }
-                          )}{' '}
-                          (~
-                          <SwapFeeFiatValue value={[network]} />)
+                        <Text>
+                          <Text as="span" color="regular" weight="500">
+                            {formatAmount(
+                              fromChainAmount(network.amount, decimals),
+                              { ticker }
+                            )}
+                          </Text>{' '}
+                          <Text as="span" color="shy">
+                            (~
+                            <SwapFeeFiatValue value={[network]} />)
+                          </Text>
                         </Text>
                       </RowComponent>
                       {swap && (
                         <RowComponent>
                           <Text>{t('swap_fee')}</Text>
-                          <Text color="shy">
+                          <Text color="supporting">
                             <SwapFeeFiatValue value={[swap]} />
                           </Text>
                         </RowComponent>

--- a/core/ui/vault/swap/form/info/SwapProvider.tsx
+++ b/core/ui/vault/swap/form/info/SwapProvider.tsx
@@ -19,7 +19,7 @@ export const SwapProvider = () => {
         value={query}
         pending={() => <Skeleton width="88px" height="12px" />}
         success={quote => (
-          <Text color="shy">{getSwapQuoteProviderName(quote)}</Text>
+          <Text color="supporting">{getSwapQuoteProviderName(quote)}</Text>
         )}
       />
     </StrictInfoRow>


### PR DESCRIPTION
## Summary
Adds visual hierarchy to the swap form fee breakdown rows, which previously all rendered their values in the same dim `shy` color.

- **Network Fee** — token amount is now bold + white (`regular`, `weight=500`); the fiat `(~$x)` in parentheses stays dim (`shy`).
- **Swap Fee** — fiat value uses the brighter `supporting` color.
- **Provider** — provider name uses `supporting`.
- **Total Fees** — fiat value uses `supporting`.

No fee calculation or query logic was touched — color/weight only.

### Out of scope
A per-fee percentage next to **Swap Fee** was requested as optional. The current quote data model exposes only `total_bps` (already used for Price Impact), not a per-fee percentage, so it was not added.

## Test plan
- [x] `yarn check` passes (typecheck + lint + i18n + knip)
- [ ] Visually confirm in swap flow: Network Fee amount is bold/white, other values are brighter

Closes #4120

🤖 Generated with [Claude Code](https://claude.com/claude-code)