### PR TITLE
fix(extension): disclose message and gate trust on plugin connect sign screen

### DIFF
--- a/core/inpage-provider/popup/view/resolvers/signMessage/overview/Connect.tsx
+++ b/core/inpage-provider/popup/view/resolvers/signMessage/overview/Connect.tsx
@@ -3,6 +3,7 @@ import { Collapse } from '@core/inpage-provider/popup/view/resolvers/signMessage
 import { Request } from '@core/inpage-provider/popup/view/resolvers/signMessage/components/Request'
 import { Sender } from '@core/inpage-provider/popup/view/resolvers/signMessage/components/Sender'
 import { SignMessageOverview } from '@core/inpage-provider/popup/view/resolvers/signMessage/overview/Default'
+import { isTrustedProductOrigin } from '@core/inpage-provider/popup/view/resolvers/signMessage/utils'
 import { usePopupContext } from '@core/inpage-provider/popup/view/state/context'
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import {
@@ -14,12 +15,12 @@ import { currentProductBrandConfig } from '@core/ui/product/brand'
 import { ProductLogo } from '@core/ui/product/ProductLogo'
 import { useCore } from '@core/ui/state/core'
 import { Button } from '@lib/ui/buttons/Button'
+import { VStack } from '@lib/ui/layout/Stack'
 import { PageContent } from '@lib/ui/page/PageContent'
 import { PageFooter } from '@lib/ui/page/PageFooter'
 import { PageHeader } from '@lib/ui/page/PageHeader'
 import { Text } from '@lib/ui/text'
-import { attempt } from '@vultisig/lib-utils/attempt'
-import { FC, useMemo, useState } from 'react'
+import { FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
@@ -34,14 +35,6 @@ export const ConnectOverview: FC<SignMessageOverview> = ({
   const { requestFavicon, requestOrigin } = usePopupContext<'signMessage'>()
   const navigate = useCoreNavigate()
   const [showPasswordModal, setShowPasswordModal] = useState(false)
-
-  const displayMessage = useMemo(() => {
-    const { data, error } = attempt(() => JSON.parse(message))
-
-    if (error) return ''
-
-    return data.message as string
-  }, [message])
 
   const onGetPassword = ({ password }: FastVaultPasswordModalResult) => {
     navigate({
@@ -59,8 +52,12 @@ export const ConnectOverview: FC<SignMessageOverview> = ({
       />
       <PageContent gap={16} scrollable>
         <Animation />
-        <Sender favicon={requestFavicon} origin={requestOrigin} isValidated />
-        <Request address={address} message={displayMessage} />
+        <Sender
+          favicon={requestFavicon}
+          origin={requestOrigin}
+          isValidated={isTrustedProductOrigin(requestOrigin)}
+        />
+        <Request address={address} message={message} />
         <Collapse title={t('signed_signature')}>
           <Text as="span" color="info" size={14} weight={500}>
             {signature}
@@ -90,6 +87,21 @@ export const ConnectOverview: FC<SignMessageOverview> = ({
             productName: currentProductBrandConfig.name,
           })}
         </Text>
+        {!!message && (
+          <VStack fullWidth>
+            <Collapse title={t('message')}>
+              <Text
+                as="span"
+                color="info"
+                size={14}
+                weight={500}
+                style={{ overflowWrap: 'anywhere' }}
+              >
+                {message}
+              </Text>
+            </Collapse>
+          </VStack>
+        )}
       </StyledPageContent>
       <PageFooter>
         <Button onClick={() => setShowPasswordModal(true)}>

--- a/core/inpage-provider/popup/view/resolvers/signMessage/overview/Connect.tsx
+++ b/core/inpage-provider/popup/view/resolvers/signMessage/overview/Connect.tsx
@@ -3,7 +3,6 @@ import { Collapse } from '@core/inpage-provider/popup/view/resolvers/signMessage
 import { Request } from '@core/inpage-provider/popup/view/resolvers/signMessage/components/Request'
 import { Sender } from '@core/inpage-provider/popup/view/resolvers/signMessage/components/Sender'
 import { SignMessageOverview } from '@core/inpage-provider/popup/view/resolvers/signMessage/overview/Default'
-import { isTrustedProductOrigin } from '@core/inpage-provider/popup/view/resolvers/signMessage/utils'
 import { usePopupContext } from '@core/inpage-provider/popup/view/state/context'
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import {
@@ -23,6 +22,8 @@ import { Text } from '@lib/ui/text'
 import { FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
+
+import { isTrustedProductOrigin } from '../utils'
 
 export const ConnectOverview: FC<SignMessageOverview> = ({
   address,

--- a/core/inpage-provider/popup/view/resolvers/signMessage/overview/Policy.tsx
+++ b/core/inpage-provider/popup/view/resolvers/signMessage/overview/Policy.tsx
@@ -35,7 +35,11 @@ import { FC, Fragment, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { PopupDeadEnd } from '../../../flow/PopupDeadEnd'
-import { parseConfiguration, ParsedConfigurationRow } from '../utils'
+import {
+  isTrustedProductOrigin,
+  parseConfiguration,
+  ParsedConfigurationRow,
+} from '../utils'
 
 type ParsedPolicy = Omit<
   ReturnType<typeof fromBinary<typeof PolicySchema>>,
@@ -110,7 +114,7 @@ export const PolicyOverview: FC<
             <Sender
               favicon={requestFavicon}
               origin={requestOrigin}
-              isValidated
+              isValidated={isTrustedProductOrigin(requestOrigin)}
             />
             <Request
               address={address}

--- a/core/inpage-provider/popup/view/resolvers/signMessage/overview/index.tsx
+++ b/core/inpage-provider/popup/view/resolvers/signMessage/overview/index.tsx
@@ -8,8 +8,6 @@ import {
 import { ConnectOverview } from '@core/inpage-provider/popup/view/resolvers/signMessage/overview/Connect'
 import { DefaultOverview } from '@core/inpage-provider/popup/view/resolvers/signMessage/overview/Default'
 import { PolicyOverview } from '@core/inpage-provider/popup/view/resolvers/signMessage/overview/Policy'
-import { isTrustedProductOrigin } from '@core/inpage-provider/popup/view/resolvers/signMessage/utils'
-import { usePopupContext } from '@core/inpage-provider/popup/view/state/context'
 import { usePopupInput } from '@core/inpage-provider/popup/view/state/input'
 import { hexStr2byteArray } from '@core/inpage-provider/popup/view/utils/hexStr2byteArray'
 import { toDisplayMessageString } from '@core/inpage-provider/popup/view/utils/toDisplayMessage'
@@ -39,6 +37,8 @@ import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { PopupDeadEnd } from '../../../flow/PopupDeadEnd'
+import { usePopupContext } from '../../../state/context'
+import { isTrustedProductOrigin } from '../utils'
 
 export const Overview = () => {
   const { t } = useTranslation()

--- a/core/inpage-provider/popup/view/resolvers/signMessage/overview/index.tsx
+++ b/core/inpage-provider/popup/view/resolvers/signMessage/overview/index.tsx
@@ -8,6 +8,8 @@ import {
 import { ConnectOverview } from '@core/inpage-provider/popup/view/resolvers/signMessage/overview/Connect'
 import { DefaultOverview } from '@core/inpage-provider/popup/view/resolvers/signMessage/overview/Default'
 import { PolicyOverview } from '@core/inpage-provider/popup/view/resolvers/signMessage/overview/Policy'
+import { isTrustedProductOrigin } from '@core/inpage-provider/popup/view/resolvers/signMessage/utils'
+import { usePopupContext } from '@core/inpage-provider/popup/view/state/context'
 import { usePopupInput } from '@core/inpage-provider/popup/view/state/input'
 import { hexStr2byteArray } from '@core/inpage-provider/popup/view/utils/hexStr2byteArray'
 import { toDisplayMessageString } from '@core/inpage-provider/popup/view/utils/toDisplayMessage'
@@ -41,6 +43,7 @@ import { PopupDeadEnd } from '../../../flow/PopupDeadEnd'
 export const Overview = () => {
   const { t } = useTranslation()
   const input = usePopupInput<'signMessage'>()
+  const { requestOrigin } = usePopupContext<'signMessage'>()
   const method = getRecordUnionKey(input)
   const { chain } = getRecordUnionValue(input)
   const [{ signature }] = useViewState<{ signature?: string }>()
@@ -108,12 +111,21 @@ export const Overview = () => {
       toDisplayMessageString(fromBase64(data)),
   })
 
-  const type = matchRecordUnion<SignMessageInput, SignMessageType>(input, {
-    eth_signTypedData_v4: () => 'default',
-    sign_message: () => 'default',
-    personal_sign: ({ type }) => type,
-    cosmos_sign_arbitrary: () => 'default',
-  })
+  const requestedType = matchRecordUnion<SignMessageInput, SignMessageType>(
+    input,
+    {
+      eth_signTypedData_v4: () => 'default',
+      sign_message: () => 'default',
+      personal_sign: ({ type }) => type,
+      cosmos_sign_arbitrary: () => 'default',
+    }
+  )
+
+  // The low-disclosure `connect`/`policy` screens are reserved for the
+  // first-party marketplace origin. Any other origin is forced onto the
+  // `default` overview, which always renders the message being signed, so a
+  // hostile dApp cannot use the branded screens to obscure what is signed.
+  const type = isTrustedProductOrigin(requestOrigin) ? requestedType : 'default'
 
   const typedData = matchRecordUnion<
     SignMessageInput,

--- a/core/inpage-provider/popup/view/resolvers/signMessage/utils/index.ts
+++ b/core/inpage-provider/popup/view/resolvers/signMessage/utils/index.ts
@@ -1,7 +1,21 @@
 import { JsonObject, JsonValue } from '@bufbuild/protobuf'
+import { currentProductBrandConfig } from '@core/ui/product/brand'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { isOneOf } from '@vultisig/lib-utils/array/isOneOf'
+import { getUrlBaseDomain } from '@vultisig/lib-utils/url/baseDomain'
+
+const trustedProductBaseDomain = getUrlBaseDomain(
+  currentProductBrandConfig.websiteUrl
+)
+
+/**
+ * Whether a dApp request originates from the official product domain (e.g.
+ * `vultisig.com` and its subdomains). Used to gate the "verified" badge so
+ * only first-party origins are presented as trusted.
+ */
+export const isTrustedProductOrigin = (origin: string): boolean =>
+  getUrlBaseDomain(origin) === trustedProductBaseDomain
 
 export type ParsedConfigurationRow = {
   key: string


### PR DESCRIPTION
## Problem

The plugin `personal_sign` flow (`window.vultisig.plugin.request`) selects its approval UI from a dApp-supplied `type` argument (`'default' | 'connect' | 'policy'`). Two problems compounded:

1. **Message hidden before signing.** When `type === 'connect'`, the approval popup rendered only the product logo and "Welcome to the Plugin Marketplace / Sign in" copy with a Continue button. The actual message being signed was never shown before the user signed — and a latent `JSON.parse(message)` bug (parsing an already-decoded plain string) left it blank even *after* signing.
2. **Unconditional trust badge.** The connect and policy screens stamped a green "✓ by Vultisig" verified badge on the requesting origin regardless of what site it actually was.

Together these let a dApp present arbitrary bytes behind a benign, seemingly first-party "sign in" screen — a blind-signing / signed-payload spoofing vector (SIWE logins, off-chain orders, gasless approvals bound to the vault address).

## Changes

- **Show the message pre-sign** in `ConnectOverview` (mirrors `DefaultOverview`), full-width with `overflow-wrap` so long messages/hashes wrap instead of overflowing.
- **Remove the broken `JSON.parse(message)`** — the `message` prop is already display-ready, so it's used directly and now renders correctly post-sign too.
- **Gate the verified badge** on a new brand-aware `isTrustedProductOrigin(origin)` helper (registrable-domain match against `currentProductBrandConfig.websiteUrl` via the Public Suffix List). Applied to both `ConnectOverview` and `PolicyOverview`.
- **Reserve the low-disclosure screens for the first-party origin** — in `overview/index.tsx`, the dApp-requested `type` is downgraded to `default` for any non-product origin, so a hostile dApp cannot select the branded `connect`/`policy` UI. `personal_sign` itself still works; it just always renders the honest overview that shows the message.

Downgrade (not reject) is intentional: arbitrary-origin `personal_sign` is legitimate, so blocking it would break normal signing — the fix strips the deceptive framing, not the capability.

## Scope

- **Must NOT do:** no changes to what bytes are signed, the keysign pipeline, or the MPC path — presentation/authorization only.

## Testing

- [x] `yarn check:all` succeeds (typecheck 0, lint 0, 738 unit tests pass, Go tests ok, markdownlint 0)

> Note: the rendered popup was not driven end-to-end in this change; the connect screen was verified visually during development (including fixing an initial full-width overflow). Reviewers reproducing locally: `yarn dev:extension`, connect a dApp, then call `window.vultisig.plugin.request({ method: 'personal_sign', params: [message, account, 'connect'] })` from a non-`vultisig.com` origin and confirm the default overview renders with the message and no verified badge.

Closes #4288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sign message screens now determine sender validity and the overview layout using whether the request origin matches the trusted product base domain.
  * Branded connect/policy-style overview routes remain available only for trusted origins.

* **Bug Fixes**
  * Untrusted requests now consistently force the default overview view.
  * Connect flow message rendering was simplified to avoid extra parsing, and the message is now shown via an expandable UI when no signature is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->