### PR TITLE
Show details for skip-broadcast dApp signing

### DIFF
--- a/core/ui/mpc/keysign/tx/TxOverviewAmount.tsx
+++ b/core/ui/mpc/keysign/tx/TxOverviewAmount.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next'
 
 import { useFormatFiatAmount } from '../../../chain/hooks/useFormatFiatAmount'
 
-type TxActionLabelKey =
+export type TxActionLabelKey =
   | 'left_pool'
   | 'contract_execution'
   | 'deposited'
@@ -21,6 +21,7 @@ type TxActionLabelKey =
   | 'redelegate'
   | 'vote'
   | 'claim_rewards'
+  | 'signed_signature'
 
 type TxOverviewAmountProps = ValueProp<Coin> & {
   amount: number
@@ -29,6 +30,7 @@ type TxOverviewAmountProps = ValueProp<Coin> & {
   /** When set, render this string instead of `{amount} {ticker}` and hide fiat.
    *  Used for "Unlimited" approvals where the numeric value is meaningless. */
   amountOverride?: string
+  hideZeroAmount?: boolean
 }
 
 export const TxOverviewAmount = ({
@@ -37,6 +39,7 @@ export const TxOverviewAmount = ({
   actionLabel,
   resolvedLabel,
   amountOverride,
+  hideZeroAmount,
 }: TxOverviewAmountProps) => {
   const priceQuery = useCoinPriceQuery({ coin: value })
   const formatFiatAmount = useFormatFiatAmount()
@@ -51,7 +54,8 @@ export const TxOverviewAmount = ({
   // Hide the "0 ETH" line for contract calls where we couldn't resolve the
   // actual token being moved (e.g. Uniswap V4 execute, multicalls). The
   // function label alone is more informative than a misleading zero amount.
-  const showAmount = !!amountOverride || amount > 0 || !resolvedLabel
+  const showAmount =
+    !!amountOverride || amount > 0 || (!resolvedLabel && !hideZeroAmount)
   const showFiat = !amountOverride && amount > 0
 
   return (

--- a/core/ui/mpc/keysign/tx/TxSuccess.tsx
+++ b/core/ui/mpc/keysign/tx/TxSuccess.tsx
@@ -40,6 +40,8 @@ import styled from 'styled-components'
 
 import { useTxHash } from '../../../chain/state/txHash'
 import { useCore } from '../../../state/core'
+import { getTxSuccessAmountPresentation } from './getTxSuccessAmountPresentation'
+import { TransactionStatusAnimation } from './TransactionStatusAnimation'
 import { TxStatusTracker } from './TxStatusTracker'
 
 export const TxSuccess = ({
@@ -178,6 +180,14 @@ export const TxSuccess = ({
   const displayAmountOverride = simulationSend
     ? undefined
     : resolvedToken?.amountOverride
+  const txActionLabel =
+    txAction?.action !== 'send' ? txAction?.labelKey : undefined
+  const amountPresentation = getTxSuccessAmountPresentation({
+    amount: displayAmount,
+    amountOverride: displayAmountOverride,
+    skipBroadcast,
+    txActionLabel,
+  })
 
   const blockExplorerUrl = getBlockExplorerUrl({
     chain: coin.chain,
@@ -206,7 +216,11 @@ export const TxSuccess = ({
 
   return (
     <VStack gap={36} data-testid="tx-success">
-      <TxStatusTracker chain={coin.chain} hash={txHash} />
+      {skipBroadcast ? (
+        <TransactionStatusAnimation status="success" />
+      ) : (
+        <TxStatusTracker chain={coin.chain} hash={txHash} />
+      )}
       <VStack gap={8}>
         {showUniversalRouterSwap ? (
           <UniversalRouterSwapSummary
@@ -219,11 +233,10 @@ export const TxSuccess = ({
           <TxOverviewAmount
             amount={displayAmount}
             value={displayCoin}
-            actionLabel={
-              txAction?.action !== 'send' ? txAction?.labelKey : undefined
-            }
+            actionLabel={amountPresentation.actionLabel}
             resolvedLabel={resolvedLabel}
             amountOverride={displayAmountOverride}
+            hideZeroAmount={amountPresentation.hideZeroAmount}
           />
         )}
         {evmChain && (knownContract || approvalCounterparty) && (
@@ -248,8 +261,8 @@ export const TxSuccess = ({
             )}
           </List>
         )}
-        {!skipBroadcast && (
-          <List>
+        <List>
+          {!skipBroadcast && (
             <ListItem
               hoverable
               extra={
@@ -283,14 +296,14 @@ export const TxSuccess = ({
                 </Text>
               }
             />
-            <ListItem
-              onClick={onSeeTxDetails}
-              title={<Text size={14}>{t('transaction_details')}</Text>}
-              hoverable
-              showArrow
-            />
-          </List>
-        )}
+          )}
+          <ListItem
+            onClick={onSeeTxDetails}
+            title={<Text size={14}>{t('transaction_details')}</Text>}
+            hoverable
+            showArrow
+          />
+        </List>
       </VStack>
     </VStack>
   )

--- a/core/ui/mpc/keysign/tx/getTxSuccessAmountPresentation.test.ts
+++ b/core/ui/mpc/keysign/tx/getTxSuccessAmountPresentation.test.ts
@@ -38,4 +38,17 @@ describe('getTxSuccessAmountPresentation', () => {
       hideZeroAmount: false,
     })
   })
+
+  it('preserves labeled zero-amount skip-broadcast results', () => {
+    expect(
+      getTxSuccessAmountPresentation({
+        amount: 0,
+        skipBroadcast: true,
+        txActionLabel: 'deposited',
+      })
+    ).toEqual({
+      actionLabel: 'deposited',
+      hideZeroAmount: false,
+    })
+  })
 })

--- a/core/ui/mpc/keysign/tx/getTxSuccessAmountPresentation.test.ts
+++ b/core/ui/mpc/keysign/tx/getTxSuccessAmountPresentation.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { getTxSuccessAmountPresentation } from './getTxSuccessAmountPresentation'
+
+describe('getTxSuccessAmountPresentation', () => {
+  it('labels zero-amount skip-broadcast results as signed signatures', () => {
+    expect(
+      getTxSuccessAmountPresentation({
+        amount: 0,
+        skipBroadcast: true,
+      })
+    ).toEqual({
+      actionLabel: 'signed_signature',
+      hideZeroAmount: true,
+    })
+  })
+
+  it('keeps parsed skip-broadcast amounts visible', () => {
+    expect(
+      getTxSuccessAmountPresentation({
+        amount: 1.25,
+        skipBroadcast: true,
+      })
+    ).toEqual({
+      actionLabel: undefined,
+      hideZeroAmount: false,
+    })
+  })
+
+  it('preserves normal broadcast action labels', () => {
+    expect(
+      getTxSuccessAmountPresentation({
+        amount: 0,
+        txActionLabel: 'contract_execution',
+      })
+    ).toEqual({
+      actionLabel: 'contract_execution',
+      hideZeroAmount: false,
+    })
+  })
+})

--- a/core/ui/mpc/keysign/tx/getTxSuccessAmountPresentation.ts
+++ b/core/ui/mpc/keysign/tx/getTxSuccessAmountPresentation.ts
@@ -13,7 +13,8 @@ export const getTxSuccessAmountPresentation = ({
   skipBroadcast,
   txActionLabel,
 }: GetTxSuccessAmountPresentationInput) => {
-  const hideZeroAmount = !!skipBroadcast && !amountOverride && amount === 0
+  const hideZeroAmount =
+    !!skipBroadcast && !txActionLabel && !amountOverride && amount === 0
 
   return {
     actionLabel: hideZeroAmount ? 'signed_signature' : txActionLabel,

--- a/core/ui/mpc/keysign/tx/getTxSuccessAmountPresentation.ts
+++ b/core/ui/mpc/keysign/tx/getTxSuccessAmountPresentation.ts
@@ -1,0 +1,25 @@
+import { TxActionLabelKey } from './TxOverviewAmount'
+
+type GetTxSuccessAmountPresentationInput = {
+  amount: number
+  amountOverride?: string
+  skipBroadcast?: boolean
+  txActionLabel?: TxActionLabelKey
+}
+
+export const getTxSuccessAmountPresentation = ({
+  amount,
+  amountOverride,
+  skipBroadcast,
+  txActionLabel,
+}: GetTxSuccessAmountPresentationInput) => {
+  const hideZeroAmount = !!skipBroadcast && !amountOverride && amount === 0
+
+  return {
+    actionLabel: hideZeroAmount ? 'signed_signature' : txActionLabel,
+    hideZeroAmount,
+  } satisfies {
+    actionLabel?: TxActionLabelKey
+    hideZeroAmount: boolean
+  }
+}


### PR DESCRIPTION
Closes #4236

![screenshot-1](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/4236-skip-broadcast-success-details/screenshot-1-1782794494741.png)
![screenshot-2](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/4236-skip-broadcast-success-details/screenshot-2-1782794494741.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced transaction success UI to support signed-only action labeling (including a new `signed_signature` action key).
  * Added logic to optionally hide zero amounts in success displays.

* **Bug Fixes**
  * Zero amounts are hidden for skipped-broadcast success states unless an action label override is present.
  * Transaction details now render even when broadcast is skipped.

* **Tests**
  * Added unit tests covering transaction success amount presentation across zero/non-zero amounts and different label combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->