### PR TITLE
fix(extension): bind getAccount authorization to the request origin

### DIFF
--- a/core/inpage-provider/background/core/authorization.test.ts
+++ b/core/inpage-provider/background/core/authorization.test.ts
@@ -1,0 +1,84 @@
+import { BackgroundError } from '@core/inpage-provider/background/error'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@core/extension/storage', () => ({
+  storage: { getCurrentVaultId: vi.fn() },
+}))
+vi.mock('@core/extension/storage/appSessions', () => ({
+  getVaultAppSessions: vi.fn(),
+}))
+vi.mock('@core/extension/storage/coins', () => ({
+  coinsStorage: { getCoins: vi.fn() },
+}))
+vi.mock('@vultisig/lib-utils/sleep', () => ({
+  sleep: vi.fn(() => Promise.resolve()),
+}))
+
+import { storage } from '@core/extension/storage'
+import { getVaultAppSessions } from '@core/extension/storage/appSessions'
+
+import { authorizeContext } from './authorization'
+
+const mockGetCurrentVaultId = vi.mocked(storage.getCurrentVaultId)
+const mockGetVaultAppSessions = vi.mocked(getVaultAppSessions)
+
+const origin = 'https://dapp.example.com'
+const session = { host: 'example.com', url: origin }
+
+describe('authorizeContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetCurrentVaultId.mockResolvedValue('vault-1')
+  })
+
+  it('binds the session to the trusted origin from storage', async () => {
+    mockGetVaultAppSessions.mockResolvedValue({ 'example.com': session })
+
+    const result = await authorizeContext({ requestOrigin: origin })
+
+    // Session is derived from storage keyed by origin — vaultId comes from
+    // storage, never from caller input.
+    expect(result.appSession).toEqual({ ...session, vaultId: 'vault-1' })
+    expect(mockGetVaultAppSessions).toHaveBeenCalledWith('vault-1')
+  })
+
+  it('rejects an origin with no stored session', async () => {
+    mockGetVaultAppSessions.mockResolvedValue({})
+
+    await expect(authorizeContext({ requestOrigin: origin })).rejects.toBe(
+      BackgroundError.Unauthorized
+    )
+  })
+
+  it('does not retry the lookup by default', async () => {
+    mockGetVaultAppSessions.mockResolvedValue({})
+
+    await expect(authorizeContext({ requestOrigin: origin })).rejects.toBe(
+      BackgroundError.Unauthorized
+    )
+    expect(mockGetVaultAppSessions).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries the lookup to absorb the post-grant write race', async () => {
+    mockGetVaultAppSessions
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ 'example.com': session })
+
+    const result = await authorizeContext(
+      { requestOrigin: origin },
+      { retryOnMissing: true }
+    )
+
+    expect(result.appSession).toEqual({ ...session, vaultId: 'vault-1' })
+    expect(mockGetVaultAppSessions).toHaveBeenCalledTimes(2)
+  })
+
+  it('gives up after exhausting retries when the session never appears', async () => {
+    mockGetVaultAppSessions.mockResolvedValue({})
+
+    await expect(
+      authorizeContext({ requestOrigin: origin }, { retryOnMissing: true })
+    ).rejects.toBe(BackgroundError.Unauthorized)
+    expect(mockGetVaultAppSessions).toHaveBeenCalledTimes(4)
+  })
+})

--- a/core/inpage-provider/background/core/authorization.ts
+++ b/core/inpage-provider/background/core/authorization.ts
@@ -4,13 +4,35 @@ import { coinsStorage } from '@core/extension/storage/coins'
 import { BackgroundError } from '@core/inpage-provider/background/error'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { getRecordKeys } from '@vultisig/lib-utils/record/getRecordKeys'
+import { sleep } from '@vultisig/lib-utils/sleep'
 import { areLowerCaseEqual } from '@vultisig/lib-utils/string/areLowerCaseEqual'
 import { getUrlBaseDomain } from '@vultisig/lib-utils/url/baseDomain'
 
 import { AuthorizedCallContext, CallInitialContext } from '../../call/context'
 
