### PR TITLE
fix(referral): allow back button on landing step (#4180)

### DIFF
--- a/core/ui/vault/settings/referral/components/ReferralLanding.tsx
+++ b/core/ui/vault/settings/referral/components/ReferralLanding.tsx
@@ -61,6 +61,7 @@ const Overlay = styled.div`
     0px -1px 4px 0px rgba(255, 255, 255, 0.2) inset,
     -2px 0px 5px -3px rgba(255, 255, 255, 0.4) inset;
   inset: 0;
+  pointer-events: none;
   position: fixed;
   z-index: 0;
 `


### PR DESCRIPTION
## Summary

Fixes #4180.

On the Referral page's `landing` onboarding step (the "Invite friends. Earn rewards. Save on fees." screen with **Get started**), the header back button (`<`) was visible but **unclickable** — the user was stuck and had to press **Get Started** before back became usable again.

### Root cause
In `ReferralLanding.tsx`, the decorative `Overlay` (`position: fixed; inset: 0`) is rendered after the `PageHeader` in DOM order and paints over the header area, capturing the pointer events on the back button.

### Fix
Mark the `Overlay` as `pointer-events: none`. It is purely decorative dimming, so clicks now pass through to the header. The dim visual is unchanged, and the `summary`/`manage` steps are unaffected.

## Affected screen
Only the not-yet-onboarded `landing` step (`isOnboarded === false`). The `manage` step ("Vultisig Referrals" with Save/Create cards) never had the overlay and was unaffected.

## Testing
- `yarn typecheck` ✅
- `eslint` on changed file ✅
- `yarn build:extension` ✅
- Manual: on the landing step the back arrow now returns to Settings without pressing Get Started; dim overlay still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed overlay interaction issue to allow users to interact with elements positioned beneath overlay components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->