### PR TITLE
feat(vult): "Upgrade held VULT → staked VULT" promo banner (#4143)

### DIFF
--- a/core/ui/defi/protocols/vultStaking/VultStakingBannerLogo.tsx
+++ b/core/ui/defi/protocols/vultStaking/VultStakingBannerLogo.tsx
@@ -10,14 +10,22 @@ const ringViewHeight = 206
 const ringCenterX = 101.283
 const ringCenterY = 102.43
 
-const ringWidth = 220
+const defaultRingWidth = 220
+const badgeFontSize = 90
+
+type VultStakingBannerLogoProps = {
+  /** Ring artwork width in px; the badge scales with it. Defaults to 220. */
+  width?: number
+}
 
 /**
  * VULT staking banner artwork: the brand badge centred inside the glowing blue
  * concentric rings, anchored to the right edge of the banner (rings bleed
  * off-edge, matching the design).
  */
-export const VultStakingBannerLogo = () => {
+export const VultStakingBannerLogo = ({
+  width = defaultRingWidth,
+}: VultStakingBannerLogoProps = {}) => {
   const id = useId()
   const outerGlow = `${id}-outer-glow`
   const innerGlow = `${id}-inner-glow`
@@ -25,7 +33,7 @@ export const VultStakingBannerLogo = () => {
   const innerStroke = `${id}-inner-stroke`
 
   return (
-    <Graphic>
+    <Graphic $width={width}>
       <Rings
         viewBox={`0 0 ${ringViewWidth} ${ringViewHeight}`}
         fill="none"
@@ -163,18 +171,18 @@ export const VultStakingBannerLogo = () => {
           </linearGradient>
         </defs>
       </Rings>
-      <Badge style={{ fontSize: 90 }} />
+      <Badge style={{ fontSize: (badgeFontSize * width) / defaultRingWidth }} />
     </Graphic>
   )
 }
 
-const Graphic = styled.div`
+const Graphic = styled.div<{ $width: number }>`
   position: absolute;
   right: -36px;
   top: 70%;
   transform: translateY(-50%);
-  width: ${ringWidth}px;
-  height: ${(ringWidth * ringViewHeight) / ringViewWidth}px;
+  width: ${({ $width }) => $width}px;
+  height: ${({ $width }) => ($width * ringViewHeight) / ringViewWidth}px;
   pointer-events: none;
 `
 

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -1248,6 +1248,10 @@ export const en = {
       'Unstaking starts a {{duration}} cooldown. Your VULT can be claimed once it ends.',
     unstake_cooldown_term_generic:
       'Your funds will be available to claim once the redemption period ends.',
+    banner_title: 'Upgrade your $VULT',
+    banner_subtitle:
+      'Stake your $VULT to unlock exclusive benefits and lower trading fees.',
+    banner_cta: 'Stake now',
   },
   waitingOnDevices: 'Waiting on devices...',
   waiting_for_devices_to_join: 'Waiting for other devices to join',

--- a/core/ui/storage/dismissedBanners.tsx
+++ b/core/ui/storage/dismissedBanners.tsx
@@ -10,6 +10,7 @@ export type BannerId =
   | 'migrate'
   | 'agentNavigationCoachmark'
   | 'buyVultPromo'
+  | 'stakeVultPromo'
 
 type GetDismissedBannersFunction = () => Promise<BannerId[]>
 type SetDismissedBannersFunction = (banners: BannerId[]) => Promise<void>

--- a/core/ui/vault/page/banners/StakeVultPromoBanner/StakeVultPromoBanner.stories.tsx
+++ b/core/ui/vault/page/banners/StakeVultPromoBanner/StakeVultPromoBanner.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { ReactNode } from 'react'
+
+import { StakeVultPromoBannerContent } from './StakeVultPromoBannerContent'
+
+const Frame = ({ width, children }: { width: number; children: ReactNode }) => (
+  <div style={{ width, padding: 20 }}>{children}</div>
+)
+
+const meta: Meta<typeof StakeVultPromoBannerContent> = {
+  title: 'Banners/StakeVultPromoBanner',
+  component: StakeVultPromoBannerContent,
+  parameters: { layout: 'centered' },
+  args: {
+    onStake: () => {},
+    onDismiss: () => {},
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof StakeVultPromoBannerContent>
+
+export const Mobile: Story = {
+  render: args => (
+    <Frame width={360}>
+      <StakeVultPromoBannerContent {...args} />
+    </Frame>
+  ),
+}
+
+export const Tablet: Story = {
+  render: args => (
+    <Frame width={600}>
+      <StakeVultPromoBannerContent {...args} />
+    </Frame>
+  ),
+}

--- a/core/ui/vault/page/banners/StakeVultPromoBanner/StakeVultPromoBanner.styles.tsx
+++ b/core/ui/vault/page/banners/StakeVultPromoBanner/StakeVultPromoBanner.styles.tsx
@@ -1,0 +1,33 @@
+import styled from 'styled-components'
+
+import {
+  HomePromoBannerCloseButton,
+  HomePromoBannerContent,
+  HomePromoBannerTextStack,
+} from '../shared/HomePromoBanner.styles'
+
+/**
+ * Blue-gradient promo card matching the VULT staking balance banner (concentric
+ * glow rings bleed off the right edge via the self-positioned logo).
+ */
+export const BannerRoot = styled.div`
+  position: relative;
+  width: 100%;
+  min-height: 134px;
+  box-sizing: border-box;
+  padding: 24px;
+  border-radius: 16px;
+  border: 1px solid rgba(95, 191, 255, 0.17);
+  background: linear-gradient(
+    180deg,
+    rgba(95, 191, 255, 0.09) 0%,
+    rgba(95, 191, 255, 0) 100%
+  );
+  overflow: hidden;
+`
+
+export const CloseButton = HomePromoBannerCloseButton
+
+export const Content = HomePromoBannerContent
+
+export const TextStack = HomePromoBannerTextStack

--- a/core/ui/vault/page/banners/StakeVultPromoBanner/StakeVultPromoBanner.tsx
+++ b/core/ui/vault/page/banners/StakeVultPromoBanner/StakeVultPromoBanner.tsx
@@ -1,0 +1,23 @@
+import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
+
+import { StakeVultPromoBannerContent } from './StakeVultPromoBannerContent'
+
+type StakeVultPromoBannerProps = {
+  onDismiss: () => void
+}
+
+/** Nudges holders of unstaked VULT to stake it and unlock a higher discount tier. */
+export const StakeVultPromoBanner = ({
+  onDismiss,
+}: StakeVultPromoBannerProps) => {
+  const navigate = useCoreNavigate()
+
+  return (
+    <StakeVultPromoBannerContent
+      onStake={() =>
+        navigate({ id: 'defi', state: { protocol: 'vultStaking' } })
+      }
+      onDismiss={onDismiss}
+    />
+  )
+}

--- a/core/ui/vault/page/banners/StakeVultPromoBanner/StakeVultPromoBannerContent.tsx
+++ b/core/ui/vault/page/banners/StakeVultPromoBanner/StakeVultPromoBannerContent.tsx
@@ -1,0 +1,50 @@
+import { VultStakingBannerLogo } from '@core/ui/defi/protocols/vultStaking/VultStakingBannerLogo'
+import { CrossIcon } from '@lib/ui/icons/CrossIcon'
+import { Text } from '@lib/ui/text'
+import { useTranslation } from 'react-i18next'
+
+import { BannerPromoCtaButton } from '../shared/BannerPromoCtaButton.styles'
+import {
+  BannerRoot,
+  CloseButton,
+  Content,
+  TextStack,
+} from './StakeVultPromoBanner.styles'
+
+type StakeVultPromoBannerContentProps = {
+  onStake: () => void
+  onDismiss: () => void
+}
+
+/** Presentational stake-VULT nudge — visuals only, all behavior via props. */
+export const StakeVultPromoBannerContent = ({
+  onStake,
+  onDismiss,
+}: StakeVultPromoBannerContentProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <BannerRoot data-testid="stake-vult-promo-banner">
+      <CloseButton size="lg" onClick={onDismiss} aria-label={t('close')}>
+        <CrossIcon style={{ fontSize: 16 }} />
+      </CloseButton>
+
+      <Content>
+        <TextStack>
+          <Text variant="caption" color="shy">
+            {t('vultStaking.banner_title')}
+          </Text>
+          <Text size={14} weight={500} height={20 / 14} color="regular">
+            {t('vultStaking.banner_subtitle')}
+          </Text>
+        </TextStack>
+
+        <BannerPromoCtaButton onClick={onStake}>
+          {t('vultStaking.banner_cta')}
+        </BannerPromoCtaButton>
+      </Content>
+
+      <VultStakingBannerLogo width={158} />
+    </BannerRoot>
+  )
+}

--- a/core/ui/vault/page/banners/StakeVultPromoBanner/StakeVultPromoBannerSlot.tsx
+++ b/core/ui/vault/page/banners/StakeVultPromoBanner/StakeVultPromoBannerSlot.tsx
@@ -1,0 +1,26 @@
+import {
+  useDismissBanner,
+  useDismissedBanners,
+} from '@core/ui/storage/dismissedBanners'
+
+import { StakeVultPromoBanner } from './StakeVultPromoBanner'
+import { useStakeVultBannerEligibility } from './useStakeVultBannerEligibility'
+
+/**
+ * Standalone, self-gated placement of the stake-VULT nudge (e.g. the Discount
+ * Tiers screen). Shares the carousel's dismissal state, so dismissing it in one
+ * place hides it everywhere.
+ */
+export const StakeVultPromoBannerSlot = () => {
+  const eligible = useStakeVultBannerEligibility()
+  const { hasLoaded, isBannerDismissed } = useDismissedBanners()
+  const dismissBanner = useDismissBanner()
+
+  if (!hasLoaded || !eligible || isBannerDismissed('stakeVultPromo')) {
+    return null
+  }
+
+  return (
+    <StakeVultPromoBanner onDismiss={() => dismissBanner('stakeVultPromo')} />
+  )
+}

--- a/core/ui/vault/page/banners/StakeVultPromoBanner/useStakeVultBannerEligibility.ts
+++ b/core/ui/vault/page/banners/StakeVultPromoBanner/useStakeVultBannerEligibility.ts
@@ -1,0 +1,41 @@
+import { useStakedVultBalanceQuery } from '@core/ui/defi/protocols/vultStaking/queries/useStakedVultBalanceQuery'
+import { useVultBalanceQuery } from '@core/ui/defi/protocols/vultStaking/queries/useVultBalanceQuery'
+import {
+  getVultDiscountTier,
+  VultDiscountTier,
+} from '@vultisig/core-chain/swap/affiliate'
+import { vultDiscountTiers } from '@vultisig/core-chain/swap/affiliate/config'
+
+const tierRank = (tier: VultDiscountTier | null): number =>
+  tier === null ? -1 : vultDiscountTiers.indexOf(tier)
+
+/**
+ * Whether to nudge the vault to stake its held VULT: it holds unstaked VULT that
+ * would raise its discount tier above what its already-staked balance reaches.
+ * Returns false until both balances have loaded so the banner never flashes.
+ * The Thorguard-NFT modifier is held constant (it shifts both tiers equally), so
+ * the comparison isolates the gain from staking the held VULT.
+ */
+export const useStakeVultBannerEligibility = (): boolean => {
+  const { data: unstakedBalance } = useVultBalanceQuery()
+  const { data: stakedBalance } = useStakedVultBalanceQuery()
+
+  if (unstakedBalance === undefined || stakedBalance === undefined) {
+    return false
+  }
+
+  if (unstakedBalance <= 0n) {
+    return false
+  }
+
+  const currentTier = getVultDiscountTier({
+    vultBalance: stakedBalance,
+    thorguardNftBalance: 0n,
+  })
+  const potentialTier = getVultDiscountTier({
+    vultBalance: stakedBalance + unstakedBalance,
+    thorguardNftBalance: 0n,
+  })
+
+  return tierRank(potentialTier) > tierRank(currentTier)
+}

--- a/core/ui/vault/page/components/VaultOverview.tsx
+++ b/core/ui/vault/page/components/VaultOverview.tsx
@@ -15,6 +15,8 @@ import { VaultTotalBalance } from '../balance/VaultTotalBalance'
 import { BannerCarousel } from '../banners/BannerCarousel/BannerCarousel'
 import { BuyVultPromoBanner } from '../banners/BuyVultPromoBanner/BuyVultPromoBanner'
 import { FollowOnXBanner } from '../banners/FollowOnXBanner/FollowOnXBanner'
+import { StakeVultPromoBanner } from '../banners/StakeVultPromoBanner/StakeVultPromoBanner'
+import { useStakeVultBannerEligibility } from '../banners/StakeVultPromoBanner/useStakeVultBannerEligibility'
 import { MigrateVaultPrompt } from '../keygen/migrate/MigrateVaultPrompt'
 import { VaultOverviewPrimaryActions } from './VaultOverviewPrimaryActions'
 import { VaultTabs } from './VaultTabs/VaultTabs'
@@ -37,6 +39,7 @@ type VaultOverviewProps = {
 
 export const VaultOverview = ({ scrollContainerRef }: VaultOverviewProps) => {
   const { libType } = useCurrentVault()
+  const showStakeVultBanner = useStakeVultBannerEligibility()
 
   const banners = [
     ...(libType !== 'DKLS'
@@ -45,6 +48,16 @@ export const VaultOverview = ({ scrollContainerRef }: VaultOverviewProps) => {
             id: 'migrate' as const,
             component: (props: { onDismiss: () => void }) => (
               <MigrateVaultPrompt onDismiss={props.onDismiss} />
+            ),
+          },
+        ]
+      : []),
+    ...(currentProductBrand === 'vultisig' && showStakeVultBanner
+      ? [
+          {
+            id: 'stakeVultPromo' as const,
+            component: (props: { onDismiss: () => void }) => (
+              <StakeVultPromoBanner onDismiss={props.onDismiss} />
             ),
           },
         ]

--- a/core/ui/vult/discount/page.tsx
+++ b/core/ui/vult/discount/page.tsx
@@ -15,6 +15,7 @@ import { PageHeaderBackButton } from '../../flow/PageHeaderBackButton'
 import { currentProductBrand } from '../../product/brand'
 import { useResponsiveness } from '../../providers/ResponsivenessProvider'
 import { useCore } from '../../state/core'
+import { StakeVultPromoBannerSlot } from '../../vault/page/banners/StakeVultPromoBanner/StakeVultPromoBannerSlot'
 import { useVultDiscountTierQuery } from './queries/tier'
 import { VultDiscountTier } from './tier'
 
@@ -47,6 +48,7 @@ const VultDiscountPageContent = () => {
       />
       <FitPageContent contentMaxWidth={isTabletOrLarger ? 600 : 360}>
         <VStack gap={24}>
+          <StakeVultPromoBannerSlot />
           <img src="/core/images/vult-banner.png" alt="Vult Banner" />
           <VStack gap={12}>
             <Text size={14} weight={400}>


### PR DESCRIPTION
## Summary

Closes #4143. Adds the **"Upgrade your \$VULT"** promo banner that nudges vaults holding **unstaked VULT** to stake it and unlock a higher discount tier — the UX bridge for the staked-tier migration (#4142).

> Stacked on **#4141** (`feat/4141-vult-staking`): it reuses that PR's staking page, navigation entry, and banner artwork. **Base is `feat/4141-vult-staking`** — retarget to `main` once #4141 merges.

##

<img width="1162" height="402" alt="telegram-cloud-photo-size-4-5879754037626867443-y" src="https://github.com/user-attachments/assets/1cf5c894-01ae-43a1-a980-57ad9197c740" />

## Trigger logic (per issue)
Shown only when the vault **holds unstaked VULT that would raise its tier**:
- `VULT (ERC-20) balance > 0`, **and**
- the tier reachable from `staked + unstaked` is higher than the tier from the already-staked balance alone.

Hidden when fully staked or holding no VULT. The Thorguard-NFT modifier is held constant so the comparison isolates the gain from staking. Returns `false` until both balances load (no flash).

## Placement
- Home banner carousel (`VaultOverview`), reusing the existing `BannerCarousel`.
- Top of the **\$VULT Discount Tiers** screen (`VultDiscountPage`).
- Both share one dismissal entry (`stakeVultPromo`) — dismissing in one place hides it everywhere; dismissal persists (consistent with the other promo banners).

## CTA
Opens the VULT staking flow (`navigate({ id: 'defi', state: { protocol: 'vultStaking' } })`).

## Reuse
- Reuses `VultStakingBannerLogo` from #4141; added an **optional `width` prop** (default `220`, unchanged for the staking page) so the promo renders the rings/badge slightly smaller.
- Split into a presentational `StakeVultPromoBannerContent` (+ Storybook story) and a thin connected `StakeVultPromoBanner`.

## Checklist status (#4143)
- [x] Banner shows only when holding unstaked VULT below the achievable staked tier
- [x] CTA routes into the staking / Deposit VULT flow
- [x] Placed on Home carousel + Discount Tiers screen
- [x] Dismiss / re-show behavior defined (shared persistent dismissal)
- [x] Copy finalized (matches the approved design)
- [ ] **Pre-fill held amount** — deferred: the staking entry (`VultStakingViewState`) has no initial-amount slot and the approved design shows no prefill affordance. Easy follow-up if product wants it.

## ⚠️ Before merge
`yarn translate` was **not** run here (`GOOGLE_TRANSLATE_PROJECT_ID` unset in this env), so only `en.ts` has the new `vultStaking.banner_*` keys. Run `yarn translate` in an environment with credentials to populate the other locales, or CI's i18n check will fail.

## Testing
- Verified visually in Storybook (`core/ui`, `Banners/StakeVultPromoBanner` — Mobile + Tablet).
- `yarn eslint` clean on changed files; `tsgo` clean except the two pre-existing `@vultisig/core-mpc/keysign/vultStaking/build` resolution errors from #4141 (resolved once the SDK build from vultisig/vultisig-sdk#767 is synced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)