### PR TITLE
fix(qbtc): set Cosmos SDK chain ID to qbtc

### DIFF
--- a/clients/extension/src/inpage/providers/keplrChainInfo.ts
+++ b/clients/extension/src/inpage/providers/keplrChainInfo.ts
@@ -34,7 +34,7 @@ const supportedKeplrChains = [
 ] as const
 
 /** QBTC chain ID. Mirrors the constant used throughout the SDK (QBTCHelper, ClaimRunner) so dApps that query the live block header see the same chain ID Vultisig signs for. */
-const qbtcChainId = 'qbtc-testnet'
+const qbtcChainId = 'qbtc'
 
 /**
  * QBTC isn't a `CosmosChain` in the SDK (it's `OtherChain.QBTC` because it

--- a/clients/extension/src/inpage/providers/qbtc.ts
+++ b/clients/extension/src/inpage/providers/qbtc.ts
@@ -44,7 +44,7 @@ const parseSendTransactionParams = (
  * see {@link handleQbtcSignAndBroadcast} for the accepted shape.
  *
  * QBTC is also reachable via the Keplr compatibility route at chainId
- * `qbtc-testnet` for dApps that can't be modified; see `xdefiKeplr.ts`.
+ * `qbtc` for dApps that can't be modified; see `xdefiKeplr.ts`.
  * Both routes funnel into the same MLDSA keysign pipeline.
  */
 export class Qbtc extends EventEmitter {

--- a/core/ui/qbtc/claim/components/ClaimPreparingTxPhase.tsx
+++ b/core/ui/qbtc/claim/components/ClaimPreparingTxPhase.tsx
@@ -18,7 +18,7 @@ import {
   getQbtcAccountInfoForClaim,
 } from '../utils/getQbtcAccountInfoForClaim'
 
-const qbtcChainId = 'qbtc-testnet'
+const qbtcChainId = 'qbtc'
 const proofServiceRBytes = 24
 const proofServiceSBytes = 32
 const proofServiceBaseUrl = 'https://api.vultisig.com/qbtc-proof'

--- a/core/ui/qbtc/claim/components/ClaimRunner.tsx
+++ b/core/ui/qbtc/claim/components/ClaimRunner.tsx
@@ -19,7 +19,7 @@ import { ClaimPreparingTxPhase } from './ClaimPreparingTxPhase'
 import { ClaimServerBroadcastWaitPhase } from './ClaimServerBroadcastWaitPhase'
 import { ClaimSignRound } from './ClaimSignRound'
 
-const qbtcChainId = 'qbtc-testnet'
+const qbtcChainId = 'qbtc'
 
 type ClaimRunnerProps = {
   utxos: ClaimableUtxo[]

--- a/core/ui/qbtc/dapp/qbtcDirectConstants.ts
+++ b/core/ui/qbtc/dapp/qbtcDirectConstants.ts
@@ -4,7 +4,7 @@
  */
 
 /** Cosmos SDK chain ID used in the SignDoc. */
-export const qbtcChainId = 'qbtc-testnet'
+export const qbtcChainId = 'qbtc'
 
 /** Native fee denom for QBTC. */
 export const qbtcFeeDenom = 'qbtc'


### PR DESCRIPTION
## What

Sets the QBTC Cosmos SDK chain ID to `qbtc` instead of `qbtc-testnet` across the desktop core UI and the browser extension, keeping them in sync with the SDK's `QBTCHelper`.

## Changes

- `core/ui/qbtc/dapp/qbtcDirectConstants.ts` — `qbtcChainId` used in the `sign_and_broadcast` SignDoc
- `core/ui/qbtc/claim/components/ClaimRunner.tsx` — claim flow chain ID
- `core/ui/qbtc/claim/components/ClaimPreparingTxPhase.tsx` — claim flow chain ID
- `clients/extension/src/inpage/providers/keplrChainInfo.ts` — Keplr-compat chain ID exposed to dApps
- `clients/extension/src/inpage/providers/qbtc.ts` — doc comment referencing the chain ID value

## Notes

Companion PR in `vultisig-sdk` updates `QBTCHelper` (the single source of truth these constants mirror).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated QBTC chain identifier configuration across claim processing, dApp transaction building, and Keplr wallet compatibility to ensure consistent integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->