### PR TITLE
[Fix] Truncate long token names in coin list & detail modal

### DIFF
--- a/core/ui/vault/chain/CoinTicker.tsx
+++ b/core/ui/vault/chain/CoinTicker.tsx
@@ -1,0 +1,61 @@
+import { MergeRefs } from '@lib/ui/base/MergeRefs'
+import { useElementSize } from '@lib/ui/hooks/useElementSize'
+import { Text, TextColor } from '@lib/ui/text'
+import { Tooltip } from '@lib/ui/tooltips/Tooltip'
+import { CSSProperties, useState } from 'react'
+
+type CoinTickerProps = {
+  ticker: string
+  size?: number
+  weight?: CSSProperties['fontWeight']
+  color?: TextColor
+  maxWidth?: number
+}
+
+/**
+ * Renders a coin ticker/name truncated with an ellipsis so long values (e.g. a
+ * raw contract address used as a token name) never break the surrounding
+ * layout, regardless of the available width. When the value is actually
+ * truncated, the full name is shown on hover via a tooltip.
+ */
+export const CoinTicker = ({
+  ticker,
+  size = 14,
+  weight,
+  color = 'contrast',
+  maxWidth = 180,
+}: CoinTickerProps) => {
+  const [element, setElement] = useState<HTMLParagraphElement | null>(null)
+  const elementSize = useElementSize(element)
+
+  const isTruncated =
+    !!element && !!elementSize && element.scrollWidth > element.clientWidth
+
+  return (
+    <Tooltip
+      content={
+        isTruncated ? (
+          <span style={{ wordBreak: 'break-all' }}>{ticker}</span>
+        ) : undefined
+      }
+      renderOpener={({ ref, ...props }) => (
+        <MergeRefs<HTMLParagraphElement>
+          refs={[ref, setElement]}
+          render={mergedRef => (
+            <Text
+              ref={mergedRef}
+              cropped
+              color={color}
+              size={size}
+              weight={weight}
+              style={{ maxWidth }}
+              {...props}
+            >
+              {ticker}
+            </Text>
+          )}
+        />
+      )}
+    />
+  )
+}

--- a/core/ui/vault/chain/VaultChainCoinItem.tsx
+++ b/core/ui/vault/chain/VaultChainCoinItem.tsx
@@ -16,6 +16,7 @@ import styled from 'styled-components'
 
 import { FiatAmountText } from '../../chain/components/FiatAmountText'
 import { useFormatFiatAmount } from '../../chain/hooks/useFormatFiatAmount'
