### PR TITLE
fix(ui): render tiny-price subscript notation legibly

### DIFF
--- a/core/ui/chain/components/FiatAmountText.tsx
+++ b/core/ui/chain/components/FiatAmountText.tsx
@@ -1,0 +1,68 @@
+import { useFormatFiatAmount } from '@core/ui/chain/hooks/useFormatFiatAmount'
+import { ReactNode } from 'react'
+import styled from 'styled-components'
+
+const subscriptDigitToNormal: Record<string, string> = {
+  '₀': '0',
+  '₁': '1',
+  '₂': '2',
+  '₃': '3',
+  '₄': '4',
+  '₅': '5',
+  '₆': '6',
+  '₇': '7',
+  '₈': '8',
+  '₉': '9',
+}
+
+const Subscript = styled.sub`
+  font-size: 0.75em;
+  line-height: 0;
+`
+
+const renderWithReadableSubscript = (text: string): ReactNode[] => {
+  const parts: ReactNode[] = []
+  let textBuffer = ''
+  let subscriptBuffer = ''
+
+  const flushText = () => {
+    if (textBuffer) {
+      parts.push(textBuffer)
+      textBuffer = ''
+    }
+  }
+
+  const flushSubscript = () => {
+    if (subscriptBuffer) {
+      parts.push(<Subscript key={parts.length}>{subscriptBuffer}</Subscript>)
+      subscriptBuffer = ''
+    }
+  }
+
+  for (const char of text) {
+    const normalDigit = subscriptDigitToNormal[char]
+    if (normalDigit) {
+      flushText()
+      subscriptBuffer += normalDigit
+    } else {
+      flushSubscript()
+      textBuffer += char
+    }
+  }
+
+  flushText()
+  flushSubscript()
+
+  return parts
+}
+
+/**
+ * Renders a formatted fiat amount, upgrading the compact subscript notation used
+ * for tiny prices (e.g. $0.0₄5962) into a real, legible `<sub>` element instead
+ * of the hard-to-read Unicode subscript glyphs.
+ */
+export const FiatAmountText = ({ value }: { value: number }) => {
+  const formatFiatAmount = useFormatFiatAmount()
+
+  return <>{renderWithReadableSubscript(formatFiatAmount(value))}</>
+}

--- a/core/ui/vault/chain/VaultChainCoinItem.tsx
+++ b/core/ui/vault/chain/VaultChainCoinItem.tsx
@@ -14,6 +14,7 @@ import { EntityWithTicker } from '@vultisig/lib-utils/entities/EntityWithTicker'
 import { formatAmount } from '@vultisig/lib-utils/formatAmount'
 import styled from 'styled-components'
 
+import { FiatAmountText } from '../../chain/components/FiatAmountText'
 import { useFormatFiatAmount } from '../../chain/hooks/useFormatFiatAmount'
 
 const PriceBadge = styled.div`
@@ -54,7 +55,7 @@ export const VaultChainCoinItem = ({
             </Text>
             <PriceBadge>
               <Text weight={500} color="shyExtra" size={12}>
-                {formatFiatAmount(price ?? 0)}
+                <FiatAmountText value={price ?? 0} />
               </Text>
             </PriceBadge>
           </VStack>

--- a/core/ui/vault/chain/coin/CoinDetailModal.tsx
+++ b/core/ui/vault/chain/coin/CoinDetailModal.tsx
@@ -1,4 +1,5 @@
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
+import { FiatAmountText } from '@core/ui/chain/components/FiatAmountText'
 import { useFormatFiatAmount } from '@core/ui/chain/hooks/useFormatFiatAmount'
 import { useCore } from '@core/ui/state/core'
 import { BalanceVisibilityAware } from '@core/ui/vault/balance/visibility/BalanceVisibilityAware'
@@ -102,7 +103,7 @@ export const CoinDetailModal = ({ coin, onClose }: CoinDetailModalProps) => {
             </Text>
             <NetworkBadge>
               <Text size={13} color="shyExtra">
-                {formatFiatAmount(coin.price || 0)}
+                <FiatAmountText value={coin.price || 0} />
               </Text>
             </NetworkBadge>
           </InfoRow>


### PR DESCRIPTION
Closes #4255
Follow-up to #4231

## Problem

Sub-cent token prices (e.g. LUNC) are formatted with compact subscript notation so they aren't rounded to `$0.00`. But the zero-count was rendered with a **Unicode subscript glyph** (`₄`), which is too small to read in the price badge / coin detail view.

## Solution

New shared `FiatAmountText` component (in `core/ui`) renders a formatted fiat amount, converting the Unicode subscript glyphs into a real `<sub>` element at a larger font size (`0.75em`) so the zero-count is legible. Wired into the two price displays:

- `VaultChainCoinItem` — token price badge in the coins list
- `CoinDetailModal` — price row

Because it lives in shared `core/ui`, both **desktop** and the **browser extension** get the fix.

> Note: the underlying "show sub-cent prices" formatting change lives in the SDK — vultisig/vultisig-sdk#918 (`@vultisig/lib-utils`). This PR only improves how that output is rendered.

## Test plan
- [ ] Open a vault with a sub-cent token (e.g. LUNC on Terra Classic)
- [ ] Confirm the price badge shows a readable subscript (e.g. `$0.0₄5962`) instead of a tiny glyph
- [ ] `yarn check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved fiat amount display with support for formatted subscript characters in prices.
  * Updated coin and vault views to use the new fiat amount presentation for more consistent pricing output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->