### PR TITLE
fix(defi): mask 'No positions found' subtitle when balances hidden

### DIFF
--- a/core/ui/defi/page/components/DefiChainItem.tsx
+++ b/core/ui/defi/page/components/DefiChainItem.tsx
@@ -61,12 +61,12 @@ export const DefiChainItem = ({ balance }: DefiChainItemProps) => {
               <Text color="shy" weight="500" size={12} centerVertically>
                 {isLoading ? (
                   <Spinner size={12} />
-                ) : positionsWithBalanceCount > 0 ? (
-                  <BalanceVisibilityAware>
-                    {positionsWithBalanceCount} {t('positions')}
-                  </BalanceVisibilityAware>
                 ) : (
-                  t('no_positions_found')
+                  <BalanceVisibilityAware>
+                    {positionsWithBalanceCount > 0
+                      ? `${positionsWithBalanceCount} ${t('positions')}`
+                      : t('no_positions_found')}
+                  </BalanceVisibilityAware>
                 )}
               </Text>
             </VStack>


### PR DESCRIPTION
## Problem

On the DeFi portfolio list, toggling **Hide DeFi balance** masked every value to `****` — except the `No positions found` subtitle, which stayed readable. That left no-position chains (THORChain, MayaChain) showing a masked `****` fiat value next to readable `No positions found` text, which is inconsistent and leaks that the row is a "no balance" row.

Fixes #4139.

## Fix

Wrap the entire row subtitle in `BalanceVisibilityAware` so both branches mask when hidden:
- `5 Positions` → `****` (already worked)
- `No positions found` → `****` (now also masked)

Single-file change in `core/ui/defi/page/components/DefiChainItem.tsx`.

## Before → After (balances hidden)

| Row | Before | After |
|-----|--------|-------|
| Circle | `****` / `****` | `****` / `****` |
| THORChain | `****` / **No positions found** | `****` / `****` |
| MayaChain | `****` / **No positions found** | `****` / `****` |

### Screenshot (hidden state, before this fix — "No positions found" still readable)

![before](https://raw.githubusercontent.com/vultisig/vultisig-windows/issue-assets-4139/issues/4139/masked.jpg)

## Verification

- Built the extension (`yarn build:extension`, exit 0) and loaded `clients/extension/dist` unpacked.
- Toggled Hide DeFi balance on the portfolio list → all row subtitles, including `No positions found`, now mask to `****`.

## Notes

- No changeset: `vultisig-windows` does not use changesets (that discipline is SDK-repo only).
- Pre-existing unrelated working-tree changes (`main.go`, `wailsjs/runtime/*`) were intentionally left out of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements to defi chain item component structure with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->