### PR TITLE
Keep stale swaps pending in transaction history

### DIFF
--- a/core/ui/transaction-history/status/staleTransaction.test.ts
+++ b/core/ui/transaction-history/status/staleTransaction.test.ts
@@ -1,0 +1,77 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { SendTransactionRecord, SwapTransactionRecord } from '../core'
+import { shouldFailStaleTransaction } from './staleTransaction'
+
+const staleTimestamp = () => new Date(Date.now() - 6 * 60 * 1000).toISOString()
+
+const freshTimestamp = () => new Date(Date.now() - 60 * 1000).toISOString()
+
+const baseRecord = {
+  id: 'record-1',
+  vaultId: 'vault-1',
+  status: 'pending',
+  chain: Chain.THORChain,
+  txHash: 'ABC123',
+  explorerUrl: 'https://runescan.io/tx/ABC123',
+  fiatValue: '',
+} as const
+
+const sendRecord = (timestamp: string): SendTransactionRecord => ({
+  ...baseRecord,
+  type: 'send',
+  timestamp,
+  data: {
+    fromAddress: 'thor1from',
+    toAddress: 'thor1to',
+    amount: '100000000',
+    token: 'RUNE',
+    tokenLogo: '',
+    decimals: 8,
+  },
+})
+
+const swapRecord = (timestamp: string): SwapTransactionRecord => ({
+  ...baseRecord,
+  type: 'swap',
+  timestamp,
+  data: {
+    fromToken: 'RUNE',
+    fromAmount: '100000000',
+    fromChain: Chain.THORChain,
+    fromTokenLogo: '',
+    fromDecimals: 8,
+    toToken: 'BTC',
+    toAmount: '0.001',
+    toChain: Chain.Bitcoin,
+    toTokenLogo: '',
+    toDecimals: 8,
+    provider: 'THORChain',
+    route: 'RUNE -> BTC',
+  },
+})
+
+describe('shouldFailStaleTransaction', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('fails stale pending sends', () => {
+    vi.setSystemTime(new Date('2026-06-25T18:00:00Z'))
+
+    expect(shouldFailStaleTransaction(sendRecord(staleTimestamp()))).toBe(true)
+  })
+
+  it('keeps fresh pending sends pending', () => {
+    vi.setSystemTime(new Date('2026-06-25T18:00:00Z'))
+
+    expect(shouldFailStaleTransaction(sendRecord(freshTimestamp()))).toBe(false)
+  })
+
+  it('keeps stale swaps pending until an authoritative status fails them', () => {
+    vi.setSystemTime(new Date('2026-06-25T18:00:00Z'))
+
+    expect(shouldFailStaleTransaction(swapRecord(staleTimestamp()))).toBe(false)
+  })
+})

--- a/core/ui/transaction-history/status/staleTransaction.ts
+++ b/core/ui/transaction-history/status/staleTransaction.ts
@@ -1,0 +1,12 @@
+import { TransactionRecord } from '../core'
+
+const stalePendingThresholdMs = 5 * 60 * 1000
+
+const isStaleTransaction = (record: TransactionRecord): boolean => {
+  const elapsed = Date.now() - new Date(record.timestamp).getTime()
+  return elapsed > stalePendingThresholdMs
+}
+
+export const shouldFailStaleTransaction = (
+  record: TransactionRecord
+): boolean => record.type === 'send' && isStaleTransaction(record)

--- a/core/ui/transaction-history/status/staleTransaction.ts
+++ b/core/ui/transaction-history/status/staleTransaction.ts
@@ -7,6 +7,11 @@ const isStaleTransaction = (record: TransactionRecord): boolean => {
   return elapsed > stalePendingThresholdMs
 }
 
+/**
+ * Decides whether a pending record should be marked failed by the client-side
+ * stale timeout. Swap records stay pending until an authoritative provider
+ * status resolves them.
+ */
 export const shouldFailStaleTransaction = (
   record: TransactionRecord
 ): boolean => record.type === 'send' && isStaleTransaction(record)

