### PR TITLE
[codex] Fix Terra Classic explorer address URL

### DIFF
--- a/core/ui/vault/chain/VaultChainPage.tsx
+++ b/core/ui/vault/chain/VaultChainPage.tsx
@@ -11,10 +11,10 @@ import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { pageBottomInsetVar, PageContent } from '@lib/ui/page/PageContent'
 import { Chain } from '@vultisig/core-chain/Chain'
-import { getBlockExplorerUrl } from '@vultisig/core-chain/utils/getBlockExplorerUrl'
 import styled from 'styled-components'
 
 import { useCurrentVaultAddress } from '../state/currentVaultCoins'
+import { getVaultChainAddressExplorerUrl } from './getVaultChainAddressExplorerUrl'
 import { RefreshVaultChainBalance } from './RefreshVaultChainBalance'
 import { VaultChainTabs } from './tabs/VaultChainTabs'
 import { TronResourcesSection } from './tron/TronResourcesSection'
@@ -26,10 +26,9 @@ export const VaultChainPage = () => {
   const chain = useCurrentVaultChain()
   const address = useCurrentVaultAddress(chain)
 
-  const blockExplorerUrl = getBlockExplorerUrl({
+  const blockExplorerUrl = getVaultChainAddressExplorerUrl({
+    address,
     chain,
-    entity: 'address',
-    value: address,
   })
 
   return (

--- a/core/ui/vault/chain/getVaultChainAddressExplorerUrl.test.ts
+++ b/core/ui/vault/chain/getVaultChainAddressExplorerUrl.test.ts
@@ -1,0 +1,28 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { describe, expect, it } from 'vitest'
+
+import { getVaultChainAddressExplorerUrl } from './getVaultChainAddressExplorerUrl'
+
+describe('getVaultChainAddressExplorerUrl', () => {
+  it('builds a Terra Classic Finder address URL without a duplicate network', () => {
+    const address = 'terra1luncaddress'
+
+    expect(
+      getVaultChainAddressExplorerUrl({
+        address,
+        chain: Chain.TerraClassic,
+      })
+    ).toBe(`https://finder.terra.money/classic/address/${address}`)
+  })
+
+  it('uses the shared block explorer resolver for other chains', () => {
+    const address = '0x1234'
+
+    expect(
+      getVaultChainAddressExplorerUrl({
+        address,
+        chain: Chain.Ethereum,
+      })
+    ).toBe(`https://etherscan.io/address/${address}`)
+  })
+})

--- a/core/ui/vault/chain/getVaultChainAddressExplorerUrl.ts
+++ b/core/ui/vault/chain/getVaultChainAddressExplorerUrl.ts
@@ -1,0 +1,28 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { getBlockExplorerUrl } from '@vultisig/core-chain/utils/getBlockExplorerUrl'
+
+type GetVaultChainAddressExplorerUrlInput = {
+  address: string
+  chain: Chain
+}
+
+const addressExplorerUrlByChain: Partial<
+  Record<Chain, (address: string) => string>
+> = {
+  [Chain.TerraClassic]: address =>
+    new URL(
+      `/classic/address/${address}`,
+      'https://finder.terra.money'
+    ).toString(),
+}
+
+export const getVaultChainAddressExplorerUrl = ({
+  address,
+  chain,
+}: GetVaultChainAddressExplorerUrlInput) => {
+  const resolveAddressExplorerUrl = addressExplorerUrlByChain[chain]
+
+  return resolveAddressExplorerUrl
+    ? resolveAddressExplorerUrl(address)
+    : getBlockExplorerUrl({ chain, entity: 'address', value: address })
+}


### PR DESCRIPTION
﻿## Summary
- fix the LUNC block icon address link so Terra Finder receives a single `classic` network segment
- preserve the shared block explorer resolver for every other chain
- add regression coverage for Terra Classic and the default resolver path

## Root cause
`@vultisig/core-chain` defines the Terra Classic explorer base as `https://finder.terra.money/classic` and then appends `/classic/address/...`, producing `.../classic/classic/address/...`. The latest published package (`2.22.1`) still contains this behavior, so this PR applies a narrow UI-boundary resolver override until the shared package is corrected.

## Impact and safety
This changes only the external address explorer URL opened from the vault chain page. It does not affect balances, transactions, signing, swaps, vault storage, MPC, or key material.

## Validation
- focused Vitest: 2 tests passed
- targeted ESLint: passed
- repository typecheck: passed
- repository lint: passed
- Knip: passed (one existing configuration hint)
- `yarn check`: progressed through asset validation, typecheck, and lint, then stopped on the pre-existing unused translation key `vault_share_banner`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vault chain addresses now open in the most relevant explorer link for each network.
  * Terra Classic addresses use the Terra Finder address page directly, while other networks continue to use the standard explorer format.
* **Tests**
  * Added coverage to confirm the correct explorer URL is generated across supported chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->