### PR TITLE
fix(extension): fit seedphrase import intro on one screen (#4150)

### DIFF
--- a/core/ui/vault/import/seedphrase/intro/ImportSeedphraseIntro.tsx
+++ b/core/ui/vault/import/seedphrase/intro/ImportSeedphraseIntro.tsx
@@ -26,8 +26,8 @@ const AnimationContainer = styled.div`
 
   & > * {
     width: 80% !important;
-    max-width: 280px !important;
-    max-height: 240px !important;
+    max-width: 220px !important;
+    max-height: 160px !important;
     aspect-ratio: 263 / 186;
   }
 `
@@ -37,7 +37,7 @@ const ContentArea = styled(VStack)`
   width: 100%;
   max-width: 576px;
   align-self: center;
-  padding-top: 32px;
+  padding-top: 16px;
 `
 
 const springConfig = { tension: 120, friction: 20 }
@@ -109,7 +109,7 @@ export const ImportSeedphraseIntroStep = () => {
             flexGrow: 1,
           }}
         >
-          <ContentArea justifyContent="space-between" gap={40}>
+          <ContentArea justifyContent="space-between" gap={24}>
             <ImportSeedphraseIntroRequirements />
             <Button onClick={() => setStep('input')}>{t('get_started')}</Button>
           </ContentArea>


### PR DESCRIPTION
## Problem
Closes #4150.

The seed-phrase import intro ("Before you start…") didn't fit on one screen in the extension popup — content overflowed and the page scrolled, pushing the "Get started" CTA below the fold.

## Cause
In `core/ui/vault/import/seedphrase/intro/ImportSeedphraseIntro.tsx`, the Rive animation (`max-height: 240px`) + `padding-top: 32px` + requirements block + `gap: 40` + button exceeded the popup's available height.

## Fix
Style-only changes to keep the requirements + CTA in view without scrolling:
- Rive animation `max-height` `240px → 160px`, `max-width` `280px → 220px`
- Content `padding-top` `32px → 16px`
- Gap between requirements and the button `40 → 24`

## Testing
- Built the extension popup chunk (`build:app`) successfully.
- Load `clients/extension/dist` as an unpacked extension → import via seed phrase → "Before you start…" now fits one screen with the CTA in view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the layout and spacing on the seed phrase import introduction screen, including repositioned content elements and refined spacing for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->