### PR TITLE
fix(send): hide memo field for Sui

### DIFF
--- a/core/ui/vault/send/memo/ManageMemo.tsx
+++ b/core/ui/vault/send/memo/ManageMemo.tsx
@@ -14,7 +14,7 @@ import styled from 'styled-components'
 
 import { TextInputWithPasteAction } from '../../../components/TextInputWithPasteAction'
 
-const chainsWithoutMemoSupport: Chain[] = [Chain.Cardano]
+const chainsWithoutMemoSupport: Chain[] = [Chain.Cardano, Chain.Sui]
 
 export const ManageMemo = () => {
   const [value, setValue] = useSendMemo()


### PR DESCRIPTION
## Problem
Sui has no native memo concept — a Sui transaction is a Programmable Transaction Block (inputs + commands + gas + sender + expiration), with no memo field. The in-wallet Send flow showed an "Add memo" input for Sui, but the value was silently dropped at signing time. Users could type a memo (e.g. an exchange memo carried over from a Cosmos/XRP habit) and wrongly assume it was attached.

## Change
Add `Chain.Sui` to the existing `chainsWithoutMemoSupport` gate in `ManageMemo.tsx`, so the memo field is not rendered for Sui — the same mechanism already used to hide it for Cardano.

## Companion change
The SDK side fails loudly if a memo ever reaches the Sui signing-input resolver (separate PR in `vultisig-sdk`).

## Out of scope
Building a custom PTB that embeds memo bytes (app-level pure-bytes input / Move call). Sui exchanges use unique deposit addresses, not memos, so there is no real use case today.

Refs vultisig/vultisig-windows#4124