### PR TITLE
fix(extension): EVM/Solana Blockaid simulation UX — error banner + pending details/indicator

### DIFF
--- a/core/inpage-provider/popup/view/resolvers/sendTx/SendTxOverview.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/SendTxOverview.tsx
@@ -71,6 +71,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { hasBlockaidSimulationErrorBanner } from './blockaid/blockaidSimulationErrorBanner'
+import { BlockaidSimulationPending } from './blockaid/BlockaidSimulationPending'
 import {
   getTransactionErrorMessage,
   isSendTxOverviewErrorQuery,
@@ -349,7 +350,7 @@ export const SendTxOverview = ({
                   value={blockaidSimulationQuery}
                   error={() => <BlockaidSimulationError />}
                   success={() => null}
-                  pending={() => null}
+                  pending={() => <BlockaidSimulationPending />}
                   inactive={() => null}
                 />
               )}

--- a/core/inpage-provider/popup/view/resolvers/sendTx/SendTxOverview.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/SendTxOverview.tsx
@@ -70,6 +70,7 @@ import { formatUnits } from 'ethers'
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { hasBlockaidSimulationErrorBanner } from './blockaid/blockaidSimulationErrorBanner'
 import {
   getTransactionErrorMessage,
   isSendTxOverviewErrorQuery,
@@ -343,16 +344,15 @@ export const SendTxOverview = ({
                   </VStack>
                 </Panel>
               )}
-              {isChainOfKind(chain, 'evm') ||
-                (chain === Chain.Solana && (
-                  <MatchQuery
-                    value={blockaidSimulationQuery}
-                    error={() => <BlockaidSimulationError />}
-                    success={() => null}
-                    pending={() => null}
-                    inactive={() => null}
-                  />
-                ))}
+              {hasBlockaidSimulationErrorBanner(chain) && (
+                <MatchQuery
+                  value={blockaidSimulationQuery}
+                  error={() => <BlockaidSimulationError />}
+                  success={() => null}
+                  pending={() => null}
+                  inactive={() => null}
+                />
+              )}
               {hasSwapPayload ? (
                 <>
                   <VStack

--- a/core/inpage-provider/popup/view/resolvers/sendTx/blockaid/BlockaidSimulationContent.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/blockaid/BlockaidSimulationContent.tsx
@@ -344,7 +344,7 @@ const BlockaidEvmSimulationContent = ({
         return fallback
       }}
       error={() => fallback}
-      pending={() => null}
+      pending={() => fallback}
       inactive={() => null}
     />
   )

--- a/core/inpage-provider/popup/view/resolvers/sendTx/blockaid/BlockaidSimulationPending.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/blockaid/BlockaidSimulationPending.tsx
@@ -1,0 +1,20 @@
+import { HStack } from '@lib/ui/layout/Stack'
+import { Spinner } from '@lib/ui/loaders/Spinner'
+import { Panel } from '@lib/ui/panel/Panel'
+import { Text } from '@lib/ui/text'
+import { useTranslation } from 'react-i18next'
+
+export const BlockaidSimulationPending = () => {
+  const { t } = useTranslation()
+
+  return (
+    <Panel>
+      <HStack gap={8} alignItems="center" justifyContent="center">
+        <Spinner />
+        <Text size={15} weight={500} centerHorizontally>
+          {t('blockaid_simulation_pending')}
+        </Text>
+      </HStack>
+    </Panel>
+  )
+}

--- a/core/inpage-provider/popup/view/resolvers/sendTx/blockaid/blockaidSimulationErrorBanner.test.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/blockaid/blockaidSimulationErrorBanner.test.ts
@@ -1,0 +1,23 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { describe, expect, it } from 'vitest'
+
+import { hasBlockaidSimulationErrorBanner } from './blockaidSimulationErrorBanner'
+
+describe('hasBlockaidSimulationErrorBanner', () => {
+  it('renders the banner for EVM chains', () => {
+    expect(hasBlockaidSimulationErrorBanner(Chain.Ethereum)).toBe(true)
+    expect(hasBlockaidSimulationErrorBanner(Chain.Base)).toBe(true)
+    expect(hasBlockaidSimulationErrorBanner(Chain.Arbitrum)).toBe(true)
+  })
+
+  it('renders the banner for Solana', () => {
+    expect(hasBlockaidSimulationErrorBanner(Chain.Solana)).toBe(true)
+  })
+
+  it('does not render the banner for other chain kinds', () => {
+    expect(hasBlockaidSimulationErrorBanner(Chain.Bitcoin)).toBe(false)
+    expect(hasBlockaidSimulationErrorBanner(Chain.THORChain)).toBe(false)
+    expect(hasBlockaidSimulationErrorBanner(Chain.Cosmos)).toBe(false)
+    expect(hasBlockaidSimulationErrorBanner(Chain.Sui)).toBe(false)
+  })
+})

--- a/core/inpage-provider/popup/view/resolvers/sendTx/blockaid/blockaidSimulationErrorBanner.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/blockaid/blockaidSimulationErrorBanner.ts
@@ -1,0 +1,10 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { isChainOfKind } from '@vultisig/core-chain/ChainKind'
+
+/**
+ * Whether the standalone Blockaid simulation-error banner should render for a
+ * chain in the send-tx overview. Covers the chains whose Blockaid simulation is
+ * surfaced there: any EVM chain plus Solana.
+ */
+export const hasBlockaidSimulationErrorBanner = (chain: Chain): boolean =>
+  isChainOfKind(chain, 'evm') || chain === Chain.Solana

--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -1659,4 +1659,5 @@ export const de = {
   solana_staking_withdraw_ready_notice: 'Abgekühlt und bereit zum Rückzug.',
   external_recipient_tooltip_content:
     'Senden Sie die getauschten Gelder an eine andere Wallet-Adresse als Ihre eigene.',
+  blockaid_simulation_pending: 'Transaktion wird simuliert…',
 }

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -107,6 +107,7 @@ export const en = {
   blockaid_simulation_failed: 'Transaction Simulation Failed',
   blockaid_simulation_failed_description:
     'Unable to simulate this transaction. You can still proceed, but we recommend reviewing the transaction details carefully.',
+  blockaid_simulation_pending: 'Simulating transaction…',
   transaction_scanned_by: 'Transaction scanned by {{provider}}',
   broadcast_error: 'The network rejected this transaction',
   broadcast_error_description:

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -1643,4 +1643,5 @@ export const es = {
     'Ya se ha enfriado y está listo para retirarse.',
   external_recipient_tooltip_content:
     'Envía los fondos intercambiados a una dirección de billetera diferente a la tuya.',
+  blockaid_simulation_pending: 'Simulando transacción…',
 }

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -1620,4 +1620,5 @@ export const hr = {
   solana_staking_withdraw_ready_notice: 'Ohlađeno i spremno za povlačenje.',
   external_recipient_tooltip_content:
     'Pošaljite zamijenjena sredstva na drugu adresu novčanika umjesto na svoju.',
+  blockaid_simulation_pending: 'Simuliranje transakcije…',
 }

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -1650,4 +1650,5 @@ export const it = {
   solana_staking_withdraw_ready_notice: 'Raffreddato e pronto per il ritiro.',
   external_recipient_tooltip_content:
     'Invia i fondi scambiati a un indirizzo di portafoglio diverso dal tuo.',
+  blockaid_simulation_pending: 'Simulazione della transazione…',
 }

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -1612,4 +1612,5 @@ export const ko = {
   solana_staking_withdraw_ready_notice: '식어서 철수할 준비가 되었습니다.',
   external_recipient_tooltip_content:
     '교환된 자금을 본인의 지갑 주소가 아닌 다른 지갑 주소로 보내세요.',
+  blockaid_simulation_pending: '거래 시뮬레이션 중…',
 }

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -1628,4 +1628,5 @@ export const nl = {
     'Afgekoeld en klaar om te worden opgenomen.',
   external_recipient_tooltip_content:
     'Stuur het omgewisselde geld naar een ander walletadres in plaats van naar je eigen adres.',
+  blockaid_simulation_pending: 'Transactie simuleren…',
 }

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -1646,4 +1646,5 @@ export const pt = {
   solana_staking_withdraw_ready_notice: 'Resfriado e pronto para retirar.',
   external_recipient_tooltip_content:
     'Envie os fundos trocados para um endereço de carteira diferente do seu.',
+  blockaid_simulation_pending: 'Simulação de transação…',
 }

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -1626,4 +1626,5 @@ export const ru = {
   solana_staking_withdraw_ready_notice: 'Остыл и готов к извлечению.',
   external_recipient_tooltip_content:
     'Отправьте переведенные средства на другой адрес кошелька, а не на свой собственный.',
+  blockaid_simulation_pending: 'Имитация транзакции…',
 }

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -1519,4 +1519,5 @@ export const zh = {
   solana_staking_withdraw_ready_notice: '冷静下来，准备撤退。',
   external_recipient_tooltip_content:
     '将兑换后的资金发送到另一个钱包地址，而不是您自己的钱包地址。',
+  blockaid_simulation_pending: '模拟交易…',
 }


### PR DESCRIPTION
Improves the Blockaid transaction-simulation UX in the dApp send-tx overview. Two related changes:

## 1. Simulation-error banner never rendered for EVM (Closes #4291)

The banner guard was:

```jsx
{isChainOfKind(chain, 'evm') ||
  (chain === Chain.Solana && <MatchQuery ... error={() => <BlockaidSimulationError />} />)}
```

`&&` binds tighter than `||`, so this parsed as `evm || (solana && <JSX>)`: for EVM it short-circuited to boolean `true` and rendered nothing, so the "Transaction Simulation Failed" banner only ever mounted for Solana. Worst impact was the EVM swap branch, which has no other Blockaid error surface.

- Extracted the guard into a pure, testable `hasBlockaidSimulationErrorBanner(chain)` predicate and gated the JSX with it, so the banner renders for EVM **and** Solana.
- Added a per-chain-kind unit test (EVM → true, Solana → true, UTXO/Cosmos/Sui → false).

## 2. Blank content + no progress signal while simulation is pending

While the Blockaid simulation was in flight (after gas estimation resolved), the EVM overview rendered nothing in the content area (`pending → null`) — no transaction details and no indication a simulation was running. Only after the simulation finished did details appear (on error) or balance changes (on success).

- **EVM:** render the calldata details fallback during `pending` (the same `EvmCalldataFallback` already used on `error`), so From/To/Network/details/fee show from the start.
- **Shared indicator:** the top-level simulation `MatchQuery` now renders a `BlockaidSimulationPending` ("Simulating transaction…" + spinner) in its `pending` branch, covering both EVM and Solana. Solana already renders its instruction display (`SignSolanaDisplay`), so only the progress indicator was missing there.
- **Other chains** (Ton/Sui/Cosmos) don't run Blockaid simulation and already render details directly + a `PendingState` during gas estimation — unchanged.

Net behavior for EVM: details visible immediately → "Simulating…" while in flight → simulated balance changes on success, or details + warning banner on failure.

## Out of scope

Aligning the simulation guard with the canonical `blockaidSimulationSupportedChains` set (which includes Sui and only a subset of EVM chains) — separate behavior change, intentionally not done here.

## Testing

- [x] `yarn check:all` succeeds (typecheck 0, lint 0, unit tests incl. new `blockaidSimulationErrorBanner.test.ts`, i18n integrity passed — `blockaid_simulation_pending` added to `en.ts` and propagated via `yarn translate`).

> The pending/success/error transitions were reasoned through against the render tree and the guard logic is unit-tested; the live popup states were validated manually from the screenshots that prompted the pending-UX change (EVM Rango swap: blank during pending → "Transaction Simulation Failed" + details after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Blockaid simulation banner behavior in the send transaction flow, making it show consistently for supported networks and remain hidden on unsupported ones.
  * Updated the simulation “pending” state to display a fallback/pending UI instead of staying blank.
* **New Features**
  * Added a localized “Simulating transaction…” message across multiple languages.
* **Tests**
  * Added test coverage for banner visibility across supported and unsupported chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->