### PR TITLE
feat(swap): show external recipient address on swap verify screen

### DIFF
--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -1539,4 +1539,5 @@ export const de = {
   swap_mode_limit: 'Limit',
   swap_mode_market: 'Markt',
   use_external_recipient: 'Externen Empfänger verwenden',
+  swap_external_recipient_warning: 'Senden an eine externe Adresse',
 }

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -1008,6 +1008,7 @@ export const en = {
   swap: 'Swap',
   swaps: 'Swaps',
   swap_discount: 'Swap Discount',
+  swap_external_recipient_warning: 'Sending to an external address',
   swap_fee: 'Swap Fee',
   swap_limit_orders: 'Limit orders',
   swap_mode_limit: 'Limit',

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -1526,4 +1526,5 @@ export const es = {
   swap_mode_limit: 'Límite',
   swap_mode_market: 'Mercado',
   use_external_recipient: 'Utilizar destinatario externo',
+  swap_external_recipient_warning: 'Enviar a una dirección externa',
 }

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -1504,4 +1504,5 @@ export const hr = {
   swap_mode_limit: 'Ograničiti',
   swap_mode_market: 'Tržište',
   use_external_recipient: 'Koristi vanjskog primatelja',
+  swap_external_recipient_warning: 'Slanje na vanjsku adresu',
 }

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -1534,4 +1534,5 @@ export const it = {
   swap_mode_limit: 'Limite',
   swap_mode_market: 'Mercato',
   use_external_recipient: 'Utilizzare un destinatario esterno',
+  swap_external_recipient_warning: 'Invio a un indirizzo esterno',
 }

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -1498,4 +1498,5 @@ export const ko = {
   swap_mode_limit: '한계',
   swap_mode_market: '시장',
   use_external_recipient: '외부 수신자 사용',
+  swap_external_recipient_warning: '외부 주소로 전송',
 }

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -1511,4 +1511,5 @@ export const nl = {
   swap_mode_limit: 'Beperken',
   swap_mode_market: 'Markt',
   use_external_recipient: 'Externe ontvanger gebruiken',
+  swap_external_recipient_warning: 'Verzenden naar een extern adres',
 }

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -1528,4 +1528,5 @@ export const pt = {
   swap_mode_limit: 'Limite',
   swap_mode_market: 'Mercado',
   use_external_recipient: 'Usar destinatário externo',
+  swap_external_recipient_warning: 'Envio para um endereço externo',
 }

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -1508,4 +1508,5 @@ export const ru = {
   swap_mode_limit: 'Лимит',
   swap_mode_market: 'Рынок',
   use_external_recipient: 'Использовать внешнего получателя',
+  swap_external_recipient_warning: 'Отправка на внешний адрес',
 }

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -1409,4 +1409,5 @@ export const zh = {
   swap_mode_limit: '限制',
   swap_mode_market: '市场',
   use_external_recipient: '使用外部收件人',
+  swap_external_recipient_warning: '发送到外部地址',
 }

--- a/core/ui/vault/swap/keysignPayload/getSwapRecipientAddress.ts
+++ b/core/ui/vault/swap/keysignPayload/getSwapRecipientAddress.ts
@@ -1,0 +1,40 @@
+import { decodeCowSwapKeysignData } from '@vultisig/core-chain/swap/general/cowswap/keysign/cowSwapKeysignData'
+import { getKeysignSwapPayload } from '@vultisig/core-mpc/keysign/swap/getKeysignSwapPayload'
+import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
+
+/**
+ * THORChain/MayaChain swap memos encode the payout destination as the third
+ * colon-separated segment: `SWAP:ASSET:DESTINATION:...`.
+ */
+const getNativeSwapMemoDestination = (memo: string | undefined) => {
+  const destination = memo?.split(':')[2]?.trim()
+  return destination || undefined
+}
+
+/**
+ * Resolves the address the swap output will actually be paid to, read from the
+ * built keysign payload (the bytes that will be signed) rather than live form
+ * state. Returns `undefined` for swaps with no explicit recipient — e.g.
+ * EVM/Solana aggregator routes that always pay the initiator's own address.
+ */
+export const getSwapRecipientAddress = (
+  keysignPayload: KeysignPayload
+): string | undefined => {
+  const swapPayload = getKeysignSwapPayload(keysignPayload)
+  if (!swapPayload) {
+    return undefined
+  }
+
+  return matchRecordUnion(swapPayload, {
+    native: () => getNativeSwapMemoDestination(keysignPayload.memo),
+    general: ({ quote }) => {
+      const data = quote?.tx?.data
+      if (!data) {
+        return undefined
+      }
+
+      return decodeCowSwapKeysignData(data)?.order.receiver
+    },
+  })
+}

--- a/core/ui/vault/swap/keysignPayload/getSwapRecipientAddress.ts
+++ b/core/ui/vault/swap/keysignPayload/getSwapRecipientAddress.ts
@@ -28,9 +28,9 @@ export const getSwapRecipientAddress = (
 
   return matchRecordUnion(swapPayload, {
     native: () => getNativeSwapMemoDestination(keysignPayload.memo),
-    general: ({ quote }) => {
+    general: ({ provider, quote }) => {
       const data = quote?.tx?.data
-      if (!data) {
+      if (provider !== 'cowswap' || !data) {
         return undefined
       }
 

--- a/core/ui/vault/swap/verify/SwapVerify/SwapExternalRecipientWarning.stories.tsx
+++ b/core/ui/vault/swap/verify/SwapVerify/SwapExternalRecipientWarning.stories.tsx
@@ -1,0 +1,52 @@
+import { VStack } from '@lib/ui/layout/Stack'
+import { Text } from '@lib/ui/text'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { SwapExternalRecipientWarning } from './SwapExternalRecipientWarning'
+
+const sampleAddress = '0x0bd442356896e0cdfC436237e6b92a9A7feF3Fe6'
+
+const meta: Meta<typeof SwapExternalRecipientWarning> = {
+  title: 'Vault/Swap/SwapExternalRecipientWarning',
+  component: SwapExternalRecipientWarning,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+  args: {
+    address: sampleAddress,
+  },
+  argTypes: {
+    kind: {
+      control: 'inline-radio',
+      options: ['warning', 'danger'],
+    },
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Warning: Story = {
+  name: 'Warning (amber)',
+  args: { kind: 'warning' },
+}
+
+export const Danger: Story = {
+  name: 'Danger (red)',
+  args: { kind: 'danger' },
+}
+
+export const Comparison: Story = {
+  name: 'Side by side',
+  render: args => (
+    <VStack gap={16} style={{ maxWidth: 420 }}>
+      <Text color="shy" size={13}>
+        warning (amber) — matches WarningBlock
+      </Text>
+      <SwapExternalRecipientWarning {...args} kind="warning" />
+      <Text color="shy" size={13}>
+        danger (red) — matches ErrorBlock
+      </Text>
+      <SwapExternalRecipientWarning {...args} kind="danger" />
+    </VStack>
+  ),
+}

--- a/core/ui/vault/swap/verify/SwapVerify/SwapExternalRecipientWarning.tsx
+++ b/core/ui/vault/swap/verify/SwapVerify/SwapExternalRecipientWarning.tsx
@@ -1,0 +1,66 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
+import { TriangleAlertIcon } from '@lib/ui/icons/TriangleAlertIcon'
+import { HStack, VStack } from '@lib/ui/layout/Stack'
+import { Text } from '@lib/ui/text'
+import { matchColor } from '@lib/ui/theme/getters'
+import { MiddleTruncate } from '@lib/ui/truncate'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+
+type SwapExternalRecipientWarningKind = 'warning' | 'danger'
+
+type SwapExternalRecipientWarningProps = {
+  address: string
+  kind?: SwapExternalRecipientWarningKind
+}
+
+/**
+ * Stateless warning row shown on the swap verify screen when the output is
+ * routed to an external address. `kind` controls the emphasis colour:
+ * `warning` (amber, matches `WarningBlock`) or `danger` (red, matches
+ * `ErrorBlock`).
+ */
+export const SwapExternalRecipientWarning = ({
+  address,
+  kind = 'warning',
+}: SwapExternalRecipientWarningProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <Container kind={kind} gap={12} alignItems="center" fullWidth>
+      <Icon kind={kind} />
+      <VStack gap={2} flexGrow>
+        <Text
+          color={kind === 'danger' ? 'danger' : 'idle'}
+          size={14}
+          weight={500}
+        >
+          {t('swap_external_recipient_warning')}
+        </Text>
+        <MiddleTruncate text={address} color="textShy" size={13} />
+      </VStack>
+    </Container>
+  )
+}
+
+type KindProp = { kind: SwapExternalRecipientWarningKind }
+
+const Container = styled(HStack)<KindProp>`
+  ${borderRadius.m};
+  padding: 16px;
+  background: ${({ kind, theme: { colors } }) =>
+    (kind === 'danger'
+      ? colors.dangerBackground
+      : colors.idleDark
+    ).toCssValue()};
+  border: 1px solid
+    ${({ kind, theme: { colors } }) =>
+      (kind === 'danger' ? colors.danger : colors.idle)
+        .getVariant({ a: () => 0.25 })
+        .toCssValue()};
+`
+
+const Icon = styled(TriangleAlertIcon)<KindProp>`
+  font-size: 20px;
+  color: ${matchColor('kind', { danger: 'danger', warning: 'idle' })};
+`

--- a/core/ui/vault/swap/verify/SwapVerify/SwapVerifyRecipient.tsx
+++ b/core/ui/vault/swap/verify/SwapVerify/SwapVerifyRecipient.tsx
@@ -1,0 +1,31 @@
+import { useCurrentVaultCoin } from '@core/ui/vault/state/currentVaultCoins'
+import { getSwapRecipientAddress } from '@core/ui/vault/swap/keysignPayload/getSwapRecipientAddress'
+import { useSwapToCoin } from '@core/ui/vault/swap/state/toCoin'
+import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+
+import { SwapExternalRecipientWarning } from './SwapExternalRecipientWarning'
+
+type SwapVerifyRecipientProps = {
+  keysignPayload: KeysignPayload
+}
+
+/**
+ * Renders an emphasized warning when the swap output is routed to an address
+ * other than the vault's own address on the destination chain. The recipient
+ * is read from the built keysign payload (the bytes that will be signed).
+ * Default own-address swaps render nothing.
+ */
+export const SwapVerifyRecipient = ({
+  keysignPayload,
+}: SwapVerifyRecipientProps) => {
+  const [toCoinKey] = useSwapToCoin()
+  const toCoin = useCurrentVaultCoin(toCoinKey)
+
+  const recipient = getSwapRecipientAddress(keysignPayload)
+
+  if (!recipient || recipient.toLowerCase() === toCoin.address.toLowerCase()) {
+    return null
+  }
+
+  return <SwapExternalRecipientWarning address={recipient} />
+}

--- a/core/ui/vault/swap/verify/SwapVerify/SwapVerifyRecipient.tsx
+++ b/core/ui/vault/swap/verify/SwapVerify/SwapVerifyRecipient.tsx
@@ -1,7 +1,9 @@
 import { useCurrentVaultCoin } from '@core/ui/vault/state/currentVaultCoins'
 import { getSwapRecipientAddress } from '@core/ui/vault/swap/keysignPayload/getSwapRecipientAddress'
 import { useSwapToCoin } from '@core/ui/vault/swap/state/toCoin'
+import { getChainKind } from '@vultisig/core-chain/ChainKind'
 import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { areLowerCaseEqual } from '@vultisig/lib-utils/string/areLowerCaseEqual'
 
 import { SwapExternalRecipientWarning } from './SwapExternalRecipientWarning'
 
@@ -22,8 +24,19 @@ export const SwapVerifyRecipient = ({
   const toCoin = useCurrentVaultCoin(toCoinKey)
 
   const recipient = getSwapRecipientAddress(keysignPayload)
+  if (!recipient) {
+    return null
+  }
 
-  if (!recipient || recipient.toLowerCase() === toCoin.address.toLowerCase()) {
+  // EVM addresses are case-insensitive (checksum vs lowercase), so compare them
+  // case-insensitively; other chains use case-sensitive address formats and must
+  // match exactly.
+  const isOwnAddress =
+    getChainKind(toCoin.chain) === 'evm'
+      ? areLowerCaseEqual(recipient, toCoin.address)
+      : recipient === toCoin.address
+
+  if (isOwnAddress) {
     return null
   }
 

--- a/core/ui/vault/swap/verify/SwapVerify/index.tsx
+++ b/core/ui/vault/swap/verify/SwapVerify/index.tsx
@@ -14,6 +14,7 @@ import {
   HorizontalLine,
   IconWrapper,
 } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerify.styled'
+import { SwapVerifyRecipient } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerifyRecipient'
 import { ArrowDownIcon } from '@lib/ui/icons/ArrowDownIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { PageHeader } from '@lib/ui/page/PageHeader'
@@ -134,6 +135,12 @@ export const SwapVerify = ({ swapQuote, onBack }: SwapVerifyProps) => {
         <VStack bgColor="foreground" gap={24} padding={12} radius={16}>
           <VerifySwapFees swapQuote={swapQuote} />
         </VStack>
+        <MatchQuery
+          value={keysignPayloadQuery}
+          success={keysignPayload => (
+            <SwapVerifyRecipient keysignPayload={keysignPayload} />
+          )}
+        />
       </VerifyKeysignStart>
     </>
   )


### PR DESCRIPTION
## Summary

Adds a warning row to the swap verify screen ([SwapVerify/index.tsx](core/ui/vault/swap/verify/SwapVerify/index.tsx)) that appears **only when the swap output is routed to an address other than the vault's own address** on the destination chain. Default own-address swaps are unchanged — no extra row.

The displayed address is sourced from the **built keysign payload** (the bytes that will actually be signed), not the live Advanced Settings provider:
- **Native (THORChain/MayaChain):** parsed from the keysign memo destination (`SWAP:ASSET:DESTINATION:…`)
- **CowSwap:** decoded `order.receiver` via the SDK's `decodeCowSwapKeysignData`
- Aggregator routes that always pay the initiator (1inch/Kyber/LiFi/SwapKit EVM/Solana) return no recipient → no row

## Design

Reuses the codebase's warning convention (same tokens as `lib/ui/status/WarningBlock` / `ErrorBlock`): `TriangleAlertIcon`, rounded block, themed background/border. The visual is a stateless component (`SwapExternalRecipientWarning`) with a `kind` prop (`warning` amber / `danger` red); a Storybook story renders both for comparison. Currently defaults to **amber (warning)** as a cautionary heads-up.

##

<img width="485" height="102" alt="telegram-cloud-document-4-5882026057686589636" src="https://github.com/user-attachments/assets/5de47166-d4af-462a-ad52-5df5c62c267e" />

## Changes
- `getSwapRecipientAddress.ts` — resolves the real payout address from the keysign payload
- `SwapExternalRecipientWarning.tsx` — stateless warning row (+ Storybook story)
- `SwapVerifyRecipient.tsx` — hook logic: compares resolved recipient vs vault's own destination address (case-insensitive)
- `SwapVerify/index.tsx` — wires the row in after the fees section
- `en.ts` — `swap_external_recipient_warning: 'Sending to an external address'`

## Test plan
- [x] `yarn typecheck`, `yarn lint`, `yarn knip` — clean
- [x] `yarn test` — 218 passed
- [ ] THORChain swap (BTC → USDT.eth) with a custom recipient shows the recipient address on verify before signing
- [ ] Normal own-address swap shows **no** recipient row
- [ ] Displayed address matches the `destination`/`receiver` in the signed keysign payload

Closes #4152

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a swap verification warning when the recipient address is external, with warning vs danger styling based on the swap context.
* **UI/UX**
  * Swap verification now surfaces the recipient warning via a dedicated recipient step for clearer review before confirmation.
* **Internationalization**
  * Added the external-recipient warning text to supported locales.
* **Documentation / Visual QA**
  * Added Storybook stories to preview warning and danger variants side-by-side.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->