### PR TITLE
Batch EVM balance queries

### DIFF
--- a/core/ui/chain/coin/queries/useBalancesQuery.test.ts
+++ b/core/ui/chain/coin/queries/useBalancesQuery.test.ts
@@ -1,0 +1,118 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { accountCoinKeyToString } from '@vultisig/core-chain/coin/AccountCoin'
+import { getCoinBalance } from '@vultisig/core-chain/coin/balance'
+import { getEvmChainBalances } from '@vultisig/core-chain/coin/balance/getEvmChainBalances'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  getBalanceQueryOptions,
+  getCoinBalanceQueryAmount,
+} from './useBalancesQuery'
+
+vi.mock('@vultisig/core-chain/coin/balance', () => ({
+  getCoinBalance: vi.fn(),
+}))
+
+vi.mock('@vultisig/core-chain/coin/balance/getEvmChainBalances', () => ({
+  getEvmChainBalances: vi.fn(),
+}))
+
+const address = '0x1111111111111111111111111111111111111111'
+
+const ethInput = {
+  chain: Chain.Ethereum,
+  address,
+} as const
+
+const usdcInput = {
+  chain: Chain.Ethereum,
+  id: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+  address,
+} as const
+
+const runeInput = {
+  chain: Chain.THORChain,
+  address: 'thor1wallet',
+} as const
+
+describe('getCoinBalanceQueryAmount', () => {
+  beforeEach(() => {
+    vi.mocked(getCoinBalance).mockReset()
+    vi.mocked(getEvmChainBalances).mockReset()
+  })
+
+  it('batches EVM balance requests by chain and wallet address', async () => {
+    vi.mocked(getEvmChainBalances).mockResolvedValue({
+      [accountCoinKeyToString(ethInput)]: 11n,
+      [accountCoinKeyToString(usdcInput)]: 22n,
+    })
+
+    const [ethBalance, usdcBalance] = await Promise.all([
+      getCoinBalanceQueryAmount(ethInput),
+      getCoinBalanceQueryAmount(usdcInput),
+    ])
+
+    expect(ethBalance).toBe(11n)
+    expect(usdcBalance).toBe(22n)
+    expect(getEvmChainBalances).toHaveBeenCalledTimes(1)
+    expect(getEvmChainBalances).toHaveBeenCalledWith({
+      chain: Chain.Ethereum,
+      address,
+      coins: [ethInput, usdcInput],
+    })
+    expect(getCoinBalance).not.toHaveBeenCalled()
+  })
+
+  it('matches batched EVM balances across wallet address casing differences', async () => {
+    const checksumAddress = '0x111111111111111111111111111111111111ABCd'
+    const lowercaseInput = {
+      chain: Chain.Ethereum,
+      address: checksumAddress.toLocaleLowerCase(),
+    } as const
+    const checksumInput = {
+      chain: Chain.Ethereum,
+      address: checksumAddress,
+    } as const
+
+    vi.mocked(getEvmChainBalances).mockResolvedValue({
+      [accountCoinKeyToString(lowercaseInput)]: 55n,
+    })
+
+    const [lowercaseBalance, checksumBalance] = await Promise.all([
+      getCoinBalanceQueryAmount(lowercaseInput),
+      getCoinBalanceQueryAmount(checksumInput),
+    ])
+
+    expect(lowercaseBalance).toBe(55n)
+    expect(checksumBalance).toBe(55n)
+    expect(getEvmChainBalances).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps non-EVM balances on the existing per-coin resolver', async () => {
+    vi.mocked(getCoinBalance).mockResolvedValue(33n)
+
+    await expect(getCoinBalanceQueryAmount(runeInput)).resolves.toBe(33n)
+
+    expect(getCoinBalance).toHaveBeenCalledWith(runeInput)
+    expect(getEvmChainBalances).not.toHaveBeenCalled()
+  })
+})
+
+describe('getBalanceQueryOptions', () => {
+  beforeEach(() => {
+    vi.mocked(getEvmChainBalances).mockReset()
+  })
+
+  it('preserves the per-coin query key while using the batched resolver', async () => {
+    vi.mocked(getEvmChainBalances).mockResolvedValue({
+      [accountCoinKeyToString(ethInput)]: 44n,
+    })
+
+    const options = getBalanceQueryOptions(ethInput)
+
+    await expect(options.queryFn()).resolves.toEqual({
+      [accountCoinKeyToString(ethInput)]: 44n,
+    })
+    expect(options.queryKey).toEqual(['coinBalance', ethInput])
+  })
+})

--- a/core/ui/chain/coin/queries/useBalancesQuery.ts
+++ b/core/ui/chain/coin/queries/useBalancesQuery.ts
@@ -77,6 +77,10 @@ const getBatchedEvmCoinBalance = (input: CoinBalanceResolverInput<EvmChain>) =>
     })
   })
 
