### PR TITLE
style(reshare): match "Threshold not met" card to the device cards (#4298)

### DIFF
--- a/core/ui/mpc/keygen/reshare/ReshareDeviceCountStep.tsx
+++ b/core/ui/mpc/keygen/reshare/ReshareDeviceCountStep.tsx
@@ -50,7 +50,7 @@ export const ReshareDeviceCountStep = ({ onFinish }: OnFinishProp<number>) => {
       })}
       renderBelowMin={selectedIndex => (
         <ThresholdOverlay alignItems="center">
-          <Text color="shy" size={13} weight={500} centerHorizontally>
+          <Text color="contrast" size={12} weight={500} centerHorizontally>
             {t('reshare_more_devices_required')}
           </Text>
           <ReshareThresholdNotMetCard

--- a/core/ui/mpc/keygen/reshare/ReshareThresholdBoltIcon.tsx
+++ b/core/ui/mpc/keygen/reshare/ReshareThresholdBoltIcon.tsx
@@ -1,0 +1,34 @@
+import { SvgProps } from '@lib/ui/props'
+
+/**
+ * Orange lightning-bolt used in the "Threshold not met" badge, matching the
+ * device-picker card icons in the Figma reshare redesign.
+ */
+export const ReshareThresholdBoltIcon = (props: SvgProps) => (
+  <svg
+    width="1em"
+    height="1em"
+    viewBox="0 0 15 15"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      d="M8.36 1.41232C8.36 0.679429 7.41436 0.384987 6.99833 0.988304L1.89113 8.39374C1.54944 8.88917 1.9041 9.56457 2.50595 9.56457H5.97005V12.9369C5.97005 13.6698 6.91564 13.9643 7.33173 13.361L12.4389 5.95557C12.7806 5.46012 12.4259 4.7847 11.8241 4.7847H8.36V1.41232Z"
+      fill="url(#reshare_bolt_gradient)"
+    />
+    <defs>
+      <linearGradient
+        id="reshare_bolt_gradient"
+        x1="7.16502"
+        y1="0.664062"
+        x2="9.2631"
+        y2="11.8715"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#F2C375" />
+        <stop offset="1" stopColor="#FFAA1C" />
+      </linearGradient>
+    </defs>
+  </svg>
+)

--- a/core/ui/mpc/keygen/reshare/ReshareThresholdNotMetCard.tsx
+++ b/core/ui/mpc/keygen/reshare/ReshareThresholdNotMetCard.tsx
@@ -1,10 +1,10 @@
-import { TriangleAlertIcon } from '@lib/ui/icons/TriangleAlertIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
-import { Panel } from '@lib/ui/panel/Panel'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
 import { useTranslation } from 'react-i18next'
-import styled from 'styled-components'
+import styled, { keyframes } from 'styled-components'
+
+import { ReshareThresholdBoltIcon } from './ReshareThresholdBoltIcon'
 
 type ReshareThresholdNotMetCardProps = {
   fromDeviceCount: number
@@ -12,22 +12,43 @@ type ReshareThresholdNotMetCardProps = {
   requiredSigners: number
 }
 
-const IconBox = styled.div`
+const Card = styled.div`
+  background: ${getColor('background')};
+  border: 1px solid ${getColor('foregroundExtra')};
+  border-radius: 20px;
+  padding: 20px;
+  width: 100%;
+`
+
+const badgeAppear = keyframes`
+  from {
+    opacity: 0;
+    transform: scale(0.6);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+`
+
+const IconBadge = styled.div`
   align-items: center;
-  background: ${({ theme }) =>
-    theme.colors.idle.getVariant({ a: () => 0.12 }).toCssValue()};
-  border-radius: 10px;
+  animation: ${badgeAppear} 0.3s ease;
+  background: ${getColor('foreground')};
+  border: 1px solid ${getColor('mistExtra')};
+  border-radius: 50%;
   color: ${getColor('idle')};
   display: flex;
   flex-shrink: 0;
-  height: 36px;
+  height: 40px;
   justify-content: center;
-  width: 36px;
+  width: 40px;
 `
 
 /**
  * "Threshold not met" card shown over the reshare device picker when the user
- * drags below the number of devices the vault needs to stay secure.
+ * drags below the number of devices the vault needs to stay secure. Styled to
+ * match the picker's other device cards (circular badge + subtle border).
  */
 export const ReshareThresholdNotMetCard = ({
   fromDeviceCount,
@@ -37,11 +58,12 @@ export const ReshareThresholdNotMetCard = ({
   const { t } = useTranslation()
 
   return (
-    <Panel>
+    <Card>
       <HStack gap={12} alignItems="flex-start">
-        <IconBox>
-          <TriangleAlertIcon fontSize={20} />
-        </IconBox>
+        {/* Re-keyed so the icon re-plays its entrance on every count change. */}
+        <IconBadge key={toDeviceCount}>
+          <ReshareThresholdBoltIcon style={{ fontSize: 18 }} />
+        </IconBadge>
         <VStack gap={4}>
           <Text color="contrast" size={15} weight={500}>
             {t('reshare_threshold_not_met')}
@@ -55,6 +77,6 @@ export const ReshareThresholdNotMetCard = ({
           </Text>
         </VStack>
       </HStack>
-    </Panel>
+    </Card>
   )
 }

--- a/core/ui/vault/create/setup-vault/DeviceCountPicker.stories.tsx
+++ b/core/ui/vault/create/setup-vault/DeviceCountPicker.stories.tsx
@@ -48,7 +48,7 @@ export const ReshareThresholdNotMet: Story = {
         gap={16}
         style={{ padding: '12px 16px 0', width: '100%' }}
       >
-        <Text color="shy" size={13} weight={500} centerHorizontally>
+        <Text color="contrast" size={12} weight={500} centerHorizontally>
           More devices required
         </Text>
         <ReshareThresholdNotMetCard


### PR DESCRIPTION
Addresses the styling notes on the "Threshold not met" card (Figma node 2-47679):

1. **"More devices required"** label is now **white** (was grey).
2. The icon is the **orange lightning bolt** inside the **circular badge** the other picker cards use (image 5), with an **entrance animation** re-played on each count change.
3. Card sizing now matches the other cards (padding 20, full width).
4. Card gets the subtle **border** (`foregroundExtra`) + dark card background, per Figma.

Verified in Storybook `Screens/Reshare/DeviceCountPicker → ReshareThresholdNotMet`.

Refs #4298

🤖 Generated with [Claude Code](https://claude.com/claude-code)