+type AuthorizeContextOptions = {
+  /**
+   * Retry the storage session lookup a few times before failing. Used right
+   * after `grantVaultAccess` writes a session, where the immediate re-read can
+   * miss the just-written value due to cross-context storage propagation lag
+   * (#3973). Only closes that race — an origin with no granted session still
+   * ends up Unauthorized.
+   */
+  retryOnMissing?: boolean
+}
+
+const sessionLookupRetries = 4
+const sessionLookupRetryDelayMs = 50
+
+/**
+ * Resolve the authorized call context by binding the trusted `requestOrigin`
+ * to a session stored for the resolved vault. The session is always read from
+ * storage keyed by origin — never taken from caller input — so a forged call
+ * cannot authorize itself for a vault its origin was never granted.
+ */
 export const authorizeContext = async (
-  context: CallInitialContext
+  context: CallInitialContext,
+  { retryOnMissing = false }: AuthorizeContextOptions = {}
 ): Promise<AuthorizedCallContext> => {
   const { requestOrigin, account } = context
 
@@ -32,17 +54,27 @@ export const authorizeContext = async (
     return shouldBePresent(await storage.getCurrentVaultId(), 'currentVaultId')
   }
 
-  const vaultId = await getVaultId()
+  const resolveAppSession = async () => {
+    const vaultId = await getVaultId()
+    const vaultSessions = await getVaultAppSessions(vaultId)
+    const appSession = vaultSessions[getUrlBaseDomain(requestOrigin)]
 
-  const vaultSessions = await getVaultAppSessions(vaultId)
-  const appSession = vaultSessions[getUrlBaseDomain(requestOrigin)]
-
-  if (!appSession) {
-    throw BackgroundError.Unauthorized
+    return appSession ? { ...appSession, vaultId } : null
   }
 
-  return {
-    ...context,
-    appSession: { ...appSession, vaultId },
+  const attempts = retryOnMissing ? sessionLookupRetries : 1
+
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    const appSession = await resolveAppSession()
+
+    if (appSession) {
+      return { ...context, appSession }
+    }
+
+    if (attempt < attempts - 1) {
+      await sleep(sessionLookupRetryDelayMs)
+    }
   }
+
+  throw BackgroundError.Unauthorized
 }

--- a/core/inpage-provider/background/interface.ts
+++ b/core/inpage-provider/background/interface.ts
@@ -21,7 +21,13 @@ export type SetAppChainInput = {
 
 export type GetAccountInput = {
   chain: Chain
-  /** When provided (e.g. from grantVaultAccess popup response), used instead of storage lookup to avoid races. */
+  /**
+   * Echoed back from the grantVaultAccess popup response on the immediate
+   * follow-up call. Its presence signals a grant just happened so background
+   * authorization tolerates the post-write storage race (#3973); its contents
+   * are not trusted — authorization is always re-derived from storage against
+   * the trusted request origin.
+   */
   appSession?: VaultAppSession
 }
 

--- a/core/inpage-provider/bridge/background.ts
+++ b/core/inpage-provider/bridge/background.ts
@@ -1,4 +1,3 @@
-import type { VaultAppSession } from '@core/extension/storage/appSessions'
 import { runBridgeBackgroundAgent } from '@lib/extension/bridge/background'
 import { isOneOf } from '@vultisig/lib-utils/array/isOneOf'
 import { attempt } from '@vultisig/lib-utils/attempt'
@@ -36,25 +35,25 @@ function resolveBackgroundCall({
   return resolver({ input, context })
 }
 
-/** If this is a getAccount call with appSession in input, return that session (avoids storage race after grantVaultAccess). */
-function getPassedAppSession(
-  message: InpageProviderBridgeMessage
-): { appSession: VaultAppSession } | null {
-  const result = matchRecordUnion<
-    InpageProviderBridgeMessage,
-    { appSession: VaultAppSession } | false
-  >(message, {
+/**
+ * Whether this is a `getAccount` call carrying an `appSession` in its input.
+ * The `grantVaultAccess` popup echoes the freshly created session back on the
+ * immediate follow-up `getAccount` (see `requestAccount`); its presence is used
+ * only as a hint that a grant just happened, so authorization tolerates the
+ * post-write storage race. The object's contents are never trusted — the
+ * session is always re-derived from storage against the trusted origin.
+ */
+function hasPassedAppSession(message: InpageProviderBridgeMessage): boolean {
+  return matchRecordUnion<InpageProviderBridgeMessage, boolean>(message, {
     background: ({ call }) => {
       if (getRecordUnionKey(call) !== 'getAccount') return false
       const input = getRecordUnionValue(call, 'getAccount') as {
-        appSession?: VaultAppSession
+        appSession?: unknown
       }
-      if (!input?.appSession) return false
-      return { appSession: input.appSession }
+      return !!input?.appSession
     },
     popup: () => false,
   })
-  return result && typeof result === 'object' ? result : null
 }
 
 /** Whether this message is for an authorized method (needs app session from storage). */
@@ -67,17 +66,15 @@ function messageRequiresAuth(message: InpageProviderBridgeMessage): boolean {
   })
 }
 
-/** Build call context: use passed session for getAccount when present, else authorize from storage when required. */
+/** Build call context: authorize from storage (bound to the trusted origin) for authorized methods. */
 async function buildCallContext(
   message: InpageProviderBridgeMessage,
   initialContext: CallContext
 ): Promise<CallContext> {
-  const passedSession = getPassedAppSession(message)
-  if (passedSession) {
-    return { ...initialContext, appSession: passedSession.appSession }
-  }
   if (messageRequiresAuth(message)) {
-    return authorizeContext(initialContext)
+    return authorizeContext(initialContext, {
+      retryOnMissing: hasPassedAppSession(message),
+    })
   }
   return initialContext
 }


### PR DESCRIPTION
## Problem

`getAccount` accepted a caller-supplied `appSession` from the bridge input and used it as the authorized context **without** running `authorizeContext` — the storage-backed `origin → session` check every other authorized method performs (`buildCallContext`, old `getPassedAppSession`). Because the inpage bridge accepts any same-window `postMessage` bearing the constant `sourceId: 'bridge-channel-inpage'`, page JS can forge a `getAccount` call with an arbitrary `appSession.vaultId` (= a vault's root ECDSA public key) and receive that vault's **address + public key** for any chain — with no approved session for its origin, and surviving revocation via the connected-dApps UI.

Blast radius is limited: the attacker must know a valid `vaultId`, and the bypass is confined to `getAccount` — signing, export, and setAppChain still authorize, so there is no signing or fund-movement bypass. Impact is cross-origin disclosure of addresses/public keys.

## Fix

Authorization is always derived from **storage keyed by the trusted `requestOrigin`** (which the background derives from the chrome `sender`, not the payload) — caller input is never trusted.

- Removed the `getPassedAppSession` trust path in `buildCallContext`; authorized methods always go through `authorizeContext`.
- The passed `appSession` (echoed back from `grantVaultAccess`) is now only a **hint** that a grant just happened. It flips `authorizeContext`'s new `retryOnMissing` flag, which retries the storage lookup up to 4×50ms to absorb the post-write propagation race (#3973) that the old shortcut existed to avoid.
- The common unauthorized path (normal `getAccount` from an unconnected origin, no passed session) does **not** retry, so the "not connected → open popup" flow keeps its fast-fail with no added latency.

Why not just check the passed session's `host`/`url` against the origin? The caller controls the entire object, so it would set `host` to its real origin while pointing `vaultId` at a different vault. The binding must be `origin → vaultId` validated against storage.

## Behavior change worth noting

Previously, if the post-grant storage write genuinely failed, the call still "succeeded" off the unverified passed session. It now returns `Unauthorized` after the bounded retries — the correct, safer behavior, but a real change.

## Tests

New `authorization.test.ts` covers: origin-bound resolution, rejection when no session exists, no-retry-by-default, retry absorbs the race, and give-up-after-retries.

- [x] `yarn check:all` — typecheck 0, lint 0, all unit tests pass (incl. the new file). The only `check:all` failure is pre-existing external dead-link checks (`vultisig-sdk`, `thorswap.finance`) in README files this PR doesn't touch.

## Manual verification

Forged call from an **unconnected** page's console (envelope matches `lib/extension/bridge/inpage.ts`):

```js
addEventListener('message', e => {
  if (e.source === window && e.data?.sourceId === 'bridge-channel-background')
    console.log('reply:', e.data.message)
})
window.postMessage({
  id: crypto.randomUUID(),
  sourceId: 'bridge-channel-inpage',
  message: { background: { call: { getAccount: {
    chain: 'Ethereum',
    appSession: { vaultId: '<TARGET_VAULT_ECDSA_PUBKEY>', host: 'evil.test', url: location.origin }
  } }, options: {} } }
}, '*')
```

- Before: reply contains `{ address, publicKey }`.
- After: reply is `{ error: 'unauthorized' }`.

Also verify: (1) a normal connect still returns the address (retry path intact), and (2) after revoking a dApp, `getAccount` from that origin no longer resolves.

Closes #4295

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account authorization reliability when session data is not available immediately.
  * Added a brief retry period so newly granted access is recognized more consistently.
  * Unauthorized access is still rejected when no valid session is found.

* **Documentation**
  * Clarified how session information is handled during account access requests and why it is not trusted directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->