### PR TITLE
Fix TRC-20 keysign display decimals

### DIFF
--- a/clients/extension/src/inpage/providers/tronWeb/tronWeb.ts
+++ b/clients/extension/src/inpage/providers/tronWeb/tronWeb.ts
@@ -1,3 +1,4 @@
+import { callBackground } from '@core/inpage-provider/background'
 import { callPopup } from '@core/inpage-provider/popup'
 import {
   TransactionDetails,
@@ -99,13 +100,21 @@ class VultisigTronWebTrx extends Trx {
             )
 
             if (trc20Transfer) {
+              const tokenMetadata = await callBackground({
+                getTokenMetadata: { chain: Chain.Tron, id: contractAddress },
+              }).catch(() => {
+                throw new Error(
+                  `Could not resolve TRC-20 token metadata for ${contractAddress}. Refusing to sign with unknown decimals.`
+                )
+              })
+
               asset = {
-                ticker: 'TRC20',
+                ticker: tokenMetadata.ticker,
                 contractAddress,
               }
               amount = {
                 amount: trc20Transfer.amount.toString(),
-                decimals: 6,
+                decimals: tokenMetadata.decimals,
               }
             }
 

--- a/clients/extension/tests/unit/tron-web.test.ts
+++ b/clients/extension/tests/unit/tron-web.test.ts
@@ -1,0 +1,128 @@
+import { callBackground } from '@core/inpage-provider/background'
+import { callPopup } from '@core/inpage-provider/popup'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { deserializeSigningOutput } from '@vultisig/core-chain/tw/signingOutput'
+import { fromHex } from 'tronweb/utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@core/inpage-provider/background', () => ({
+  callBackground: vi.fn(),
+}))
+
+vi.mock('@core/inpage-provider/popup', () => ({
+  callPopup: vi.fn(),
+}))
+
+vi.mock('@vultisig/core-chain/tw/signingOutput', () => ({
+  deserializeSigningOutput: vi.fn(),
+}))
+
+vi.mock('@clients/extension/src/inpage/providers/ethereum', () => ({
+  processSignature: vi.fn((signature: string) => signature),
+}))
+
+import { VultisigTronWeb } from '@clients/extension/src/inpage/providers/tronWeb/tronWeb'
+
+const ownerHex = '411111111111111111111111111111111111111111'
+const contractHex = '412222222222222222222222222222222222222222'
+const recipientHex = '413333333333333333333333333333333333333333'
+
+const pad64 = (value: string) => value.padStart(64, '0')
+
+const makeTrc20TransferData = (amount: bigint) =>
+  ['a9059cbb', pad64(recipientHex.slice(2)), pad64(amount.toString(16))].join(
+    ''
+  )
+
+const makeTriggerSmartContractTransaction = (amount: bigint) =>
+  ({
+    raw_data: {
+      contract: [
+        {
+          type: 'TriggerSmartContract',
+          parameter: {
+            value: {
+              owner_address: ownerHex,
+              contract_address: contractHex,
+              data: makeTrc20TransferData(amount),
+              call_value: 0,
+            },
+          },
+        },
+      ],
+      expiration: 1,
+      timestamp: 2,
+      ref_block_bytes: '0000',
+      ref_block_hash: '00'.repeat(8),
+      fee_limit: 100_000_000,
+    },
+  }) as any
+
+describe('VultisigTronWeb.trx.sign', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(deserializeSigningOutput).mockReturnValue({
+      signature: Uint8Array.from([1, 2, 3]),
+    } as never)
+    vi.mocked(callPopup).mockResolvedValue([
+      { data: new Uint8Array() },
+    ] as never)
+  })
+
+  it('uses TRC-20 token metadata decimals and ticker for keysign display', async () => {
+    vi.mocked(callBackground).mockResolvedValue({
+      ticker: 'JST',
+      decimals: 18,
+      logo: undefined,
+    } as never)
+
+    const tronWeb = new VultisigTronWeb()
+    await tronWeb.trx.sign(
+      makeTriggerSmartContractTransaction(10_000_000_000_000_000_000n)
+    )
+
+    expect(callBackground).toHaveBeenCalledWith({
+      getTokenMetadata: {
+        chain: Chain.Tron,
+        id: fromHex(contractHex),
+      },
+    })
+
+    expect(callPopup).toHaveBeenCalledWith(
+      {
+        sendTx: {
+          keysign: {
+            chain: Chain.Tron,
+            transactionDetails: expect.objectContaining({
+              asset: {
+                ticker: 'JST',
+                contractAddress: fromHex(contractHex),
+              },
+              amount: {
+                amount: '10000000000000000000',
+                decimals: 18,
+              },
+              to: recipientHex,
+            }),
+          },
+        },
+      },
+      {
+        account: fromHex(ownerHex),
+      }
+    )
+  })
+
+  it('refuses TRC-20 signing when token metadata cannot be resolved', async () => {
+    vi.mocked(callBackground).mockRejectedValue(
+      new Error('metadata unavailable')
+    )
+
+    const tronWeb = new VultisigTronWeb()
+
+    await expect(
+      tronWeb.trx.sign(makeTriggerSmartContractTransaction(1_000_000n))
+    ).rejects.toThrow('Could not resolve TRC-20 token metadata')
+    expect(callPopup).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Closes #4179

Fixes #4179.

Summary:
- Resolve TRC-20 token metadata from the existing background resolver during Tron `trx.sign`.
- Display the resolved ticker and token decimals in keysign details instead of hardcoded `TRC20` / 6 decimals.
- Refuse TRC-20 signing when metadata lookup fails, avoiding a misleading fallback amount.

Verification:
- `yarn workspace @clients/extension test:unit tron-web.test.ts` PASS (2 tests).
- `yarn eslint clients/extension/src/inpage/providers/tronWeb/tronWeb.ts clients/extension/tests/unit/tron-web.test.ts` PASS.
- `yarn typecheck` PASS.
- `yarn workspace @clients/extension build` PASS, including extension brand assertion.
- `git diff --check` PASS.

Known proof gap:
- Full real extension popup QA for a dApp TRC-20 transaction review was not captured in this finish lane.
- `yarn check` reaches the repo i18n gate and fails on pre-existing missing locale key `swap_invalid_external_recipient` in de/es/it/hr/ru/nl/pt/zh/ko.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved TRC-20 transaction handling by automatically fetching token details before signing.
  * TRC-20 transfers now use the token’s actual ticker and decimals instead of fixed defaults.

* **Bug Fixes**
  * Signing is now blocked when token details can’t be resolved, preventing incomplete or incorrect TRC-20 transaction requests.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->