### PR TITLE
Wire Station Jupiter fee owner

### DIFF
--- a/core/ui/vault/swap/affiliate/stationSwapAffiliateConfig.ts
+++ b/core/ui/vault/swap/affiliate/stationSwapAffiliateConfig.ts
@@ -16,6 +16,9 @@ export const stationKyberSwapSource =
     ? __VULTISIG_STATION_KYBER_SOURCE__
     : stationKyberSwapFallbackSource
 
+export const stationJupiterFeeOwner =
+  '5QXePTiaWgmqSCHh9YDWAiVvEeKWaM5cUN62K4SXwUSB'
+
 export const stationSwapAffiliateConfig = {
   native: {
     affiliateFeeAddress: stationNativeSwapAffiliateName,
@@ -28,5 +31,8 @@ export const stationSwapAffiliateConfig = {
   kyber: {
     source: stationKyberSwapSource,
     referral: stationSwapAffiliateFeeReceiver,
+  },
+  jupiter: {
+    feeOwner: stationJupiterFeeOwner,
   },
 } satisfies SwapAffiliateConfig

--- a/core/ui/vault/swap/queries/buildSwapQuoteInput.test.ts
+++ b/core/ui/vault/swap/queries/buildSwapQuoteInput.test.ts
@@ -3,6 +3,7 @@ import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
 import { describe, expect, it } from 'vitest'
 
 import {
+  stationJupiterFeeOwner,
   stationKyberSwapFallbackSource,
   stationKyberSwapSource,
   stationNativeSwapAffiliateName,
@@ -54,6 +55,9 @@ describe('buildSwapQuoteInput', () => {
     )
     expect(input.affiliateConfig?.kyber?.source).toBe(stationKyberSwapSource)
     expect(stationKyberSwapSource).toBe(stationKyberSwapFallbackSource)
+    expect(input.affiliateConfig?.jupiter?.feeOwner).toBe(
+      stationJupiterFeeOwner
+    )
   })
 
   it('preserves Vultisig quote input behavior', () => {


### PR DESCRIPTION
Closes #4207
Summary
- Add the Station Jupiter fee owner to the Station swap affiliate config.
- Assert quote input preserves the Station Jupiter fee owner.

Verification
- Real Station Jupiter swap proof: Solana tx 3zd644MwEWcEoVxVB5N228SY1sgG4r9StS4zSTdJL1QEN7PvUa27ZN1TFGcH5FTFFNqSE8PNP99kqWU9fgKeuoTu finalized with err: null; Station fee owner 5QXePTiaWgmqSCHh9YDWAiVvEeKWaM5cUN62K4SXwUSB received USDC via ATA CRz7ucCE6ZFhN297AC56ihUBbdDuZNzN3D7MVw2cYPna.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional swap affiliate fee-owner configuration.
  * Station swap quotes now include the new Jupiter fee-owner setting where applicable.

* **Tests**
  * Updated swap quote validation to confirm the new affiliate configuration is applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->