### PR TITLE
fix(extension): extend dApp insufficient-funds gate to Cosmos & Ton (#4276)

### DIFF
--- a/core/inpage-provider/popup/view/resolvers/sendTx/SendTxOverview.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/SendTxOverview.tsx
@@ -235,11 +235,18 @@ export const SendTxOverview = ({
 
     // `toAmount` is native for EVM (it's the tx `value`), but for Cosmos/Ton it
     // is only native when the sent coin is the fee coin — a token amount there
-    // must not be added to the native fee.
+    // must not be added to the native fee. Ton Connect also batches up to
+    // `maxMessages` transfers into a single request while `toAmount` carries
+    // only the first, so sum every message's native amount for the Ton gate.
     const nativeValue =
-      isChainOfKind(chain, 'evm') || isFeeCoin(coin)
-        ? BigInt(payload.toAmount)
-        : 0n
+      payload.signData.case === 'signTon'
+        ? payload.signData.value.tonMessages.reduce(
+            (sum, message) => sum + BigInt(message.amount),
+            0n
+          )
+        : isChainOfKind(chain, 'evm') || isFeeCoin(coin)
+          ? BigInt(payload.toAmount)
+          : 0n
 
     if (nativeValue + fee > nativeBalance) {
       return nativeValue > 0n

--- a/core/inpage-provider/popup/view/resolvers/sendTx/SendTxOverview.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/SendTxOverview.tsx
@@ -12,6 +12,7 @@ import { NetworkFeeSection } from '@core/inpage-provider/popup/view/resolvers/se
 import { SwapAmountDisplay } from '@core/inpage-provider/popup/view/resolvers/sendTx/components/SwapAmountDisplay'
 import { ParsedTx } from '@core/inpage-provider/popup/view/resolvers/sendTx/core/parsedTx'
 import { getGasEstimationQuery } from '@core/inpage-provider/popup/view/resolvers/sendTx/gasEstimation/getGasEstimationQuery'
+import { getNonNativeDappCosmosFeeDisplay } from '@core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/dappCosmosFee'
 import { useSendTxKeysignPayloadQuery } from '@core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/query'
 import { PendingState } from '@core/inpage-provider/popup/view/resolvers/sendTx/PendingState'
 import { SuiTxIntentDisplay } from '@core/inpage-provider/popup/view/resolvers/signMessage/components/SuiTxIntentDisplay'
@@ -30,6 +31,7 @@ import { SignTonDisplay } from '@core/ui/mpc/keysign/tx/components/SignTonDispla
 import { parseSuiTx } from '@core/ui/mpc/keysign/tx/sui/parser'
 import { SignSuiDisplay } from '@core/ui/mpc/keysign/tx/sui/SignSuiDisplay'
 import { useCore } from '@core/ui/state/core'
+import { useCurrentVaultNullablePublicKey } from '@core/ui/vault/state/currentVault'
 import {
   HorizontalLine,
   IconWrapper,
@@ -58,11 +60,13 @@ import {
   extractAccountCoinKey,
 } from '@vultisig/core-chain/coin/AccountCoin'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
+import { isFeeCoin } from '@vultisig/core-chain/coin/utils/isFeeCoin'
 import { getTxBlockaidSimulation } from '@vultisig/core-chain/security/blockaid/tx/simulation'
 import { parseBlockaidSuiSimulation } from '@vultisig/core-chain/security/blockaid/tx/simulation/api/core'
 import { BlockaidSolanaSimulationInfo } from '@vultisig/core-chain/security/blockaid/tx/simulation/core'
 import { FeeSettings } from '@vultisig/core-mpc/keysign/chainSpecific/FeeSettings'
 import { getBlockchainSpecificValue } from '@vultisig/core-mpc/keysign/chainSpecific/KeysignChainSpecific'
+import { getFeeAmount } from '@vultisig/core-mpc/keysign/fee'
 import { getKeysignChain } from '@vultisig/core-mpc/keysign/utils/getKeysignChain'
 import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
@@ -108,6 +112,34 @@ export const SendTxOverview = ({
   const nativeBalanceQuery = useBalanceQuery(
     extractAccountCoinKey({ ...chainFeeCoin[chain], address })
   )
+
+  const publicKey = useCurrentVaultNullablePublicKey(chain)
+
+  // Chains whose dApp keysign we can gate on native funds before signing: the
+  // wallet knows both the native value and the fee up front, and the node
+  // rejects `value + fee > balance` at broadcast (mirrors the in-wallet send
+  // form). Others can't form a meaningful check — Sui/Polkadot don't surface a
+  // value, UTXO pre-selects its inputs, and Solana txs are dApp-built.
+  const canCheckFunds =
+    isChainOfKind(chain, 'evm') ||
+    isChainOfKind(chain, 'cosmos') ||
+    isChainOfKind(chain, 'ton')
+
+  const nativeFeeQuery = useQuery({
+    queryKey: [
+      'dappNativeFee',
+      keysignPayloadQuery.data,
+      publicKey,
+      walletCore,
+    ],
+    queryFn: () =>
+      getFeeAmount({
+        keysignPayload: shouldBePresent(keysignPayloadQuery.data),
+        walletCore,
+        publicKey: shouldBePresent(publicKey),
+      }),
+    enabled: canCheckFunds && !!keysignPayloadQuery.data && !!publicKey,
+  })
 
   const blockaidSimulationQuery = useBlockaidSimulationQuery({
     keysignPayloadQuery,
@@ -179,33 +211,40 @@ export const SendTxOverview = ({
   const memo = keysignPayloadQuery.data?.memo
   const isEvm = isChainOfKind(chain, 'evm')
 
-  // Gate an EVM keysign before it starts: the node requires the account to
-  // cover `value + gasLimit * maxFeePerGas`, so a dApp tx that exceeds the
-  // native balance is rejected at broadcast — after the MPC ceremony has
-  // already run. Block it here instead, mirroring the in-wallet send form.
+  // Gate keysign before it starts: the node rejects a tx whose
+  // `value + fee` exceeds the native balance at broadcast — after the MPC
+  // ceremony has already run. Block it here instead, mirroring the in-wallet
+  // send form. Applies to EVM, Cosmos and Ton (see `canCheckFunds`).
   const insufficientFundsMessage = (() => {
     const payload = keysignPayloadQuery.data
     const nativeBalance = nativeBalanceQuery.data
+    const fee = nativeFeeQuery.data
 
-    if (!isEvm || !payload || nativeBalance == null) {
+    if (!canCheckFunds || !payload || nativeBalance == null || fee == null) {
       return undefined
     }
 
-    const evmSpecific = getBlockchainSpecificValue(
-      payload.blockchainSpecific,
-      'ethereumSpecific'
-    )
+    // A Cosmos dApp tx can pay its fee in a non-native token; that amount isn't
+    // comparable to the native balance, so don't gate those.
+    if (
+      isChainOfKind(chain, 'cosmos') &&
+      getNonNativeDappCosmosFeeDisplay({ keysignPayload: payload, chain })
+    ) {
+      return undefined
+    }
 
-    const value = BigInt(payload.toAmount)
-    const maxGasFee =
-      BigInt(evmSpecific.gasLimit) * BigInt(evmSpecific.maxFeePerGasWei)
+    // `toAmount` is native for EVM (it's the tx `value`), but for Cosmos/Ton it
+    // is only native when the sent coin is the fee coin — a token amount there
+    // must not be added to the native fee.
+    const nativeValue =
+      isChainOfKind(chain, 'evm') || isFeeCoin(coin)
+        ? BigInt(payload.toAmount)
+        : 0n
 
-    if (value > 0n) {
-      if (value + maxGasFee > nativeBalance) {
-        return t('insufficient_balance')
-      }
-    } else if (maxGasFee > nativeBalance) {
-      return t('insufficient_native_balance_for_fee')
+    if (nativeValue + fee > nativeBalance) {
+      return nativeValue > 0n
+        ? t('insufficient_balance')
+        : t('insufficient_native_balance_for_fee')
     }
 
     return undefined
@@ -253,9 +292,10 @@ export const SendTxOverview = ({
     if (
       gasEstimationDataQuery.isPending ||
       isContractDecodingPending ||
-      // Keep the start button disabled until the native balance is known, or
-      // the insufficient-funds gate below would be bypassed during its load.
-      (isEvm && nativeBalanceQuery.isPending)
+      // Keep the start button disabled until the balance and fee are known, or
+      // the insufficient-funds gate below would be bypassed during their load.
+      (canCheckFunds &&
+        (nativeBalanceQuery.isPending || nativeFeeQuery.isPending))
     ) {
       return t('loading')
     }


### PR DESCRIPTION
Stacked on top of #4274 (base branch is `fix/4267-dapp-insufficient-funds-pre-keysign`). Review/merge #4274 first; this PR retargets to `main` automatically once it lands.

## Problem

#4274 added a pre-keysign insufficient-funds gate for **EVM** dApp txs. A follow-up review of the dApp `sendTx` path found the **same wasted-keysign bug** on two more families: **Cosmos** and **Ton**. Both let the wallet know the native value and the fee before signing, and both reject `value + fee > balance` at broadcast — so today they run the full MPC ceremony only to fail. Fixes #4276.

## Fix (single shared gate)

Extend the existing `insufficientFundsMessage` block in `SendTxOverview.tsx` to cover EVM + Cosmos + Ton (`canCheckFunds`):

- **Unified fee source**: replace the inline EVM `gasLimit * maxFeePerGasWei` with the SDK `getFeeAmount` (verified identical for EVM: `getEvmFeeAmount` = `maxFeePerGasWei * gasLimit`). Cosmos and Ton resolve synchronously through the same function.
- **Safe native value**: `toAmount` is always native for EVM (it's the tx `value`), but for Cosmos/Ton it's only native when the sent coin is the fee coin — so a token amount is never added to the native fee (`nativeValue = isEvm || isFeeCoin(coin) ? toAmount : 0n`).
- **Cosmos non-native fee guard**: a Cosmos dApp tx can pay its fee in a non-native token; those aren't comparable to the native balance, so they're skipped (reusing `getNonNativeDappCosmosFeeDisplay`).
- **No premature enable**: the start button stays disabled until *both* the balance and fee queries resolve.
- Reuses all #4274 infra: `disabledMessage` on `VerifyKeysignStart`, the warning `Panel`, and the existing i18n keys `insufficient_balance` / `insufficient_native_balance_for_fee`.

## Out of scope (documented inline)

Sui/Polkadot surface no native value (`getTxAmount` → `0`), UTXO pre-selects its inputs, and Solana txs are dApp-built (+ Blockaid already simulates). None can form a meaningful `value + fee` check.

## Verification

- `yarn typecheck` ✅ / `yarn lint` ✅ / existing `sendTx` tests (24) ✅
- EVM behavior preserved (fee value unchanged; same message branches).
- Cosmos/Ton manual testing pending (see issue #4276 acceptance criteria).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded insufficient-funds checks to use native-fee-based validation across EVM, Cosmos, and Ton.
  * Improved the send flow so the button waits for both balance and fee information when needed.
  * Fixed native balance calculations on Cosmos and Ton so non-fee token amounts are not included.
  * Adjusted Cosmos fee handling so the warning is skipped when fees are not paid in the native token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->