### PR TITLE
Retry cold-start request accounts

### DIFF
--- a/clients/extension/src/inpage/providers/core/requestAccount.ts
+++ b/clients/extension/src/inpage/providers/core/requestAccount.ts
@@ -7,6 +7,14 @@ import { attempt } from '@vultisig/lib-utils/attempt'
 
 import { EIP1193Error } from '../../../background/handlers/errorHandler'
 
+const isBridgeTransportError = (error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error)
+
+  return /Failed to send message to background script|Receiving end does not exist|Could not establish connection|message port closed|Extension context invalidated/i.test(
+    message
+  )
+}
+
 export const requestAccount = async (
   chain: Chain,
   options?: { preselectFastVault?: boolean }
@@ -59,7 +67,11 @@ export const requestAccount = async (
   // Origin not authorized for the current vault, or vault is authorized but
   // has no account for this chain (e.g. Solana on an EVM-only import) →
   // prompt the user to pick a vault that supports this chain.
-  if (error === BackgroundError.Unauthorized || data !== undefined) {
+  if (
+    error === BackgroundError.Unauthorized ||
+    data !== undefined ||
+    isBridgeTransportError(error)
+  ) {
     return grantAccessAndGetAccount()
   }
 

--- a/clients/extension/src/inpage/providers/core/requestAccount.ts
+++ b/clients/extension/src/inpage/providers/core/requestAccount.ts
@@ -9,9 +9,13 @@ import { EIP1193Error } from '../../../background/handlers/errorHandler'
 
 const isBridgeTransportError = (error: unknown) => {
   const message = error instanceof Error ? error.message : String(error)
+  const unwrappedMessage = message.replace(
+    /^Failed to send message to background script after \d+ attempts:\s*/i,
+    ''
+  )
 
-  return /Failed to send message to background script|Receiving end does not exist|Could not establish connection|message port closed|Extension context invalidated/i.test(
-    message
+  return /Receiving end does not exist|Could not establish connection|message port closed|Extension context invalidated/i.test(
+    unwrappedMessage
   )
 }
 

--- a/clients/extension/tests/unit/requestAccount.test.ts
+++ b/clients/extension/tests/unit/requestAccount.test.ts
@@ -1,7 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-
 import { BackgroundError } from '@core/inpage-provider/background/error'
 import { PopupError } from '@core/inpage-provider/popup/error'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // We need to mock callBackground and callPopup before importing requestAccount
 const mockCallBackground = vi.fn()
@@ -16,7 +15,6 @@ vi.mock('@core/inpage-provider/popup', () => ({
 }))
 
 import { requestAccount } from '@clients/extension/src/inpage/providers/core/requestAccount'
-
 // We need to know the Chain enum value for Solana
 import { Chain } from '@vultisig/core-chain/Chain'
 
@@ -41,7 +39,11 @@ describe('requestAccount', () => {
 
   it('falls through to popup on BackgroundError.Unauthorized, then retries', async () => {
     const accountData = { address: '0xABCDEF' }
-    const appSession = { vaultId: 'v1', host: 'example.com', url: 'https://example.com' }
+    const appSession = {
+      vaultId: 'v1',
+      host: 'example.com',
+      url: 'https://example.com',
+    }
 
     // First call: background rejects with Unauthorized
     mockCallBackground
@@ -69,7 +71,11 @@ describe('requestAccount', () => {
   })
 
   it('passes preselectFastVault option to popup', async () => {
-    const appSession = { vaultId: 'v1', host: 'example.com', url: 'https://example.com' }
+    const appSession = {
+      vaultId: 'v1',
+      host: 'example.com',
+      url: 'https://example.com',
+    }
     mockCallBackground
       .mockRejectedValueOnce(BackgroundError.Unauthorized)
       .mockResolvedValueOnce({ address: '0x123' })
@@ -81,6 +87,32 @@ describe('requestAccount', () => {
     expect(mockCallPopup).toHaveBeenCalledWith({
       grantVaultAccess: {
         preselectFastVault: true,
+        chain: Chain.Ethereum,
+      },
+    })
+  })
+
+  it('opens the popup when the initial getAccount fails with a bridge transport error', async () => {
+    const appSession = {
+      vaultId: 'v1',
+      host: 'example.com',
+      url: 'https://example.com',
+    }
+    const accountData = { address: '0x123' }
+
+    mockCallBackground
+      .mockRejectedValueOnce(
+        'Failed to send message to background script after 3 attempts: The message port closed before a response was received.'
+      )
+      .mockResolvedValueOnce(accountData)
+    mockCallPopup.mockResolvedValue({ appSession })
+
+    const result = await requestAccount(Chain.Ethereum)
+
+    expect(result).toEqual(accountData)
+    expect(mockCallPopup).toHaveBeenCalledWith({
+      grantVaultAccess: {
+        preselectFastVault: undefined,
         chain: Chain.Ethereum,
       },
     })
@@ -103,7 +135,9 @@ describe('requestAccount', () => {
     // Background rejects with something other than BackgroundError.Unauthorized
     // — e.g. shouldBePresent('currentVaultId') throwing when no vault exists.
     // Per EIP-1193, the dApp should see 4100 (Unauthorized), not -32603.
-    mockCallBackground.mockRejectedValue(new Error('currentVaultId is required'))
+    mockCallBackground.mockRejectedValue(
+      new Error('currentVaultId is required')
+    )
 
     await expect(requestAccount(Chain.Ethereum)).rejects.toMatchObject({
       code: 4100,

--- a/clients/extension/tests/unit/requestAccount.test.ts
+++ b/clients/extension/tests/unit/requestAccount.test.ts
@@ -118,6 +118,18 @@ describe('requestAccount', () => {
     })
   })
 
+  it('does not open the popup for wrapped non-transport bridge errors', async () => {
+    mockCallBackground.mockRejectedValue(
+      'Failed to send message to background script after 3 attempts: Permission denied'
+    )
+
+    await expect(requestAccount(Chain.Ethereum)).rejects.toMatchObject({
+      code: 4100,
+      message: 'Unauthorized',
+    })
+    expect(mockCallPopup).not.toHaveBeenCalled()
+  })
+
   it('throws EIP1193Error(UserRejectedRequest) when user rejects popup', async () => {
     // Background rejects with Unauthorized so popup is shown
     mockCallBackground.mockRejectedValueOnce(BackgroundError.Unauthorized)

--- a/lib/extension/bridge/content.test.ts
+++ b/lib/extension/bridge/content.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { isTransientRuntimeMessageError } from './content'
+
+describe('isTransientRuntimeMessageError', () => {
+  it.each([
+    'Receiving end does not exist.',
+    'Could not establish connection. Receiving end does not exist.',
+    'The message port closed before a response was received.',
+    'Extension context invalidated.',
+  ])('treats %s as retryable', error => {
+    expect(isTransientRuntimeMessageError(error)).toBe(true)
+  })
+
+  it('does not retry arbitrary runtime errors', () => {
+    expect(isTransientRuntimeMessageError('Permission denied')).toBe(false)
+  })
+})

--- a/lib/extension/bridge/content.ts
+++ b/lib/extension/bridge/content.ts
@@ -9,6 +9,11 @@ import {
 const sendMaxAttempts = 3
 const sendInitialDelay = 75
 
+export const isTransientRuntimeMessageError = (error: string) =>
+  /Receiving end does not exist|Could not establish connection|message port closed|Extension context invalidated/i.test(
+    error
+  )
+
 export const runBridgeContentAgent = () => {
   window.addEventListener('message', ({ source, data }) => {
     if (source !== window) return
@@ -22,7 +27,7 @@ export const runBridgeContentAgent = () => {
         const error = chrome.runtime.lastError?.message
 
         if (error) {
-          if (attemptsLeft > 0 && /Receiving end does not exist/i.test(error)) {
+          if (attemptsLeft > 0 && isTransientRuntimeMessageError(error)) {
             setTimeout(() => send(attemptsLeft - 1, delayMs * 2), delayMs)
             return
           }


### PR DESCRIPTION
## Summary
- Retry transient Chrome runtime message failures in the inpage/content bridge path so MV3 service-worker cold starts do not immediately fail a dApp request.
- Open the existing Connect dApp approval popup when the first getAccount attempt fails with a bridge transport error, then retry with the granted app session.
- Preserve existing no-vault behavior as EIP-1193 Unauthorized without opening the popup.

Closes #4213

## Testing
- yarn workspace @clients/extension test:unit requestAccount.test.ts
- yarn test lib/extension/bridge/content.test.ts
- yarn build:extension
- yarn check:all
- Real built-extension cold-start proof: imported the QA vault, stopped the MV3 service worker via CDP, clicked eth_requestAccounts from a localhost dApp, and verified the existing Connect dApp popup opened while the dApp stayed pending instead of receiving Unauthorized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved account connection handling to recover from additional transient bridge/runtime failures while still showing the access prompt when authorization is needed.
* **Bug Fixes**
  * Broadened retry behavior for temporary background/message runtime connection errors, reducing failed requests during intermittent transport issues.
  * Updated account request authorization fallback to recognize specific bridge/transport connection errors and route them through the existing access flow instead of returning an unauthorized error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->