### PR TITLE
fix: progressive vault & DeFi totals instead of blocking on the slowest coin/chain

### DIFF
--- a/core/ui/defi/page/components/DefiPortfolioBalance.tsx
+++ b/core/ui/defi/page/components/DefiPortfolioBalance.tsx
@@ -34,11 +34,16 @@ export const DefiPortfolioBalance = () => {
             </HStack>
           )}
           success={value => (
-            <Text size={34}>
-              <BalanceVisibilityAware size="l">
-                {formatFiatAmount(value)}
-              </BalanceVisibilityAware>
-            </Text>
+            <HStack gap={8} alignItems="center">
+              <Text size={34}>
+                <BalanceVisibilityAware size="l">
+                  {formatFiatAmount(value)}
+                </BalanceVisibilityAware>
+              </Text>
+              {query.isUpdating ? (
+                <Spinner size="0.9em" style={{ opacity: 0.5 }} />
+              ) : null}
+            </HStack>
           )}
         />
         <ManageVaultBalanceVisibility

--- a/core/ui/defi/page/hooks/useDefiPortfolios.ts
+++ b/core/ui/defi/page/hooks/useDefiPortfolios.ts
@@ -255,8 +255,12 @@ export const useDefiPortfolioBalance = () => {
   const chainTotal = sum(resolvedChains.map(portfolio => portfolio.totalFiat))
 
   const isCirclePending = isCircleIncluded && circleFiatBalanceQuery.isPending
-  const isCircleResolved = isCircleIncluded && !circleFiatBalanceQuery.isPending
-  const circleTotal = isCircleResolved ? (circleFiatBalanceQuery.data ?? 0) : 0
+  // Count Circle only on success — a failed query is no longer pending but its
+  // data is undefined, so treating "not pending" as resolved would silently
+  // mask the failure as a zero contribution.
+  const isCircleResolved =
+    isCircleIncluded && circleFiatBalanceQuery.data !== undefined
+  const circleTotal = isCircleResolved ? circleFiatBalanceQuery.data : 0
 
   const resolvedCount = resolvedChains.length + (isCircleResolved ? 1 : 0)
   const isUpdating = portfolios.isPending || isCirclePending
@@ -265,6 +269,8 @@ export const useDefiPortfolioBalance = () => {
     data: resolvedCount > 0 ? chainTotal + circleTotal : undefined,
     isPending: resolvedCount === 0 && isUpdating,
     isUpdating,
-    error: portfolios.error,
+    error:
+      portfolios.error ??
+      (isCircleIncluded ? circleFiatBalanceQuery.error : null),
   }
 }

--- a/core/ui/defi/page/hooks/useDefiPortfolios.ts
+++ b/core/ui/defi/page/hooks/useDefiPortfolios.ts
@@ -237,36 +237,34 @@ export const useDefiChainPortfolios = () => {
   }
 }
 
+/**
+ * DeFi portfolio total, resolved progressively. `data` sums the chains (and the
+ * Circle USDC balance) that have already landed, so the header shows a running
+ * total instead of blocking on the slowest chain. `isUpdating` stays true while
+ * any chain or the Circle balance is still pending so the UI can render an
+ * "updating" affordance alongside the partial number.
+ */
 export const useDefiPortfolioBalance = () => {
   const portfolios = useDefiChainPortfolios()
   const isCircleIncluded = useIsCircleIncluded()
   const circleFiatBalanceQuery = useCircleAccountUsdcFiatBalanceQuery()
 
-  const total = useMemo(() => {
-    if (portfolios.isPending || circleFiatBalanceQuery.isPending) {
-      return undefined
-    }
+  const resolvedChains = portfolios.data.filter(
+    portfolio => !portfolio.isLoading
+  )
+  const chainTotal = sum(resolvedChains.map(portfolio => portfolio.totalFiat))
 
-    const chainTotal = sum(
-      portfolios.data.map(portfolio => portfolio.totalFiat)
-    )
+  const isCirclePending = isCircleIncluded && circleFiatBalanceQuery.isPending
+  const isCircleResolved = isCircleIncluded && !circleFiatBalanceQuery.isPending
+  const circleTotal = isCircleResolved ? (circleFiatBalanceQuery.data ?? 0) : 0
 
-    const circleTotal = isCircleIncluded
-      ? (circleFiatBalanceQuery.data ?? 0)
-      : 0
-
-    return chainTotal + circleTotal
-  }, [
-    portfolios.data,
-    portfolios.isPending,
-    circleFiatBalanceQuery.data,
-    circleFiatBalanceQuery.isPending,
-    isCircleIncluded,
-  ])
+  const resolvedCount = resolvedChains.length + (isCircleResolved ? 1 : 0)
+  const isUpdating = portfolios.isPending || isCirclePending
 
   return {
-    ...portfolios,
-    data: total,
+    data: resolvedCount > 0 ? chainTotal + circleTotal : undefined,
+    isPending: resolvedCount === 0 && isUpdating,
+    isUpdating,
     error: portfolios.error,
   }
 }

