### PR TITLE
fix(tokens): clean up Choose Tokens empty-search layout

### DIFF
--- a/core/ui/chain/coin/addCustomToken/CustomTokenResult.tsx
+++ b/core/ui/chain/coin/addCustomToken/CustomTokenResult.tsx
@@ -52,11 +52,7 @@ export const CustomTokenResult = ({ id }: { id: string }) => {
             title={t('no_token_found')}
             description={t('token_not_found_description')}
           />
-          <Button
-            kind="primary"
-            onClick={() => query.refetch()}
-            style={{ marginTop: 8 }}
-          >
+          <Button kind="primary" onClick={() => query.refetch()}>
             {t('retry')}
           </Button>
         </ErrorStateWrapper>
@@ -142,9 +138,15 @@ const ErrorStateWrapper = styled.div`
   flex-direction: column;
   align-items: center;
   gap: 16px;
-  padding: 20px;
+  padding: 24px 20px;
   max-width: 450px;
   margin-inline: auto;
+  border-radius: 16px;
+  background: ${getColor('foreground')};
+
+  & > button {
+    width: 100%;
+  }
 `
 
 const LoadingWrapper = styled.div`

--- a/core/ui/vault/chain/manage/coin/AddCustomTokenPrompt.tsx
+++ b/core/ui/vault/chain/manage/coin/AddCustomTokenPrompt.tsx
@@ -30,7 +30,7 @@ export const AddCustomTokenPrompt = () => {
           <PlusIcon />
         </CustomIconWrapper>
         <TextWrapper>
-          <Text cropped color="contrast" size={12} weight={500}>
+          <Text color="contrast" size={12} weight={500}>
             {t('custom_token')}
           </Text>
         </TextWrapper>

--- a/core/ui/vault/chain/manage/coin/index.tsx
+++ b/core/ui/vault/chain/manage/coin/index.tsx
@@ -20,6 +20,7 @@ import { extractAccountCoinKey } from '@vultisig/core-chain/coin/AccountCoin'
 import {
   areEqualCoins,
   Coin,
+  coinKeyToString,
   extractCoinKey,
 } from '@vultisig/core-chain/coin/Coin'
 import { getSolanaCoingeckoId } from '@vultisig/core-chain/coin/coingecko/getCoingeckoId'
@@ -159,9 +160,9 @@ export const ManageVaultChainCoinsPage = () => {
         </VStack>
         <ItemGrid>
           <AddCustomTokenPrompt />
-          {filteredCoins.map((coin, index) => (
+          {filteredCoins.map(coin => (
             <TokenItem
-              key={index}
+              key={coinKeyToString(coin)}
               value={coin}
               currentCoins={currentCoins}
               onToggle={handleToggle}

--- a/core/ui/vault/chain/manage/coin/index.tsx
+++ b/core/ui/vault/chain/manage/coin/index.tsx
@@ -14,7 +14,6 @@ import { useCurrentVaultChainCoins } from '@core/ui/vault/state/currentVaultCoin
 import { VStack } from '@lib/ui/layout/Stack'
 import { PageContent } from '@lib/ui/page/PageContent'
 import { PageHeader } from '@lib/ui/page/PageHeader'
-import { EmptyState } from '@lib/ui/status/EmptyState'
 import { Text } from '@lib/ui/text'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { extractAccountCoinKey } from '@vultisig/core-chain/coin/AccountCoin'
@@ -158,27 +157,18 @@ export const ManageVaultChainCoinsPage = () => {
           </Text>
           <SearchInput value={search} onChange={setSearch} />
         </VStack>
-        {filteredCoins.length > 0 || !search.trim() ? (
-          <ItemGrid>
-            <AddCustomTokenPrompt />
-            {filteredCoins.map((coin, index) => (
-              <TokenItem
-                key={index}
-                value={coin}
-                currentCoins={currentCoins}
-                onToggle={handleToggle}
-                isLoading={isLoading}
-              />
-            ))}
-          </ItemGrid>
-        ) : (
-          <VStack gap={24} alignItems="center">
-            <EmptyState title={t('no_tokens_found')} />
-            <ItemGrid>
-              <AddCustomTokenPrompt />
-            </ItemGrid>
-          </VStack>
-        )}
+        <ItemGrid>
+          <AddCustomTokenPrompt />
+          {filteredCoins.map((coin, index) => (
+            <TokenItem
+              key={index}
+              value={coin}
+              currentCoins={currentCoins}
+              onToggle={handleToggle}
+              isLoading={isLoading}
+            />
+          ))}
+        </ItemGrid>
       </PageContent>
     </VStack>
   )


### PR DESCRIPTION
## Summary

Fixes the weird empty-search state on the **Choose Tokens** screen reported in #4149, plus a small related cleanup on the custom-token "Token not found" card.

### Changes
- **Choose Tokens empty results** — the no-results branch no longer renders a centered `No tokens found` card with a separately-floating Custom Token tile. The search now always renders a single `ItemGrid`; when nothing matches, only the Custom Token tile remains, consistent with the populated layout.
- **Custom Token label** — removed `cropped` so the label wraps to two lines instead of truncating to `Custom To...` (keeps the 74px grid alignment intact rather than widening one tile).
- **Token not found card** — moved the `Retry` button inside the card and made it full-width, instead of floating below the card.

### Testing
- `yarn typecheck` ✓
- Built the extension and verified the popup visually (empty search shows only the Custom Token tile; invalid contract shows the Retry button inside the card).

Fixes #4149

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  - Refined error state button styling with improved layout consistency
  - Enhanced error container appearance with better spacing, rounded corners, and visual refinement
  - Improved text contrast in custom token prompt display
  - Streamlined token list presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->