--- a/core/ui/transaction-history/status/useRefreshPendingTransactions.ts
+++ b/core/ui/transaction-history/status/useRefreshPendingTransactions.ts
@@ -8,16 +8,10 @@ import {
   getCowSwapOrderApiBase,
   getCowSwapOrderRecordUpdate,
 } from './getCowSwapOrderRecordUpdate'
+import { shouldFailStaleTransaction } from './staleTransaction'
 import { toRecordStatus } from './toRecordStatus'
 
 const pendingStatuses: TransactionRecordStatus[] = ['broadcasted', 'pending']
-
-const stalePendingThresholdMs = 5 * 60 * 1000
-
-const isStaleTransaction = (record: TransactionRecord): boolean => {
-  const elapsed = Date.now() - new Date(record.timestamp).getTime()
-  return elapsed > stalePendingThresholdMs
-}
 
 /** Checks chain status for pending/broadcasted transactions and updates their status in storage. */
 export const useRefreshPendingTransactions = (records: TransactionRecord[]) => {
@@ -59,7 +53,7 @@ export const useRefreshPendingTransactions = (records: TransactionRecord[]) => {
             )
 
             if ('error' in result) {
-              if (isStaleTransaction(record)) {
+              if (shouldFailStaleTransaction(record)) {
                 updateRecord({ ...record, status: 'failed' })
               }
               return
@@ -67,7 +61,7 @@ export const useRefreshPendingTransactions = (records: TransactionRecord[]) => {
 
             const newStatus = toRecordStatus[result.data.status]
 
-            if (newStatus === 'pending' && isStaleTransaction(record)) {
+            if (newStatus === 'pending' && shouldFailStaleTransaction(record)) {
               updateRecord({ ...record, status: 'failed' })
               return
             }

--- a/core/ui/transaction-history/status/useTransactionStatusPolling.ts
+++ b/core/ui/transaction-history/status/useTransactionStatusPolling.ts
@@ -8,18 +8,12 @@ import {
   getCowSwapOrderApiBase,
   getCowSwapOrderRecordUpdate,
 } from './getCowSwapOrderRecordUpdate'
+import { shouldFailStaleTransaction } from './staleTransaction'
 import { toRecordStatus } from './toRecordStatus'
 
 const pendingStatuses: TransactionRecordStatus[] = ['broadcasted', 'pending']
 
 const pollingInterval = 3000
-
-const stalePendingThresholdMs = 5 * 60 * 1000
-
-const isStaleTransaction = (record: TransactionRecord): boolean => {
-  const elapsed = Date.now() - new Date(record.timestamp).getTime()
-  return elapsed > stalePendingThresholdMs
-}
 
 /** Polls chain status for a single pending transaction and updates its record when finalized. */
 export const useTransactionStatusPolling = (record: TransactionRecord) => {
@@ -50,7 +44,7 @@ export const useTransactionStatusPolling = (record: TransactionRecord) => {
         return { status }
       }
 
-      if (isStaleTransaction(current)) {
+      if (shouldFailStaleTransaction(current)) {
         updateRecord({ ...current, status: 'failed' })
         return { status: 'error' as const }
       }


### PR DESCRIPTION
Closes #4201

Prevents client-side stale timeout from marking swap history records failed before provider status resolves. Live QA: performed a real THORChain 5 RUNE to BTC swap and verified desktop transaction history after the old five-minute stale window showed the swap confirmed, not failed.

![screenshot-1](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/4201-swap-history-stale-status/screenshot-1-1782451327396.png)
![screenshot-2](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/4201-swap-history-stale-status/screenshot-2-1782451327396.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of stale pending transactions by applying a 5-minute staleness rule and marking failed only eligible send transactions.
  * Kept swap transactions pending unless an authoritative status update explicitly fails them.
* **Tests**
  * Added a deterministic test suite covering fresh vs. stale pending sends and swap transaction behavior using controlled system time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->