### PR TITLE
feat(settings):Remove post-quantum key generation message

### DIFF
--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -279,8 +279,6 @@ export const de = {
   post_quantum_keygen: 'Post-Quanten-Schlüsselerzeugung',
   post_quantum_keygen_description:
     'Generieren Sie einen Post-Quantum-Schlüssel (MLDSA) für diesen Tresor.',
-  post_quantum_key_already_generated:
-    'Dieser Tresor verfügt bereits über einen Post-Quanten-Schlüssel',
   enable_token_instruction:
     'Aktivieren Sie mindestens ein Token, um Kontostände anzuzeigen und Positionen zu verwalten.',
   encrypting_vault_keyshares: 'Verschlüsselung der Tresor-Schlüsselanteile...',

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -351,8 +351,6 @@ export const en = {
   post_quantum_keygen: 'Post-Quantum Key Generation',
   post_quantum_keygen_description:
     'Generate a post-quantum (MLDSA) key for this vault',
-  post_quantum_key_already_generated:
-    'This vault already has a post-quantum key',
   enable_token_instruction:
     'Enable at least one token to view balances and manage positions.',
   encrypting_vault_keyshares: 'Encrypting vault keyshares...',

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -279,8 +279,6 @@ export const es = {
   post_quantum_keygen: 'Generación de claves post-cuántica',
   post_quantum_keygen_description:
     'Genera una clave post-cuántica (MLDSA) para esta bóveda.',
-  post_quantum_key_already_generated:
-    'Esta bóveda ya tiene una llave post-cuántica.',
   enable_token_instruction:
     'Habilite al menos un token para ver saldos y administrar posiciones.',
   encrypting_vault_keyshares: 'Cifrado de claves compartidas de bóveda...',

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -275,7 +275,6 @@ export const hr = {
   post_quantum_keygen: 'Postkvantno generiranje ključeva',
   post_quantum_keygen_description:
     'Generiraj postkvantni (MLDSA) ključ za ovaj trezor',
-  post_quantum_key_already_generated: 'Ovaj trezor već ima postkvantni ključ',
   enable_token_instruction:
     'Omogućite barem jedan token za pregled stanja i upravljanje pozicijama.',
   encrypting_vault_keyshares: 'Šifriranje dijeljenja ključeva trezora...',

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -281,8 +281,6 @@ export const it = {
   post_quantum_keygen: 'Generazione di chiavi post-quantistiche',
   post_quantum_keygen_description:
     'Genera una chiave post-quantistica (MLDSA) per questo vault',
-  post_quantum_key_already_generated:
-    'Questa cassaforte ha già una chiave post-quantistica',
   enable_token_instruction:
     'Abilita almeno un token per visualizzare i saldi e gestire le posizioni.',
   encrypting_vault_keyshares:

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -275,8 +275,6 @@ export const ko = {
   post_quantum_keygen: '양자 후 키 생성',
   post_quantum_keygen_description:
     '이 금고에 대한 양자 후 보안(MLDSA) 키를 생성하세요.',
-  post_quantum_key_already_generated:
-    '이 금고에는 이미 양자 후 보안 키가 있습니다.',
   enable_token_instruction:
     '잔액을 확인하고 포지션을 관리하려면 최소 하나 이상의 토큰을 활성화해야 합니다.',
   encrypting_vault_keyshares: '금고 키 공유를 암호화하는 중...',

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -276,8 +276,6 @@ export const nl = {
   post_quantum_keygen: 'Post-kwantum sleutelgeneratie',
   post_quantum_keygen_description:
     'Genereer een post-quantum (MLDSA) sleutel voor deze kluis.',
-  post_quantum_key_already_generated:
-    'Deze kluis heeft al een post-kwantumsleutel.',
   enable_token_instruction:
     'Schakel minstens één token in om saldi te bekijken en posities te beheren.',
   encrypting_vault_keyshares: 'Kluis-keyshares versleutelen...',

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -278,8 +278,6 @@ export const pt = {
   post_quantum_keygen: 'Geração de chaves pós-quânticas',
   post_quantum_keygen_description:
     'Gere uma chave pós-quântica (MLDSA) para este cofre.',
-  post_quantum_key_already_generated:
-    'Este cofre já possui uma chave pós-quântica.',
   enable_token_instruction:
     'Habilite pelo menos um token para visualizar saldos e gerenciar posições.',
   encrypting_vault_keyshares:

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -274,8 +274,6 @@ export const ru = {
   post_quantum_keygen: 'Постквантовая генерация ключей',
   post_quantum_keygen_description:
     'Сгенерируйте постквантовый (MLDSA) ключ для этого хранилища.',
-  post_quantum_key_already_generated:
-    'В этом хранилище уже есть постквантовый ключ.',
   enable_token_instruction:
     'Включите минимум один токен, чтобы видеть балансы и управлять позициями.',
   encrypting_vault_keyshares: 'Шифрование keyshares хранилища...',

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -261,7 +261,6 @@ export const zh = {
   enable_tss_batching: '启用 TSS 批处理',
   post_quantum_keygen: '后量子密钥生成',
   post_quantum_keygen_description: '为该保险库生成后量子（MLDSA）密钥',
-  post_quantum_key_already_generated: '这个保险库已经拥有后量子时代的密钥。',
   enable_token_instruction: '至少启用一个代币才能查看余额和管理持仓。',
   encrypting_vault_keyshares: '加密保险库密钥共享...',
   enter: '进入',

--- a/core/ui/vault/settings/advanced/index.tsx
+++ b/core/ui/vault/settings/advanced/index.tsx
@@ -77,21 +77,6 @@ export const VaultSettingsAdvancedPage: FC = () => {
               showArrow
             />
           )}
-          {vault.publicKeyMldsa && (
-            <ListItem
-              icon={
-                <ListItemIconWrapper>
-                  <ShieldIcon />
-                </ListItemIconWrapper>
-              }
-              description={
-                <DescriptionText>
-                  {t('post_quantum_key_already_generated')}
-                </DescriptionText>
-              }
-              title={t('post_quantum_keygen')}
-            />
-          )}
           <ListItem
             icon={
               <ListItemIconWrapper>


### PR DESCRIPTION
## Description

Remove post-quantum key generation message when when MLDSA key already exists.

Fixes #4251


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added updated post-quantum key generation wording in several languages.

* **Bug Fixes**
  * Removed an outdated “key already generated” message from the Advanced Vault Settings page.
  * The page now shows the relevant setup prompt only when a post-quantum key has not yet been created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->