+import { CoinTicker } from './CoinTicker'
 
 const PriceBadge = styled.div`
   display: inline-flex;
@@ -49,17 +50,15 @@ export const VaultChainCoinItem = ({
           justifyContent="space-between"
           gap={20}
         >
-          <VStack gap={4}>
-            <Text color="contrast" size={14}>
-              {ticker}
-            </Text>
+          <VStack gap={4} flexGrow style={{ minWidth: 0 }}>
+            <CoinTicker ticker={ticker} />
             <PriceBadge>
               <Text weight={500} color="shyExtra" size={12}>
                 <FiatAmountText value={price ?? 0} />
               </Text>
             </PriceBadge>
           </VStack>
-          <HStack gap={8} alignItems="center">
+          <HStack gap={8} alignItems="center" style={{ flexShrink: 0 }}>
             <VStack
               gap={8}
               justifyContent="space-between"
@@ -70,7 +69,13 @@ export const VaultChainCoinItem = ({
                   {formatFiatAmount((price || 0) * balance)}
                 </BalanceVisibilityAware>
               </Text>
-              <Text weight={500} color="shy" size={12} centerVertically>
+              <Text
+                weight={500}
+                color="shy"
+                size={12}
+                cropped
+                style={{ maxWidth: 160 }}
+              >
                 <BalanceVisibilityAware>
                   {formatAmount(balance, { precision: 'high' })} {ticker}
                 </BalanceVisibilityAware>

--- a/core/ui/vault/chain/coin/CoinDetailModal.tsx
+++ b/core/ui/vault/chain/coin/CoinDetailModal.tsx
@@ -4,6 +4,7 @@ import { useFormatFiatAmount } from '@core/ui/chain/hooks/useFormatFiatAmount'
 import { useCore } from '@core/ui/state/core'
 import { BalanceVisibilityAware } from '@core/ui/vault/balance/visibility/BalanceVisibilityAware'
 import { AddressQRModal } from '@core/ui/vault/chain/address/AddressQRModal'
+import { CoinTicker } from '@core/ui/vault/chain/CoinTicker'
 import { VaultPrimaryActions } from '@core/ui/vault/components/VaultPrimaryActions'
 import { VaultChainCoin } from '@core/ui/vault/queries/useVaultChainCoinsQuery'
 import { useCurrentVaultAddress } from '@core/ui/vault/state/currentVaultCoins'
@@ -51,7 +52,7 @@ export const CoinDetailModal = ({ coin, onClose }: CoinDetailModalProps) => {
       }}
     >
       <ContentContainer>
-        <VStack alignItems="center" fullWidth>
+        <VStack alignItems="center" fullWidth style={{ zIndex: 2 }}>
           <HStack justifyContent="space-between" fullWidth gap={8}>
             <ModalCloseButton
               style={{ color: 'hsl(215, 40%, 85%)', fontSize: 16 }}
@@ -65,9 +66,12 @@ export const CoinDetailModal = ({ coin, onClose }: CoinDetailModalProps) => {
           </HStack>
           <HStack alignItems="center" gap={8}>
             <CoinIcon coin={coin} style={{ fontSize: 24 }} />
-            <Text size={20} weight={600} color="contrast">
-              {coin.ticker}
-            </Text>
+            <CoinTicker
+              ticker={coin.ticker}
+              size={20}
+              weight={600}
+              maxWidth={240}
+            />
           </HStack>
         </VStack>
         <VStack alignItems="center" gap={8}>
@@ -76,7 +80,13 @@ export const CoinDetailModal = ({ coin, onClose }: CoinDetailModalProps) => {
               {formatFiatAmount(fiatValue)}
             </BalanceVisibilityAware>
           </Text>
-          <Text size={15} weight={500} color="shy">
+          <Text
+            size={15}
+            weight={500}
+            color="shy"
+            cropped
+            style={{ maxWidth: 240 }}
+          >
             <BalanceVisibilityAware>
               {formatAmount(balance, { precision: 'high' })} {coin.ticker}
             </BalanceVisibilityAware>


### PR DESCRIPTION
Fixes #4260

## Problem
Some tokens use a raw contract address as their name/ticker (e.g. `0BB9D8513E8E8E9AE6A9D211D9136E6DA42288DDE6CFAA453A150A4566054DC5`). Rendered without any width constraint, the long value overflowed and broke the layout of:
- the chain coin **list item**, and
- the coin **detail modal** (both the header title and the amount row).

The token name appears in **two spots per screen** (the name/title and the secondary `amount + ticker` line) — all four were affected.

## Solution
- Add a reusable `CoinTicker` component (`core/ui/vault/chain/CoinTicker.tsx`) that:
  - crops the ticker with an ellipsis and a **capped max-width**, so it truncates regardless of how much space is available (not only on narrow screens);
  - shows the **full name on hover via a tooltip**, but only when the value is actually truncated (short tickers like `LUNC` get no tooltip);
  - wraps the tooltip content with `word-break: break-all` so a long, space-less hex string wraps inside the tooltip instead of overflowing it.
- Apply the same ellipsis cropping to the secondary `amount + ticker` rows in both the list item and the modal.
- Lift the detail modal header above its sibling blocks (`z-index`) so the open tooltip is not painted under the fiat value / amount (which are forced to `z-index: 1` by `ContentContainer > *`).

## Where token names are now handled
| Location | Ellipsis | Tooltip |
|----------|----------|---------|
| Token list — name | ✅ | ✅ |
| Token list — amount row | ✅ | — |
| Detail modal — header | ✅ | ✅ |
| Detail modal — amount row | ✅ | — |

## Scope
- Layout-only fix. No change to how tickers/token names are sourced or formatted.

## Testing
- [x] `yarn check:all` passes (lint, typecheck, tests, knip)
- [x] Verified in the desktop app (Wails dev) on TerraClassic with a contract-address-named token: list item and detail modal no longer break; ellipsis + hover tooltip work; normal short tickers render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smart ticker display that automatically truncates long coin/token names and shows the full value on hover.
  * Updated coin views and the coin details modal to use the new ticker display for a cleaner layout.

* **Bug Fixes**
  * Improved spacing and width handling in coin rows and balance text to reduce overflow and layout issues on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->