### PR TITLE
feat(solana): staking foundation read-layer hooks

### DIFF
--- a/core/ui/chain/solana/staking/queries/useSolanaEpochInfoQuery.ts
+++ b/core/ui/chain/solana/staking/queries/useSolanaEpochInfoQuery.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchSolanaEpochInfo } from '@vultisig/core-chain/chains/solana/staking/rpc'
+
+/**
+ * Current Solana epoch info — drives activation-state derivation and the
+ * cooldown copy. Cached ~45s (the epoch advances slowly relative to UI reads).
+ */
+export const useSolanaEpochInfoQuery = () =>
+  useQuery({
+    queryKey: ['solanaEpochInfo'] as const,
+    queryFn: fetchSolanaEpochInfo,
+    staleTime: 45_000,
+  })

--- a/core/ui/chain/solana/staking/queries/useSolanaRentReserveQuery.ts
+++ b/core/ui/chain/solana/staking/queries/useSolanaRentReserveQuery.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query'
+import { solanaStakingConfig } from '@vultisig/core-chain/chains/solana/staking/config'
+import { fetchSolanaRentReserve } from '@vultisig/core-chain/chains/solana/staking/rpc'
+
+/**
+ * The rent-exempt reserve for a 200-byte stake account, in lamports. Changes
+ * rarely, so it is cached 24h and seeded with the deterministic
+ * `rentExemptReserveLamports` default so the delegate form can subtract the
+ * reserve from the stakeable max before the live read returns.
+ */
+export const useSolanaRentReserveQuery = () =>
+  useQuery({
+    queryKey: ['solanaRentReserve'] as const,
+    queryFn: fetchSolanaRentReserve,
+    staleTime: 24 * 60 * 60 * 1000,
+    placeholderData: solanaStakingConfig.rentExemptReserveLamports,
+  })

--- a/core/ui/chain/solana/staking/queries/useSolanaStakeAccountsQuery.ts
+++ b/core/ui/chain/solana/staking/queries/useSolanaStakeAccountsQuery.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchSolanaStakeAccounts } from '@vultisig/core-chain/chains/solana/staking/rpc'
+
+/**
+ * Fetches the owner's Solana stake accounts. Intentionally NOT cached
+ * (`staleTime: 0`, `gcTime: 0`) — stake accounts must reflect a just-submitted
+ * stake/unstake and newly accrued (auto-compounded) rewards.
+ */
+export const useSolanaStakeAccountsQuery = (owner: string) =>
+  useQuery({
+    queryKey: ['solanaStakeAccounts', owner] as const,
+    queryFn: () => fetchSolanaStakeAccounts(owner),
+    enabled: owner.length > 0,
+    staleTime: 0,
+    gcTime: 0,
+  })


### PR DESCRIPTION
**Phase 1** of Solana native staking — windows-side data layer. Closes part of #4234 · Epic #4222.

Depends on the SDK foundation: **vultisig/vultisig-sdk#900**.

React-query hooks over the new `@vultisig/core-chain/chains/solana/staking` read functions, with the iOS-matching cache TTLs:

- **`useSolanaStakeAccountsQuery`** — uncached (`staleTime`/`gcTime` 0): stake accounts must reflect a just-submitted stake/unstake and newly accrued (auto-compounded) rewards.
- **`useSolanaEpochInfoQuery`** — ~45s: drives activation-state derivation and cooldown copy.
- **`useSolanaRentReserveQuery`** — 24h, seeded with the deterministic reserve default.

### ⚠️ Draft — merge gated on the SDK
- The hooks import `@vultisig/core-chain/chains/solana/staking/*`, which ships in vultisig-sdk#900. CI typecheck stays red until that's **published** and the `@vultisig/core-chain` dependency is bumped here.
- The hooks gain their UI consumers in later phases (delegate flow / DeFi-tab wiring), so a `knip` unused-export flag here is expected until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)