### PR TITLE
fix(swap): show external recipient warning to keysign joiners

### DIFF
--- a/core/ui/mpc/keysign/join/tx/JoinKeysignSwapVerify.tsx
+++ b/core/ui/mpc/keysign/join/tx/JoinKeysignSwapVerify.tsx
@@ -7,6 +7,7 @@ import {
   HorizontalLine,
   IconWrapper,
 } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerify.styled'
+import { SwapVerifyRecipient } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerifyRecipient'
 import { ArrowDownIcon } from '@lib/ui/icons/ArrowDownIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { List } from '@lib/ui/list'
@@ -118,6 +119,7 @@ export const JoinKeysignSwapVerify = ({ value }: ValueProp<KeysignPayload>) => {
           )}
         </List>
       </VStack>
+      <SwapVerifyRecipient keysignPayload={value} />
     </>
   )
 }

--- a/core/ui/vault/swap/verify/SwapVerify/SwapVerifyRecipient.tsx
+++ b/core/ui/vault/swap/verify/SwapVerify/SwapVerifyRecipient.tsx
@@ -1,8 +1,9 @@
-import { useCurrentVaultCoin } from '@core/ui/vault/state/currentVaultCoins'
 import { getSwapRecipientAddress } from '@core/ui/vault/swap/keysignPayload/getSwapRecipientAddress'
-import { useSwapToCoin } from '@core/ui/vault/swap/state/toCoin'
 import { getChainKind } from '@vultisig/core-chain/ChainKind'
+import { getKeysignSwapPayload } from '@vultisig/core-mpc/keysign/swap/getKeysignSwapPayload'
+import { fromCommCoin } from '@vultisig/core-mpc/types/utils/commCoin'
 import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { getRecordUnionValue } from '@vultisig/lib-utils/record/union/getRecordUnionValue'
 import { areLowerCaseEqual } from '@vultisig/lib-utils/string/areLowerCaseEqual'
 
 import { SwapExternalRecipientWarning } from './SwapExternalRecipientWarning'
@@ -13,31 +14,38 @@ type SwapVerifyRecipientProps = {
 
 /**
  * Renders an emphasized warning when the swap output is routed to an address
- * other than the vault's own address on the destination chain. The recipient
- * is read from the built keysign payload (the bytes that will be signed).
- * Default own-address swaps render nothing.
+ * other than the vault's own address on the destination chain. Both the
+ * recipient and the vault's own destination address are read from the built
+ * keysign payload (the bytes that will be signed) rather than live swap form
+ * state, so the warning shows for the initiator and every co-signing joiner
+ * alike. Default own-address swaps render nothing.
  */
 export const SwapVerifyRecipient = ({
   keysignPayload,
 }: SwapVerifyRecipientProps) => {
-  const [toCoinKey] = useSwapToCoin()
-  const toCoin = useCurrentVaultCoin(toCoinKey)
-
   const recipient = getSwapRecipientAddress(keysignPayload)
   if (!recipient) {
     return null
   }
 
-  // EVM addresses are case-insensitive (checksum vs lowercase), so compare them
-  // case-insensitively; other chains use case-sensitive address formats and must
-  // match exactly.
-  const isOwnAddress =
-    getChainKind(toCoin.chain) === 'evm'
-      ? areLowerCaseEqual(recipient, toCoin.address)
-      : recipient === toCoin.address
+  const swapPayload = getKeysignSwapPayload(keysignPayload)
+  const toCoin = swapPayload
+    ? getRecordUnionValue(swapPayload).toCoin
+    : undefined
 
-  if (isOwnAddress) {
-    return null
+  if (toCoin) {
+    const ownCoin = fromCommCoin(toCoin)
+    // EVM addresses are case-insensitive (checksum vs lowercase), so compare
+    // them case-insensitively; other chains use case-sensitive address formats
+    // and must match exactly.
+    const isOwnAddress =
+      getChainKind(ownCoin.chain) === 'evm'
+        ? areLowerCaseEqual(recipient, ownCoin.address)
+        : recipient === ownCoin.address
+
+    if (isOwnAddress) {
+      return null
+    }
   }
 
   return <SwapExternalRecipientWarning address={recipient} />


### PR DESCRIPTION
## Problem

When a swap is configured with a custom **External Recipient** (via *Advanced Settings*), the transaction-confirmation screen shows a warning box telling the user the swap output will be paid to an address other than the vault's own. This worked for the **initiator**, but in a multi-device (Secure Vault) keysign the **joiner** co-signing the transaction saw no warning at all — they co-signed a redirected payout with no visible indication.

## Root cause

The warning was only wired into the initiator's verify component (`SwapVerify` → `SwapVerifyRecipient`, added in #4154). `SwapVerifyRecipient` determined the vault's own destination address via `useSwapToCoin()` — swap form state that only exists on the initiator device. The joiner renders a separate component (`JoinKeysignSwapVerify`) which never included the warning.

## Fix

- `SwapVerifyRecipient` now derives **both** the recipient and the vault's own destination address from the built keysign payload (the bytes that will be signed) — the recipient via `getSwapRecipientAddress`, the own address via the swap payload's `toCoin`. No dependency on swap form state, so it works for any role.
- Render the warning on the joiner's `JoinKeysignSwapVerify` screen too.
- Initiator behavior is unchanged: the payload's `toCoin` is the same vault-owned destination coin that the form provided, so the own-address comparison yields the identical result. EVM addresses still compared case-insensitively; other chains exact.

## Testing

- `yarn check` passes (typecheck + lint + i18n).
- Extension built and verified manually on a Secure Vault:
  - With a custom external recipient → warning box now shows on **both** the initiator and the joiner verify screens.
  - Normal own-address swap → no warning on either screen.

Fixes #4165

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recipient verification display to the key signing swap confirmation flow.

* **Bug Fixes**
  * Enhanced swap recipient address validation to correctly identify vault destinations across blockchain networks, with improved support for case-insensitive address matching on EVM chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->