### PR TITLE
fix(reshare): large vaults could bypass the reshare threshold (#4298)

### DIFF
--- a/core/ui/mpc/keygen/reshare/ReshareDeviceCountStep.tsx
+++ b/core/ui/mpc/keygen/reshare/ReshareDeviceCountStep.tsx
@@ -60,7 +60,13 @@ export const ReshareDeviceCountStep = ({ onFinish }: OnFinishProp<number>) => {
           />
         </ThresholdOverlay>
       )}
-      onSubmit={selectedDeviceCount => onFinish(selectedDeviceCount + 1)}
+      onSubmit={selectedDeviceCount =>
+        // The slider caps at "4+" (index 3), so for vaults whose minimum
+        // exceeds 4 the raw selection would understate the target and let peer
+        // discovery proceed below the threshold — clamp the target up to the
+        // required minimum.
+        onFinish(Math.max(selectedDeviceCount + 1, minDeviceCount))
+      }
     />
   )
 }


### PR DESCRIPTION
Fixes the threshold bypass rcoderdev flagged on #4317: the slider caps at "4+" (index 3), so a vault whose minimum exceeds 4 (e.g. 7 devices → min 5) submitted a target of 4 and peer discovery only required 3 peers. Now the submitted target is clamped up to `minDeviceCount`, so peer discovery enforces the real minimum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)