### PR TITLE
fix: surface Blockaid's real risk reason instead of hardcoded copy

### DIFF
--- a/core/ui/chain/security/blockaid/tx/BlockaidTxScanStatus.tsx
+++ b/core/ui/chain/security/blockaid/tx/BlockaidTxScanStatus.tsx
@@ -2,12 +2,12 @@ import { BlockaidNoScanStatus } from '@core/ui/chain/security/blockaid/scan/Bloc
 import { BlockaidScanning } from '@core/ui/chain/security/blockaid/scan/BlockaidScanning'
 import { BlockaidScanStatusContainer } from '@core/ui/chain/security/blockaid/scan/BlockaidScanStatusContainer'
 import { BlockaidTxValidationResult } from '@core/ui/chain/security/blockaid/tx/BlockaidTxValidationResult'
+import { BlockaidTxScanResult } from '@core/ui/chain/security/blockaid/tx/queries/blockaidTxValidation'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
 import { Query } from '@lib/ui/query/Query'
-import { BlockaidValidationResult } from '@vultisig/core-chain/security/blockaid/tx/validation/core'
 
 type BlockaidTxScanStatusProps = {
-  value: Query<BlockaidValidationResult | undefined>
+  value: Query<BlockaidTxScanResult | undefined>
 }
 
 /**

--- a/core/ui/chain/security/blockaid/tx/BlockaidTxValidationResult.tsx
+++ b/core/ui/chain/security/blockaid/tx/BlockaidTxValidationResult.tsx
@@ -1,7 +1,6 @@
 import { CheckIcon } from '@lib/ui/icons/CheckIcon'
 import { ValueProp } from '@lib/ui/props'
 import { Tooltip } from '@lib/ui/tooltips/Tooltip'
-import { BlockaidValidationResult as BlockaidValidationResultType } from '@vultisig/core-chain/security/blockaid/tx/validation/core'
 import { capitalizeFirstLetter } from '@vultisig/lib-utils/capitalizeFirstLetter'
 import { Trans, useTranslation } from 'react-i18next'
 import { useTheme } from 'styled-components'
@@ -11,11 +10,12 @@ import { BlockaidOverlay } from '../BlockaidOverlay'
 import { riskLevelIcon } from '../riskLevelIcon'
 import { BlockaidScanStatusContainer } from '../scan/BlockaidScanStatusContainer'
 import { getBlockaidScanEntityName } from '../utils/entity'
+import { BlockaidTxScanResult } from './queries/blockaidTxValidation'
 import { getRiskyTxColor } from './utils/color'
 
 export const BlockaidTxValidationResult = ({
   value,
-}: ValueProp<BlockaidValidationResultType>) => {
+}: ValueProp<BlockaidTxScanResult>) => {
   const { colors } = useTheme()
 
   const { t } = useTranslation()
@@ -25,17 +25,19 @@ export const BlockaidTxValidationResult = ({
 
     const color = getRiskyTxColor(value.level, colors)
 
+    const warning = value.description ?? t('risky_tx_warning')
+
     return (
       <>
         <BlockaidOverlay
           riskLevel={value.level}
-          description={t('risky_tx_warning')}
+          description={warning}
           title={t('risky_transaction_detected', {
             riskLevel: capitalizeFirstLetter(value.level),
           })}
         />
         <Tooltip
-          content={t('risky_tx_warning')}
+          content={warning}
           renderOpener={props => (
             <BlockaidScanStatusContainer
               {...props}

--- a/core/ui/chain/security/blockaid/tx/queries/blockaidTxValidation.ts
+++ b/core/ui/chain/security/blockaid/tx/queries/blockaidTxValidation.ts
@@ -1,13 +1,47 @@
 import { noRefetchQueryOptions } from '@lib/ui/query/utils/options'
+import { RiskLevel } from '@vultisig/core-chain/security/blockaid/core/riskLevel'
 import { getTxBlockaidValidation } from '@vultisig/core-chain/security/blockaid/tx/validation'
-import { parseBlockaidValidation } from '@vultisig/core-chain/security/blockaid/tx/validation/api/core'
+import {
+  BlockaidValidation,
+  parseBlockaidValidation,
+} from '@vultisig/core-chain/security/blockaid/tx/validation/api/core'
 import { BlockaidTxValidationInput } from '@vultisig/core-chain/security/blockaid/tx/validation/resolver'
+
+export type BlockaidTxScanResult = {
+  level: RiskLevel
+  description?: string
+} | null
+
+const getValidationDescription = ({
+  description,
+  features,
+  extended_features,
+}: BlockaidValidation): string | undefined => {
+  if (description) {
+    return description
+  }
+
+  return (
+    [...(features ?? []), ...(extended_features ?? [])]
+      .map(feature => feature.description)
+      .filter(Boolean)
+      .join(' ') || undefined
+  )
+}
 
 export const getBlockaidTxValidationQuery = (
   input: BlockaidTxValidationInput
 ) => ({
   queryKey: ['blockaidTxValidation', input],
-  queryFn: async () =>
-    parseBlockaidValidation(await getTxBlockaidValidation(input)),
+  queryFn: async (): Promise<BlockaidTxScanResult> => {
+    const validation = await getTxBlockaidValidation(input)
+    const result = parseBlockaidValidation(validation)
+
+    if (!result) {
+      return null
+    }
+
+    return { ...result, description: getValidationDescription(validation) }
+  },
   ...noRefetchQueryOptions,
 })


### PR DESCRIPTION
## Summary
- The tx-scan risk warning on the keysign verify screen showed a hardcoded "This transaction involves a malicious address" string for **every** risk level — including a medium-risk `Warning` where Blockaid never claimed the address was malicious.
- Blockaid's actual `description` (and feature descriptions) were fetched but discarded; only the risk level survived.
- The validation query now keeps Blockaid's reason and the overlay/tooltip render it, falling back to the generic string only when Blockaid returns no detail. This brings extension + desktop to parity with iOS and Android, which already surface the real reason.

## Changes
| File | Change |
|------|--------|
| `core/ui/chain/security/blockaid/tx/queries/blockaidTxValidation.ts` | New `BlockaidTxScanResult` type + `getValidationDescription` helper: keeps Blockaid's `description`, falls back to joined `features`/`extended_features` descriptions. |
| `core/ui/chain/security/blockaid/tx/BlockaidTxValidationResult.tsx` | Renders `value.description ?? t('risky_tx_warning')` in the overlay title-body and tooltip. |
| `core/ui/chain/security/blockaid/tx/BlockaidTxScanStatus.tsx` | Prop type updated to the new result shape. |

## Context
Reported from the extension: an in-app swap surfaced the full-screen "Medium risk transaction detected — This transaction involves a malicious address" warning. In-app swap calldata comes from external aggregator APIs (1inch/LiFi/Kyber/SwapKit), so the scan itself is correct to run and must stay — but a medium-risk `Warning` is not a "malicious address", and the hardcoded copy was misleading.

Fix is kept UI-side rather than in `@vultisig/core-chain`'s `parseBlockaidValidation` on purpose: core-chain is a published dependency (2.23.0), so moving it into the SDK would gate this fix behind a changeset + release.

Bottom-sheet presentation for the medium-risk variant (per Figma) is tracked separately in #4296 — this PR is copy-only.

## Test plan
- [x] `yarn check` green (typecheck + lint + i18n integrity)
- [x] Extraction logic verified: description → features → extended_features → undefined fallback
- [ ] Live medium-risk scan screenshot (needs a Blockaid-flagged tx; all current swap routes scan Benign on demand)

## receipts

`yarn check` (typecheck + lint):
```
[0] yarn typecheck exited with code 0
[1] yarn lint:fix exited with code 0
i18n integrity check passed
exit: 0
```

Extraction behavior (mirrors `getValidationDescription`):
```
1. description present -> "Interacts with a known scam contract."
2. only features      -> "Transfer to a flagged address."
3. extended_features  -> "Approval to high-risk spender."
4. empty (fallback)   -> undefined
```
Case 4 returning `undefined` is what makes `value.description ?? t('risky_tx_warning')` fall back to the generic string when Blockaid returns no detail.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transaction security checks now show richer risk details, including a human-readable description when available.
  * Warning messages for risky transactions can now use more specific information instead of a generic fallback.

* **Bug Fixes**
  * Improved the transaction scan flow so security status displays stay in sync with the latest scan results and handle missing data more gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->