### PR TITLE
feat(balance): animated count-up for vault & DeFi totals

### DIFF
--- a/core/ui/chain/components/AnimatedFiatAmount.tsx
+++ b/core/ui/chain/components/AnimatedFiatAmount.tsx
@@ -1,0 +1,29 @@
+import { useFormatFiatAmount } from '@core/ui/chain/hooks/useFormatFiatAmount'
+import { useAnimatedNumber } from '@lib/ui/hooks/useAnimatedNumber'
+import styled from 'styled-components'
+
+type AnimatedFiatAmountProps = {
+  value: number
+  cacheKey: string
+}
+
+/**
+ * Renders a fiat amount that animates with a count-up effect when `value`
+ * changes — used for vault and DeFi totals. The `cacheKey` keeps each usage's
+ * last shown value isolated so re-entering a screen with an unchanged total does
+ * not replay the animation. Digits are rendered tabular (equal width) so the
+ * currency symbol and surrounding layout don't jitter as digits change.
+ */
+export const AnimatedFiatAmount = ({
+  value,
+  cacheKey,
+}: AnimatedFiatAmountProps) => {
+  const formatFiatAmount = useFormatFiatAmount()
+  const animatedValue = useAnimatedNumber({ value, cacheKey })
+
+  return <TabularNumbers>{formatFiatAmount(animatedValue)}</TabularNumbers>
+}
+
+const TabularNumbers = styled.span`
+  font-variant-numeric: tabular-nums;
+`

--- a/core/ui/defi/page/components/DefiPortfolioBalance.tsx
+++ b/core/ui/defi/page/components/DefiPortfolioBalance.tsx
@@ -1,4 +1,4 @@
-import { useFormatFiatAmount } from '@core/ui/chain/hooks/useFormatFiatAmount'
+import { AnimatedFiatAmount } from '@core/ui/chain/components/AnimatedFiatAmount'
 import { useDefiPortfolioBalance } from '@core/ui/defi/page/hooks/useDefiPortfolios'
 import { BalanceVisibilityAware } from '@core/ui/vault/balance/visibility/BalanceVisibilityAware'
 import { ManageVaultBalanceVisibility } from '@core/ui/vault/page/balance/visibility/ManageVaultBalanceVisibility'
