### PR TITLE
fix(swap): collapse double debounce on from-amount → quote path

### DIFF
--- a/core/ui/vault/swap/form/amount/ManageFromAmount.tsx
+++ b/core/ui/vault/swap/form/amount/ManageFromAmount.tsx
@@ -1,6 +1,5 @@
 import { AmountSuggestion } from '@core/ui/vault/send/amount/AmountSuggestion'
 import { useCurrentVaultCoin } from '@core/ui/vault/state/currentVaultCoins'
-import { useDebounce } from '@lib/ui/hooks/useDebounce'
 import { TextInput } from '@lib/ui/inputs/TextInput'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
@@ -17,8 +16,6 @@ import { useSwapFromCoin } from '../../state/fromCoin'
 import { SwapCoinBalanceDependant } from '../balance/SwapCoinBalanceDependant'
 import { AmountContainer } from './AmountContainer'
 import { SwapFiatAmount } from './SwapFiatAmount'
-
-const fromAmountInputDebounceMs = 300
 
 const parseAmountInputValue = (value: string, decimals: number) => {
   if (value === '') {
@@ -45,11 +42,6 @@ export const ManageFromAmount = () => {
     ? fullDecimalString.replace(/\.?0+$/, '')
     : fullDecimalString
   const [inputValue, setInputValue] = useState<string>(trimmedDecimalString)
-  const inputAmount = parseAmountInputValue(inputValue, decimals)
-  const debouncedInputAmount = useDebounce(
-    inputAmount,
-    fromAmountInputDebounceMs
-  )
   const isFeeCoinSelected = isFeeCoin(fromCoinKey)
 
   useEffect(() => {
@@ -65,21 +57,7 @@ export const ManageFromAmount = () => {
     }
   }, [value, trimmedDecimalString, inputValue, decimals])
 
-  useEffect(() => {
-    if (
-      debouncedInputAmount === undefined ||
-      debouncedInputAmount !== inputAmount
-    ) {
-      return
-    }
-
-    if (debouncedInputAmount !== value) {
-      previousValueRef.current = debouncedInputAmount
-      setValue?.(debouncedInputAmount)
-    }
-  }, [debouncedInputAmount, inputAmount, setValue, value])
-
-  const handleInputValueChange = (value: string, shouldCommitNow = false) => {
+  const handleInputValueChange = (value: string) => {
     value = value.replace(/-/g, '')
 
     if (value.startsWith('.')) {
@@ -88,10 +66,8 @@ export const ManageFromAmount = () => {
 
     if (value === '') {
       setInputValue('')
-      if (shouldCommitNow) {
-        previousValueRef.current = null
-        setValue?.(null)
-      }
+      previousValueRef.current = null
+      setValue?.(null)
       return
     }
 
@@ -105,10 +81,8 @@ export const ManageFromAmount = () => {
     }
 
     setInputValue(value)
-    if (shouldCommitNow) {
-      previousValueRef.current = chainAmount
-      setValue?.(chainAmount)
-    }
+    previousValueRef.current = chainAmount
+    setValue?.(chainAmount)
   }
 
   const suggestions = isFeeCoinSelected
@@ -127,7 +101,7 @@ export const ManageFromAmount = () => {
           onValueChange={handleInputValueChange}
           onPaste={event => {
             event.preventDefault()
-            handleInputValueChange(event.clipboardData.getData('text'), true)
+            handleInputValueChange(event.clipboardData.getData('text'))
           }}
           data-testid="swap-from-amount-input"
         />
@@ -164,7 +138,7 @@ export const ManageFromAmount = () => {
                   const trimmed = cropped.includes('.')
                     ? cropped.replace(/\.?0+$/, '')
                     : cropped
-                  handleInputValueChange(trimmed, true)
+                  handleInputValueChange(trimmed)
                 }}
                 key={suggestion}
                 value={suggestion}


### PR DESCRIPTION
Closes #4079

## Problem

After #4044 a typed from-amount was debounced **twice** before a firm quote fired:

1. `ManageFromAmount` debounced the input → committed `value` (300ms)
2. `useSwapQuoteQuery` debounced `value` → query (300ms, `quoteAmountDebounceMs`)

So a typed amount triggered the firm-quote request ~600ms after the last keystroke (vs ~300ms before). The indicative estimate also reads the committed `value`, so it lagged 300ms too.

## Fix

Keep a single debounce point. `ManageFromAmount` now commits the typed input to the shared `value` immediately on every keystroke; the only debounce left is the one inside `useSwapQuoteQuery`. Paste and quick-suggestions already committed immediately, so their behaviour is unchanged.

Result:
- **Firm quote** fires ~300ms after the last keystroke (was ~600ms)
- **Indicative estimate** updates instantly while the firm quote loads — matching the original "instant display" intent of #4044 (was lagging 300ms)

## Changes

- `ManageFromAmount.tsx`: drop `fromAmountInputDebounceMs`, the `useDebounce` usage, and the debounced-commit effect; `handleInputValueChange` commits immediately. The local `inputValue` string state and external-sync effect are retained so in-progress strings (e.g. `1.`) still display correctly.
- `useSwapQuoteQuery` and its pending helpers (`shouldDebouncedSwapQuoteAmountShowPending` / `getDebouncedSwapQuoteAmount`) are untouched — they remain the single debounce/pending gate.

## Validation

- `yarn typecheck` — clean
- `yarn eslint` on the changed file — clean
- `useSwapQuoteQuery.test.ts` — 6/6 pass (logic unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)