### PR TITLE
Move advanced swap settings to tab header

### DIFF
--- a/core/ui/vault/swap/form/MarketSwapForm.tsx
+++ b/core/ui/vault/swap/form/MarketSwapForm.tsx
@@ -18,7 +18,6 @@ import styled from 'styled-components'
 import { useCoreViewState } from '../../../navigation/hooks/useCoreViewState'
 import { useSwapQuoteQuery } from '../queries/useSwapQuoteQuery'
 import { useSwapValidationQuery } from '../queries/useSwapValidationQuery'
-import { AdvancedSwapSettings } from './advanced/AdvancedSwapSettings'
 
 export const MarketSwapForm: FC<OnFinishProp<SwapQuote>> = ({ onFinish }) => {
   const {
@@ -116,7 +115,6 @@ export const MarketSwapForm: FC<OnFinishProp<SwapQuote>> = ({ onFinish }) => {
         </VStack>
       </VStack>
       <VStack gap={20}>
-        <AdvancedSwapSettings />
         <Button
           disabled={!!errorMessage}
           type="submit"

--- a/core/ui/vault/swap/form/SwapForm.tsx
+++ b/core/ui/vault/swap/form/SwapForm.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
 
 import { RefreshSwap } from '../components/RefreshSwap'
+import { AdvancedSwapSettings } from './advanced/AdvancedSwapSettings'
 import { LimitSwapForm } from './LimitSwapForm'
 import { MarketSwapForm } from './MarketSwapForm'
 
@@ -19,6 +20,7 @@ type SwapMode = 'market' | 'limit'
 export const SwapForm: FC<OnFinishProp<SwapQuote>> = ({ onFinish }) => {
   const { t } = useTranslation()
   const [swapMode, setSwapMode] = useState<SwapMode>('market')
+  const showAdvancedSettings = swapMode === 'market'
 
   const tabs: Tab<SwapMode>[] = [
     {
@@ -45,7 +47,11 @@ export const SwapForm: FC<OnFinishProp<SwapQuote>> = ({ onFinish }) => {
         tabs={tabs}
         value={swapMode}
         onValueChange={setSwapMode}
-        triggersContainer={SwapModeTabsHeader}
+        triggersContainer={({ children }) => (
+          <SwapModeTabsHeader showAdvancedSettings={showAdvancedSettings}>
+            {children}
+          </SwapModeTabsHeader>
+        )}
         triggerSlot={({ tab: { label }, isActive, ...triggerProps }) => (
           <TriggerItem {...triggerProps} isActive={isActive}>
             <Text
@@ -62,13 +68,27 @@ export const SwapForm: FC<OnFinishProp<SwapQuote>> = ({ onFinish }) => {
   )
 }
 
-const SwapModeTabsHeader = ({ children }: ChildrenProp) => (
-  <Header>{children}</Header>
+type SwapModeTabsHeaderProps = ChildrenProp & {
+  showAdvancedSettings: boolean
+}
+
+const SwapModeTabsHeader = ({
+  children,
+  showAdvancedSettings,
+}: SwapModeTabsHeaderProps) => (
+  <Header>
+    <TabsHeader>{children}</TabsHeader>
+    {showAdvancedSettings ? <AdvancedSwapSettings /> : null}
+  </Header>
 )
 
 const Header = styled.div`
-  ${hStack({ gap: 24, alignItems: 'center' })};
+  ${hStack({ justifyContent: 'space-between', alignItems: 'center', gap: 16 })};
   padding: 16px 16px 0;
+`
+
+const TabsHeader = styled.div`
+  ${hStack({ gap: 24, alignItems: 'center' })};
 `
 
 const TriggerItem = styled(UnstyledButton)<IsActiveProp>`

--- a/core/ui/vault/swap/form/advanced/AdvancedSwapSettings.tsx
+++ b/core/ui/vault/swap/form/advanced/AdvancedSwapSettings.tsx
@@ -1,8 +1,7 @@
-import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { IconButton } from '@lib/ui/buttons/IconButton'
 import { useBoolean } from '@lib/ui/hooks/useBoolean'
+import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { SettingsIcon } from '@lib/ui/icons/SettingsIcon'
-import { HStack } from '@lib/ui/layout/Stack'
-import { Text } from '@lib/ui/text'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -31,6 +30,9 @@ export const AdvancedSwapSettings = () => {
   return (
     <>
       <Trigger
+        aria-label={t('advanced_settings')}
+        data-testid="advanced-swap-settings"
+        kind="secondary"
         onClick={() => {
           if (isPending) return
           if (isEligible) {
@@ -39,13 +41,13 @@ export const AdvancedSwapSettings = () => {
             setIsGateOpen(true)
           }
         }}
+        size="lg"
+        title={t('advanced_settings')}
       >
-        <HStack alignItems="center" gap={8}>
-          <Text size={14} color="shy">
-            {t('advanced_settings')}
-          </Text>
-          <TierBadge badge={badge} />
-        </HStack>
+        <IconWrapper size={20}>
+          <SettingsIcon />
+        </IconWrapper>
+        <TierBadge badge={badge} />
       </Trigger>
       {isOpen && (
         <AdvancedSwapSettingsSheet
@@ -78,10 +80,7 @@ export const AdvancedSwapSettings = () => {
   )
 }
 
-const Trigger = styled(UnstyledButton)`
-  align-self: center;
-
-  &:hover {
-    opacity: 0.8;
-  }
+const Trigger = styled(IconButton)`
+  gap: 6px;
+  padding: 0 10px;
 `

--- a/core/ui/vault/swap/form/advanced/AdvancedSwapSettings.tsx
+++ b/core/ui/vault/swap/form/advanced/AdvancedSwapSettings.tsx
@@ -26,11 +26,14 @@ export const AdvancedSwapSettings = () => {
   const [isGateOpen, setIsGateOpen] = useState(false)
   const [settings, setSettings] = useAdvancedSwapSettings()
   const { isEligible, isPending, badge } = useTierBadge({ requiredTier })
+  const triggerLabel = badge
+    ? `${t('advanced_settings')}: ${badge.label}`
+    : t('advanced_settings')
 
   return (
     <>
       <Trigger
-        aria-label={t('advanced_settings')}
+        aria-label={triggerLabel}
         data-testid="advanced-swap-settings"
         kind="secondary"
         onClick={() => {


### PR DESCRIPTION
Closes #4238

![screenshot-1](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/4238-swap-advanced-settings-header/screenshot-1-1782792922159.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advanced swap settings are now shown in the swap tab header for market swaps, using a cleaner icon-based control.
* **Bug Fixes**
  * The advanced settings section was removed from the main market swap form to prevent duplicate or misplaced controls.
  * Updated the advanced settings trigger for better accessibility (aria labeling) and consistent header spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->