--- a/core/ui/defi/page/hooks/useDefiPortfolios.ts
+++ b/core/ui/defi/page/hooks/useDefiPortfolios.ts
@@ -260,7 +260,7 @@ export const useDefiPortfolioBalance = () => {
   // mask the failure as a zero contribution.
   const isCircleResolved =
     isCircleIncluded && circleFiatBalanceQuery.data !== undefined
-  const circleTotal = isCircleResolved ? circleFiatBalanceQuery.data : 0
+  const circleTotal = isCircleResolved ? (circleFiatBalanceQuery.data ?? 0) : 0
 
   const resolvedCount = resolvedChains.length + (isCircleResolved ? 1 : 0)
   const isUpdating = portfolios.isPending || isCirclePending

--- a/core/ui/vault/page/balance/VaultTotalBalance.tsx
+++ b/core/ui/vault/page/balance/VaultTotalBalance.tsx
@@ -30,16 +30,21 @@ export const VaultTotalBalance = () => {
           </HStack>
         )}
         success={value => (
-          <Text
-            color="contrast"
-            size={28}
-            centerVertically
-            data-testid="balance-value"
-          >
-            <BalanceVisibilityAware size="l">
-              {formatFiatAmount(value)}
-            </BalanceVisibilityAware>
-          </Text>
+          <HStack gap={8} alignItems="center">
+            <Text
+              color="contrast"
+              size={28}
+              centerVertically
+              data-testid="balance-value"
+            >
+              <BalanceVisibilityAware size="l">
+                {formatFiatAmount(value)}
+              </BalanceVisibilityAware>
+            </Text>
+            {query.isUpdating ? (
+              <Spinner size="0.9em" style={{ opacity: 0.5 }} />
+            ) : null}
+          </HStack>
         )}
       />
       <ManageVaultBalanceVisibility />

--- a/core/ui/vault/queries/useVaultTotalBalanceQuery.ts
+++ b/core/ui/vault/queries/useVaultTotalBalanceQuery.ts
@@ -1,7 +1,7 @@
 import { useCoinPricesQuery } from '@core/ui/chain/coin/price/queries/useCoinPricesQuery'
 import { useBalancesQuery } from '@core/ui/chain/coin/queries/useBalancesQuery'
 import { usePortfolioVaultCoins } from '@core/ui/vault/state/currentVaultCoins'
