### PR TITLE
Remove localhost from the shipped extension manifest

### DIFF
--- a/clients/extension/public/manifest.json
+++ b/clients/extension/public/manifest.json
@@ -41,9 +41,9 @@
     }
   ],
   "content_security_policy": {
-    "extension_pages": "script-src 'self' 'wasm-unsafe-eval' http://localhost;object-src 'self'"
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval';object-src 'self'"
   },
-  "host_permissions": ["https://*/*", "http://localhost/*"],
+  "host_permissions": ["https://*/*"],
   "icons": {
     "16": "icon16.png",
     "32": "icon32.png",


### PR DESCRIPTION
Closes #4123

## What

Removes `http://localhost` from the extension manifest:
- `content_security_policy.extension_pages` `script-src` → now `'self' 'wasm-unsafe-eval'`
- `host_permissions` → now `["https://*/*"]`

## Why

Both entries were dev leftovers shipped in the release build. They let any local process serve scripts into the extension's privileged context — extra attack surface for a wallet holding key shares, with no feature relying on it.

Dev hot-reload uses the `ws://localhost:18732` WebSocket (gated behind `VITE_DEV_RELOAD`), which is governed by `connect-src`, not `script-src`, so it keeps working.

## Verify

- `yarn dev:extension` still hot-reloads on file changes
- Built `dist/manifest.json` no longer contains `http://localhost`

🤖 Generated with [Claude Code](https://claude.com/claude-code)