### PR TITLE
Implement Ethereum wallet permissions

### DIFF
--- a/clients/extension/src/inpage/providers/ethereum/resolvers/wallet_getPermissions.ts
+++ b/clients/extension/src/inpage/providers/ethereum/resolvers/wallet_getPermissions.ts
@@ -1,1 +1,31 @@
-export const getWalletPermissions = async (): Promise<any[]> => []
+import { getEthAccounts } from './eth_accounts'
+
+export type Web3WalletPermission = {
+  parentCapability: 'eth_accounts'
+  caveats: [
+    {
+      type: 'restrictReturnedAccounts'
+      value: string[]
+    },
+  ]
+}
+
+export const getEthAccountsPermission = (
+  accounts: string[]
+): Web3WalletPermission => ({
+  parentCapability: 'eth_accounts',
+  caveats: [
+    {
+      type: 'restrictReturnedAccounts',
+      value: accounts,
+    },
+  ],
+})
+
+export const getWalletPermissions = async (): Promise<
+  Web3WalletPermission[]
+> => {
+  const accounts = await getEthAccounts()
+
+  return accounts.length > 0 ? [getEthAccountsPermission(accounts)] : []
+}

--- a/clients/extension/src/inpage/providers/ethereum/resolvers/wallet_requestPermissions.ts
+++ b/clients/extension/src/inpage/providers/ethereum/resolvers/wallet_requestPermissions.ts
@@ -1,1 +1,23 @@
-export const requestWalletPermissions = async (): Promise<any[]> => []
+import { requestEthAccounts } from './eth_requestAccounts'
+import {
+  getEthAccountsPermission,
+  type Web3WalletPermission,
+} from './wallet_getPermissions'
+
+type WalletRequestPermissionsInput = Array<
+  Partial<Record<Web3WalletPermission['parentCapability'], unknown>>
+>
+
+export const requestWalletPermissions = async (
+  params?: WalletRequestPermissionsInput
+): Promise<Web3WalletPermission[]> => {
+  const requestedPermissions = params?.[0]
+
+  if (!requestedPermissions || !('eth_accounts' in requestedPermissions)) {
+    return []
+  }
+
+  const accounts = await requestEthAccounts(undefined)
+
+  return [getEthAccountsPermission(accounts)]
+}

--- a/clients/extension/tests/unit/ethereum-permissions.test.ts
+++ b/clients/extension/tests/unit/ethereum-permissions.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockGetEthAccounts = vi.fn()
+const mockRequestEthAccounts = vi.fn()
+
+vi.mock(
+  '@clients/extension/src/inpage/providers/ethereum/resolvers/eth_accounts',
+  () => ({
+    getEthAccounts: (...args: unknown[]) => mockGetEthAccounts(...args),
+  })
+)
+
+vi.mock(
+  '@clients/extension/src/inpage/providers/ethereum/resolvers/eth_requestAccounts',
+  () => ({
+    requestEthAccounts: (...args: unknown[]) => mockRequestEthAccounts(...args),
+  })
+)
+
+import { getWalletPermissions } from '@clients/extension/src/inpage/providers/ethereum/resolvers/wallet_getPermissions'
+import { requestWalletPermissions } from '@clients/extension/src/inpage/providers/ethereum/resolvers/wallet_requestPermissions'
+
+describe('Ethereum wallet permissions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns no permissions when no Ethereum accounts are connected', async () => {
+    mockGetEthAccounts.mockResolvedValue([])
+
+    await expect(getWalletPermissions()).resolves.toEqual([])
+  })
+
+  it('returns the eth_accounts permission for connected accounts', async () => {
+    mockGetEthAccounts.mockResolvedValue(['0xabc'])
+
+    await expect(getWalletPermissions()).resolves.toEqual([
+      {
+        parentCapability: 'eth_accounts',
+        caveats: [
+          {
+            type: 'restrictReturnedAccounts',
+            value: ['0xabc'],
+          },
+        ],
+      },
+    ])
+  })
+
+  it('requests accounts and returns the granted eth_accounts permission', async () => {
+    mockRequestEthAccounts.mockResolvedValue(['0xdef'])
+
+    await expect(
+      requestWalletPermissions([{ eth_accounts: {} }])
+    ).resolves.toEqual([
+      {
+        parentCapability: 'eth_accounts',
+        caveats: [
+          {
+            type: 'restrictReturnedAccounts',
+            value: ['0xdef'],
+          },
+        ],
+      },
+    ])
+    expect(mockRequestEthAccounts).toHaveBeenCalledWith(undefined)
+  })
+
+  it('does not prompt when no permissions were requested', async () => {
+    await expect(requestWalletPermissions()).resolves.toEqual([])
+    await expect(requestWalletPermissions([])).resolves.toEqual([])
+    expect(mockRequestEthAccounts).not.toHaveBeenCalled()
+  })
+
+  it('does not prompt when eth_accounts was not requested', async () => {
+    await expect(
+      requestWalletPermissions([{ wallet_snap: {} }])
+    ).resolves.toEqual([])
+    expect(mockRequestEthAccounts).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Closes #4181

Implements EIP-2255-style Ethereum wallet permission responses for wallet_getPermissions and wallet_requestPermissions, including eth_accounts caveats and no-prompt handling for unsupported or empty permission requests.\n\nVerification:\n- yarn workspace @clients/extension test:unit ethereum-permissions.test.ts\n- yarn eslint clients/extension/src/inpage/providers/ethereum/resolvers/wallet_getPermissions.ts clients/extension/src/inpage/providers/ethereum/resolvers/wallet_requestPermissions.ts clients/extension/tests/unit/ethereum-permissions.test.ts\n- yarn typecheck\n- git diff --check origin/main...HEAD\n\nKnown gaps:\n- yarn check currently fails on baseline missing non-English locale entries for swap_invalid_external_recipient.\n- Full browser dApp permission-flow QA was not captured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wallet permission reporting is now fully functional, allowing the extension to properly communicate account permissions to decentralized applications.
  * Permission requests are now properly handled, enabling users to manage permissions through standard request workflows.

* **Tests**
  * Added comprehensive unit tests for wallet permission functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->