### PR TITLE
fix(defi): add Manage Positions CTA to empty positions state

### DIFF
--- a/core/ui/defi/chain/tabs/BondedPositions.tsx
+++ b/core/ui/defi/chain/tabs/BondedPositions.tsx
@@ -144,7 +144,7 @@ export const BondedPositions = () => {
   }
 
   if (selectedPositions.length === 0) {
-    return <DefiPositionEmptyState />
+    return <DefiPositionEmptyState returnTab="bonded" />
   }
 
   const selected = new Set(selectedPositions)

--- a/core/ui/defi/chain/tabs/DefiPositionEmptyState.tsx
+++ b/core/ui/defi/chain/tabs/DefiPositionEmptyState.tsx
@@ -1,3 +1,5 @@
+import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
+import { Button } from '@lib/ui/buttons/Button'
 import { CryptoIcon } from '@lib/ui/icons/CryptoIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { VStack } from '@lib/ui/layout/Stack'
@@ -6,8 +8,19 @@ import { getColor } from '@lib/ui/theme/getters'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
-export const DefiPositionEmptyState = () => {
+import { useCurrentDefiChain } from '../useCurrentDefiChain'
+import { DefiChainPageTab } from './config'
+
+type DefiPositionEmptyStateProps = {
+  returnTab?: DefiChainPageTab
+}
+
+export const DefiPositionEmptyState = ({
+  returnTab,
+}: DefiPositionEmptyStateProps) => {
   const { t } = useTranslation()
+  const chain = useCurrentDefiChain()
+  const navigate = useCoreNavigate()
 
   return (
     <EmptyWrapper>
@@ -24,6 +37,18 @@ export const DefiPositionEmptyState = () => {
           </Text>
         </VStack>
       </VStack>
+      <CtaWrapper>
+        <Button
+          onClick={() =>
+            navigate({
+              id: 'manageDefiPositions',
+              state: { chain, returnTab },
+            })
+          }
+        >
+          {t('manage_positions')}
+        </Button>
+      </CtaWrapper>
     </EmptyWrapper>
   )
 }
@@ -36,4 +61,8 @@ const EmptyWrapper = styled.div`
   padding: 40px 20px;
   background-color: ${getColor('foreground')};
   border-radius: 12px;
+`
+
+const CtaWrapper = styled.div`
+  width: fit-content;
 `

--- a/core/ui/defi/chain/tabs/LpPositions.tsx
+++ b/core/ui/defi/chain/tabs/LpPositions.tsx
@@ -264,7 +264,7 @@ export const LpPositions = () => {
   }
 
   if (selectedPositions.length === 0) {
-    return <DefiPositionEmptyState />
+    return <DefiPositionEmptyState returnTab="lps" />
   }
 
   const lpDataMap = new Map((lpQuery.data ?? []).map(d => [d.position.id, d]))

--- a/core/ui/defi/chain/tabs/StakedPositions.tsx
+++ b/core/ui/defi/chain/tabs/StakedPositions.tsx
@@ -74,10 +74,10 @@ export const StakedPositions = () => {
     if (!stakingCoin) {
       // Vault hasn't yet derived this chain. Fall through to the existing
       // empty surface; the user can enable Terra in chain selection.
-      return <DefiPositionEmptyState />
+      return <DefiPositionEmptyState returnTab="staked" />
     }
     if (selectedPositions.length === 0) {
-      return <DefiPositionEmptyState />
+      return <DefiPositionEmptyState returnTab="staked" />
     }
     return (
       <CosmosDelegationsView
@@ -141,7 +141,7 @@ const ThorchainStakedPositions = () => {
   }
 
   if (selectedPositions.length === 0) {
-    return <DefiPositionEmptyState />
+    return <DefiPositionEmptyState returnTab="staked" />
   }
 
   const selected = new Set(selectedPositions)
@@ -149,7 +149,7 @@ const ThorchainStakedPositions = () => {
     data?.stake?.positions.filter(position => selected.has(position.id)) ?? []
 
   if (!isPending && positions.length === 0) {
-    return <DefiPositionEmptyState />
+    return <DefiPositionEmptyState returnTab="staked" />
   }
 
   const autoEnableCoinIfNeeded = async (coinId: string, token: any) => {

--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -1540,4 +1540,5 @@ export const de = {
   swap_mode_market: 'Markt',
   use_external_recipient: 'Externen Empfänger verwenden',
   swap_external_recipient_warning: 'Senden an eine externe Adresse',
+  manage_positions: 'Positionen verwalten',
 }

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -611,6 +611,7 @@ export const en = {
   no_positions_selected: 'No positions selected',
   no_positions_selected_description:
     "You've disabled all positions for this chain. Enable at least one position to view balances and manage actions.",
+  manage_positions: 'Manage Positions',
   total_bonded: 'Total Bonded {{ticker}}',
   active_nodes: 'Active Nodes',
   vulti_node: 'VultiNode',

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -1527,5 +1527,5 @@ export const es = {
   swap_mode_market: 'Mercado',
   use_external_recipient: 'Utilizar destinatario externo',
   swap_external_recipient_warning: 'Enviar a una dirección externa',
-  manage_positions: 'Gestionar puestos',
+  manage_positions: 'Gestionar posiciones',
 }

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -1527,4 +1527,5 @@ export const es = {
   swap_mode_market: 'Mercado',
   use_external_recipient: 'Utilizar destinatario externo',
   swap_external_recipient_warning: 'Enviar a una dirección externa',
+  manage_positions: 'Gestionar puestos',
 }

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -1505,4 +1505,5 @@ export const hr = {
   swap_mode_market: 'Tržište',
   use_external_recipient: 'Koristi vanjskog primatelja',
   swap_external_recipient_warning: 'Slanje na vanjsku adresu',
+  manage_positions: 'Upravljanje pozicijama',
 }

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -1535,4 +1535,5 @@ export const it = {
   swap_mode_market: 'Mercato',
   use_external_recipient: 'Utilizzare un destinatario esterno',
   swap_external_recipient_warning: 'Invio a un indirizzo esterno',
+  manage_positions: 'Gestisci posizioni',
 }

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -1499,5 +1499,5 @@ export const ko = {
   swap_mode_market: '시장',
   use_external_recipient: '외부 수신자 사용',
   swap_external_recipient_warning: '외부 주소로 전송',
-  manage_positions: '직위 관리',
+  manage_positions: '포지션 관리',
 }

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -1499,4 +1499,5 @@ export const ko = {
   swap_mode_market: '시장',
   use_external_recipient: '외부 수신자 사용',
   swap_external_recipient_warning: '외부 주소로 전송',
+  manage_positions: '직위 관리',
 }

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -1512,4 +1512,5 @@ export const nl = {
   swap_mode_market: 'Markt',
   use_external_recipient: 'Externe ontvanger gebruiken',
   swap_external_recipient_warning: 'Verzenden naar een extern adres',
+  manage_positions: 'Posities beheren',
 }

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -1529,4 +1529,5 @@ export const pt = {
   swap_mode_market: 'Mercado',
   use_external_recipient: 'Usar destinatário externo',
   swap_external_recipient_warning: 'Envio para um endereço externo',
+  manage_positions: 'Gerenciar Cargos',
 }

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -1529,5 +1529,5 @@ export const pt = {
   swap_mode_market: 'Mercado',
   use_external_recipient: 'Usar destinatário externo',
   swap_external_recipient_warning: 'Envio para um endereço externo',
-  manage_positions: 'Gerenciar Cargos',
+  manage_positions: 'Gerenciar posições',
 }

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -1509,4 +1509,5 @@ export const ru = {
   swap_mode_market: 'Рынок',
   use_external_recipient: 'Использовать внешнего получателя',
   swap_external_recipient_warning: 'Отправка на внешний адрес',
+  manage_positions: 'Управление позициями',
 }

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -1410,4 +1410,5 @@ export const zh = {
   swap_mode_market: '市场',
   use_external_recipient: '使用外部收件人',
   swap_external_recipient_warning: '发送到外部地址',
+  manage_positions: '管理职位',
 }

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -1410,5 +1410,5 @@ export const zh = {
   swap_mode_market: '市场',
   use_external_recipient: '使用外部收件人',
   swap_external_recipient_warning: '发送到外部地址',
-  manage_positions: '管理职位',
+  manage_positions: '管理仓位',
 }


### PR DESCRIPTION
## Problem
On the DeFi chain view, when all positions are disabled the empty state showed the title + description but **no CTA button** to enable positions. Users were told to "enable at least one position" with no way to act on it from this screen (only the easily-missed pen icon in the tab header).

Closes #4148

## Fix
Add a primary **"Manage Positions"** CTA to `DefiPositionEmptyState`, matching the iOS `ActionBannerView`. It reuses the existing navigation action already wired to the pen icon:

```ts
navigate({ id: 'manageDefiPositions', state: { chain, returnTab } })
```

- `chain` is read directly inside the component via `useCurrentDefiChain()` (no prop threading).
- The shared empty state is used by the **Staked / LP / Bonded** tabs, so each passes its own `returnTab` so the user returns to the tab they came from.

## Changes
- `DefiPositionEmptyState.tsx` — render the CTA `Button` (primary, hug-width) + wire navigation
- `BondedPositions` / `LpPositions` / `StakedPositions` — pass the matching `returnTab`
- `i18n` — new `manage_positions` key in `en.ts`, propagated via `yarn translate`

## Testing
- `yarn typecheck` ✅ and `yarn eslint` on changed files ✅
- `yarn build:extension` ✅ (built clean)
- Manually: open a DeFi chain (THORChain), disable all positions → the empty state now shows the **Manage Positions** button that opens the manage screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **“Manage Positions”** call-to-action to the DeFi empty-state screens for **Bonded**, **LP**, and **Staked** positions, taking you directly to position management and preserving the related tab context.
* **Localization / i18n**
  * Extended translations for **“Manage Positions”** across multiple languages (including **EN, DE, ES, HR, IT, KO, NL, PT, RU, ZH** and others).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->