+/**
+ * Resolves a coin balance, batching EVM requests issued in the same microtask
+ * per chain and wallet address while preserving the existing non-EVM resolver.
+ */
 export const getCoinBalanceQueryAmount = (input: CoinBalanceResolverInput) => {
   if (isChainOfKind(input.chain, 'evm')) {
     return getBatchedEvmCoinBalance(input as CoinBalanceResolverInput<EvmChain>)

--- a/core/ui/chain/coin/queries/useBalancesQuery.ts
+++ b/core/ui/chain/coin/queries/useBalancesQuery.ts
@@ -1,11 +1,89 @@
 import { useCombineQueries } from '@lib/ui/query/hooks/useCombineQueries'
 import { persistQueryOptions } from '@lib/ui/query/utils/options'
 import { useQueries } from '@tanstack/react-query'
+import { EvmChain } from '@vultisig/core-chain/Chain'
+import { isChainOfKind } from '@vultisig/core-chain/ChainKind'
 import { accountCoinKeyToString } from '@vultisig/core-chain/coin/AccountCoin'
 import { getCoinBalance } from '@vultisig/core-chain/coin/balance'
+import { getEvmChainBalances } from '@vultisig/core-chain/coin/balance/getEvmChainBalances'
 import { CoinBalanceResolverInput } from '@vultisig/core-chain/coin/balance/resolver'
 import { mergeRecords } from '@vultisig/lib-utils/record/mergeRecords'
 import { Exact } from '@vultisig/lib-utils/types/Exact'
+import { Address } from 'viem'
+
+type EvmBalanceRequest = {
+  input: CoinBalanceResolverInput<EvmChain>
+  resolve: (amount: bigint) => void
+  reject: (error: unknown) => void
+}
+
+const evmBalanceRequests = new Map<string, EvmBalanceRequest[]>()
+
+const getEvmBalanceBatchKey = ({
+  chain,
+  address,
+}: CoinBalanceResolverInput<EvmChain>) =>
+  `${chain}:${address.toLocaleLowerCase()}`
+
+const getNormalizedBalanceKey = (input: CoinBalanceResolverInput) =>
+  accountCoinKeyToString({
+    ...input,
+    address: input.address.toLocaleLowerCase(),
+  }).toLocaleLowerCase()
+
+const resolveEvmBalanceBatch = async (requests: EvmBalanceRequest[]) => {
+  const [firstRequest] = requests
+
+  if (!firstRequest) return
+
+  const balances = await getEvmChainBalances({
+    chain: firstRequest.input.chain,
+    address: firstRequest.input.address as Address,
+    coins: requests.map(({ input }) => input),
+  })
+  const normalizedBalances = Object.fromEntries(
+    Object.entries(balances).map(([key, value]) => [
+      key.toLocaleLowerCase(),
+      value,
+    ])
+  )
+
+  requests.forEach(({ input, resolve }) => {
+    resolve(normalizedBalances[getNormalizedBalanceKey(input)] ?? 0n)
+  })
+}
+
+const getBatchedEvmCoinBalance = (input: CoinBalanceResolverInput<EvmChain>) =>
+  new Promise<bigint>((resolve, reject) => {
+    const batchKey = getEvmBalanceBatchKey(input)
+    const existingRequests = evmBalanceRequests.get(batchKey)
+
+    evmBalanceRequests.set(batchKey, [
+      ...(existingRequests ?? []),
+      { input, resolve, reject },
+    ])
+
+    if (existingRequests) return
+
+    queueMicrotask(() => {
+      const requests = evmBalanceRequests.get(batchKey)
+      evmBalanceRequests.delete(batchKey)
+
+      if (!requests) return
+
+      resolveEvmBalanceBatch(requests).catch(error => {
+        requests.forEach(({ reject }) => reject(error))
+      })
+    })
+  })
+
+export const getCoinBalanceQueryAmount = (input: CoinBalanceResolverInput) => {
+  if (isChainOfKind(input.chain, 'evm')) {
+    return getBatchedEvmCoinBalance(input as CoinBalanceResolverInput<EvmChain>)
+  }
+
+  return getCoinBalance(input)
+}
 
 export function getBalanceQueryKey<T extends CoinBalanceResolverInput>(
   input: Exact<CoinBalanceResolverInput, T>
@@ -18,7 +96,7 @@ export const getBalanceQueryOptions = <T extends CoinBalanceResolverInput>(
 ) => ({
   queryKey: getBalanceQueryKey(input),
   queryFn: async () => {
-    const amount = await getCoinBalance(input)
+    const amount = await getCoinBalanceQueryAmount(input)
     return {
       [accountCoinKeyToString(input)]: amount,
     }


### PR DESCRIPTION
Closes #4208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved EVM coin balance fetching by batching requests for the same chain and wallet address, reducing duplicate lookups across related balance queries.

- **Bug Fixes**
  - Balance resolution is now consistent for EVM addresses regardless of letter casing.
  - Missing balances are handled gracefully by resolving to zero rather than failing.

- **Tests**
  - Added coverage for the new batched balance behavior and query option construction, including EVM vs non-EVM paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->