### PR TITLE
Use Terra as Station mainnet primary connect chain

### DIFF
--- a/clients/extension/src/inpage/providers/station.ts
+++ b/clients/extension/src/inpage/providers/station.ts
@@ -269,6 +269,7 @@ const networkPrimaryChain: Record<SupportedNetworkName, SupportedStationChain> =
     classic: Chain.TerraClassic,
   }
 
+/** Returns the Station primary chain for a supported Station network. */
 export const getStationPrimaryChainForNetwork = (
   network: SupportedNetworkName
 ): SupportedStationChain => networkPrimaryChain[network]

--- a/clients/extension/src/inpage/providers/station.ts
+++ b/clients/extension/src/inpage/providers/station.ts
@@ -258,11 +258,20 @@ const buildStationInfoForNetwork = (
 // once). Subsequent chains in the same network are fetched silently via
 // `callBackground({ getAccount })` — they piggyback on the same dApp
 // authorization, no extra popups even for normal multi-chain vaults.
+//
+// Mainnet starts with Terra, not Cosmos Hub, so Station-migrated key-import
+// vaults that only contain Terra-family keys remain eligible in the grant
+// popup. Normal multi-chain vaults still report Cosmos Hub and other 118
+// chains through the silent secondary fetch.
 const networkPrimaryChain: Record<SupportedNetworkName, SupportedStationChain> =
   {
-    mainnet: Chain.Cosmos,
+    mainnet: Chain.Terra,
     classic: Chain.TerraClassic,
   }
+
+export const getStationPrimaryChainForNetwork = (
+  network: SupportedNetworkName
+): SupportedStationChain => networkPrimaryChain[network]
 
 // Builds the `pubkey` field for ConnectResponse — base64-encoded pubkeys
 // keyed by the chain's BIP44 coinType. cosmos-kit's
@@ -381,8 +390,8 @@ export class Station {
    * silently mark the wallet as not-connected.
    *
    * Account fetching is two-phase to avoid stacked grant popups:
-   * 1. The network's primary chain (Cosmos Hub for mainnet, Terra Classic
-   *    for classic) goes through {@link requestAccount}, which surfaces the
+   * 1. The network's primary chain (Terra for mainnet, Terra Classic for
+   *    classic) goes through {@link requestAccount}, which surfaces the
    *    grant-vault popup on first connect.
    * 2. Every other chain is fetched silently via `getAccount` background
    *    call. Once the dApp is authorized in step 1, normal multi-chain
@@ -405,7 +414,7 @@ export class Station {
    */
   async connect(): Promise<ConnectResponse> {
     const chains = stationChainsByNetwork[this.currentNetwork]
-    const primaryChain = networkPrimaryChain[this.currentNetwork]
+    const primaryChain = getStationPrimaryChainForNetwork(this.currentNetwork)
 
     const primaryAccount = await requestAccount(primaryChain)
 

--- a/clients/extension/tests/unit/station-provider.test.ts
+++ b/clients/extension/tests/unit/station-provider.test.ts
@@ -1,0 +1,13 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+
+import { getStationPrimaryChainForNetwork } from '../../src/inpage/providers/station'
+
+describe('Station provider', () => {
+  it('uses Terra as the mainnet primary chain so migrated Station key-import vaults can connect', () => {
+    expect(getStationPrimaryChainForNetwork('mainnet')).toBe(Chain.Terra)
+  })
+
+  it('keeps Terra Classic as the classic-network primary chain', () => {
+    expect(getStationPrimaryChainForNetwork('classic')).toBe(Chain.TerraClassic)
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the authorization flow’s primary blockchain selection: **mainnet now uses Terra**, while **classic continues using Terra Classic**.
  * Network-aware primary-chain selection is now used automatically during connection.
* **Documentation**
  * Refreshed connection behavior documentation to match the updated primary-chain selection.
* **Tests**
  * Added unit coverage to verify the primary-chain mapping for mainnet and classic.
* **Chores**
  * Adjusted local agent directory ignore rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->