### PR TITLE
Support QBTC Keplr sendTx broadcast

### DIFF
--- a/clients/extension/src/inpage/providers/xdefiKeplr.ts
+++ b/clients/extension/src/inpage/providers/xdefiKeplr.ts
@@ -780,7 +780,7 @@ export class XDEFIKeplrProvider extends Keplr {
     // dApp page's CSP via the SDK's shared broadcast path. Returns the tx-hash
     // bytes the dApp uses to track inclusion. `_mode` is ignored — the SDK
     // broadcast resolver picks the broadcast semantics.
-    const chain = getCosmosChainByChainId(chainId)
+    const chain = getKeplrSupportedChainByChainId(chainId)
     if (!chain) {
       throw new Error(`Keplr.sendTx is not supported for chain ${chainId}`)
     }

--- a/clients/extension/tests/unit/keplrChainInfo.test.ts
+++ b/clients/extension/tests/unit/keplrChainInfo.test.ts
@@ -1,0 +1,19 @@
+import { CosmosChain, OtherChain } from '@vultisig/core-chain/Chain'
+
+import { getKeplrSupportedChainByChainId } from '../../src/inpage/providers/keplrChainInfo'
+
+describe('getKeplrSupportedChainByChainId', () => {
+  it('resolves QBTC even though it is not an SDK CosmosChain', () => {
+    expect(getKeplrSupportedChainByChainId('qbtc')).toBe(OtherChain.QBTC)
+  })
+
+  it('keeps native Cosmos chain resolution intact', () => {
+    expect(getKeplrSupportedChainByChainId('cosmoshub-4')).toBe(
+      CosmosChain.Cosmos
+    )
+  })
+
+  it('rejects unsupported chain IDs', () => {
+    expect(getKeplrSupportedChainByChainId('unknown-1')).toBeUndefined()
+  })
+})

--- a/core/inpage-provider/background/interface.ts
+++ b/core/inpage-provider/background/interface.ts
@@ -2,7 +2,7 @@ import { VaultAppSession } from '@core/extension/storage/appSessions'
 import { KeplrSuggestedChainsRecord } from '@core/extension/storage/keplrSuggestedChains'
 import { VaultExport } from '@core/ui/vault/export/core'
 import { ChainInfo } from '@keplr-wallet/types'
-import { Chain, CosmosChain } from '@vultisig/core-chain/Chain'
+import { Chain, CosmosChain, OtherChain } from '@vultisig/core-chain/Chain'
 import { ChainOfKind } from '@vultisig/core-chain/ChainKind'
 import { CoinKey, CoinMetadata, Token } from '@vultisig/core-chain/coin/Coin'
 import { ChainWithTokenMetadataDiscovery } from '@vultisig/core-chain/coin/token/metadata/chains'
@@ -25,6 +25,8 @@ export type GetAccountInput = {
   appSession?: VaultAppSession
 }
 
+type BroadcastTxChain = CosmosChain | OtherChain.QBTC
+
 export type BackgroundInterface = {
   getAppChainId: Method<{ chainKind: ActiveChainKind }, string>
   setAppChain: Method<SetAppChainInput>
@@ -37,7 +39,7 @@ export type BackgroundInterface = {
   exportVault: Method<{}, VaultExport>
   getTx: Method<{ chain: Chain; hash: string }, unknown>
   broadcastTx: Method<
-    { chain: CosmosChain; txBytes: string },
+    { chain: BroadcastTxChain; txBytes: string },
     { txHash: string }
   >
   suiBuildTransaction: Method<


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated transaction broadcast logic to use Keplr's native supported-chain registry, ensuring accurate recognition of compatible networks

* **Tests**
  * Added comprehensive unit tests validating chain detection, including verification of newly supported networks and proper error handling for unsupported chains

<!-- end of auto-generated comment: release notes by coderabbit.ai -->