### PR TITLE
fix(extension): gate dApp EVM keysign on insufficient funds (#4267)

### DIFF
--- a/core/inpage-provider/popup/view/resolvers/sendTx/SendTxOverview.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/SendTxOverview.tsx
@@ -16,6 +16,7 @@ import { useSendTxKeysignPayloadQuery } from '@core/inpage-provider/popup/view/r
 import { PendingState } from '@core/inpage-provider/popup/view/resolvers/sendTx/PendingState'
 import { SuiTxIntentDisplay } from '@core/inpage-provider/popup/view/resolvers/signMessage/components/SuiTxIntentDisplay'
 import { usePopupInput } from '@core/inpage-provider/popup/view/state/input'
+import { useBalanceQuery } from '@core/ui/chain/coin/queries/useBalanceQuery'
 import { useGetCoin } from '@core/ui/chain/coin/useGetCoin'
 import { useAssertWalletCore } from '@core/ui/chain/providers/WalletCoreProvider'
 import { BlockaidEvmSimulationView } from '@core/ui/chain/security/blockaid/tx/blockaidEvmSimulationView'
@@ -52,7 +53,11 @@ import { Text } from '@lib/ui/text'
 import { useQuery } from '@tanstack/react-query'
 import { Chain, OtherChain } from '@vultisig/core-chain/Chain'
 import { isChainOfKind } from '@vultisig/core-chain/ChainKind'
-import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+import {
+  AccountCoin,
+  extractAccountCoinKey,
+} from '@vultisig/core-chain/coin/AccountCoin'
+import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { getTxBlockaidSimulation } from '@vultisig/core-chain/security/blockaid/tx/simulation'
 import { parseBlockaidSuiSimulation } from '@vultisig/core-chain/security/blockaid/tx/simulation/api/core'
 import { BlockaidSolanaSimulationInfo } from '@vultisig/core-chain/security/blockaid/tx/simulation/core'
@@ -97,6 +102,10 @@ export const SendTxOverview = ({
     parsedTx,
     feeSettings: feeSettings || undefined,
   })
+
+  const nativeBalanceQuery = useBalanceQuery(
+    extractAccountCoinKey({ ...chainFeeCoin[chain], address })
+  )
 
   const blockaidSimulationQuery = useBlockaidSimulationQuery({
     keysignPayloadQuery,
@@ -167,6 +176,38 @@ export const SendTxOverview = ({
 
   const memo = keysignPayloadQuery.data?.memo
   const isEvm = isChainOfKind(chain, 'evm')
+
+  // Gate an EVM keysign before it starts: the node requires the account to
+  // cover `value + gasLimit * maxFeePerGas`, so a dApp tx that exceeds the
+  // native balance is rejected at broadcast — after the MPC ceremony has
+  // already run. Block it here instead, mirroring the in-wallet send form.
+  const insufficientFundsMessage = (() => {
+    const payload = keysignPayloadQuery.data
+    const nativeBalance = nativeBalanceQuery.data
+
+    if (!isEvm || !payload || nativeBalance == null) {
+      return undefined
+    }
+
+    const evmSpecific = getBlockchainSpecificValue(
+      payload.blockchainSpecific,
+      'ethereumSpecific'
+    )
+
+    const value = BigInt(payload.toAmount)
+    const maxGasFee =
+      BigInt(evmSpecific.gasLimit) * BigInt(evmSpecific.maxFeePerGasWei)
+
+    if (value > 0n) {
+      if (value + maxGasFee > nativeBalance) {
+        return t('insufficient_balance')
+      }
+    } else if (maxGasFee > nativeBalance) {
+      return t('insufficient_native_balance_for_fee')
+    }
+
+    return undefined
+  })()
   const isContractMemo =
     !!memo && memo.startsWith('0x') && memo.length > 2 && isEvm
 
@@ -220,6 +261,7 @@ export const SendTxOverview = ({
     <VerifyKeysignStart
       keysignPayloadQuery={keysignPayloadQuery}
       extraPendingMessage={extraPendingMessage}
+      disabledMessage={insufficientFundsMessage}
       footer={
         isSendTxOverviewError ? (
           <Button onClick={goBack}>{t('back')}</Button>
@@ -257,6 +299,21 @@ export const SendTxOverview = ({
 
           return (
             <>
+              {insufficientFundsMessage && (
+                <Panel>
+                  <VStack gap={12} alignItems="center">
+                    <TriangleAlertIcon color="danger" fontSize={24} />
+                    <Text
+                      size={15}
+                      weight={500}
+                      color="danger"
+                      centerHorizontally
+                    >
+                      {insufficientFundsMessage}
+                    </Text>
+                  </VStack>
+                </Panel>
+              )}
               {isInsufficientGas && (
                 <Panel>
                   <VStack gap={12} alignItems="center">

--- a/core/inpage-provider/popup/view/resolvers/sendTx/SendTxOverview.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/SendTxOverview.tsx
@@ -248,7 +248,13 @@ export const SendTxOverview = ({
     if (isSendTxOverviewError) {
       return undefined
     }
-    if (gasEstimationDataQuery.isPending || isContractDecodingPending) {
+    if (
+      gasEstimationDataQuery.isPending ||
+      isContractDecodingPending ||
+      // Keep the start button disabled until the native balance is known, or
+      // the insufficient-funds gate below would be bypassed during its load.
+      (isEvm && nativeBalanceQuery.isPending)
+    ) {
       return t('loading')
     }
     if (isContractDecodingFailed) {

--- a/core/ui/mpc/keysign/start/VerifyKeysignStart.tsx
+++ b/core/ui/mpc/keysign/start/VerifyKeysignStart.tsx
@@ -31,6 +31,12 @@ type VerifyKeysignStartInput = {
   terms?: string[]
   toAddressLabel?: string
   extraPendingMessage?: string
+  /**
+   * Blocks the start-keysign button with this message even when the payload is
+   * ready. Use for pre-keysign gates such as an insufficient-funds check that
+   * would otherwise waste an MPC ceremony on a transaction that can't broadcast.
+   */
+  disabledMessage?: string
   footer?: ReactNode
   swapQuote?: SwapQuote
 }
@@ -47,6 +53,7 @@ export const VerifyKeysignStart = ({
   terms = [],
   toAddressLabel,
   extraPendingMessage,
+  disabledMessage,
   footer,
   swapQuote,
 }: VerifyKeysignStartInput) => {
@@ -136,12 +143,17 @@ export const VerifyKeysignStart = ({
       return {}
     }
 
+    if (disabledMessage) {
+      return { disabledMessage }
+    }
+
     return {
       keysignPayload: { keysign },
       ...(toAddressLabel ? { toAddressLabel } : {}),
       ...(swapQuote ? { swapQuote } : {}),
     }
   }, [
+    disabledMessage,
     extraPendingMessage,
     keysignPayloadQuery.data,
     keysignPayloadQuery.error,


### PR DESCRIPTION
## Problem

A dApp `eth_sendTransaction` whose `value + gas*price` exceeds the account's native balance was **not caught before keysign**. `SendTxOverview` only checked estimated-gas vs the gas *limit* (a warning panel that never disabled signing), so the start-keysign button stayed enabled regardless of balance.

The result: the full MPC signing ceremony runs, and the failure only surfaces at broadcast — wasting a multi-device signing round on a transaction that can never broadcast.

```
insufficient funds for gas * price + value: have 2278690000000000 want 2404206743500000
```

The in-wallet send flow already gates before keysign (`validateSendForm.ts` → `insufficient_balance` / `insufficient_native_balance_for_fee`); the dApp path had no equivalent.

Fixes #4267.

## Fix

- Add an optional `disabledMessage` prop to `VerifyKeysignStart` that disables the start-keysign button even when the payload is ready — a reusable pre-keysign gate.
- In `SendTxOverview`, fetch the native-token balance and, for EVM chains, compute `value + gasLimit * maxFeePerGasWei` (the exact amount the node requires — the EIP-1559 cap, so no false positives/negatives). If it exceeds the balance:
  - disable the keysign start button (`disabledMessage`), and
  - show a red warning panel using the existing i18n keys (`insufficient_balance` when native value is being sent, `insufficient_native_balance_for_fee` for fee-only contract calls).

No new translation keys — both messages already exist and are reused from the send flow.

## Verification

- `yarn typecheck` ✅ / `yarn lint:fix` ✅ (pre-existing `solana_*` i18n missing-key issues on `main` are unrelated).
- Manually reproduced against PancakeSwap on the reported vault (~0.002278 ETH):
  - **Full-balance swap (0.002278 ETH)** → red "Insufficient balance" panel shown, **Sign Transaction disabled**, keysign never starts. ✅
  - **Partial swap (0.001278 ETH)** → no warning, signing proceeds normally (no regression / no false positive). ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a clear warning and blocked transaction signing when the native coin balance is too low to cover the transfer amount and network fees.
  * The signing screen now shows a specific disabled message when funds are insufficient, while preserving existing gas warning behavior.
  * EVM keysign start now waits for the latest balance check to load before allowing the action, preventing bypass of the insufficiency gate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->