### PR TITLE
fix(vault): "Something is wrong" on Review Devices abandons the vault

### DIFF
--- a/core/ui/mpc/keygen/backup/VaultKeygenBackupFlow.tsx
+++ b/core/ui/mpc/keygen/backup/VaultKeygenBackupFlow.tsx
@@ -37,5 +37,5 @@ export const VaultKeygenBackupFlow = ({
     )
   }
 
-  return <BackupSecureVault onFinish={onFinish} />
+  return <BackupSecureVault />
 }

--- a/core/ui/vault/backup/secure/BackupSecureVault.tsx
+++ b/core/ui/vault/backup/secure/BackupSecureVault.tsx
@@ -1,3 +1,5 @@
+import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
+import { useDeleteVaultMutation, useVaults } from '@core/ui/storage/vaults'
 import { BackupOverviewScreen } from '@core/ui/vault/backup/BackupOverviewScreen'
 import { VaultCreatedSuccessScreen } from '@core/ui/vault/backup/fast/VaultCreatedSuccessScreen'
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
@@ -5,8 +7,8 @@ import { Match } from '@lib/ui/base/Match'
 import { useStepNavigation } from '@lib/ui/hooks/useStepNavigation'
 import { ArrowSplitIcon } from '@lib/ui/icons/ArrowSplitIcon'
 import { CloudUploadIcon } from '@lib/ui/icons/CloudUploadIcon'
-import { OnFinishProp } from '@lib/ui/props'
 import { isServer } from '@vultisig/core-mpc/devices/localPartyId'
+import { getVaultId } from '@vultisig/core-mpc/vault/Vault'
 import { useTranslation } from 'react-i18next'
 
 import { InitiateSecureVaultBackup } from './InitiateSecureVaultBackup'
@@ -19,11 +21,21 @@ const steps = [
   'vaultCreatedSuccess',
 ] as const
 
-export const BackupSecureVault = ({ onFinish }: OnFinishProp) => {
+export const BackupSecureVault = () => {
   const { step, toNextStep, toPreviousStep } = useStepNavigation({ steps })
   const { t } = useTranslation()
   const vault = useCurrentVault()
+  const vaults = useVaults()
+  const navigate = useCoreNavigate()
+  const { mutate: deleteVault } = useDeleteVaultMutation()
   const userDeviceCount = vault.signers.filter(s => !isServer(s)).length
+
+  const abandonVault = () => {
+    const isLastVault = vaults.length <= 1
+    deleteVault(getVaultId(vault), {
+      onSuccess: () => navigate({ id: isLastVault ? 'newVault' : 'vault' }),
+    })
+  }
 
   const secureInfoRows = [
     {
@@ -46,7 +58,7 @@ export const BackupSecureVault = ({ onFinish }: OnFinishProp) => {
     <Match
       value={step}
       reviewDevices={() => (
-        <ReviewVaultDevicesScreen onFinish={toNextStep} onBack={onFinish} />
+        <ReviewVaultDevicesScreen onFinish={toNextStep} onBack={abandonVault} />
       )}
       backupOverview={() => (
         <BackupOverviewScreen


### PR DESCRIPTION
## Problem
Fixes #4199.

When creating a **Secure Vault**, the "Review your vault devices" screen offers **Looks good** and **Something is wrong**. Tapping **Something is wrong** did **not** abandon the vault — it completed the flow and the user landed on home with the unwanted vault created.

## Root cause
For the secure path, the vault is persisted in `SaveVaultStep` *before* the review screen (`KeygenFlow` renders `StepTransition` with `from = SaveVaultStep` → `to = KeygenFlowEnding`). In `BackupSecureVault`, the negative action (`onBack`) was wired to the parent's `onFinish`, which just advances/completes the flow — so the already-saved vault was kept.

Notably, the legit **Looks good** path never uses the parent `onFinish` either: it walks `BackupSecureVault`'s own steps and ends at its internal `VaultCreatedSuccessScreen` (which self-navigates). So `onFinish` was *only* ever consumed by the buggy negative button.

## Fix
- Add a dedicated `abandonVault` handler that deletes the current vault and routes out of the creation flow, reusing the established discard path (`useDeleteVaultMutation` + `getVaultId`, same as the Delete Vault settings page): `newVault` if it was the only vault, otherwise `vault`.
- Wire **Something is wrong** (`onBack`) to `abandonVault`.
- Remove the now-dead `onFinish` prop from `BackupSecureVault` and its pass-through in `VaultKeygenBackupFlow` (`onFinish` is still used by `BackupFastVault`, left untouched).
- **Looks good** behavior is unchanged.

## Validation
- `tsgo --noEmit` ✅, `lint:fix` ✅
- `VaultKeygenBackupFlow.test.tsx` (3 tests) ✅
- `yarn build:extension` ✅
- Manual end-to-end requires a second co-signing device (Secure Vault), so the on-device check is left to a reviewer with a paired device.

> Note: `yarn check`/`i18n:check` is red on a pre-existing unused key `vault_share_banner` (introduced by the "Remove Share Vault QR screen" change on `main`), unrelated to this PR and intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)