@@ -12,7 +12,6 @@ import styled from 'styled-components'
 
 export const DefiPortfolioBalance = () => {
   const query = useDefiPortfolioBalance()
-  const formatFiatAmount = useFormatFiatAmount()
   const { t } = useTranslation()
 
   return (
@@ -37,7 +36,7 @@ export const DefiPortfolioBalance = () => {
             <HStack gap={8} alignItems="center">
               <Text size={34}>
                 <BalanceVisibilityAware size="l">
-                  {formatFiatAmount(value)}
+                  <AnimatedFiatAmount value={value} cacheKey="defi-total" />
                 </BalanceVisibilityAware>
               </Text>
               {query.isUpdating ? (

--- a/core/ui/vault/page/balance/VaultTotalBalance.tsx
+++ b/core/ui/vault/page/balance/VaultTotalBalance.tsx
@@ -1,4 +1,4 @@
-import { useFormatFiatAmount } from '@core/ui/chain/hooks/useFormatFiatAmount'
+import { AnimatedFiatAmount } from '@core/ui/chain/components/AnimatedFiatAmount'
 import { useFiatCurrency } from '@core/ui/storage/fiatCurrency'
 import { BalanceVisibilityAware } from '@core/ui/vault/balance/visibility/BalanceVisibilityAware'
 import { useVaultTotalBalanceQuery } from '@core/ui/vault/queries/useVaultTotalBalanceQuery'
@@ -14,7 +14,6 @@ import { ManageVaultBalanceVisibility } from './visibility/ManageVaultBalanceVis
 export const VaultTotalBalance = () => {
   const query = useVaultTotalBalanceQuery()
   const fiatCurrency = useFiatCurrency()
-  const formatFiatAmount = useFormatFiatAmount()
 
   const { t } = useTranslation()
 
@@ -38,7 +37,7 @@ export const VaultTotalBalance = () => {
               data-testid="balance-value"
             >
               <BalanceVisibilityAware size="l">
-                {formatFiatAmount(value)}
+                <AnimatedFiatAmount value={value} cacheKey="vault-total" />
               </BalanceVisibilityAware>
             </Text>
             {query.isUpdating ? (

--- a/lib/ui/hooks/useAnimatedNumber.ts
+++ b/lib/ui/hooks/useAnimatedNumber.ts
@@ -1,0 +1,101 @@
+import { useEffect, useRef, useState } from 'react'
+
+const defaultDuration = 1000
+
+const easeOutCubic = (progress: number) => 1 - Math.pow(1 - progress, 3)
+
+/**
+ * Remembers the last number shown per `cacheKey`, surviving unmounts. Re-entering
+ * a screen with an unchanged total reads from here and skips the count-up; only a
+ * genuine change re-animates.
+ */
+const lastShownValues = new Map<string, number>()
+
+/**
+ * Rounds intermediate frames to a magnitude-based step so the fast-changing
+ * low-order digits don't flicker: small totals count in cents, large totals count
+ * in clean hundreds/thousands. This keeps the number of visible increments roughly
+ * constant regardless of magnitude, so the motion always reads as smooth. The
+ * final value is always shown exactly (not stepped).
+ */
+const quantizationStep = (value: number) => {
+  const abs = Math.abs(value)
+  if (abs < 1) {
+    return 0.01
+  }
+  return Math.max(0.01, Math.pow(10, Math.floor(Math.log10(abs)) - 3))
+}
+
+const roundToStep = (value: number, step: number) =>
+  Math.round(value / step) * step
+
+type UseAnimatedNumberInput = {
+  value: number
+  cacheKey: string
+  duration?: number
+}
+
+/**
+ * Animates a number towards `value` only when it actually changes — a currency
+ * switch, chains resolving, a refresh that moves the total. The first value (and
+ * re-entering a screen with the same total) is shown instantly, so the count-up is
+ * not replayed on every navigation. When `value` changes mid-flight the animation
+ * resumes from the current number instead of snapping.
+ *
+ * Duration is fixed, so the per-second speed scales with the change: a small delta
+ * counts slowly enough to read, a huge delta counts fast. Intermediate frames are
+ * quantized (see `quantizationStep`) so large totals step in hundreds/thousands
+ * rather than churning every digit.
+ */
+export const useAnimatedNumber = ({
+  value,
+  cacheKey,
+  duration = defaultDuration,
+}: UseAnimatedNumberInput) => {
+  const [displayValue, setDisplayValue] = useState(
+    () => lastShownValues.get(cacheKey) ?? value
+  )
+  const currentValueRef = useRef(displayValue)
+  const frameRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    const startValue = currentValueRef.current
+
+    if (startValue === value) {
+      lastShownValues.set(cacheKey, value)
+      return
+    }
+
+    const step = quantizationStep(value)
+    let startTime: number | null = null
+
+    const tick = (time: number) => {
+      if (startTime === null) {
+        startTime = time
+      }
+
+      const progress = Math.min((time - startTime) / duration, 1)
+      const rawValue =
+        startValue + (value - startValue) * easeOutCubic(progress)
+      const nextValue = progress < 1 ? roundToStep(rawValue, step) : value
+
+      currentValueRef.current = rawValue
+      lastShownValues.set(cacheKey, nextValue)
+      setDisplayValue(nextValue)
+
+      if (progress < 1) {
+        frameRef.current = requestAnimationFrame(tick)
+      }
+    }
+
+    frameRef.current = requestAnimationFrame(tick)
+
+    return () => {
+      if (frameRef.current !== null) {
+        cancelAnimationFrame(frameRef.current)
+      }
+    }
+  }, [value, duration, cacheKey])
+
+  return displayValue
+}


### PR DESCRIPTION
## Summary

Makes the **vault header total** and the **DeFi portfolio total** animate with a smooth count-up instead of snapping between values. On a currency switch, a refresh, or chains resolving, the number rolls up (or down) at a pace that reads naturally at any magnitude.

Closes #4250. Sits on top of #4232 (now merged) — the progressive totals there make the count-up especially visible as chains land one by one, and the `isUpdating` spinner is kept alongside the animated number.

## Behavior

- **Animates only on a genuine change.** The first value, and re-entering a screen with an unchanged total, are shown instantly — the last shown value is remembered per usage (`cacheKey`), so the count-up is **not replayed on every navigation**. A currency switch / chains resolving / a refresh that moves the total does animate.
- **Resumes mid-flight.** If the target changes while animating, it continues from the current number instead of snapping, so a sequence like 100 → 150 → 1000 reads as one continuous count.
- **Magnitude-aware, always smooth.** Intermediate frames are quantized to a step based on the value's size — cents for small totals, hundreds/thousands for large — so big numbers step cleanly (e.g. by 100s) rather than churning every digit. Duration is fixed, so the per-second speed scales with the change (a small delta counts slowly enough to read; a large delta counts fast). The final value is always shown exactly.
- **No jitter.** Digits render tabular (equal width) so the currency symbol and surrounding layout don't shift as digits change.

## Changes

- `lib/ui/hooks/useAnimatedNumber.ts` (new) — `requestAnimationFrame` count-up with per-usage last-value memory, magnitude-based quantization, and ease-out. Fixed duration → speed scales with magnitude.
- `core/ui/chain/components/AnimatedFiatAmount.tsx` (new) — formats the animated number; renders tabular figures.
- `core/ui/vault/page/balance/VaultTotalBalance.tsx`, `core/ui/defi/page/components/DefiPortfolioBalance.tsx` — use `AnimatedFiatAmount` for the total (alongside the existing `isUpdating` spinner from #4232).

These are shared `core/ui` / `lib/ui` components, so **desktop and the extension both get the effect** (extension renders the same `VaultPage`).

## Validation

- `yarn typecheck`, `yarn eslint`, and `yarn knip` pass.
- Verified live in `yarn dev:desktop` and `yarn dev:extension`.

## Notes

- Pure display change — no change to how totals are computed (`useVaultTotalBalanceQuery` / `useDefiPortfolioBalance` math is untouched).
- Tabular-figure jitter fix relies on the UI font exposing tabular digits; the magnitude quantization independently reduces digit churn, so motion stays clean regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)