### PR TITLE
fix(extension): gate dApp connect on the Blockaid malicious-site verdict

### DIFF
--- a/core/inpage-provider/popup/view/resolvers/grantVaultAccess/index.tsx
+++ b/core/inpage-provider/popup/view/resolvers/grantVaultAccess/index.tsx
@@ -290,6 +290,7 @@ export const GrantVaultAccess: PopupResolver<'grantVaultAccess'> = ({
               success={value => (
                 <BlockaidSiteScanResult
                   value={value}
+                  domain={displayDomain}
                   onAcknowledgeRisk={() => setHasAcknowledgedSiteRisk(true)}
                 />
               )}

--- a/core/inpage-provider/popup/view/resolvers/grantVaultAccess/index.tsx
+++ b/core/inpage-provider/popup/view/resolvers/grantVaultAccess/index.tsx
@@ -291,6 +291,7 @@ export const GrantVaultAccess: PopupResolver<'grantVaultAccess'> = ({
                 <BlockaidSiteScanResult
                   value={value}
                   domain={displayDomain}
+                  isRiskAcknowledged={hasAcknowledgedSiteRisk}
                   onAcknowledgeRisk={() => setHasAcknowledgedSiteRisk(true)}
                 />
               )}

--- a/core/inpage-provider/popup/view/resolvers/grantVaultAccess/index.tsx
+++ b/core/inpage-provider/popup/view/resolvers/grantVaultAccess/index.tsx
@@ -24,6 +24,7 @@ import { PageContent } from '@lib/ui/page/PageContent'
 import { PageHeader } from '@lib/ui/page/PageHeader'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
 import { usePotentialQuery } from '@lib/ui/query/hooks/usePotentialQuery'
+import { WarningBlock } from '@lib/ui/status/WarningBlock'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
 import { useMutation } from '@tanstack/react-query'
@@ -152,6 +153,7 @@ export const GrantVaultAccess: PopupResolver<'grantVaultAccess'> = ({
     string | undefined
   >(undefined)
   const [view, setView] = useState<ConnectView>('connect')
+  const [hasAcknowledgedSiteRisk, setHasAcknowledgedSiteRisk] = useState(false)
 
   const userSelectionStillEligible =
     userSelectedVaultId !== undefined &&
@@ -198,9 +200,18 @@ export const GrantVaultAccess: PopupResolver<'grantVaultAccess'> = ({
     ? eligibleVaults.find(vault => getVaultId(vault) === selectedVaultId)
     : undefined
 
+  // A site Blockaid flags as malicious blocks connecting until the user
+  // explicitly acknowledges the risk — gating both the Connect button and the
+  // vault-picker so neither path can silently connect past the warning.
+  const isMaliciousSite = siteScanQuery.data === 'malicious'
+  const isSiteBlocked = isMaliciousSite && !hasAcknowledgedSiteRisk
+
   const canConnect =
-    !isPending && !siteScanQuery.isPending && selectedVaultId !== undefined
-  const pickerLocked = isPending || siteScanQuery.isPending
+    !isPending &&
+    !siteScanQuery.isPending &&
+    selectedVaultId !== undefined &&
+    !isSiteBlocked
+  const pickerLocked = isPending || siteScanQuery.isPending || isSiteBlocked
 
   const header = (
     <PageHeader
@@ -225,6 +236,9 @@ export const GrantVaultAccess: PopupResolver<'grantVaultAccess'> = ({
       <VStack fullHeight>
         {header}
         <PageContent gap={12} flexGrow scrollable>
+          {isMaliciousSite && (
+            <WarningBlock>{t('risky_site_detected')}</WarningBlock>
+          )}
           <Text color="supporting" size={12} weight={500}>
             {t('select_vault')}
           </Text>
@@ -273,7 +287,12 @@ export const GrantVaultAccess: PopupResolver<'grantVaultAccess'> = ({
           {isBlockaidEnabled && (
             <MatchQuery
               value={siteScanQuery}
-              success={value => <BlockaidSiteScanResult value={value} />}
+              success={value => (
+                <BlockaidSiteScanResult
+                  value={value}
+                  onAcknowledgeRisk={() => setHasAcknowledgedSiteRisk(true)}
+                />
+              )}
               pending={() => <BlockaidScanning />}
               error={() => <BlockaidNoScanStatus entity="site" />}
               inactive={() => <BlockaidScanStatusContainer />}

--- a/core/ui/chain/security/blockaid/BlockaidOverlay.tsx
+++ b/core/ui/chain/security/blockaid/BlockaidOverlay.tsx
@@ -29,12 +29,14 @@ const DismissButton = styled(UnstyledButton)`
 type BlockaidOverlayProps = TitleProp & {
   riskLevel: RiskLevel
   description?: string
+  onProceed?: () => void
 }
 
 export const BlockaidOverlay = ({
   riskLevel,
   description,
   title,
+  onProceed,
 }: BlockaidOverlayProps) => {
   const [isDismissed, { set: dismiss }] = useBoolean(false)
 
@@ -55,7 +57,12 @@ export const BlockaidOverlay = ({
       footer={
         <VStack gap={20}>
           <Button onClick={goBack}>{t('go_back')}</Button>
-          <DismissButton onClick={dismiss}>
+          <DismissButton
+            onClick={() => {
+              onProceed?.()
+              dismiss()
+            }}
+          >
             {t('continue_anyway')}
           </DismissButton>
         </VStack>

--- a/core/ui/chain/security/blockaid/BlockaidOverlay.tsx
+++ b/core/ui/chain/security/blockaid/BlockaidOverlay.tsx
@@ -29,14 +29,12 @@ const DismissButton = styled(UnstyledButton)`
 type BlockaidOverlayProps = TitleProp & {
   riskLevel: RiskLevel
   description?: string
-  onProceed?: () => void
 }
 
 export const BlockaidOverlay = ({
   riskLevel,
   description,
   title,
-  onProceed,
 }: BlockaidOverlayProps) => {
   const [isDismissed, { set: dismiss }] = useBoolean(false)
 
@@ -57,12 +55,7 @@ export const BlockaidOverlay = ({
       footer={
         <VStack gap={20}>
           <Button onClick={goBack}>{t('go_back')}</Button>
-          <DismissButton
-            onClick={() => {
-              onProceed?.()
-              dismiss()
-            }}
-          >
+          <DismissButton onClick={dismiss}>
             {t('continue_anyway')}
           </DismissButton>
         </VStack>

--- a/core/ui/chain/security/blockaid/site/BlockaidSiteScanMaliciousOverlay.tsx
+++ b/core/ui/chain/security/blockaid/site/BlockaidSiteScanMaliciousOverlay.tsx
@@ -3,7 +3,6 @@ import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
 import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
 import { BodyPortal } from '@lib/ui/dom/BodyPortal'
-import { useBoolean } from '@lib/ui/hooks/useBoolean'
 import { TriangleAlertIcon } from '@lib/ui/icons/TriangleAlertIcon'
 import { VStack } from '@lib/ui/layout/Stack'
 import { Text, text } from '@lib/ui/text'
@@ -44,7 +43,7 @@ const ContinueButton = styled(UnstyledButton)`
 
 type BlockaidSiteScanMaliciousOverlayProps = {
   domain: string
-  onAcknowledgeRisk?: () => void
+  onAcknowledgeRisk: () => void
 }
 
 export const BlockaidSiteScanMaliciousOverlay = ({
@@ -53,9 +52,6 @@ export const BlockaidSiteScanMaliciousOverlay = ({
 }: BlockaidSiteScanMaliciousOverlayProps) => {
   const { t } = useTranslation()
   const { goBack } = useCore()
-  const [isDismissed, { set: dismiss }] = useBoolean(false)
-
-  if (isDismissed) return null
 
   return (
     <BodyPortal>
@@ -78,12 +74,7 @@ export const BlockaidSiteScanMaliciousOverlay = ({
           </Text>
           <VStack fullWidth gap={20}>
             <Button onClick={goBack}>{t('go_back')}</Button>
-            <ContinueButton
-              onClick={() => {
-                onAcknowledgeRisk?.()
-                dismiss()
-              }}
-            >
+            <ContinueButton onClick={onAcknowledgeRisk}>
               {t('continue_anyway')}
             </ContinueButton>
           </VStack>

--- a/core/ui/chain/security/blockaid/site/BlockaidSiteScanMaliciousOverlay.tsx
+++ b/core/ui/chain/security/blockaid/site/BlockaidSiteScanMaliciousOverlay.tsx
@@ -1,0 +1,94 @@
+import { Button } from '@lib/ui/buttons/Button'
+import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
+import { centerContent } from '@lib/ui/css/centerContent'
+import { BodyPortal } from '@lib/ui/dom/BodyPortal'
+import { useBoolean } from '@lib/ui/hooks/useBoolean'
+import { TriangleAlertIcon } from '@lib/ui/icons/TriangleAlertIcon'
+import { VStack } from '@lib/ui/layout/Stack'
+import { Text, text } from '@lib/ui/text'
+import { getColor } from '@lib/ui/theme/getters'
+import { Trans, useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+
+import { useCore } from '../../../../state/core'
+import { BlockaidLogo } from '../BlockaidLogo'
+
+const Backdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 1;
+  padding: 24px;
+  ${centerContent};
+  background: ${getColor('overlay')};
+  backdrop-filter: blur(4px);
+`
+
+const Card = styled(VStack)`
+  width: 100%;
+  max-width: 400px;
+  padding: 24px;
+  ${borderRadius.m};
+  background: ${getColor('foreground')};
+  border: 1px solid ${getColor('foregroundExtra')};
+`
+
+const ContinueButton = styled(UnstyledButton)`
+  ${text({ color: 'supporting', size: 12, weight: 500 })}
+  align-self: center;
+
+  &:hover {
+    color: ${getColor('danger')};
+  }
+`
+
+type BlockaidSiteScanMaliciousOverlayProps = {
+  domain: string
+  onAcknowledgeRisk?: () => void
+}
+
+export const BlockaidSiteScanMaliciousOverlay = ({
+  domain,
+  onAcknowledgeRisk,
+}: BlockaidSiteScanMaliciousOverlayProps) => {
+  const { t } = useTranslation()
+  const { goBack } = useCore()
+  const [isDismissed, { set: dismiss }] = useBoolean(false)
+
+  if (isDismissed) return null
+
+  return (
+    <BodyPortal>
+      <Backdrop>
+        <Card gap={24} alignItems="center">
+          <TriangleAlertIcon color="danger" fontSize={24} />
+          <VStack gap={12} alignItems="center">
+            <Text size={22} color="danger" centerHorizontally>
+              {t('malicious_dapp_detected')}
+            </Text>
+            <Text size={14} color="supporting" centerHorizontally>
+              {t('malicious_dapp_detected_description', { dapp: domain })}
+            </Text>
+          </VStack>
+          <Text color="supporting" size={14} centerVertically={{ gap: 4 }}>
+            <Trans
+              i18nKey="powered_by"
+              components={{ provider: <BlockaidLogo /> }}
+            />
+          </Text>
+          <VStack fullWidth gap={20}>
+            <Button onClick={goBack}>{t('go_back')}</Button>
+            <ContinueButton
+              onClick={() => {
+                onAcknowledgeRisk?.()
+                dismiss()
+              }}
+            >
+              {t('continue_anyway')}
+            </ContinueButton>
+          </VStack>
+        </Card>
+      </Backdrop>
+    </BodyPortal>
+  )
+}

--- a/core/ui/chain/security/blockaid/site/BlockaidSiteScanResult.tsx
+++ b/core/ui/chain/security/blockaid/site/BlockaidSiteScanResult.tsx
@@ -13,12 +13,14 @@ import { BlockaidSiteScanMaliciousOverlay } from './BlockaidSiteScanMaliciousOve
 
 type BlockaidSiteScanResultProps = ValueProp<BlockaidSiteScanResultType> & {
   domain: string
-  onAcknowledgeRisk?: () => void
+  isRiskAcknowledged: boolean
+  onAcknowledgeRisk: () => void
 }
 
 export const BlockaidSiteScanResult = ({
   value,
   domain,
+  isRiskAcknowledged,
   onAcknowledgeRisk,
 }: BlockaidSiteScanResultProps) => {
   const { colors } = useTheme()
@@ -31,10 +33,12 @@ export const BlockaidSiteScanResult = ({
 
     return (
       <>
-        <BlockaidSiteScanMaliciousOverlay
-          domain={domain}
-          onAcknowledgeRisk={onAcknowledgeRisk}
-        />
+        {!isRiskAcknowledged && (
+          <BlockaidSiteScanMaliciousOverlay
+            domain={domain}
+            onAcknowledgeRisk={onAcknowledgeRisk}
+          />
+        )}
         <BlockaidScanStatusContainer
           style={{
             color: colors.danger.toCssValue(),

--- a/core/ui/chain/security/blockaid/site/BlockaidSiteScanResult.tsx
+++ b/core/ui/chain/security/blockaid/site/BlockaidSiteScanResult.tsx
@@ -11,9 +11,14 @@ import { riskLevelIcon } from '../riskLevelIcon'
 import { BlockaidScanStatusContainer } from '../scan/BlockaidScanStatusContainer'
 import { getBlockaidScanEntityName } from '../utils/entity'
 
+type BlockaidSiteScanResultProps = ValueProp<BlockaidSiteScanResultType> & {
+  onAcknowledgeRisk?: () => void
+}
+
 export const BlockaidSiteScanResult = ({
   value,
-}: ValueProp<BlockaidSiteScanResultType>) => {
+  onAcknowledgeRisk,
+}: BlockaidSiteScanResultProps) => {
   const { colors } = useTheme()
   const { t } = useTranslation()
 
@@ -27,6 +32,7 @@ export const BlockaidSiteScanResult = ({
         <BlockaidOverlay
           riskLevel={riskLevel}
           title={t('risky_site_detected')}
+          onProceed={onAcknowledgeRisk}
         />
         <BlockaidScanStatusContainer
           style={{

--- a/core/ui/chain/security/blockaid/site/BlockaidSiteScanResult.tsx
+++ b/core/ui/chain/security/blockaid/site/BlockaidSiteScanResult.tsx
@@ -6,17 +6,19 @@ import { Trans, useTranslation } from 'react-i18next'
 import { useTheme } from 'styled-components'
 
 import { BlockaidLogo } from '../BlockaidLogo'
-import { BlockaidOverlay } from '../BlockaidOverlay'
 import { riskLevelIcon } from '../riskLevelIcon'
 import { BlockaidScanStatusContainer } from '../scan/BlockaidScanStatusContainer'
 import { getBlockaidScanEntityName } from '../utils/entity'
+import { BlockaidSiteScanMaliciousOverlay } from './BlockaidSiteScanMaliciousOverlay'
 
 type BlockaidSiteScanResultProps = ValueProp<BlockaidSiteScanResultType> & {
+  domain: string
   onAcknowledgeRisk?: () => void
 }
 
 export const BlockaidSiteScanResult = ({
   value,
+  domain,
   onAcknowledgeRisk,
 }: BlockaidSiteScanResultProps) => {
   const { colors } = useTheme()
@@ -29,10 +31,9 @@ export const BlockaidSiteScanResult = ({
 
     return (
       <>
-        <BlockaidOverlay
-          riskLevel={riskLevel}
-          title={t('risky_site_detected')}
-          onProceed={onAcknowledgeRisk}
+        <BlockaidSiteScanMaliciousOverlay
+          domain={domain}
+          onAcknowledgeRisk={onAcknowledgeRisk}
         />
         <BlockaidScanStatusContainer
           style={{

--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -1660,4 +1660,7 @@ export const de = {
   external_recipient_tooltip_content:
     'Senden Sie die getauschten Gelder an eine andere Wallet-Adresse als Ihre eigene.',
   blockaid_simulation_pending: 'Transaktion wird simuliert…',
+  malicious_dapp_detected: 'Bösartiges dApp erkannt',
+  malicious_dapp_detected_description:
+    '{{dapp}} wurde von Blockaid als schädlich eingestuft. Führen Sie immer eigene Recherchen durch, bevor Sie fortfahren.',
 }

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -618,6 +618,9 @@ export const en = {
   lp_units: 'LP Units',
   m_of_n_vault: '{{m}}-of-{{n}} Vault',
   make_sure_chains: 'Make sure that the chain you’re looking for is enabled.',
+  malicious_dapp_detected: 'Malicious dApp detected',
+  malicious_dapp_detected_description:
+    '{{dapp}} has been flagged as malicious by Blockaid. Always do your own research before proceeding.',
   manage_chains: 'Manage Chains',
   manage_notifications_in_settings:
     'You can manage notifications in system settings.',

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -1644,4 +1644,7 @@ export const es = {
   external_recipient_tooltip_content:
     'Envía los fondos intercambiados a una dirección de billetera diferente a la tuya.',
   blockaid_simulation_pending: 'Simulando transacción…',
+  malicious_dapp_detected: 'Se ha detectado el token malicioso dApp',
+  malicious_dapp_detected_description:
+    'Blockaid ha marcado el token {{dapp}} como malicioso. Investigue siempre por su cuenta antes de continuar.',
 }

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -1621,4 +1621,7 @@ export const hr = {
   external_recipient_tooltip_content:
     'Pošaljite zamijenjena sredstva na drugu adresu novčanika umjesto na svoju.',
   blockaid_simulation_pending: 'Simuliranje transakcije…',
+  malicious_dapp_detected: 'Otkriven zlonamjerni dApp',
+  malicious_dapp_detected_description:
+    'Blockaid je označio {{dapp}} kao zlonamjeran. Uvijek provedite vlastito istraživanje prije nego što nastavite.',
 }

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -1651,4 +1651,7 @@ export const it = {
   external_recipient_tooltip_content:
     'Invia i fondi scambiati a un indirizzo di portafoglio diverso dal tuo.',
   blockaid_simulation_pending: 'Simulazione della transazione…',
+  malicious_dapp_detected: 'Rilevato token dannoso dApp',
+  malicious_dapp_detected_description:
+    '{{dapp}} è stato segnalato come dannoso da Blockaid. Effettua sempre le tue ricerche prima di procedere.',
 }

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -1613,4 +1613,7 @@ export const ko = {
   external_recipient_tooltip_content:
     '교환된 자금을 본인의 지갑 주소가 아닌 다른 지갑 주소로 보내세요.',
   blockaid_simulation_pending: '거래 시뮬레이션 중…',
+  malicious_dapp_detected: '악성 dApp 가 감지되었습니다.',
+  malicious_dapp_detected_description:
+    'Blockaid에서 {{dapp}} 악성 토큰으로 표시했습니다. 진행하기 전에 항상 직접 조사하십시오.',
 }

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -1629,4 +1629,7 @@ export const nl = {
   external_recipient_tooltip_content:
     'Stuur het omgewisselde geld naar een ander walletadres in plaats van naar je eigen adres.',
   blockaid_simulation_pending: 'Transactie simuleren…',
+  malicious_dapp_detected: 'Kwaadaardige dApp gedetecteerd',
+  malicious_dapp_detected_description:
+    '{{dapp}} is door Blockaid als schadelijk aangemerkt. Doe altijd zelf onderzoek voordat u verdergaat.',
 }

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -1647,4 +1647,7 @@ export const pt = {
   external_recipient_tooltip_content:
     'Envie os fundos trocados para um endereço de carteira diferente do seu.',
   blockaid_simulation_pending: 'Simulação de transação…',
+  malicious_dapp_detected: 'Token malicioso dApp detectado',
+  malicious_dapp_detected_description:
+    '{{dapp}} foi sinalizado como malicioso pelo Blockaid. Sempre faça sua própria pesquisa antes de prosseguir.',
 }

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -1627,4 +1627,7 @@ export const ru = {
   external_recipient_tooltip_content:
     'Отправьте переведенные средства на другой адрес кошелька, а не на свой собственный.',
   blockaid_simulation_pending: 'Имитация транзакции…',
+  malicious_dapp_detected: 'Обнаружен вредоносный dApp',
+  malicious_dapp_detected_description:
+    '{{dapp}} помечен Blockaid как вредоносный. Всегда проводите собственное исследование, прежде чем продолжить.',
 }

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -1520,4 +1520,7 @@ export const zh = {
   external_recipient_tooltip_content:
     '将兑换后的资金发送到另一个钱包地址，而不是您自己的钱包地址。',
   blockaid_simulation_pending: '模拟交易…',
+  malicious_dapp_detected: '检测到恶意dApp',
+  malicious_dapp_detected_description:
+    '{{dapp}}已被 Blockaid 标记为恶意程序。操作前请务必自行调查。',
 }


### PR DESCRIPTION
## Problem

The "Connect dApp" popup runs a Blockaid site scan and, for a `malicious` verdict, shows a `BlockaidOverlay` warning modal. But the button-enable logic never consulted the verdict:

```ts
const canConnect =
  !isPending && !siteScanQuery.isPending && selectedVaultId !== undefined
const pickerLocked = isPending || siteScanQuery.isPending
```

Two concrete gaps:

1. **No defense-in-depth on the Connect button.** The security decision rested entirely on the warning modal, which is dismissable by design ("Continue anyway"). Its acknowledgement state lived inside `BlockaidOverlay` and was never lifted, so `canConnect` stayed `true` for a flagged site.
2. **The vault-picker path had no warning or gate.** The overlay is only rendered in the connect view; the picker view rendered neither the scan result nor the overlay, and selecting a vault fired `connect()` immediately, gated only by the verdict-blind `pickerLocked`. Dismiss the modal once → "Change" → pick a vault → connected, no second warning.

## Changes

- **Gate on the verdict.** Derive `isMaliciousSite = siteScanQuery.data === 'malicious'` and `isSiteBlocked = isMaliciousSite && !hasAcknowledgedSiteRisk`, and fold `!isSiteBlocked` into `canConnect` and `pickerLocked`. Now a flagged site blocks **both** the Connect button and the picker until acknowledged.
- **Lift the acknowledgement.** Added an optional `onProceed` callback to `BlockaidOverlay`, fired on "Continue anyway"; `BlockaidSiteScanResult` forwards it as `onAcknowledgeRisk`, and the resolver uses it to flip `hasAcknowledgedSiteRisk`. The modal dismissal and the button gate are now one verdict-driven mechanism.
- **Warn on the picker.** The picker view now renders a `WarningBlock` when the site is malicious, so it's no longer a silent bypass.

`onProceed` is optional, so `BlockaidOverlay`'s other consumer (`BlockaidTxValidationResult`) is unchanged. Clean sites (`null`) and disabled/inactive Blockaid scans (verdict `undefined`) keep their current behavior — `isMaliciousSite` is false for both. No new i18n keys (reused `risky_site_detected`).

## Behavior

Malicious site → Connect disabled + warning modal → user picks "Go Back" (leaves) or "Continue anyway" (explicitly acknowledges) → only then is Connect enabled, on both the connect and picker views.

## Scope

- **Must NOT do:** no change to the scan query, the session-writing mutation, or clean/disabled-scan behavior; no hard-block without a path forward (explicit confirm is intended).

## Testing

- [x] `yarn check:all` succeeds (typecheck 0, lint 0, unit tests pass, i18n integrity passed).

> This is a UI gating change; the states were reasoned through against the render tree (verdict `undefined`/`null`/`malicious` × connect/picker views) rather than driven live. Manual repro for reviewers: connect from a Blockaid-flagged domain and confirm Connect is disabled until "Continue anyway", and that the picker shows the warning and stays gated.

Closes #4293

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a malicious-site warning overlay with dedicated “go back” and “continue anyway” actions.
  * Users must acknowledge the risk before proceeding, and the warning includes localized, domain-specific messaging.
* **Bug Fixes**
  * Blocked vault access and prevented both connection and vault-picker interactions for malicious sites until the warning is acknowledged.
  * Updated the Blockaid scan result flow to support risk acknowledgment in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->