-import { getResolvedQuery, pendingQuery, Query } from '@lib/ui/query/Query'
+import { Query } from '@lib/ui/query/Query'
 import {
   accountCoinKeyToString,
   extractAccountCoinKey,
@@ -9,10 +9,17 @@ import {
 import { coinKeyToString } from '@vultisig/core-chain/coin/Coin'
 import { getCoinValue } from '@vultisig/core-chain/coin/utils/getCoinValue'
 import { sum } from '@vultisig/lib-utils/array/sum'
-import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
-import { useMemo } from 'react'
 
-export const useVaultTotalBalanceQuery = () => {
+/**
+ * Vault total balance, resolved progressively. `data` reflects the partial sum
+ * of every coin whose price and balance have already landed, so the header can
+ * show a running total instead of blocking on the slowest chain. `isUpdating`
+ * stays true while any coin is still pending so the UI can render an
+ * "updating" affordance alongside the partial number.
+ */
+export type VaultTotalBalanceQuery = Query<number> & { isUpdating: boolean }
+
+export const useVaultTotalBalanceQuery = (): VaultTotalBalanceQuery => {
   const coins = usePortfolioVaultCoins()
 
   const pricesQuery = useCoinPricesQuery({
@@ -21,36 +28,35 @@ export const useVaultTotalBalanceQuery = () => {
 
   const balancesQuery = useBalancesQuery(coins.map(extractAccountCoinKey))
 
-  return useMemo((): Query<number> => {
-    if (pricesQuery.isPending || balancesQuery.isPending) {
-      return pendingQuery
-    }
+  const prices = pricesQuery.data ?? {}
+  const balances = balancesQuery.data ?? {}
 
-    if (pricesQuery.data && balancesQuery.data) {
-      const data = sum(
-        coins.map(coin => {
-          const price = shouldBePresent(pricesQuery.data)[coinKeyToString(coin)]
-          const balanceKey = accountCoinKeyToString(extractAccountCoinKey(coin))
-          const amount = shouldBePresent(balancesQuery.data)[balanceKey]
+  let resolvedCount = 0
+  const data = sum(
+    coins.map(coin => {
+      const price = prices[coinKeyToString(coin)]
+      const amount =
+        balances[accountCoinKeyToString(extractAccountCoinKey(coin))]
 
-          if (price === undefined || amount === undefined) {
-            return 0
-          }
-          return getCoinValue({
-            amount,
-            decimals: coin.decimals,
-            price: price,
-          })
-        })
-      )
+      if (price === undefined || amount === undefined) {
+        return 0
+      }
 
-      return getResolvedQuery(data)
-    }
+      resolvedCount++
+      return getCoinValue({
+        amount,
+        decimals: coin.decimals,
+        price,
+      })
+    })
+  )
 
-    return {
-      isPending: false,
-      data: undefined,
-      error: [...balancesQuery.errors, ...pricesQuery.errors][0],
-    }
-  }, [balancesQuery, coins, pricesQuery])
+  const isUpdating = pricesQuery.isPending || balancesQuery.isPending
+
+  return {
+    data: resolvedCount > 0 ? data : undefined,
+    isPending: resolvedCount === 0 && isUpdating,
+    isUpdating,
+    error: [...balancesQuery.errors, ...pricesQuery.errors][0] ?? null,
+  }
 }

--- a/core/ui/vault/queries/useVaultTotalBalanceQuery.ts
+++ b/core/ui/vault/queries/useVaultTotalBalanceQuery.ts
@@ -17,7 +17,7 @@ import { sum } from '@vultisig/lib-utils/array/sum'
  * stays true while any coin is still pending so the UI can render an
  * "updating" affordance alongside the partial number.
  */
-export type VaultTotalBalanceQuery = Query<number> & { isUpdating: boolean }
+type VaultTotalBalanceQuery = Query<number> & { isUpdating: boolean }
 
 export const useVaultTotalBalanceQuery = (): VaultTotalBalanceQuery => {
   const coins = usePortfolioVaultCoins()

--- a/core/ui/vault/queries/useVaultTotalBalanceQuery.ts
+++ b/core/ui/vault/queries/useVaultTotalBalanceQuery.ts
@@ -32,7 +32,7 @@ export const useVaultTotalBalanceQuery = (): VaultTotalBalanceQuery => {
   const balances = balancesQuery.data ?? {}
 
   let resolvedCount = 0
-  const data = sum(
+  const total = sum(
     coins.map(coin => {
       const price = prices[coinKeyToString(coin)]
       const amount =
@@ -51,11 +51,14 @@ export const useVaultTotalBalanceQuery = (): VaultTotalBalanceQuery => {
     })
   )
 
+  // An empty vault is a settled zero, not a loading state — resolve it to 0 so
+  // callers (e.g. the delete-vault page) read a number instead of undefined.
+  const isSettledZero = coins.length === 0
   const isUpdating = pricesQuery.isPending || balancesQuery.isPending
 
   return {
-    data: resolvedCount > 0 ? data : undefined,
-    isPending: resolvedCount === 0 && isUpdating,
+    data: resolvedCount > 0 || isSettledZero ? total : undefined,
+    isPending: resolvedCount === 0 && !isSettledZero && isUpdating,
     isUpdating,
     error: [...balancesQuery.errors, ...pricesQuery.errors][0] ?? null,
   }


### PR DESCRIPTION
## Summary

Both the **vault header total** and the **DeFi portfolio total** spun a full-screen spinner until the *slowest single coin/chain* resolved, because the aggregation gated on all-or-nothing `isPending`. This renders a **partial total as soon as the first coin/chain resolves** and fills in as slow chains land, with a subtle "updating" affordance while anything is still pending.

The underlying `useBalancesQuery` / `useCoinPricesQuery` are built on `useCombineQueries` (eager by default), so `.data` already holds the partial record of resolved coins — no new plumbing needed, just stop gating on `isPending`.

Closes #4221

## Changes

**Vault**
- `useVaultTotalBalanceQuery.ts` — sum resolved coins (price + balance both present), return `undefined` only while nothing has resolved; expose an `isUpdating` flag.
- `VaultTotalBalance.tsx` — full spinner only when truly cold; otherwise the partial number + a subtle updating spinner.

**DeFi** (same blocking pattern)
- `useDefiPortfolios.ts` (`useDefiPortfolioBalance`) — sum the chains (`!isLoading`) and the Circle USDC balance as they resolve, expose `isUpdating`. Side improvement: only block on the Circle balance when it's actually included in the view.
- `DefiPortfolioBalance.tsx` — partial number + subtle updating spinner.

`DefiChainsList` is left as-is — it already renders per-chain progressively (spinner only on the empty/cold state).

## Behavior
- Cold refresh shows a partial total as soon as the first coin/chain resolves (no full-screen spinner once ≥1 is in).
- "Updating" affordance (small 0.5-opacity spinner) visible while any coin/price/chain is still pending.
- Full spinner only when nothing has resolved yet.
- Final total matches the pre-change value once everything resolves.
- Error path unchanged (data stays `undefined` while nothing resolved, so the error branch still renders).

##
<img width="874" height="412" alt="balance" src="https://github.com/user-attachments/assets/148d1d13-0a7e-46c5-95a3-d06483bf02fb" />

## Notes
- Pure display-gating change; in-repo, no package bump.
- A partial total is understated until all coins/chains land — paired with the "updating" affordance so it's never presented as final while pending (same tradeoff Android chose on home).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DeFi and vault total balances now render progressively as underlying chain/coin data becomes available, rather than waiting for everything to finish loading.
  * When a balance refresh is in progress, the updated UI shows a small loading spinner alongside the formatted value.

* **Bug Fixes**
  * Improved loading-state handling so partially resolved totals appear earlier while background updates continue.
  * Refined error selection to surface a clear first error during price/balance aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->