### PR TITLE
Remove local vault constants from import e2e

### DIFF
--- a/clients/extension/tests/e2e/helpers/vault-import.ts
+++ b/clients/extension/tests/e2e/helpers/vault-import.ts
@@ -387,10 +387,10 @@ export function getVaultConfigFromEnv(): {
   vaultPath: string
   password: string
 } | null {
-  const vaultPath = process.env.TEST_VAULT_PATH ?? process.env.VAULT_SHARE_PATH
-  const password = process.env.TEST_VAULT_PASSWORD ?? process.env.VAULT_PASSWORD
+  const vaultPath = firstPresentEnv('TEST_VAULT_PATH', 'VAULT_SHARE_PATH')
+  const password = firstPresentEnv('TEST_VAULT_PASSWORD', 'VAULT_PASSWORD')
 
-  if (!vaultPath || !password) {
+  if (!vaultPath || !password || !existsSync(vaultPath)) {
     return null
   }
 
@@ -404,20 +404,27 @@ export function getSecureVaultConfigFromEnv(): Array<{
   vaultPath: string
   password: string
 }> {
-  const sharesEnv =
-    process.env.SECURE_VAULT_SHARES ??
-    [process.env.SECURE_VAULT_SHARE1, process.env.SECURE_VAULT_SHARE2]
-      .filter(Boolean)
-      .join(',')
-  const password = process.env.SECURE_VAULT_PASSWORD
+  const sharesEnv = firstPresentEnv('SECURE_VAULT_SHARES')
+  const password = firstPresentEnv('SECURE_VAULT_PASSWORD')
 
-  if (!sharesEnv || !password) {
+  const sharePaths =
+    sharesEnv?.split(',') ??
+    [
+      firstPresentEnv('SECURE_VAULT_SHARE1'),
+      firstPresentEnv('SECURE_VAULT_SHARE2'),
+    ].filter((share): share is string => Boolean(share))
+
+  if (!password) {
     return []
   }
 
-  return sharesEnv
-    .split(',')
+  return sharePaths
     .map(s => s.trim())
     .filter(s => existsSync(s))
     .map(vaultPath => ({ vaultPath, password }))
 }
+
+const firstPresentEnv = (...names: string[]) =>
+  names
+    .map(name => process.env[name]?.trim())
+    .find((value): value is string => Boolean(value))

--- a/clients/extension/tests/e2e/helpers/vault-import.ts
+++ b/clients/extension/tests/e2e/helpers/vault-import.ts
@@ -11,17 +11,17 @@
  * 4. ImportVaultPage -> Upload file -> Enter password -> Continue -> VaultPage
  */
 
-import type { Page, BrowserContext } from '@playwright/test'
-import { existsSync } from 'fs'
+import type { BrowserContext, Page } from '@playwright/test'
 import { config } from 'dotenv'
+import { existsSync } from 'fs'
 import { resolve } from 'path'
 import { fileURLToPath } from 'url'
 
 // Load .env from e2e directory
-const __edir = fileURLToPath(new URL('..', import.meta.url))
-config({ path: resolve(__edir, '.env') })
+const e2eDir = fileURLToPath(new URL('..', import.meta.url))
+config({ path: resolve(e2eDir, '.env') })
 
-export interface VaultImportConfig {
+export type VaultImportConfig = {
   vaultPath: string
   password: string
   extensionId: string
@@ -31,16 +31,23 @@ export interface VaultImportConfig {
  * Wait for the extension UI to be fully loaded
  */
 async function waitForExtensionUI(page: Page, timeout = 15_000): Promise<void> {
-  await page.waitForFunction(() => {
-    // Wait for React to render and have visible buttons
-    const buttons = document.querySelectorAll('button')
-    const hasVisibleButtons = buttons.length > 0 && Array.from(buttons).some(b => b.offsetParent !== null)
+  await page.waitForFunction(
+    () => {
+      // Wait for React to render and have visible buttons
+      const buttons = document.querySelectorAll('button')
+      const hasVisibleButtons =
+        buttons.length > 0 &&
+        Array.from(buttons).some(b => b.offsetParent !== null)
 
-    // Or wait for text content
-    const hasContent = document.body.textContent && document.body.textContent.trim().length > 10
+      // Or wait for text content
+      const hasContent =
+        document.body.textContent &&
+        document.body.textContent.trim().length > 10
 
-    return hasVisibleButtons || hasContent
-  }, { timeout })
+      return hasVisibleButtons || hasContent
+    },
+    { timeout }
+  )
 }
 
 /**
@@ -67,8 +74,14 @@ export async function isOnVaultPage(page: Page): Promise<boolean> {
   const hasVaultPage = await vaultPage.isVisible().catch(() => false)
 
   // Also check for balance or chain list which indicate vault is loaded
-  const hasBalance = await page.locator('text=/\\$|USD|Balance/i').isVisible().catch(() => false)
-  const hasChains = await page.locator('[data-testid="chain-list"]').isVisible().catch(() => false)
+  const hasBalance = await page
+    .locator('text=/\\$|USD|Balance/i')
+    .isVisible()
+    .catch(() => false)
+  const hasChains = await page
+    .locator('[data-testid="chain-list"]')
+    .isVisible()
+    .catch(() => false)
 
   return hasVaultPage || hasBalance || hasChains
 }
@@ -82,11 +95,17 @@ export async function isOnFileUploadPage(page: Page): Promise<boolean> {
   const hasImportForm = await importForm.isVisible().catch(() => false)
 
   // Check for file input
-  const fileInputCount = await page.locator('input[type="file"]').count().catch(() => 0)
+  const fileInputCount = await page
+    .locator('input[type="file"]')
+    .count()
+    .catch(() => 0)
   const hasFileInput = fileInputCount > 0
 
   // Check for dropzone text
-  const hasDropzoneText = await page.getByText(/select.*backup.*file|click.*browse|drop.*file/i).isVisible().catch(() => false)
+  const hasDropzoneText = await page
+    .getByText(/select.*backup.*file|click.*browse|drop.*file/i)
+    .isVisible()
+    .catch(() => false)
 
   return hasImportForm || hasFileInput || hasDropzoneText
 }
@@ -95,8 +114,14 @@ export async function isOnFileUploadPage(page: Page): Promise<boolean> {
  * Check if we're on the import options page (shows "Import Seedphrase" and "Import vault share")
  */
 export async function isOnImportOptionsPage(page: Page): Promise<boolean> {
-  const hasImportShare = await page.getByText(/import.*vault.*share/i).isVisible().catch(() => false)
-  const hasImportSeedphrase = await page.getByText(/import.*seedphrase/i).isVisible().catch(() => false)
+  const hasImportShare = await page
+    .getByText(/import.*vault.*share/i)
+    .isVisible()
+    .catch(() => false)
+  const hasImportSeedphrase = await page
+    .getByText(/import.*seedphrase/i)
+    .isVisible()
+    .catch(() => false)
 
   return hasImportShare || hasImportSeedphrase
 }
@@ -104,7 +129,10 @@ export async function isOnImportOptionsPage(page: Page): Promise<boolean> {
 /**
  * Navigate through onboarding to the file upload import page
  */
-export async function navigateToFileImport(page: Page, extensionId: string): Promise<boolean> {
+export async function navigateToFileImport(
+  page: Page,
+  extensionId: string
+): Promise<boolean> {
   try {
     // Go to extension
     await page.goto(`chrome-extension://${extensionId}/index.html`)
@@ -148,7 +176,9 @@ export async function navigateToFileImport(page: Page, extensionId: string): Pro
 
       // Click "Import vault share" option
       const importShareButton = page.getByText(/import.*vault.*share/i).first()
-      if (await importShareButton.isVisible({ timeout: 3000 }).catch(() => false)) {
+      if (
+        await importShareButton.isVisible({ timeout: 3000 }).catch(() => false)
+      ) {
         console.log('✅ Found "Import vault share" option, clicking...')
         await importShareButton.click()
         await page.waitForTimeout(1000)
@@ -169,7 +199,10 @@ export async function navigateToFileImport(page: Page, extensionId: string): Pro
     }
 
     console.log('⚠️ Could not navigate to file upload page')
-    const pageText = await page.locator('body').textContent().catch(() => '')
+    const pageText = await page
+      .locator('body')
+      .textContent()
+      .catch(() => '')
     console.log('Final page content:', pageText?.substring(0, 500))
     return false
   } catch (error) {
@@ -228,8 +261,12 @@ export async function importVaultViaUI(
       await page.waitForTimeout(2000)
     } else {
       // Fallback to generic continue button
-      const genericContinue = page.getByRole('button', { name: /continue/i }).first()
-      if (await genericContinue.isEnabled({ timeout: 3000 }).catch(() => false)) {
+      const genericContinue = page
+        .getByRole('button', { name: /continue/i })
+        .first()
+      if (
+        await genericContinue.isEnabled({ timeout: 3000 }).catch(() => false)
+      ) {
         console.log('✅ Found generic Continue button, clicking...')
         await genericContinue.click()
         await page.waitForTimeout(2000)
@@ -244,12 +281,16 @@ export async function importVaultViaUI(
       await page.waitForTimeout(500)
 
       // Click Continue again after password
-      const continueAfterPassword = page.locator('[data-testid="import-continue"]')
+      const continueAfterPassword = page.locator(
+        '[data-testid="import-continue"]'
+      )
       if (await continueAfterPassword.isVisible().catch(() => false)) {
         console.log('✅ Clicking Continue after password...')
         await continueAfterPassword.click()
       } else {
-        const genericContinue = page.getByRole('button', { name: /continue|unlock|import/i }).first()
+        const genericContinue = page
+          .getByRole('button', { name: /continue|unlock|import/i })
+          .first()
         if (await genericContinue.isEnabled().catch(() => false)) {
           await genericContinue.click()
         }
@@ -265,7 +306,8 @@ export async function importVaultViaUI(
       console.log('✅ Vault imported successfully')
     } else {
       // Check for error message
-      const errorText = await page.locator('[role="alert"], text=/error|invalid|wrong|failed/i')
+      const errorText = await page
+        .locator('[role="alert"], text=/error|invalid|wrong|failed/i')
         .textContent()
         .catch(() => null)
       if (errorText) {
@@ -273,7 +315,10 @@ export async function importVaultViaUI(
       } else {
         console.error('Import did not complete - not on vault page')
         console.log('Current URL:', page.url())
-        const bodyText = await page.locator('body').textContent().catch(() => '')
+        const bodyText = await page
+          .locator('body')
+          .textContent()
+          .catch(() => '')
         console.log('Page content:', bodyText?.substring(0, 500))
       }
     }
@@ -338,9 +383,12 @@ export async function ensureVaultExists(
 /**
  * Get vault import config from environment variables
  */
-export function getVaultConfigFromEnv(): { vaultPath: string; password: string } | null {
-  const vaultPath = process.env.TEST_VAULT_PATH
-  const password = process.env.TEST_VAULT_PASSWORD
+export function getVaultConfigFromEnv(): {
+  vaultPath: string
+  password: string
+} | null {
+  const vaultPath = process.env.TEST_VAULT_PATH ?? process.env.VAULT_SHARE_PATH
+  const password = process.env.TEST_VAULT_PASSWORD ?? process.env.VAULT_PASSWORD
 
   if (!vaultPath || !password) {
     return null
@@ -352,8 +400,15 @@ export function getVaultConfigFromEnv(): { vaultPath: string; password: string }
 /**
  * Get secure vault import config from environment variables
  */
-export function getSecureVaultConfigFromEnv(): Array<{ vaultPath: string; password: string }> {
-  const sharesEnv = process.env.SECURE_VAULT_SHARES
+export function getSecureVaultConfigFromEnv(): Array<{
+  vaultPath: string
+  password: string
+}> {
+  const sharesEnv =
+    process.env.SECURE_VAULT_SHARES ??
+    [process.env.SECURE_VAULT_SHARE1, process.env.SECURE_VAULT_SHARE2]
+      .filter(Boolean)
+      .join(',')
   const password = process.env.SECURE_VAULT_PASSWORD
 
   if (!sharesEnv || !password) {

--- a/clients/extension/tests/e2e/specs/vault-import-export.spec.ts
+++ b/clients/extension/tests/e2e/specs/vault-import-export.spec.ts
@@ -5,6 +5,8 @@
  * Uses the actual UI flow via importVaultViaUI helper.
  */
 
+import type { Locator } from '@playwright/test'
+
 import { expect, test } from '../fixtures/extension-loader'
 import {
   getSecureVaultConfigFromEnv,
@@ -14,6 +16,26 @@ import {
 import { VaultPage } from '../page-objects/VaultPage.po'
 
 const getWrongPassword = (password: string) => `${password}-wrong-password`
+
+const isVisibleWithin = async (locator: Locator, timeout = 3_000) => {
+  try {
+    await locator.waitFor({ state: 'visible', timeout })
+    return true
+  } catch {
+    return false
+  }
+}
+
+const clickFirstVisible = async (...locators: Locator[]) => {
+  for (const locator of locators) {
+    if (await isVisibleWithin(locator)) {
+      await locator.click()
+      return true
+    }
+  }
+
+  return false
+}
 
 test.describe('Vault Import', () => {
   test('import FastVault .vult file with password succeeds', async ({
@@ -130,7 +152,7 @@ test.describe('Vault Import', () => {
 
       // Find Import button
       const importBtn = page.getByText(/import/i).first()
-      if (!(await importBtn.isVisible({ timeout: 5000 }).catch(() => false))) {
+      if (!(await isVisibleWithin(importBtn, 5_000))) {
         console.log('Import button not visible, skipping')
         test.skip()
         return
@@ -143,9 +165,7 @@ test.describe('Vault Import', () => {
       const importShareOption = page
         .getByText(/import.*vault.*share|vault.*share/i)
         .first()
-      if (
-        await importShareOption.isVisible({ timeout: 3000 }).catch(() => false)
-      ) {
+      if (await isVisibleWithin(importShareOption)) {
         await importShareOption.click()
         await page.waitForTimeout(500)
       }
@@ -158,24 +178,27 @@ test.describe('Vault Import', () => {
 
       // Click Continue
       const continueBtn = page.getByRole('button', { name: /continue/i })
-      if (await continueBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
+      if (await isVisibleWithin(continueBtn)) {
         await continueBtn.click()
         await page.waitForTimeout(500)
       }
 
       // Enter WRONG password
       const passwordInput = page.locator('input[type="password"]')
-      if (await passwordInput.isVisible({ timeout: 3000 }).catch(() => false)) {
+      if (await isVisibleWithin(passwordInput)) {
         await passwordInput.fill(getWrongPassword(config.password))
         await page.waitForTimeout(300)
 
         // Submit
-        const submitBtn = page.locator('[data-testid="fast-vault-submit"]').or(
-          page.getByRole('button', {
-            name: /submit|confirm|continue|unlock/i,
-          })
+        const submitted = await clickFirstVisible(
+          page.locator('[data-testid="fast-vault-submit"]').first(),
+          page
+            .getByRole('button', {
+              name: /submit|confirm|continue|unlock/i,
+            })
+            .first()
         )
-        await submitBtn.first().click()
+        expect(submitted).toBe(true)
         await page.waitForTimeout(1500)
 
         // Should show error or stay on password page (not navigate to vault)

--- a/clients/extension/tests/e2e/specs/vault-import-export.spec.ts
+++ b/clients/extension/tests/e2e/specs/vault-import-export.spec.ts
@@ -5,21 +5,26 @@
  * Uses the actual UI flow via importVaultViaUI helper.
  */
 
-import { test, expect } from '../fixtures/extension-loader'
+import { expect, test } from '../fixtures/extension-loader'
+import {
+  getSecureVaultConfigFromEnv,
+  getVaultConfigFromEnv,
+  importVaultViaUI,
+} from '../helpers/vault-import'
 import { VaultPage } from '../page-objects/VaultPage.po'
-import { importVaultViaUI, getVaultConfigFromEnv } from '../helpers/vault-import'
-import * as fs from 'fs'
 
-// Test vault files
-const TEST_VAULTS_PATH = '/Users/crusty/vultisig-sdk-bot/credentials/test-vaults'
-const FAST_VAULT_FILE = `${TEST_VAULTS_PATH}/SdkFastVault1-extension-7085-share1of2.vult`
-const FAST_VAULT_PASSWORD = 'SHjsd76sa65aLKsdiU$'
-const SECURE_VAULT_FILE = `${TEST_VAULTS_PATH}/SdkSecure1-extension-2318-share1of2.vult`
-const SECURE_VAULT_PASSWORD = '12345678'
+const getWrongPassword = (password: string) => `${password}-wrong-password`
 
 test.describe('Vault Import', () => {
-  test('import FastVault .vult file with password succeeds', async ({ context, extensionId }) => {
-    test.skip(!fs.existsSync(FAST_VAULT_FILE), 'FastVault file not found')
+  test('import FastVault .vult file with password succeeds', async ({
+    context,
+    extensionId,
+  }) => {
+    const config = getVaultConfigFromEnv()
+    if (!config) {
+      test.skip(true, 'No FastVault config')
+      return
+    }
 
     const page = await context.newPage()
     const vaultPage = new VaultPage(page, extensionId)
@@ -28,21 +33,25 @@ test.describe('Vault Import', () => {
       // Import via UI
       const result = await importVaultViaUI(page, {
         extensionId,
-        vaultPath: FAST_VAULT_FILE,
-        password: FAST_VAULT_PASSWORD,
+        vaultPath: config.vaultPath,
+        password: config.password,
       })
 
       expect(result).toBe(true)
 
       // Verify vault page loads (waitForView confirms we're on vault page, not onboarding)
       await vaultPage.waitForView(15_000)
-      
+
       // Verify balance area is visible (confirms vault loaded)
       const balanceText = await vaultPage.getTotalBalance()
       console.log('Vault balance:', balanceText)
-      
+
       // Verify we can see portfolio/chains (vault is functional)
-      const hasChains = await vaultPage.page.locator('text=/ethereum|bitcoin|solana|portfolio/i').first().isVisible().catch(() => false)
+      const hasChains = await vaultPage.page
+        .locator('text=/ethereum|bitcoin|solana|portfolio/i')
+        .first()
+        .isVisible()
+        .catch(() => false)
       console.log('Has chain indicators:', hasChains)
       expect(hasChains).toBe(true)
     } finally {
@@ -50,8 +59,15 @@ test.describe('Vault Import', () => {
     }
   })
 
-  test('import SecureVault .vult file with password succeeds', async ({ context, extensionId }) => {
-    test.skip(!fs.existsSync(SECURE_VAULT_FILE), 'SecureVault file not found')
+  test('import SecureVault .vult file with password succeeds', async ({
+    context,
+    extensionId,
+  }) => {
+    const [config] = getSecureVaultConfigFromEnv()
+    if (!config) {
+      test.skip(true, 'No SecureVault config')
+      return
+    }
 
     const page = await context.newPage()
     const vaultPage = new VaultPage(page, extensionId)
@@ -60,17 +76,21 @@ test.describe('Vault Import', () => {
       // Import via UI
       const result = await importVaultViaUI(page, {
         extensionId,
-        vaultPath: SECURE_VAULT_FILE,
-        password: SECURE_VAULT_PASSWORD,
+        vaultPath: config.vaultPath,
+        password: config.password,
       })
 
       expect(result).toBe(true)
 
       // Verify vault page loads
       await vaultPage.waitForView(15_000)
-      
+
       // Verify we can see portfolio/chains (vault is functional)
-      const hasChains = await vaultPage.page.locator('text=/ethereum|bitcoin|solana|portfolio/i').first().isVisible().catch(() => false)
+      const hasChains = await vaultPage.page
+        .locator('text=/ethereum|bitcoin|solana|portfolio/i')
+        .first()
+        .isVisible()
+        .catch(() => false)
       console.log('SecureVault has chain indicators:', hasChains)
       expect(hasChains).toBe(true)
     } finally {
@@ -78,8 +98,15 @@ test.describe('Vault Import', () => {
     }
   })
 
-  test('import with wrong password shows error or stays on password page', async ({ context, extensionId }) => {
-    test.skip(!fs.existsSync(FAST_VAULT_FILE), 'FastVault file not found')
+  test('import with wrong password shows error or stays on password page', async ({
+    context,
+    extensionId,
+  }) => {
+    const config = getVaultConfigFromEnv()
+    if (!config) {
+      test.skip(true, 'No FastVault config')
+      return
+    }
 
     const page = await context.newPage()
 
@@ -89,10 +116,13 @@ test.describe('Vault Import', () => {
       await page.waitForTimeout(2000)
 
       // Check if we're on new vault page or existing vault
-      const pageText = await page.locator('body').textContent() || ''
-      
+      const pageText = (await page.locator('body').textContent()) || ''
+
       // If extension already has a vault from prior test, skip
-      if (!pageText.toLowerCase().includes('import') && !pageText.toLowerCase().includes('create')) {
+      if (
+        !pageText.toLowerCase().includes('import') &&
+        !pageText.toLowerCase().includes('create')
+      ) {
         console.log('Extension already has vault, skipping wrong password test')
         test.skip()
         return
@@ -100,18 +130,22 @@ test.describe('Vault Import', () => {
 
       // Find Import button
       const importBtn = page.getByText(/import/i).first()
-      if (!await importBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
+      if (!(await importBtn.isVisible({ timeout: 5000 }).catch(() => false))) {
         console.log('Import button not visible, skipping')
         test.skip()
         return
       }
-      
+
       await importBtn.click()
       await page.waitForTimeout(500)
 
       // Find "Import vault share" option
-      const importShareOption = page.getByText(/import.*vault.*share|vault.*share/i).first()
-      if (await importShareOption.isVisible({ timeout: 3000 }).catch(() => false)) {
+      const importShareOption = page
+        .getByText(/import.*vault.*share|vault.*share/i)
+        .first()
+      if (
+        await importShareOption.isVisible({ timeout: 3000 }).catch(() => false)
+      ) {
         await importShareOption.click()
         await page.waitForTimeout(500)
       }
@@ -119,7 +153,7 @@ test.describe('Vault Import', () => {
       // Upload file
       const fileInput = page.locator('input[type="file"]')
       await fileInput.waitFor({ state: 'attached', timeout: 5000 })
-      await fileInput.setInputFiles(FAST_VAULT_FILE)
+      await fileInput.setInputFiles(config.vaultPath)
       await page.waitForTimeout(500)
 
       // Click Continue
@@ -132,25 +166,31 @@ test.describe('Vault Import', () => {
       // Enter WRONG password
       const passwordInput = page.locator('input[type="password"]')
       if (await passwordInput.isVisible({ timeout: 3000 }).catch(() => false)) {
-        await passwordInput.fill('WrongPassword123!')
+        await passwordInput.fill(getWrongPassword(config.password))
         await page.waitForTimeout(300)
 
         // Submit
-        const submitBtn = page.locator('[data-testid="fast-vault-submit"]')
-          .or(page.getByRole('button', { name: /submit|confirm|continue|unlock/i }))
+        const submitBtn = page.locator('[data-testid="fast-vault-submit"]').or(
+          page.getByRole('button', {
+            name: /submit|confirm|continue|unlock/i,
+          })
+        )
         await submitBtn.first().click()
         await page.waitForTimeout(1500)
 
         // Should show error or stay on password page (not navigate to vault)
-        const stillOnPassword = await passwordInput.isVisible().catch(() => false)
-        const bodyText = await page.locator('body').textContent() || ''
-        const hasErrorText = bodyText.toLowerCase().includes('invalid') ||
-                            bodyText.toLowerCase().includes('wrong') ||
-                            bodyText.toLowerCase().includes('incorrect')
+        const stillOnPassword = await passwordInput
+          .isVisible()
+          .catch(() => false)
+        const bodyText = (await page.locator('body').textContent()) || ''
+        const hasErrorText =
+          bodyText.toLowerCase().includes('invalid') ||
+          bodyText.toLowerCase().includes('wrong') ||
+          bodyText.toLowerCase().includes('incorrect')
 
         console.log('Still on password page:', stillOnPassword)
         console.log('Has error text:', hasErrorText)
-        
+
         // Either error shown OR still on password page = test passes
         expect(stillOnPassword || hasErrorText).toBe(true)
       } else {
@@ -162,9 +202,15 @@ test.describe('Vault Import', () => {
     }
   })
 
-  test('imported vault persists across page reloads', async ({ context, extensionId }) => {
+  test('imported vault persists across page reloads', async ({
+    context,
+    extensionId,
+  }) => {
     const config = getVaultConfigFromEnv()
-    test.skip(!config, 'No vault config')
+    if (!config) {
+      test.skip(true, 'No vault config')
+      return
+    }
 
     const page = await context.newPage()
     const vaultPage = new VaultPage(page, extensionId)
@@ -173,16 +219,20 @@ test.describe('Vault Import', () => {
       // Import vault
       const result = await importVaultViaUI(page, {
         extensionId,
-        vaultPath: config!.vaultPath,
-        password: config!.password,
+        vaultPath: config.vaultPath,
+        password: config.password,
       })
       expect(result).toBe(true)
 
       // Verify vault page loads
       await vaultPage.waitForView(15_000)
-      
+
       // Check for chains before reload
-      const hasChainsBefore = await page.locator('text=/ethereum|bitcoin|solana|portfolio/i').first().isVisible().catch(() => false)
+      const hasChainsBefore = await page
+        .locator('text=/ethereum|bitcoin|solana|portfolio/i')
+        .first()
+        .isVisible()
+        .catch(() => false)
       console.log('Has chains before reload:', hasChainsBefore)
 
       // Reload page
@@ -191,11 +241,15 @@ test.describe('Vault Import', () => {
 
       // Vault should still be there (not show onboarding)
       await vaultPage.waitForView(15_000)
-      
+
       // Check for chains after reload
-      const hasChainsAfter = await page.locator('text=/ethereum|bitcoin|solana|portfolio/i').first().isVisible().catch(() => false)
+      const hasChainsAfter = await page
+        .locator('text=/ethereum|bitcoin|solana|portfolio/i')
+        .first()
+        .isVisible()
+        .catch(() => false)
       console.log('Has chains after reload:', hasChainsAfter)
-      
+
       expect(hasChainsAfter).toBe(true)
     } finally {
       await page.close()


### PR DESCRIPTION
Replaces hardcoded local vault fixture paths/passwords in the extension vault import/export E2E spec with env-owned fixture helpers.\n\nVerification:\n- prettier/eslint on edited spec/helper\n- git diff --check\n- removed local path/password identifier scan\n- yarn quality:secrets\n- yarn workspace @clients/extension test:e2e tests/e2e/specs/vault-import-export.spec.ts --project=ui-isolated (3 passed, 3 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vault import test reliability with stronger UI readiness detection and more resilient button selection.
  * Updated E2E vault-import configuration to pull vault path/password from runtime environment settings with sensible fallbacks, reducing unnecessary test skips.
  * Enhanced negative and persistence scenarios, including better wrong-password validation and confirmation that imported vault functionality remains after extension reloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->