### PR TITLE
fix(i18n): stray hyphen in German reshare_min_devices_required (#4298)

### DIFF
--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -1680,7 +1680,7 @@ export const de = {
   reshare_backup_old_backups_wont_work: 'Alte Backups funktionieren nicht.',
   reshare_backup_old_backups_wont_work_description:
     'Backups aus früheren Vault-Konfigurationen können nicht verwendet werden. Nur Backups, die während dieser Konfiguration erstellt wurden, sind gültig.',
-  reshare_min_devices_required: 'Mindestens {{count}} -Geräte erforderlich',
+  reshare_min_devices_required: 'Mindestens {{count}} Geräte erforderlich',
   reshare_more_devices_required: 'Weitere Geräte erforderlich',
   reshare_threshold_not_met: 'Schwellenwert nicht erreicht',
   reshare_threshold_not_met_description:


### PR DESCRIPTION
Removes the stray " -" before "Geräte" in the German translation of `reshare_min_devices_required` (CodeRabbit finding on #4317). No key changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)