### PR TITLE
fix(extension): Terra/Station wallet detection + expose EVM under TronLink flag

### DIFF
--- a/clients/extension/src/inpage/providers/ethereum/index.ts
+++ b/clients/extension/src/inpage/providers/ethereum/index.ts
@@ -18,6 +18,7 @@ export class Ethereum extends EventEmitter<EthereumProviderEvents> {
   public connected: boolean
   public isCtrl: boolean
   public isMetaMask: boolean
+  public isTronLink: boolean
   public isVultiConnect: boolean
   public isXDEFI: boolean
   public networkVersion: string
@@ -31,6 +32,12 @@ export class Ethereum extends EventEmitter<EthereumProviderEvents> {
     this.connected = false
     this.isCtrl = true
     this.isMetaMask = true
+    // The real TronLink extension serves Ethereum + BNB Smart Chain through
+    // plain `window.ethereum` tagged with `isTronLink`. dApps that detect
+    // TronLink read this flag and then route their `eth_*` / `wallet_*`
+    // requests to `window.ethereum`, so exposing it lets Vultisig serve the
+    // EVM half of TronLink-aware multichain flows.
+    this.isTronLink = true
     this.isVultiConnect = true
     this.isXDEFI = true
     this.networkVersion = '1'

--- a/clients/extension/src/inpage/providers/keplrChainInfo.ts
+++ b/clients/extension/src/inpage/providers/keplrChainInfo.ts
@@ -9,11 +9,17 @@ import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 
 export type SupportedKeplrChain = (typeof supportedKeplrChains)[number]
 
-// Terra Classic (columbus-5) deliberately omitted: it shares the `terra`
-// bech32 prefix with Terra v2 (phoenix-1), and cosmos-kit / wallet-kit
-// reject duplicate prefixes within a single chain set — including both
-// makes dApps see Terra as "not in wallet". Terra Classic is still
-// reachable through the Station provider's `switchNetwork('classic')`.
+// Terra Classic (columbus-5) is resolvable and signable by chainID, but is
+// kept out of the *advertised* chain list (see `advertisedKeplrChains`): it
+// shares the `terra` bech32 prefix with Terra v2 (phoenix-1), and some
+// cosmos-kit / wallet-kit dApps build a prefix→chain map from the enumerated
+// `getChainInfosWithoutEndpoints()` list, where a duplicate `terra` prefix
+// makes them resolve Terra to the wrong chain and show it as "not in wallet".
+// Terra Classic dApps connect through their own Station extension
+// connector, which probes `window.station.keplr.getKey('columbus-5')`
+// — a chainID-keyed call routed here that is unaffected by enumeration, so it
+// must resolve. (Terra Classic also remains reachable through the Station
+// provider's `switchNetwork('classic')`.)
 //
 // QBTC is included here so Keplr-shaped dApps can connect via the
 // standard `window.keplr` API in addition to the dedicated
@@ -26,12 +32,23 @@ const supportedKeplrChains = [
   CosmosChain.Dydx,
   CosmosChain.Kujira,
   CosmosChain.Terra,
+  CosmosChain.TerraClassic,
   CosmosChain.Noble,
   CosmosChain.Akash,
   CosmosChain.THORChain,
   CosmosChain.MayaChain,
   OtherChain.QBTC,
 ] as const
+
+// Chains advertised in the enumerated `getChainInfosWithoutEndpoints()`
+// response. Excludes Terra Classic so dApps that register chains by bech32
+// prefix don't collide Terra v2 (`phoenix-1`) and Terra Classic
+// (`columbus-5`), which share the `terra` prefix. Per-chainID lookups
+// (`getKey`, `enable`, signing) still resolve Terra Classic via
+// `supportedKeplrChains`.
+const advertisedKeplrChains = supportedKeplrChains.filter(
+  chain => chain !== CosmosChain.TerraClassic
+)
 
 /** QBTC chain ID. Mirrors the constant used throughout the SDK (QBTCHelper, ClaimRunner) so dApps that query the live block header see the same chain ID Vultisig signs for. */
 const qbtcChainId = 'qbtc-testnet'
@@ -51,6 +68,7 @@ const bech32Prefix: Record<SupportedKeplrChain, string> = {
   Dydx: 'dydx',
   Kujira: 'kujira',
   Terra: 'terra',
+  TerraClassic: 'terra',
   Noble: 'noble',
   Akash: 'akash',
   THORChain: 'thor',
@@ -66,6 +84,7 @@ const bip44CoinType: Record<SupportedKeplrChain, number> = {
   Noble: 118,
   Akash: 118,
   Terra: 330,
+  TerraClassic: 330,
   THORChain: 931,
   MayaChain: 931,
   QBTC: 118,
@@ -77,6 +96,7 @@ const chainName: Record<SupportedKeplrChain, string> = {
   Dydx: 'dYdX',
   Kujira: 'Kujira',
   Terra: 'Terra',
+  TerraClassic: 'Terra Classic',
   Noble: 'Noble',
   Akash: 'Akash',
   THORChain: 'THORChain',
@@ -100,6 +120,10 @@ export const keplrAverageGasPrice: Record<SupportedKeplrChain, number> = {
   Dydx: 12500000000,
   Kujira: 0.0034,
   Terra: 0.015,
+  // Terra Classic's on-chain minimum gas price for uluna is far higher than
+  // Terra v2's; mirror the Station provider's `classic` gas price so injected
+  // fees clear the network floor.
+  TerraClassic: 28.325,
   Noble: 0.025,
   Akash: 0.025,
   THORChain: 0,
@@ -203,7 +227,7 @@ export const isNativeKeplrChainId = (chainId: string): boolean =>
  */
 export const getKeplrCosmosChainInfos = async (): Promise<ChainInfo[]> => {
   const suggested = await callBackground({ getKeplrSuggestedChains: {} })
-  const native = supportedKeplrChains.map(buildKeplrChainInfo)
+  const native = advertisedKeplrChains.map(buildKeplrChainInfo)
   const additions = Object.values(suggested).filter(
     info => !nativeChainIds.has(info.chainId)
   )

--- a/clients/extension/src/inpage/utils/windowInjector.ts
+++ b/clients/extension/src/inpage/utils/windowInjector.ts
@@ -139,6 +139,64 @@ export const injectToWindow = () => {
     installKeplrProxyBridge(providers.keplr)
   }
 
+  // Terra/Station injection mirrors the Keplr treatment above: synchronous
+  // and ungated. Cosmos/Terra discovery must not depend on EVM precedence
+  // (the "Prioritize Vultisig" setting) — that flag only exists to win the
+  // `window.ethereum` fight with other EVM wallets. dApps that snapshot
+  // installed wallets on page load can also miss a late injection deferred
+  // behind the async `setupContentScriptMessenger` background round-trip.
+  // The `!window.station` / `!window.terra` guards defer to the official
+  // Station extension when it injected first; the `terraWallets` /
+  // `interchainWallets` arrays still advertise this build as its own picker
+  // row so the two extensions co-exist instead of silently clobbering each
+  // other. Each global is set behind its own existence check so a
+  // preexisting non-configurable one can't block the others.
+  if (!window.station) {
+    attempt(() =>
+      Object.defineProperty(window, 'station', {
+        value: providers.station,
+        configurable: false,
+        writable: false,
+      })
+    )
+  }
+  if (!window.terra) {
+    attempt(() =>
+      Object.defineProperty(window, 'terra', {
+        value: providers.station,
+        configurable: false,
+        writable: false,
+      })
+    )
+  }
+  // Detection flags Terra dApps probe before showing Station in the wallet
+  // picker — both legacy (`isTerraExtensionAvailable`) and the newer
+  // interchain alias (`isStationExtensionAvailable`).
+  if (!window.isTerraExtensionAvailable) {
+    attempt(() =>
+      Object.defineProperty(window, 'isTerraExtensionAvailable', {
+        value: true,
+        configurable: false,
+        writable: false,
+      })
+    )
+  }
+  if (!window.isStationExtensionAvailable) {
+    attempt(() =>
+      Object.defineProperty(window, 'isStationExtensionAvailable', {
+        value: true,
+        configurable: false,
+        writable: false,
+      })
+    )
+  }
+  // Register this build in the Station-style wallet-picker arrays. dApps
+  // iterate these to enumerate installed Station-compatible wallets, so
+  // missing this entry hides the provider from the picker even when
+  // `window.station` is present.
+  attempt(() => pushToWalletArray('terraWallets'))
+  attempt(() => pushToWalletArray('interchainWallets'))
+
   setupContentScriptMessenger(providers)
 }
 
@@ -251,29 +309,6 @@ async function setupContentScriptMessenger(
           configurable: false,
           writable: false,
         },
-        station: {
-          value: providers.station,
-          configurable: false,
-          writable: false,
-        },
-        terra: {
-          value: providers.station,
-          configurable: false,
-          writable: false,
-        },
-        // Detection flags Terra dApps probe before showing Station in the
-        // wallet picker — both legacy (`isTerraExtensionAvailable`) and the
-        // newer interchain alias (`isStationExtensionAvailable`).
-        isTerraExtensionAvailable: {
-          value: true,
-          configurable: false,
-          writable: false,
-        },
-        isStationExtensionAvailable: {
-          value: true,
-          configurable: false,
-          writable: false,
-        },
         injectedWeb3: {
           value: {
             ...(window.injectedWeb3 || {}),
@@ -291,12 +326,5 @@ async function setupContentScriptMessenger(
         },
       })
     )
-
-    // Register this build in the Station-style wallet-picker arrays. dApps
-    // iterate these to enumerate installed Station-compatible wallets, so
-    // missing this entry hides the provider from the picker even when
-    // `window.station` is present.
-    attempt(() => pushToWalletArray('terraWallets'))
-    attempt(() => pushToWalletArray('interchainWallets'))
   }
 }


### PR DESCRIPTION
## Summary

Fixes #4147 — Terra dApps did not detect Vultisig as a connectable wallet. Two independent defects, both in *how/when* the Station surface is exposed (the Station provider itself is solid):

### 1. Terra/Station injection ungated + made synchronous
`window.station` / `window.terra`, the `isTerraExtensionAvailable` / `isStationExtensionAvailable` detection flags, and the `terraWallets` / `interchainWallets` picker arrays were defined **only inside the `if (vultisigDefaultProvider)` block** of the async `setupContentScriptMessenger`. Consequences:
- Disabling **"Prioritize Vultisig"** (common for multi-wallet users) removed all Terra detection. EVM prioritization should not gate non-EVM Cosmos/Terra namespaces.
- Injection happened *after* a background round-trip, so dApps that snapshot installed wallets on page load could miss it (a race Keplr was already fixed for).
- No existence guard meant a load-order race with the official Station extension silently dropped one of the two.

Moved this into the synchronous, ungated `injectToWindow` path (mirroring the existing Keplr block), each global behind its own `!window.x` guard so we **defer to an already-installed Station extension** while still advertising ourselves in the additive `terraWallets`/`interchainWallets` arrays.

### 2. Terra Classic (`columbus-5`) made resolvable via `window.station.keplr`
After (1), the wallet picker reached our provider but connecting to a Terra **Classic** dApp threw `There is no chain info for columbus-5`. These dApps connect through their own Station connector, which calls `window.station.keplr.enable(['columbus-5'])` + `getKey('columbus-5')` — i.e. our `XDEFIKeplrProvider`, **not** `window.station.info()`/`.connect()`. Terra Classic was excluded from the Keplr provider's supported-chain set, so the chainID didn't resolve.

Added Terra Classic to the chains the Keplr provider **resolves and signs by chainID**, while keeping it **out of the advertised `getChainInfosWithoutEndpoints()` list** (`advertisedKeplrChains`). This preserves the original safeguard: the shared `terra` bech32 prefix can't collide with Terra v2 (`phoenix-1`) for cosmos-kit dApps that build a prefix→chain map from the enumerated list, since those requests are chainID-keyed and unaffected by enumeration.

## Changes
- `clients/extension/src/inpage/utils/windowInjector.ts` — ungate + synchronize Station/Terra injection with per-namespace guards.
- `clients/extension/src/inpage/providers/keplrChainInfo.ts` — Terra Classic resolvable/signable by chainID; excluded from advertised enumeration.

No SDK changes needed — `@vultisig/core-chain` already defines `columbus-5`, its `uluna` fee denom, and LCD URL.

## Testing
- `yarn typecheck` and `yarn eslint --fix` pass on both files. (Pre-existing unrelated `gasLimitOverride` typecheck error in `core/ui/vault/swap` exists on `main`.)
- Manual: with a Cosmos/Terra-capable vault, Vultisig now appears in the Terra wallet picker regardless of the "Prioritize Vultisig" setting, and connecting to a Terra Classic dApp resolves the `terra1…` account instead of throwing.

## Notes / follow-ups
- This addresses connection. If signing on `columbus-5` surfaces issues, that's a separate keysign trace.
- The dApp-side detection question raised in the issue is resolved empirically: the affected Terra Classic dApp uses a Station connector that reads `window.station.keplr.getKey(chainID)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for **Terra Classic (columbus-5)**, enabling direct chain resolution and transaction signing for compatible dApps.

* **Bug Fixes**
  * Improved early wallet/extension availability detection to speed up initialization and enhance reliability.
  * Updated Ethereum provider behavior with an **isTronLink** indicator to better match TronLink-style request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Also in this PR: expose Ethereum + BSC under the TronLink flag (closes #4063)

The real TronLink extension serves Ethereum + BNB Smart Chain through plain `window.ethereum` tagged with `isTronLink: true` — dApps detect that flag and then route their `eth_*` / `wallet_*` requests to `window.ethereum` (per the issue's follow-up investigation). So rather than routing EVM through `window.tronLink`, the fix is to set `isTronLink: true` on Vultisig's existing `Ethereum` provider.

- `clients/extension/src/inpage/providers/ethereum/index.ts` — add `isTronLink` flag (init `true`).
- BSC is served through the existing `wallet_switchEthereumChain` path (`0x38`); no new chain plumbing.
- `window.ethereum` / Phantom override behavior and Tron signing semantics are unchanged; `window.tronLink` keeps its existing `tron_requestAccounts`-only surface.
