### PR TITLE
fix(extension): keep side panel toggle on in Vivaldi (#4178)

### DIFF
--- a/clients/extension/src/components/side-panel/ManageSidePanel.tsx
+++ b/clients/extension/src/components/side-panel/ManageSidePanel.tsx
@@ -15,17 +15,12 @@ const switchToSidePanel = async () => {
   const currentWindow = await chrome.windows.getCurrent()
   if (currentWindow.id == null) return false
 
+  // A non-throwing open() is our success signal: real failures (missing user
+  // gesture, unsupported API) reject and are caught by the attempt() wrapper in
+  // handleToggle. We intentionally do not gate on chrome.runtime.getContexts —
+  // Chromium forks like Vivaldi open the panel but never report the SIDE_PANEL
+  // context, which previously reverted the toggle despite a successful open.
   await chrome.sidePanel.open({ windowId: currentWindow.id })
-
-  await new Promise(resolve => setTimeout(resolve, 500))
-
-  if (!chrome.runtime.getContexts) return false
-
-  const contexts = await chrome.runtime.getContexts({
-    contextTypes: [chrome.runtime.ContextType.SIDE_PANEL],
-  })
-
-  if (contexts.length === 0) return false
 
   await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true })
 


### PR DESCRIPTION
## Summary

Fixes #4178.

In Vivaldi, tapping **Settings → Open as Side Panel** opened the side panel but the toggle reverted to **off**, leaving the panel visibly open while the setting reported it as disabled.

### Root cause
`switchToSidePanel()` verified success by polling `chrome.runtime.getContexts({ contextTypes: [SIDE_PANEL] })` after a 500ms delay. Chromium forks like Vivaldi open the panel but never report a `SIDE_PANEL` context, so this check returned 0 and `handleToggle` rolled the setting back to `false` despite a successful open.

### Fix
Drop the `getContexts` verification gate and treat a non-throwing `chrome.sidePanel.open()` (+ `setPanelBehavior`) as success. Genuine failures (missing user gesture, unsupported API) still reject and are caught by the existing `attempt()` wrapper in `handleToggle`, which reverts the toggle as before.

## Behavior
- **Vivaldi**: panel opens and toggle stays on. ✅
- **Chrome / Brave**: unchanged — `open()` + `setPanelBehavior` still applied.
- **Firefox**: unchanged — `chrome.sidePanel` is unavailable, the component returns `null` and the guard returns `false`.

## Testing
- `yarn typecheck` ✅
- `eslint` on changed file ✅
- `yarn build:extension` ✅

> Note: after reloading the extension, Chrome/Vivaldi do not auto-reload — reload it in the extensions page and reopen the popup to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced side panel opening reliability across Chromium-based browsers. The side panel now opens without additional verification delays, resolving cases where it failed to open on certain browser variants despite successful API calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->