### PR TITLE
feat(qbtc): support secure vaults for QBTC claim

### DIFF
--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -709,8 +709,14 @@ export const de = {
   qbtc_claim_done: 'Erledigt',
   qbtc_claim_failed:
     'Die Reklamation ist fehlgeschlagen. Bitte versuchen Sie es erneut.',
-  qbtc_claim_fast_vault_only:
-    'Für die Geltendmachung von Ansprüchen ist derzeit ein Fast Vault erforderlich. Die Unterstützung für Secure Vault ist in Vorbereitung.',
+  qbtc_claim_cosign_title: 'Co-sign QBTC claim',
+  qbtc_claim_cosign_description:
+    'This device will co-sign a QBTC claim with its Bitcoin key. The claim is recomputed from this vault, so there is no transaction to review.',
+  qbtc_claim_cosign_amount: 'Amount',
+  qbtc_claim_cosign_btc_address: 'Bitcoin address (ownership proof)',
+  qbtc_claim_cosign_qbtc_address: 'QBTC address (claim recipient)',
+  qbtc_claim_cosign_success:
+    "You've co-signed the QBTC claim. The other device will finish and broadcast it.",
   qbtc_claim_password_description:
     'Geben Sie Ihr Fast Vault-Passwort ein, um die Schadensabwicklung mitzuunterzeichnen.',
   receive: 'Erhalten',

--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -711,12 +711,12 @@ export const de = {
     'Die Reklamation ist fehlgeschlagen. Bitte versuchen Sie es erneut.',
   qbtc_claim_cosign_title: 'Co-sign QBTC claim',
   qbtc_claim_cosign_description:
-    'This device will co-sign a QBTC claim with its Bitcoin key. The claim is recomputed from this vault, so there is no transaction to review.',
-  qbtc_claim_cosign_amount: 'Amount',
-  qbtc_claim_cosign_btc_address: 'Bitcoin address (ownership proof)',
-  qbtc_claim_cosign_qbtc_address: 'QBTC address (claim recipient)',
+    'Prüfen Sie den unten stehenden Anspruchsantrag und genehmigen Sie anschließend die Mitunterzeichnung mit dem Bitcoin-Schlüssel dieses Tresors.',
+  qbtc_claim_cosign_amount: 'Menge',
+  qbtc_claim_cosign_btc_address: 'Bitcoin-Adresse (Eigentumsnachweis)',
+  qbtc_claim_cosign_qbtc_address: 'Adresse QBTC (Anspruchsempfänger)',
   qbtc_claim_cosign_success:
-    "You've co-signed the QBTC claim. The other device will finish and broadcast it.",
+    'Sie haben den Anspruch QBTC mitsigniert. Das andere Gerät wird ihn abschließen und senden.',
   qbtc_claim_password_description:
     'Geben Sie Ihr Fast Vault-Passwort ein, um die Schadensabwicklung mitzuunterzeichnen.',
   receive: 'Erhalten',
@@ -1555,4 +1555,6 @@ export const de = {
   feature_gate_your_balance: 'Ihr Guthaben',
   get_vult: 'Hol dir $VULT',
   manage_positions: 'Positionen verwalten',
+  swap_invalid_external_recipient:
+    'Die Empfängeradresse ist für {{chain}} ungültig.',
 }

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -751,8 +751,14 @@ export const en = {
   qbtc_claim_utxos_skipped: 'UTXOs skipped',
   qbtc_claim_done: 'Done',
   qbtc_claim_failed: 'Claim failed. Please try again.',
-  qbtc_claim_fast_vault_only:
-    'Claiming currently requires a Fast Vault. Secure Vault support is on the way.',
+  qbtc_claim_cosign_title: 'Co-sign QBTC claim',
+  qbtc_claim_cosign_description:
+    "Review the claim request below, then approve co-signing it with this vault's Bitcoin key.",
+  qbtc_claim_cosign_amount: 'Amount',
+  qbtc_claim_cosign_btc_address: 'Bitcoin address (ownership proof)',
+  qbtc_claim_cosign_qbtc_address: 'QBTC address (claim recipient)',
+  qbtc_claim_cosign_success:
+    "You've co-signed the QBTC claim. The other device will finish and broadcast it.",
   qbtc_claim_password_description:
     'Enter your Fast Vault password to co-sign the claim transaction.',
   receive: 'Receive',

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -702,14 +702,15 @@ export const es = {
   qbtc_claim_done: 'Hecho',
   qbtc_claim_failed:
     'La reclamación ha fallado. Por favor, inténtelo de nuevo.',
-  qbtc_claim_cosign_title: 'Co-sign QBTC claim',
+  qbtc_claim_cosign_title: 'Firma conjunta de la reclamación QBTC',
   qbtc_claim_cosign_description:
-    'This device will co-sign a QBTC claim with its Bitcoin key. The claim is recomputed from this vault, so there is no transaction to review.',
-  qbtc_claim_cosign_amount: 'Amount',
-  qbtc_claim_cosign_btc_address: 'Bitcoin address (ownership proof)',
-  qbtc_claim_cosign_qbtc_address: 'QBTC address (claim recipient)',
+    'Revise la solicitud de reclamación a continuación y, a continuación, apruebe la firma conjunta con la clave Bitcoin de esta bóveda.',
+  qbtc_claim_cosign_amount: 'Cantidad',
+  qbtc_claim_cosign_btc_address: 'Dirección de Bitcoin (prueba de propiedad)',
+  qbtc_claim_cosign_qbtc_address:
+    'Dirección QBTC (destinatario de la reclamación)',
   qbtc_claim_cosign_success:
-    "You've co-signed the QBTC claim. The other device will finish and broadcast it.",
+    'Has firmado conjuntamente la reclamación QBTC. El otro dispositivo la finalizará y la transmitirá.',
   qbtc_claim_password_description:
     'Ingrese su contraseña de Fast Vault para firmar conjuntamente la transacción de reclamación.',
   receive: 'Recibir',
@@ -1541,4 +1542,6 @@ export const es = {
   feature_gate_your_balance: 'Tu saldo',
   get_vult: 'Obtén $VULT',
   manage_positions: 'Gestionar posiciones',
+  swap_invalid_external_recipient:
+    'La dirección del destinatario no es válida para {{chain}}.',
 }

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -702,8 +702,14 @@ export const es = {
   qbtc_claim_done: 'Hecho',
   qbtc_claim_failed:
     'La reclamación ha fallado. Por favor, inténtelo de nuevo.',
-  qbtc_claim_fast_vault_only:
-    'Actualmente, para reclamar se requiere Fast Vault. La compatibilidad con Secure Vault estará disponible próximamente.',
+  qbtc_claim_cosign_title: 'Co-sign QBTC claim',
+  qbtc_claim_cosign_description:
+    'This device will co-sign a QBTC claim with its Bitcoin key. The claim is recomputed from this vault, so there is no transaction to review.',
+  qbtc_claim_cosign_amount: 'Amount',
+  qbtc_claim_cosign_btc_address: 'Bitcoin address (ownership proof)',
+  qbtc_claim_cosign_qbtc_address: 'QBTC address (claim recipient)',
+  qbtc_claim_cosign_success:
+    "You've co-signed the QBTC claim. The other device will finish and broadcast it.",
   qbtc_claim_password_description:
     'Ingrese su contraseña de Fast Vault para firmar conjuntamente la transacción de reclamación.',
   receive: 'Recibir',

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -692,8 +692,14 @@ export const hr = {
   qbtc_claim_utxos_skipped: 'Preskočeni UTXO-i',
   qbtc_claim_done: 'Gotovo',
   qbtc_claim_failed: 'Zahtjev nije uspio. Pokušajte ponovno.',
-  qbtc_claim_fast_vault_only:
-    'Za polaganje prava trenutno je potreban Fast Vault. Podrška za Secure Vault uskoro će biti dostupna.',
+  qbtc_claim_cosign_title: 'Co-sign QBTC claim',
+  qbtc_claim_cosign_description:
+    'This device will co-sign a QBTC claim with its Bitcoin key. The claim is recomputed from this vault, so there is no transaction to review.',
+  qbtc_claim_cosign_amount: 'Amount',
+  qbtc_claim_cosign_btc_address: 'Bitcoin address (ownership proof)',
+  qbtc_claim_cosign_qbtc_address: 'QBTC address (claim recipient)',
+  qbtc_claim_cosign_success:
+    "You've co-signed the QBTC claim. The other device will finish and broadcast it.",
   qbtc_claim_password_description:
     'Unesite svoju lozinku za Fast Vault kako biste supotpisali transakciju potraživanja.',
   receive: 'Primi',

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -692,14 +692,14 @@ export const hr = {
   qbtc_claim_utxos_skipped: 'Preskočeni UTXO-i',
   qbtc_claim_done: 'Gotovo',
   qbtc_claim_failed: 'Zahtjev nije uspio. Pokušajte ponovno.',
-  qbtc_claim_cosign_title: 'Co-sign QBTC claim',
+  qbtc_claim_cosign_title: 'Supotpišite zahtjev QBTC',
   qbtc_claim_cosign_description:
-    'This device will co-sign a QBTC claim with its Bitcoin key. The claim is recomputed from this vault, so there is no transaction to review.',
-  qbtc_claim_cosign_amount: 'Amount',
-  qbtc_claim_cosign_btc_address: 'Bitcoin address (ownership proof)',
-  qbtc_claim_cosign_qbtc_address: 'QBTC address (claim recipient)',
+    'Pregledajte zahtjev za polaganje prava u nastavku, a zatim odobrite njegovo supotpisivanje Bitcoin ključem ovog trezora.',
+  qbtc_claim_cosign_amount: 'Iznositi',
+  qbtc_claim_cosign_btc_address: 'Bitcoin adresa (dokaz vlasništva)',
+  qbtc_claim_cosign_qbtc_address: 'Adresa QBTC (primatelj zahtjeva)',
   qbtc_claim_cosign_success:
-    "You've co-signed the QBTC claim. The other device will finish and broadcast it.",
+    'Supotpisali ste zahtjev QBTC. Drugi uređaj će ga završiti i emitirati.',
   qbtc_claim_password_description:
     'Unesite svoju lozinku za Fast Vault kako biste supotpisali transakciju potraživanja.',
   receive: 'Primi',
@@ -1519,4 +1519,6 @@ export const hr = {
   feature_gate_your_balance: 'Vaš saldo',
   get_vult: 'Uzmi $VULT',
   manage_positions: 'Upravljanje pozicijama',
+  swap_invalid_external_recipient:
+    'Adresa primatelja nije valjana za {{chain}}',
 }

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -695,7 +695,7 @@ export const hr = {
   qbtc_claim_cosign_title: 'Supotpišite zahtjev QBTC',
   qbtc_claim_cosign_description:
     'Pregledajte zahtjev za polaganje prava u nastavku, a zatim odobrite njegovo supotpisivanje Bitcoin ključem ovog trezora.',
-  qbtc_claim_cosign_amount: 'Iznositi',
+  qbtc_claim_cosign_amount: 'Iznos',
   qbtc_claim_cosign_btc_address: 'Bitcoin adresa (dokaz vlasništva)',
   qbtc_claim_cosign_qbtc_address: 'Adresa QBTC (primatelj zahtjeva)',
   qbtc_claim_cosign_success:

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -705,8 +705,14 @@ export const it = {
   qbtc_claim_utxos_skipped: 'UTXO saltati',
   qbtc_claim_done: 'Fatto',
   qbtc_claim_failed: 'Richiesta non riuscita. Riprova.',
-  qbtc_claim_fast_vault_only:
-    'Al momento, per riscattare i propri beni è necessario un Fast Vault. Il supporto per Secure Vault sarà disponibile a breve.',
+  qbtc_claim_cosign_title: 'Co-sign QBTC claim',
+  qbtc_claim_cosign_description:
+    'This device will co-sign a QBTC claim with its Bitcoin key. The claim is recomputed from this vault, so there is no transaction to review.',
+  qbtc_claim_cosign_amount: 'Amount',
+  qbtc_claim_cosign_btc_address: 'Bitcoin address (ownership proof)',
+  qbtc_claim_cosign_qbtc_address: 'QBTC address (claim recipient)',
+  qbtc_claim_cosign_success:
+    "You've co-signed the QBTC claim. The other device will finish and broadcast it.",
   qbtc_claim_password_description:
     'Inserisci la password di Fast Vault per controfirmare la transazione di richiesta.',
   receive: 'Ricevere',

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -705,14 +705,15 @@ export const it = {
   qbtc_claim_utxos_skipped: 'UTXO saltati',
   qbtc_claim_done: 'Fatto',
   qbtc_claim_failed: 'Richiesta non riuscita. Riprova.',
-  qbtc_claim_cosign_title: 'Co-sign QBTC claim',
+  qbtc_claim_cosign_title: 'Co-firma la rivendicazione QBTC',
   qbtc_claim_cosign_description:
-    'This device will co-sign a QBTC claim with its Bitcoin key. The claim is recomputed from this vault, so there is no transaction to review.',
-  qbtc_claim_cosign_amount: 'Amount',
-  qbtc_claim_cosign_btc_address: 'Bitcoin address (ownership proof)',
-  qbtc_claim_cosign_qbtc_address: 'QBTC address (claim recipient)',
+    'Esamina la richiesta di rivendicazione qui sotto, quindi approva la controfirma utilizzando la chiave Bitcoin di questo vault.',
+  qbtc_claim_cosign_amount: 'Quantità',
+  qbtc_claim_cosign_btc_address: 'Indirizzo Bitcoin (prova di proprietà)',
+  qbtc_claim_cosign_qbtc_address:
+    'Indirizzo QBTC (destinatario della richiesta)',
   qbtc_claim_cosign_success:
-    "You've co-signed the QBTC claim. The other device will finish and broadcast it.",
+    'Hai controfirmato la rivendicazione QBTC. L&#39;altro dispositivo la completerà e la trasmetterà.',
   qbtc_claim_password_description:
     'Inserisci la password di Fast Vault per controfirmare la transazione di richiesta.',
   receive: 'Ricevere',
@@ -1549,4 +1550,6 @@ export const it = {
   feature_gate_your_balance: 'Il tuo saldo',
   get_vult: 'Ottieni $VULT',
   manage_positions: 'Gestisci posizioni',
+  swap_invalid_external_recipient:
+    'L&#39;indirizzo del destinatario non è valido per {{chain}}',
 }

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -690,14 +690,14 @@ export const ko = {
   qbtc_claim_utxos_skipped: 'UTXO가 건너뛰었습니다',
   qbtc_claim_done: '완료',
   qbtc_claim_failed: '청구가 실패했습니다. 다시 시도해 주세요.',
-  qbtc_claim_cosign_title: 'Co-sign QBTC claim',
+  qbtc_claim_cosign_title: 'QBTC 클레임에 공동 서명',
   qbtc_claim_cosign_description:
-    'This device will co-sign a QBTC claim with its Bitcoin key. The claim is recomputed from this vault, so there is no transaction to review.',
-  qbtc_claim_cosign_amount: 'Amount',
-  qbtc_claim_cosign_btc_address: 'Bitcoin address (ownership proof)',
-  qbtc_claim_cosign_qbtc_address: 'QBTC address (claim recipient)',
+    '아래의 청구 요청을 검토하신 후, 이 금고의 비트코인 ​​키로 공동 서명하는 것을 승인해 주세요.',
+  qbtc_claim_cosign_amount: '양',
+  qbtc_claim_cosign_btc_address: '비트코인 주소(소유권 증명)',
+  qbtc_claim_cosign_qbtc_address: 'QBTC 주소(클레임 수신자)',
   qbtc_claim_cosign_success:
-    "You've co-signed the QBTC claim. The other device will finish and broadcast it.",
+    'QBTC 클레임에 공동 서명하셨습니다. 다른 기기에서 서명을 완료하고 브로드캐스트할 것입니다.',
   qbtc_claim_password_description:
     '청구 거래에 공동 서명하려면 Fast Vault 비밀번호를 입력하십시오.',
   receive: '받다',
@@ -1513,4 +1513,6 @@ export const ko = {
   feature_gate_your_balance: '잔액',
   get_vult: '$VULT를 가져오세요',
   manage_positions: '포지션 관리',
+  swap_invalid_external_recipient:
+    '수신자 주소가 {{chain}}에 대해 유효하지 않습니다.',
 }

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -690,8 +690,14 @@ export const ko = {
   qbtc_claim_utxos_skipped: 'UTXO가 건너뛰었습니다',
   qbtc_claim_done: '완료',
   qbtc_claim_failed: '청구가 실패했습니다. 다시 시도해 주세요.',
-  qbtc_claim_fast_vault_only:
-    '현재 클레임을 위해서는 Fast Vault가 필요합니다. Secure Vault 지원은 곧 제공될 예정입니다.',
+  qbtc_claim_cosign_title: 'Co-sign QBTC claim',
+  qbtc_claim_cosign_description:
+    'This device will co-sign a QBTC claim with its Bitcoin key. The claim is recomputed from this vault, so there is no transaction to review.',
+  qbtc_claim_cosign_amount: 'Amount',
+  qbtc_claim_cosign_btc_address: 'Bitcoin address (ownership proof)',
+  qbtc_claim_cosign_qbtc_address: 'QBTC address (claim recipient)',
+  qbtc_claim_cosign_success:
+    "You've co-signed the QBTC claim. The other device will finish and broadcast it.",
   qbtc_claim_password_description:
     '청구 거래에 공동 서명하려면 Fast Vault 비밀번호를 입력하십시오.',
   receive: '받다',

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -696,8 +696,14 @@ export const nl = {
   qbtc_claim_utxos_skipped: 'UTXO&#39;s overgeslagen',
   qbtc_claim_done: 'Klaar',
   qbtc_claim_failed: 'Claim mislukt. Probeer het opnieuw.',
-  qbtc_claim_fast_vault_only:
-    'Voor het claimen van gegevens is momenteel een Fast Vault vereist. Ondersteuning voor Secure Vault is in ontwikkeling.',
+  qbtc_claim_cosign_title: 'Co-sign QBTC claim',
+  qbtc_claim_cosign_description:
+    'This device will co-sign a QBTC claim with its Bitcoin key. The claim is recomputed from this vault, so there is no transaction to review.',
+  qbtc_claim_cosign_amount: 'Amount',
+  qbtc_claim_cosign_btc_address: 'Bitcoin address (ownership proof)',
+  qbtc_claim_cosign_qbtc_address: 'QBTC address (claim recipient)',
+  qbtc_claim_cosign_success:
+    "You've co-signed the QBTC claim. The other device will finish and broadcast it.",
   qbtc_claim_password_description:
     'Voer uw Fast Vault-wachtwoord in om de claimtransactie mede te ondertekenen.',
   receive: 'Ontvangen',

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -696,14 +696,14 @@ export const nl = {
   qbtc_claim_utxos_skipped: 'UTXO&#39;s overgeslagen',
   qbtc_claim_done: 'Klaar',
   qbtc_claim_failed: 'Claim mislukt. Probeer het opnieuw.',
-  qbtc_claim_cosign_title: 'Co-sign QBTC claim',
+  qbtc_claim_cosign_title: 'Medeonderteken de QBTC-claim',
   qbtc_claim_cosign_description:
-    'This device will co-sign a QBTC claim with its Bitcoin key. The claim is recomputed from this vault, so there is no transaction to review.',
-  qbtc_claim_cosign_amount: 'Amount',
-  qbtc_claim_cosign_btc_address: 'Bitcoin address (ownership proof)',
-  qbtc_claim_cosign_qbtc_address: 'QBTC address (claim recipient)',
+    'Bekijk het onderstaande claimverzoek en keur vervolgens de medeondertekening ervan goed met de Bitcoin-sleutel van deze kluis.',
+  qbtc_claim_cosign_amount: 'Hoeveelheid',
+  qbtc_claim_cosign_btc_address: 'Bitcoin-adres (bewijs van eigendom)',
+  qbtc_claim_cosign_qbtc_address: 'QBTC-adres (claimontvanger)',
   qbtc_claim_cosign_success:
-    "You've co-signed the QBTC claim. The other device will finish and broadcast it.",
+    'Je hebt de claim QBTC medeondertekend. Het andere apparaat zal de claim voltooien en verzenden.',
   qbtc_claim_password_description:
     'Voer uw Fast Vault-wachtwoord in om de claimtransactie mede te ondertekenen.',
   receive: 'Ontvangen',
@@ -1526,4 +1526,6 @@ export const nl = {
   feature_gate_your_balance: 'Uw saldo',
   get_vult: 'Haal $VULT op',
   manage_positions: 'Posities beheren',
+  swap_invalid_external_recipient:
+    'Het ontvangersadres is niet geldig voor {{chain}}',
 }

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -703,8 +703,14 @@ export const pt = {
   qbtc_claim_utxos_skipped: 'UTXOs ignorados',
   qbtc_claim_done: 'Feito',
   qbtc_claim_failed: 'A solicitação falhou. Tente novamente.',
-  qbtc_claim_fast_vault_only:
-    'Atualmente, o resgate requer um Fast Vault. O suporte para Secure Vault está a caminho.',
+  qbtc_claim_cosign_title: 'Co-sign QBTC claim',
+  qbtc_claim_cosign_description:
+    'This device will co-sign a QBTC claim with its Bitcoin key. The claim is recomputed from this vault, so there is no transaction to review.',
+  qbtc_claim_cosign_amount: 'Amount',
+  qbtc_claim_cosign_btc_address: 'Bitcoin address (ownership proof)',
+  qbtc_claim_cosign_qbtc_address: 'QBTC address (claim recipient)',
+  qbtc_claim_cosign_success:
+    "You've co-signed the QBTC claim. The other device will finish and broadcast it.",
   qbtc_claim_password_description:
     'Insira sua senha do Fast Vault para coassinar a transação de reivindicação.',
   receive: 'Receber',

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -703,14 +703,15 @@ export const pt = {
   qbtc_claim_utxos_skipped: 'UTXOs ignorados',
   qbtc_claim_done: 'Feito',
   qbtc_claim_failed: 'A solicitação falhou. Tente novamente.',
-  qbtc_claim_cosign_title: 'Co-sign QBTC claim',
+  qbtc_claim_cosign_title: 'Assinar em conjunto a declaração QBTC',
   qbtc_claim_cosign_description:
-    'This device will co-sign a QBTC claim with its Bitcoin key. The claim is recomputed from this vault, so there is no transaction to review.',
-  qbtc_claim_cosign_amount: 'Amount',
-  qbtc_claim_cosign_btc_address: 'Bitcoin address (ownership proof)',
-  qbtc_claim_cosign_qbtc_address: 'QBTC address (claim recipient)',
+    'Analise o pedido de reivindicação abaixo e, em seguida, aprove a assinatura conjunta com a chave Bitcoin deste cofre.',
+  qbtc_claim_cosign_amount: 'Quantia',
+  qbtc_claim_cosign_btc_address:
+    'Endereço Bitcoin (comprovante de propriedade)',
+  qbtc_claim_cosign_qbtc_address: 'Endereço QBTC (destinatário da solicitação)',
   qbtc_claim_cosign_success:
-    "You've co-signed the QBTC claim. The other device will finish and broadcast it.",
+    'Você assinou em conjunto a declaração QBTC. O outro dispositivo irá concluir e transmiti-la.',
   qbtc_claim_password_description:
     'Insira sua senha do Fast Vault para coassinar a transação de reivindicação.',
   receive: 'Receber',
@@ -1543,4 +1544,6 @@ export const pt = {
   feature_gate_your_balance: 'Seu saldo',
   get_vult: 'Obtenha $VULT',
   manage_positions: 'Gerenciar posições',
+  swap_invalid_external_recipient:
+    'O endereço do destinatário não é válido para {{chain}}',
 }

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -692,14 +692,15 @@ export const ru = {
   qbtc_claim_utxos_skipped: 'UTXO пропущены',
   qbtc_claim_done: 'Готово',
   qbtc_claim_failed: 'Заявка не прошла. Пожалуйста, попробуйте еще раз.',
-  qbtc_claim_cosign_title: 'Co-sign QBTC claim',
+  qbtc_claim_cosign_title: 'Подписать совместно заявку QBTC',
   qbtc_claim_cosign_description:
-    'This device will co-sign a QBTC claim with its Bitcoin key. The claim is recomputed from this vault, so there is no transaction to review.',
-  qbtc_claim_cosign_amount: 'Amount',
-  qbtc_claim_cosign_btc_address: 'Bitcoin address (ownership proof)',
-  qbtc_claim_cosign_qbtc_address: 'QBTC address (claim recipient)',
+    'Ознакомьтесь с запросом на получение средств ниже, а затем подтвердите его, подписав его совместно с биткойн-ключом этого хранилища.',
+  qbtc_claim_cosign_amount: 'Количество',
+  qbtc_claim_cosign_btc_address:
+    'Биткоин-адрес (подтверждение права собственности)',
+  qbtc_claim_cosign_qbtc_address: 'Адрес QBTC (получатель заявки)',
   qbtc_claim_cosign_success:
-    "You've co-signed the QBTC claim. The other device will finish and broadcast it.",
+    'Вы подписали совместно запрос QBTC. Другое устройство завершит его и передаст дальше.',
   qbtc_claim_password_description:
     'Введите свой пароль от Fast Vault, чтобы подписать транзакцию по заявке.',
   receive: 'Получить',
@@ -1524,4 +1525,6 @@ export const ru = {
   feature_gate_your_balance: 'Ваш баланс',
   get_vult: 'Получить $VULT',
   manage_positions: 'Управление позициями',
+  swap_invalid_external_recipient:
+    'Адрес получателя недействителен для {{chain}}',
 }

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -692,8 +692,14 @@ export const ru = {
   qbtc_claim_utxos_skipped: 'UTXO пропущены',
   qbtc_claim_done: 'Готово',
   qbtc_claim_failed: 'Заявка не прошла. Пожалуйста, попробуйте еще раз.',
-  qbtc_claim_fast_vault_only:
-    'В настоящее время для получения средств требуется Fast Vault. Поддержка Secure Vault появится в будущем.',
+  qbtc_claim_cosign_title: 'Co-sign QBTC claim',
+  qbtc_claim_cosign_description:
+    'This device will co-sign a QBTC claim with its Bitcoin key. The claim is recomputed from this vault, so there is no transaction to review.',
+  qbtc_claim_cosign_amount: 'Amount',
+  qbtc_claim_cosign_btc_address: 'Bitcoin address (ownership proof)',
+  qbtc_claim_cosign_qbtc_address: 'QBTC address (claim recipient)',
+  qbtc_claim_cosign_success:
+    "You've co-signed the QBTC claim. The other device will finish and broadcast it.",
   qbtc_claim_password_description:
     'Введите свой пароль от Fast Vault, чтобы подписать транзакцию по заявке.',
   receive: 'Получить',

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -647,8 +647,14 @@ export const zh = {
   qbtc_claim_utxos_skipped: 'UTXO 跳过',
   qbtc_claim_done: '完毕',
   qbtc_claim_failed: '申领失败，请重试。',
-  qbtc_claim_fast_vault_only:
-    '目前申领需要 Fast Vault。Secure Vault 支持即将推出。',
+  qbtc_claim_cosign_title: 'Co-sign QBTC claim',
+  qbtc_claim_cosign_description:
+    'This device will co-sign a QBTC claim with its Bitcoin key. The claim is recomputed from this vault, so there is no transaction to review.',
+  qbtc_claim_cosign_amount: 'Amount',
+  qbtc_claim_cosign_btc_address: 'Bitcoin address (ownership proof)',
+  qbtc_claim_cosign_qbtc_address: 'QBTC address (claim recipient)',
+  qbtc_claim_cosign_success:
+    "You've co-signed the QBTC claim. The other device will finish and broadcast it.",
   qbtc_claim_password_description:
     '输入您的 Fast Vault 密码以共同签署申领交易。',
   receive: '收到',

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -647,14 +647,14 @@ export const zh = {
   qbtc_claim_utxos_skipped: 'UTXO 跳过',
   qbtc_claim_done: '完毕',
   qbtc_claim_failed: '申领失败，请重试。',
-  qbtc_claim_cosign_title: 'Co-sign QBTC claim',
+  qbtc_claim_cosign_title: '共同签名 QBTC 声明',
   qbtc_claim_cosign_description:
-    'This device will co-sign a QBTC claim with its Bitcoin key. The claim is recomputed from this vault, so there is no transaction to review.',
-  qbtc_claim_cosign_amount: 'Amount',
-  qbtc_claim_cosign_btc_address: 'Bitcoin address (ownership proof)',
-  qbtc_claim_cosign_qbtc_address: 'QBTC address (claim recipient)',
+    '请查看下面的索赔请求，然后批准使用此金库的比特币密钥对其进行共同签名。',
+  qbtc_claim_cosign_amount: '数量',
+  qbtc_claim_cosign_btc_address: '比特币地址（所有权证明）',
+  qbtc_claim_cosign_qbtc_address: 'QBTC 地址（索赔接收人）',
   qbtc_claim_cosign_success:
-    "You've co-signed the QBTC claim. The other device will finish and broadcast it.",
+    '您已共同签署了 QBTC 声明。另一台设备将完成并广播该声明。',
   qbtc_claim_password_description:
     '输入您的 Fast Vault 密码以共同签署申领交易。',
   receive: '收到',
@@ -1424,4 +1424,5 @@ export const zh = {
   feature_gate_your_balance: '您的余额',
   get_vult: '获取 $VULT',
   manage_positions: '管理仓位',
+  swap_invalid_external_recipient: '收件人地址对 {{chain}} 无效。',
 }

--- a/core/ui/mpc/keysign/DownloadKeysignQrCode.tsx
+++ b/core/ui/mpc/keysign/DownloadKeysignQrCode.tsx
@@ -1,7 +1,6 @@
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { SaveAsImage } from '@core/ui/file/SaveAsImage'
 import { useJoinKeysignUrlQuery } from '@core/ui/mpc/keysign/queries/useJoinKeysignUrlQuery'
-import { useCoreViewState } from '@core/ui/navigation/hooks/useCoreViewState'
 import {
   PrintableQrCode,
   PrintableQrCodeRow,
@@ -10,9 +9,11 @@ import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { IconButton } from '@lib/ui/buttons/IconButton'
 import { FileUpIcon } from '@lib/ui/icons/FileUpIcon'
 import { HStack } from '@lib/ui/layout/Stack'
+import { ValueProp } from '@lib/ui/props'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
 import { Text } from '@lib/ui/text'
 import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
+import { KeysignMessagePayload } from '@vultisig/core-mpc/keysign/keysignPayload/KeysignMessagePayload'
 import { fromCommCoin } from '@vultisig/core-mpc/types/utils/commCoin'
 import { formatAmount } from '@vultisig/lib-utils/formatAmount'
 import { formatWalletAddress } from '@vultisig/lib-utils/formatWalletAddress'
@@ -22,8 +23,9 @@ import { useTranslation } from 'react-i18next'
 import { currentProductBrandConfig } from '../../product/brand'
 import { getVaultExportUid } from '../../vault/export/core/uid'
 
-export const DownloadKeysignQrCode = () => {
-  const [{ keysignPayload }] = useCoreViewState<'keysign'>()
+export const DownloadKeysignQrCode = ({
+  value: keysignPayload,
+}: ValueProp<KeysignMessagePayload>) => {
   const joinKeysignUrlQuery = useJoinKeysignUrlQuery(keysignPayload)
   const { t } = useTranslation()
   const vault = useCurrentVault()

--- a/core/ui/mpc/keysign/KeysignSigningStep.tsx
+++ b/core/ui/mpc/keysign/KeysignSigningStep.tsx
@@ -59,6 +59,28 @@ export const KeysignSigningStep = ({
             value={payload}
             handlers={{
               keysign: payload => {
+                // A QBTC claim co-sign produces a raw signature, not a tx —
+                // the initiating device broadcasts. Show a simple confirmation
+                // instead of the tx-overview path (which expects `txs`).
+                if (payload.isQbtcClaim) {
+                  return (
+                    <>
+                      <PageContent alignItems="center" scrollable>
+                        <VStack gap={16} maxWidth={576} fullWidth>
+                          <Panel>
+                            <Text>{t('qbtc_claim_cosign_success')}</Text>
+                          </Panel>
+                        </VStack>
+                      </PageContent>
+                      <PageFooter alignItems="center">
+                        <VStack maxWidth={576} fullWidth>
+                          <Button onClick={goHome}>{t('complete')}</Button>
+                        </VStack>
+                      </PageFooter>
+                    </>
+                  )
+                }
+
                 const { swapPayload } = payload
                 const isSwapTx = swapPayload && swapPayload.value
                 const txs = getRecordUnionValue(result, 'txs')

--- a/core/ui/mpc/keysign/action/mutations/useKeysignMutation.ts
+++ b/core/ui/mpc/keysign/action/mutations/useKeysignMutation.ts
@@ -47,6 +47,7 @@ import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
 import { chainPromises } from '@vultisig/lib-utils/promise/chainPromises'
 import { recordFromItems } from '@vultisig/lib-utils/record/recordFromItems'
 
+import { getClaimMessageHashHex } from '../../../../qbtc/claim/utils/getClaimMessageHashHex'
 import {
   getCowSwapKeysignData,
   signCowSwapOrder,
@@ -67,6 +68,34 @@ export const useKeysignMutation = (payload: KeysignMessagePayload) => {
         payload,
         {
           keysign: async payload => {
+            // Secure-vault QBTC claim round 1: a flag-only Bitcoin payload.
+            // Recompute the claim hash from THIS device's own vault (never
+            // trust the wire) and BTC-ECDSA co-sign it. The hash is fully
+            // determined by the vault, so a compromised initiator cannot
+            // divert this signature to an arbitrary Bitcoin spend.
+            if (payload.isQbtcClaim) {
+              const messageHashHex = getClaimMessageHashHex({
+                vault,
+                walletCore,
+              })
+              const [signature] = await keysignAction({
+                msgs: [messageHashHex],
+                signatureAlgorithm: 'ecdsa',
+                coinType: getCoinType({ walletCore, chain: Chain.Bitcoin }),
+                chain: Chain.Bitcoin,
+              })
+
+              const result = generateSignature({
+                walletCore,
+                signature,
+                signatureFormat: signatureFormats.utxo,
+              })
+
+              return {
+                signature: Buffer.from(result).toString('hex'),
+              }
+            }
+
             const chain = getKeysignChain(payload)
 
             // CowSwap RFQ: off-chain order signed via EIP-712 and submitted to

--- a/core/ui/mpc/keysign/join/JoinKeysignQbtcClaimVerify.tsx
+++ b/core/ui/mpc/keysign/join/JoinKeysignQbtcClaimVerify.tsx
@@ -1,0 +1,60 @@
+import { TxOverviewPanel } from '@core/ui/chain/tx/TxOverviewPanel'
+import {
+  TxOverviewChainDataRow,
+  TxOverviewRow,
+} from '@core/ui/chain/tx/TxOverviewRow'
+import { VStack } from '@lib/ui/layout/Stack'
+import { ValueProp } from '@lib/ui/props'
+import { Text } from '@lib/ui/text'
+import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
+import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
+import { formatAmount } from '@vultisig/lib-utils/formatAmount'
+import { useTranslation } from 'react-i18next'
+
+/**
+ * Verify screen shown to a secure-vault co-signer for a QBTC claim. Every value
+ * is read straight from the pairing QR: the Bitcoin address and decimals from
+ * `coin`, the QBTC recipient from `toAddress`, and the claimed total (base
+ * units) from `toAmount`. (The signature itself is still recomputed from this
+ * device's own vault, so these display values can't redirect the signing.)
+ */
+export const JoinKeysignQbtcClaimVerify = ({
+  value,
+}: ValueProp<KeysignPayload>) => {
+  const { t } = useTranslation()
+
+  const coin = shouldBePresent(value.coin, 'QBTC claim coin')
+
+  const claimedAmount = formatAmount(
+    fromChainAmount(BigInt(value.toAmount), coin.decimals),
+    { precision: 'high' }
+  )
+
+  return (
+    <VStack gap={16}>
+      <VStack gap={8}>
+        <Text size={18} weight="600" color="contrast">
+          {t('qbtc_claim_cosign_title')}
+        </Text>
+        <Text size={14} color="supporting">
+          {t('qbtc_claim_cosign_description')}
+        </Text>
+      </VStack>
+      <TxOverviewPanel>
+        <TxOverviewRow>
+          <span>{t('qbtc_claim_cosign_amount')}</span>
+          <span>{`${claimedAmount} QBTC`}</span>
+        </TxOverviewRow>
+        <TxOverviewChainDataRow>
+          <span>{t('qbtc_claim_cosign_btc_address')}</span>
+          <span>{coin.address}</span>
+        </TxOverviewChainDataRow>
+        <TxOverviewChainDataRow>
+          <span>{t('qbtc_claim_cosign_qbtc_address')}</span>
+          <span>{value.toAddress}</span>
+        </TxOverviewChainDataRow>
+      </TxOverviewPanel>
+    </VStack>
+  )
+}

--- a/core/ui/mpc/keysign/join/JoinKeysignQbtcClaimVerify.tsx
+++ b/core/ui/mpc/keysign/join/JoinKeysignQbtcClaimVerify.tsx
@@ -9,6 +9,7 @@ import { Text } from '@lib/ui/text'
 import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
 import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
+import { attempt } from '@vultisig/lib-utils/attempt'
 import { formatAmount } from '@vultisig/lib-utils/formatAmount'
 import { useTranslation } from 'react-i18next'
 
@@ -26,10 +27,14 @@ export const JoinKeysignQbtcClaimVerify = ({
 
   const coin = shouldBePresent(value.coin, 'QBTC claim coin')
 
-  const claimedAmount = formatAmount(
-    fromChainAmount(BigInt(value.toAmount), coin.decimals),
-    { precision: 'high' }
+  // `toAmount` comes off the wire — guard the BigInt parse so a malformed value
+  // shows a placeholder instead of crashing the verify screen.
+  const parsedAmount = attempt(() =>
+    formatAmount(fromChainAmount(BigInt(value.toAmount), coin.decimals), {
+      precision: 'high',
+    })
   )
+  const claimedAmount = 'data' in parsedAmount ? parsedAmount.data : '—'
 
   return (
     <VStack gap={16}>

--- a/core/ui/mpc/keysign/join/JoinKeysignVerifyStep.tsx
+++ b/core/ui/mpc/keysign/join/JoinKeysignVerifyStep.tsx
@@ -1,5 +1,6 @@
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { JoinKeysignCustomMessageVerify } from '@core/ui/mpc/keysign/join/JoinKeysignCustomMessageVerify'
+import { JoinKeysignQbtcClaimVerify } from '@core/ui/mpc/keysign/join/JoinKeysignQbtcClaimVerify'
 import { JoinKeysignButton } from '@core/ui/mpc/keysign/join/tx/JoinKeysignButton'
 import { JoinKeysignTransactionVerify } from '@core/ui/mpc/keysign/join/tx/JoinKeysignTransactionVerify'
 import { useCoreViewState } from '@core/ui/navigation/hooks/useCoreViewState'
@@ -32,9 +33,24 @@ export const JoinKeysignVerifyStep = ({ onFinish }: OnFinishProp) => {
       <MatchRecordUnion
         value={keysignPayload}
         handlers={{
-          keysign: payload => (
-            <JoinKeysignTransactionVerify value={payload} onFinish={onFinish} />
-          ),
+          keysign: payload =>
+            payload.isQbtcClaim ? (
+              <>
+                <PageContent scrollable>
+                  <VStack flexGrow>
+                    <JoinKeysignQbtcClaimVerify value={payload} />
+                  </VStack>
+                </PageContent>
+                <PageFooter>
+                  <JoinKeysignButton onClick={onFinish} />
+                </PageFooter>
+              </>
+            ) : (
+              <JoinKeysignTransactionVerify
+                value={payload}
+                onFinish={onFinish}
+              />
+            ),
           custom: value => (
             <>
               <PageContent scrollable>

--- a/core/ui/mpc/keysign/peers/KeysignPeerDiscoveryStep.tsx
+++ b/core/ui/mpc/keysign/peers/KeysignPeerDiscoveryStep.tsx
@@ -77,7 +77,7 @@ export const KeysignPeerDiscoveryStep = ({
       <MpcPeersCorrector />
       <PageHeader
         primaryControls={<PageHeaderBackButton />}
-        secondaryControls={<DownloadKeysignQrCode />}
+        secondaryControls={<DownloadKeysignQrCode value={payload} />}
         title={t('scan_qr')}
         hasBorder
       />

--- a/core/ui/qbtc/claim/components/ClaimPreparingTxPhase.tsx
+++ b/core/ui/qbtc/claim/components/ClaimPreparingTxPhase.tsx
@@ -1,4 +1,5 @@
 import { FullPageFlowErrorState } from '@core/ui/flow/FullPageFlowErrorState'
+import { useCurrentVaultSecurityType } from '@core/ui/vault/state/currentVault'
 import { VStack } from '@lib/ui/layout/Stack'
 import { Spinner } from '@lib/ui/loaders/Spinner'
 import { PageHeader } from '@lib/ui/page/PageHeader'
@@ -11,6 +12,7 @@ import { KeysignSignature } from '@vultisig/core-mpc/keysign/KeysignSignature'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { qbtcChainId } from '../../dapp/qbtcDirectConstants'
 import { buildClaimPreSignHash } from '../utils/buildClaimSignDoc'
 import { generateClaimProofForClaim } from '../utils/generateClaimProofForClaim'
 import {
@@ -18,7 +20,6 @@ import {
   getQbtcAccountInfoForClaim,
 } from '../utils/getQbtcAccountInfoForClaim'
 
-const qbtcChainId = 'qbtc'
 const proofServiceRBytes = 24
 const proofServiceSBytes = 32
 const proofServiceBaseUrl = 'https://api.vultisig.com/qbtc-proof'
@@ -85,6 +86,7 @@ export const ClaimPreparingTxPhase = ({
   onError,
 }: ClaimPreparingTxPhaseProps) => {
   const { t } = useTranslation()
+  const securityType = useCurrentVaultSecurityType()
 
   const { mutate, ...state } = useMutation({
     mutationFn: async (): Promise<ClaimPreparingTxMutationResult> => {
@@ -100,7 +102,10 @@ export const ClaimPreparingTxPhase = ({
         claimerAddress: qbtcAddress,
         chainId: qbtcChainId,
         baseUrl: proofServiceBaseUrl,
-        broadcast: !accountExists,
+        // Secure vaults have no client-side MLDSA round — the proof service
+        // signs and broadcasts MsgClaimWithProof for them (matches Android).
+        // Fast vaults sign the SignDoc locally unless the account is new.
+        broadcast: securityType === 'secure' ? true : !accountExists,
       })
 
       if (proofResult.kind === 'server') {

--- a/core/ui/qbtc/claim/components/ClaimRunner.tsx
+++ b/core/ui/qbtc/claim/components/ClaimRunner.tsx
@@ -4,13 +4,13 @@ import { useCurrentVaultAddress } from '@core/ui/vault/state/currentVaultCoins'
 import { MatchRecordUnion } from '@lib/ui/base/MatchRecordUnion'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { ClaimableUtxo } from '@vultisig/core-chain/chains/cosmos/qbtc/claim/ClaimableUtxo'
-import { computeAllClaimHashes } from '@vultisig/core-chain/chains/cosmos/qbtc/claim/computeClaimHashes'
 import { type ClaimProofResult } from '@vultisig/core-chain/chains/cosmos/qbtc/claim/proofService'
 import { getPublicKey } from '@vultisig/core-chain/publicKey/getPublicKey'
 import { KeysignSignature } from '@vultisig/core-mpc/keysign/KeysignSignature'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { useState } from 'react'
 
+import { getClaimMessageHashHex } from '../utils/getClaimMessageHashHex'
 import {
   ClaimBroadcastingPhase,
   QbtcClaimResultData,
@@ -19,11 +19,10 @@ import { ClaimPreparingTxPhase } from './ClaimPreparingTxPhase'
 import { ClaimServerBroadcastWaitPhase } from './ClaimServerBroadcastWaitPhase'
 import { ClaimSignRound } from './ClaimSignRound'
 
-const qbtcChainId = 'qbtc'
-
 type ClaimRunnerProps = {
   utxos: ClaimableUtxo[]
-  password: string
+  /** Fast-vault password. Absent for secure vaults (second-device co-sign). */
+  password?: string
   onSuccess: (result: QbtcClaimResultData) => void
   onError: (error: Error) => void
 }
@@ -66,7 +65,6 @@ export const ClaimRunner = ({
 }: ClaimRunnerProps) => {
   const walletCore = useAssertWalletCore()
   const vault = useCurrentVault()
-  const btcAddress = useCurrentVaultAddress(Chain.Bitcoin)
   const qbtcAddress = useCurrentVaultAddress(Chain.QBTC)
 
   const [claimInputs] = useState(() => {
@@ -77,16 +75,11 @@ export const ClaimRunner = ({
       chainPublicKeys: vault.chainPublicKeys,
       chain: Chain.Bitcoin,
     })
-    const compressedPubkey = btcPublicKey.data()
-    const compressedPubkeyHex = Buffer.from(compressedPubkey).toString('hex')
+    const compressedPubkeyHex = Buffer.from(btcPublicKey.data()).toString('hex')
 
-    const { messageHash } = computeAllClaimHashes({
-      btcAddress,
-      compressedPubkey,
-      qbtcAddress,
-      chainId: qbtcChainId,
-    })
-    const messageHashHex = Buffer.from(messageHash).toString('hex')
+    // Same derivation a secure-vault co-signer uses, so both sign an identical
+    // round-1 hash.
+    const messageHashHex = getClaimMessageHashHex({ vault, walletCore })
 
     return { compressedPubkeyHex, messageHashHex }
   })
@@ -103,6 +96,9 @@ export const ClaimRunner = ({
             signatureAlgorithm="ecdsa"
             chain={Chain.Bitcoin}
             password={password}
+            claimAmount={String(
+              utxos.reduce((sum, utxo) => sum + utxo.amount, 0)
+            )}
             onFinish={btcSig =>
               setPhase({
                 preparingTx: {

--- a/core/ui/qbtc/claim/components/ClaimSignRound.tsx
+++ b/core/ui/qbtc/claim/components/ClaimSignRound.tsx
@@ -1,14 +1,25 @@
+import { useAssertWalletCore } from '@core/ui/chain/providers/WalletCoreProvider'
 import { WaitForServerStep } from '@core/ui/mpc/fast/WaitForServerStep'
 import { KeysignActionProvider } from '@core/ui/mpc/keysign/action/KeysignActionProvider'
+import { KeysignPeerDiscoveryStep } from '@core/ui/mpc/keysign/peers/KeysignPeerDiscoveryStep'
 import { StartKeysignProviders } from '@core/ui/mpc/keysign/start/StartKeysignProviders'
 import { StartMpcSessionFlow } from '@core/ui/mpc/session/StartMpcSessionFlow'
 import { MpcPeersProvider } from '@core/ui/mpc/state/mpcPeers'
+import { MpcPeersSelectionProvider } from '@core/ui/mpc/state/mpcSelectedPeers'
+import {
+  useCurrentVault,
+  useCurrentVaultSecurityType,
+} from '@core/ui/vault/state/currentVault'
+import { useCurrentVaultAddress } from '@core/ui/vault/state/currentVaultCoins'
 import { StepTransition } from '@lib/ui/base/StepTransition'
 import { ValueTransfer } from '@lib/ui/base/ValueTransfer'
 import { Chain } from '@vultisig/core-chain/Chain'
+import { getPublicKey } from '@vultisig/core-chain/publicKey/getPublicKey'
 import type { SignatureAlgorithm } from '@vultisig/core-chain/signing/SignatureAlgorithm'
 import { KeysignSignature } from '@vultisig/core-mpc/keysign/KeysignSignature'
+import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 
+import { getClaimKeysignPayload } from '../utils/getClaimKeysignPayload'
 import { ClaimMldsaSignRunner } from './ClaimMldsaSignRunner'
 import { ClaimSignRunner } from './ClaimSignRunner'
 import { FastClaimServerStep } from './FastClaimServerStep'
@@ -17,70 +28,123 @@ type ClaimSignRoundProps = {
   messageHashHex: string
   signatureAlgorithm: SignatureAlgorithm
   chain: Chain
-  password: string
+  /** Fast-vault password. Absent for secure vaults (second-device co-sign). */
+  password?: string
+  /** Claimed total in satoshis, shown to a secure-vault co-signer. */
+  claimAmount?: string
   onFinish: (signature: KeysignSignature) => void
   onError: (error: Error) => void
 }
 
 /**
  * One full MPC signing round for the QBTC claim flow. Mounts a fresh
- * StartKeysignProviders subtree so each round (BTC ECDSA, then MLDSA)
- * gets its own session ID, encryption key, and server-server handshake.
+ * StartKeysignProviders subtree so each round gets its own session ID,
+ * encryption key, and handshake.
+ *
+ * Fast vaults co-sign with the VultiServer (password → server kickoff). Secure
+ * vaults co-sign with a second device: the round is published as an
+ * `isQbtcClaim` Bitcoin pairing QR and the joining device recomputes the claim
+ * hash from its own vault before co-signing. Secure vaults only ever run the
+ * BTC ECDSA round here — they broadcast via the proof service (no client-side
+ * MLDSA round).
  */
 export const ClaimSignRound = ({
   messageHashHex,
   signatureAlgorithm,
   chain,
   password,
+  claimAmount,
   onFinish,
   onError,
-}: ClaimSignRoundProps) => (
-  <StartKeysignProviders>
-    <StepTransition
-      from={({ onFinish: onServerKickoff }) => (
-        <FastClaimServerStep
+}: ClaimSignRoundProps) => {
+  const securityType = useCurrentVaultSecurityType()
+  const vault = useCurrentVault()
+  const walletCore = useAssertWalletCore()
+  const btcAddress = useCurrentVaultAddress(Chain.Bitcoin)
+  const qbtcAddress = useCurrentVaultAddress(Chain.QBTC)
+
+  const renderSigner = () =>
+    signatureAlgorithm === 'mldsa' ? (
+      <ClaimMldsaSignRunner
+        messageHashHex={messageHashHex}
+        chain={chain}
+        onFinish={onFinish}
+        onError={onError}
+      />
+    ) : (
+      <KeysignActionProvider>
+        <ClaimSignRunner
           messageHashHex={messageHashHex}
           signatureAlgorithm={signatureAlgorithm}
           chain={chain}
-          password={password}
-          onFinish={onServerKickoff}
+          onFinish={onFinish}
           onError={onError}
         />
-      )}
-      to={() => (
+      </KeysignActionProvider>
+    )
+
+  const renderSession = (peers: string[]) => (
+    <MpcPeersProvider value={peers}>
+      <StartMpcSessionFlow value="keysign" render={renderSigner} />
+    </MpcPeersProvider>
+  )
+
+  if (securityType === 'secure') {
+    const btcPublicKey = getPublicKey({
+      walletCore,
+      hexChainCode: vault.hexChainCode,
+      publicKeys: vault.publicKeys,
+      chainPublicKeys: vault.chainPublicKeys,
+      chain: Chain.Bitcoin,
+    })
+
+    const payload = getClaimKeysignPayload({
+      vault,
+      btcAddress,
+      btcPublicKeyHex: Buffer.from(btcPublicKey.data()).toString('hex'),
+      qbtcAddress,
+      claimAmount: claimAmount ?? '0',
+    })
+
+    return (
+      <StartKeysignProviders>
         <ValueTransfer<string[]>
           from={({ onFinish: onPeersReady }) => (
-            <WaitForServerStep onFinish={onPeersReady} />
-          )}
-          to={({ value: peers }) => (
-            <MpcPeersProvider value={peers}>
-              <StartMpcSessionFlow
-                value="keysign"
-                render={() =>
-                  signatureAlgorithm === 'mldsa' ? (
-                    <ClaimMldsaSignRunner
-                      messageHashHex={messageHashHex}
-                      chain={chain}
-                      onFinish={onFinish}
-                      onError={onError}
-                    />
-                  ) : (
-                    <KeysignActionProvider>
-                      <ClaimSignRunner
-                        messageHashHex={messageHashHex}
-                        signatureAlgorithm={signatureAlgorithm}
-                        chain={chain}
-                        onFinish={onFinish}
-                        onError={onError}
-                      />
-                    </KeysignActionProvider>
-                  )
-                }
+            <MpcPeersSelectionProvider>
+              <KeysignPeerDiscoveryStep
+                payload={payload}
+                onFinish={onPeersReady}
               />
-            </MpcPeersProvider>
+            </MpcPeersSelectionProvider>
           )}
+          to={({ value: peers }) => renderSession(peers)}
         />
-      )}
-    />
-  </StartKeysignProviders>
-)
+      </StartKeysignProviders>
+    )
+  }
+
+  return (
+    <StartKeysignProviders>
+      <StepTransition
+        from={({ onFinish: onServerKickoff }) => (
+          <FastClaimServerStep
+            messageHashHex={messageHashHex}
+            signatureAlgorithm={signatureAlgorithm}
+            chain={chain}
+            password={shouldBePresent(password, 'fast vault password')}
+            onFinish={onServerKickoff}
+            onError={onError}
+          />
+        )}
+        to={() => (
+          <ValueTransfer<string[]>
+            from={({ onFinish: onPeersReady }) => (
+              <WaitForServerStep onFinish={onPeersReady} />
+            )}
+            to={({ value: peers }) => renderSession(peers)}
+          />
+        )}
+      />
+    </StartKeysignProviders>
+  )
+}

--- a/core/ui/qbtc/claim/components/QbtcClaimPage.tsx
+++ b/core/ui/qbtc/claim/components/QbtcClaimPage.tsx
@@ -23,7 +23,7 @@ import { ClaimUtxoSelection } from './ClaimUtxoSelection'
 
 type ClaimStep =
   | { select: null }
-  | { claiming: { utxos: ClaimableUtxo[]; password: string } }
+  | { claiming: { utxos: ClaimableUtxo[]; password?: string } }
   | { result: { data: QbtcClaimResultData } }
 
 /** Page that drives the QBTC claim flow end-to-end. */
@@ -45,11 +45,16 @@ export const QbtcClaimPage = () => {
   // Fail closed — keep the CTA off until the kill-switch query resolves.
   const claimGateClosed =
     disabledQuery.isPending || disabledQuery.isError || claimExplicitlyDisabled
-  const isFastVault = securityType === 'fast'
 
   const handleConfirm = (utxos: ClaimableUtxo[]) => {
     setError(null)
-    setPendingUtxos(utxos)
+    // Fast vaults co-sign with the server and need the password up front.
+    // Secure vaults co-sign with a second device, so go straight to signing.
+    if (securityType === 'fast') {
+      setPendingUtxos(utxos)
+    } else {
+      setStep({ claiming: { utxos } })
+    }
   }
 
   const handlePasswordFinish = ({ password }: { password: string }) => {
@@ -80,9 +85,6 @@ export const QbtcClaimPage = () => {
               {claimExplicitlyDisabled && (
                 <WarningBlock>{t('qbtc_claim_disabled_notice')}</WarningBlock>
               )}
-              {!isFastVault && (
-                <WarningBlock>{t('qbtc_claim_fast_vault_only')}</WarningBlock>
-              )}
               {error && (
                 <WarningBlock>
                   {error.message || t('qbtc_claim_failed')}
@@ -100,7 +102,7 @@ export const QbtcClaimPage = () => {
                     utxos={utxos}
                     selected={selected}
                     onSelectedChange={setSelected}
-                    disabled={claimGateClosed || !isFastVault}
+                    disabled={claimGateClosed}
                     onConfirm={handleConfirm}
                   />
                 )}

--- a/core/ui/qbtc/claim/utils/getClaimKeysignPayload.ts
+++ b/core/ui/qbtc/claim/utils/getClaimKeysignPayload.ts
@@ -1,0 +1,66 @@
+import { create } from '@bufbuild/protobuf'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
+import { KeysignMessagePayload } from '@vultisig/core-mpc/keysign/keysignPayload/KeysignMessagePayload'
+import { toCommCoin } from '@vultisig/core-mpc/types/utils/commCoin'
+import { UTXOSpecificSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
+import { KeysignPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { getVaultId, Vault } from '@vultisig/core-mpc/vault/Vault'
+
+type GetClaimKeysignPayloadInput = {
+  vault: Vault
+  btcAddress: string
+  btcPublicKeyHex: string
+  /** QBTC claim recipient address, surfaced to the co-signer's verify screen
+   * via `toAddress`. */
+  qbtcAddress: string
+  /** Total claimed amount in satoshis, surfaced to the co-signer's verify
+   * screen. Advisory metadata only — round 1's signature doesn't commit to it. */
+  claimAmount: string
+}
+
+/**
+ * Builds the pairing-QR payload for a secure-vault QBTC claim round 1. It is a
+ * normal Bitcoin keysign payload carrying no signing material — only the
+ * `isQbtcClaim` flag. The co-signing device recomputes the claim hash from its
+ * own vault (see `getClaimMessageHashHex`), so nothing here can divert the
+ * Bitcoin signature. Wire-compatible with the iOS/Android `is_qbtc_claim`
+ * flow.
+ */
+export const getClaimKeysignPayload = ({
+  vault,
+  btcAddress,
+  btcPublicKeyHex,
+  qbtcAddress,
+  claimAmount,
+}: GetClaimKeysignPayloadInput): KeysignMessagePayload => ({
+  keysign: create(KeysignPayloadSchema, {
+    coin: toCommCoin({
+      chain: Chain.Bitcoin,
+      ticker: chainFeeCoin[Chain.Bitcoin].ticker,
+      logo: chainFeeCoin[Chain.Bitcoin].logo,
+      decimals: chainFeeCoin[Chain.Bitcoin].decimals,
+      priceProviderId: chainFeeCoin[Chain.Bitcoin].priceProviderId,
+      address: btcAddress,
+      hexPublicKey: btcPublicKeyHex,
+    }),
+    blockchainSpecific: {
+      case: 'utxoSpecific',
+      value: create(UTXOSpecificSchema, {
+        byteFee: '0',
+        sendMaxAmount: false,
+      }),
+    },
+    // `toAddress` carries the QBTC claim recipient and `toAmount` the claimed
+    // total (satoshis), both surfaced on the co-signer's verify screen. Other
+    // platforms ignore them for claims but still parse `toAmount` as a number
+    // (e.g. Android `BigInteger(toAmount)`), so it must be numeric.
+    toAddress: qbtcAddress,
+    toAmount: claimAmount,
+    vaultPublicKeyEcdsa: getVaultId(vault),
+    vaultLocalPartyId: vault.localPartyId,
+    libType: vault.libType,
+    isQbtcClaim: true,
+    skipBroadcast: true,
+  }),
+})

--- a/core/ui/qbtc/claim/utils/getClaimMessageHashHex.ts
+++ b/core/ui/qbtc/claim/utils/getClaimMessageHashHex.ts
@@ -1,0 +1,63 @@
+import { WalletCore } from '@trustwallet/wallet-core'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { computeAllClaimHashes } from '@vultisig/core-chain/chains/cosmos/qbtc/claim/computeClaimHashes'
+import { getChainAddress } from '@vultisig/core-chain/publicKey/address/getChainAddress'
+import { getPublicKey } from '@vultisig/core-chain/publicKey/getPublicKey'
+import { Vault } from '@vultisig/core-mpc/vault/Vault'
+
+import { qbtcChainId } from '../../dapp/qbtcDirectConstants'
+
+type GetClaimMessageHashHexInput = {
+  vault: Vault
+  walletCore: WalletCore
+}
+
+/**
+ * Recomputes the QBTC claim round-1 message hash purely from the vault's own
+ * derived Bitcoin + QBTC keys — never from anything carried on the wire. Both
+ * the initiating device and a secure-vault co-signer call this so they sign
+ * the identical hash, and a co-signer can never be tricked into signing an
+ * attacker-supplied Bitcoin spend (the claim digest is fully determined by the
+ * vault).
+ */
+export const getClaimMessageHashHex = ({
+  vault,
+  walletCore,
+}: GetClaimMessageHashHexInput): string => {
+  const { hexChainCode, publicKeys, publicKeyMldsa, chainPublicKeys } = vault
+
+  const btcAddress = getChainAddress({
+    chain: Chain.Bitcoin,
+    walletCore,
+    hexChainCode,
+    publicKeys,
+    publicKeyMldsa,
+    chainPublicKeys,
+  })
+
+  const qbtcAddress = getChainAddress({
+    chain: Chain.QBTC,
+    walletCore,
+    hexChainCode,
+    publicKeys,
+    publicKeyMldsa,
+    chainPublicKeys,
+  })
+
+  const btcPublicKey = getPublicKey({
+    walletCore,
+    hexChainCode,
+    publicKeys,
+    chainPublicKeys,
+    chain: Chain.Bitcoin,
+  })
+
+  const { messageHash } = computeAllClaimHashes({
+    btcAddress,
+    compressedPubkey: btcPublicKey.data(),
+    qbtcAddress,
+    chainId: qbtcChainId,
+  })
+
+  return Buffer.from(messageHash).toString('hex')
+}


### PR DESCRIPTION
## Summary
Adds secure (multi-device) vault support to the QBTC claim flow. Previously claiming was limited to Fast Vaults (single-device, server co-sign).

For Secure vaults, the claim page now goes straight to a **pairing QR** instead of a password prompt. A second device scans it, recomputes the claim message hash from its **own vault**, and co-signs the round-1 BTC ECDSA ownership-proof. The proof service then signs and broadcasts the claim, so there's no client-side post-quantum round. Fast Vault behavior is unchanged.

## How it works
- **Pairing payload** is a flag-only Bitcoin keysign payload (`isQbtcClaim`) — no signing material on the wire.
- **Co-signer** recomputes the hash from its own vault, so a compromised initiator can't redirect the signature to an arbitrary Bitcoin spend. It only ever signs round 1 (the proof service broadcasts).
- **Verify screen**: the co-signer sees a dedicated screen with the claim amount + Bitcoin/QBTC addresses read from the request (display only — the signature is recomputed locally).
- Wire format is compatible with our other platform clients.

## Notable changes
- `getClaimKeysignPayload` / `getClaimMessageHashHex` — build the pairing payload and the shared (initiator + co-signer) hash derivation.
- `useKeysignMutation` / `KeysignSigningStep` / `JoinKeysignVerifyStep` — co-signer detection, signing, verify + success screens.
- `ClaimSignRound` / `ClaimRunner` / `ClaimPreparingTxPhase` / `QbtcClaimPage` — secure initiator path, no password, force proof-service broadcast.
- `DownloadKeysignQrCode` now takes its payload as a prop instead of reading keysign view state (so peer discovery works outside the standard keysign flow).

## Notes / follow-ups
- The co-sign verify screen currently uses a functional placeholder built from generic tx-overview components. A proper design is tracked in #4194.
- The displayed amount/addresses are advisory (not bound by the round-1 signature). Binding them would need a richer payload type — intentionally out of scope.

## Testing
- `yarn check:all` (typecheck, lint, knip, tests) passes; existing QBTC/keysign tests pass.


Closes #4193

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added QBTC claim co-signing for secure vaults, including a co-signer verification screen and a co-sign success confirmation.

* **Improvements**
  * Streamlined the QBTC claim flow for non-fast vaults so password entry is only requested when needed.
  * Removed the “fast vault only” restriction from the claim UI, allowing unsupported cases to proceed.

* **Localization**
  * Updated QBTC claim co-signing text across multiple languages.
  * Added a per-chain validation message for invalid external swap recipients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->