### PR TITLE
fix(vault): restore Rive device selection

### DIFF
--- a/clients/desktop/src/main.tsx
+++ b/clients/desktop/src/main.tsx
@@ -1,3 +1,5 @@
+import '@core/ui/animations/configureRiveRuntime'
+
 import { Buffer } from 'buffer'
 import { createRoot } from 'react-dom/client'
 

--- a/clients/extension/src/pages/index.tsx
+++ b/clients/extension/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import '../polyfills/installFirefoxProcessGlobal'
+import '@core/ui/animations/configureRiveRuntime'
 
 import { NavigationProvider } from '@clients/extension/src/navigation/NavigationProvider'
 import { views } from '@clients/extension/src/navigation/views'

--- a/clients/extension/tests/e2e/specs/onboarding.spec.ts
+++ b/clients/extension/tests/e2e/specs/onboarding.spec.ts
@@ -149,7 +149,10 @@ test.describe('Onboarding Flow', () => {
     const sliderY = canvasBounds.y + canvasBounds.height * 0.39
     await page.mouse.move(canvasBounds.x + canvasBounds.width * 0.1, sliderY)
     await page.mouse.down()
-    await page.mouse.move(canvasBounds.x + canvasBounds.width * 0.9, sliderY)
+    await page.mouse.move(
+      canvasBounds.x + canvasBounds.width * 0.9,
+      canvasBounds.y + canvasBounds.height * 0.6
+    )
     await page.mouse.up()
 
     await page.getByRole('button', { name: /get.*started/i }).first().click()

--- a/clients/extension/tests/e2e/specs/onboarding.spec.ts
+++ b/clients/extension/tests/e2e/specs/onboarding.spec.ts
@@ -96,4 +96,67 @@ test.describe('Onboarding Flow', () => {
 
     await page.close()
   })
+
+  test('Rive plus control selects a two-device vault', async ({ context, extensionId }) => {
+    const page = await context.newPage()
+    const onboardingPage = new OnboardingPage(page, extensionId)
+
+    await onboardingPage.goto()
+    await waitForExtensionReady(page)
+    await onboardingPage.completeOnboarding()
+    await onboardingPage.navigateToSetupVault()
+
+    const riveCanvas = page.locator('canvas').first()
+    const canvasBounds = await riveCanvas.boundingBox()
+    expect(canvasBounds).not.toBeNull()
+
+    if (!canvasBounds) {
+      throw new Error('Device-selection Rive canvas is unavailable')
+    }
+
+    const plusY = canvasBounds.y + canvasBounds.height * 0.29
+    // The Rive +/- controls remain the primary interaction.
+    await page.mouse.click(
+      canvasBounds.x + canvasBounds.width * 0.91,
+      plusY
+    )
+
+    await page.getByRole('button', { name: /get.*started/i }).first().click()
+    await expect(
+      page.locator('[data-testid="vault-setup-overview-content"]')
+    ).toContainText(/2-device vault/i)
+
+    await page.close()
+  })
+
+  test('Rive slider drag selects a four-device vault', async ({ context, extensionId }) => {
+    const page = await context.newPage()
+    const onboardingPage = new OnboardingPage(page, extensionId)
+
+    await onboardingPage.goto()
+    await waitForExtensionReady(page)
+    await onboardingPage.completeOnboarding()
+    await onboardingPage.navigateToSetupVault()
+
+    const riveCanvas = page.locator('canvas').first()
+    const canvasBounds = await riveCanvas.boundingBox()
+    expect(canvasBounds).not.toBeNull()
+
+    if (!canvasBounds) {
+      throw new Error('Device-selection Rive canvas is unavailable')
+    }
+
+    const sliderY = canvasBounds.y + canvasBounds.height * 0.39
+    await page.mouse.move(canvasBounds.x + canvasBounds.width * 0.1, sliderY)
+    await page.mouse.down()
+    await page.mouse.move(canvasBounds.x + canvasBounds.width * 0.9, sliderY)
+    await page.mouse.up()
+
+    await page.getByRole('button', { name: /get.*started/i }).first().click()
+    await expect(
+      page.locator('[data-testid="vault-setup-overview-content"]')
+    ).toContainText(/4\+-device vault/i)
+
+    await page.close()
+  })
 })

--- a/core/ui/animations/configureRiveRuntime.ts
+++ b/core/ui/animations/configureRiveRuntime.ts
@@ -1,0 +1,3 @@
+import { RuntimeLoader } from '@rive-app/react-webgl2'
+
+RuntimeLoader.setWasmUrl('/rive.wasm')

--- a/core/ui/vault/create/setup-vault/DeviceCountPicker.tsx
+++ b/core/ui/vault/create/setup-vault/DeviceCountPicker.tsx
@@ -91,14 +91,16 @@ export const DeviceCountPicker = ({
     useDeviceSelectionAnimation({ initialIndex })
   const isDraggingSliderRef = useRef(false)
 
-  const updateSliderSelection = (event: PointerEvent<HTMLCanvasElement>) => {
+  const isWithinSliderBand = (event: PointerEvent<HTMLCanvasElement>) => {
     const bounds = event.currentTarget.getBoundingClientRect()
     const pointerY = (event.clientY - bounds.top) / bounds.height
 
-    if (pointerY < sliderMinY || pointerY > sliderMaxY) return false
+    return pointerY >= sliderMinY && pointerY <= sliderMaxY
+  }
 
+  const updateSliderSelection = (event: PointerEvent<HTMLCanvasElement>) => {
+    const bounds = event.currentTarget.getBoundingClientRect()
     setSelectedDeviceCount(((event.clientX - bounds.left) / bounds.width) * 3)
-    return true
   }
 
   const isBelowMin = selectedDeviceCount < minSelectableIndex
@@ -128,7 +130,8 @@ export const DeviceCountPicker = ({
             <RiveComponent
               style={{ width: '100%', height: '100%' }}
               onPointerDown={event => {
-                if (updateSliderSelection(event)) {
+                if (isWithinSliderBand(event)) {
+                  updateSliderSelection(event)
                   const canvas = event.target
                   if (canvas instanceof HTMLCanvasElement) {
                     canvas.setPointerCapture(event.pointerId)

--- a/core/ui/vault/create/setup-vault/DeviceCountPicker.tsx
+++ b/core/ui/vault/create/setup-vault/DeviceCountPicker.tsx
@@ -4,11 +4,13 @@ import { Button } from '@lib/ui/buttons/Button'
 import { ScreenLayout } from '@lib/ui/layout/ScreenLayout/ScreenLayout'
 import { VStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
-import { ReactNode } from 'react'
+import { PointerEvent, ReactNode, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
 const animationMaxWidth = 400
+const sliderMinY = 0.35
+const sliderMaxY = 0.45
 
 const GradientWrapper = styled.div`
   position: relative;
@@ -85,9 +87,19 @@ export const DeviceCountPicker = ({
   renderBelowMin,
 }: DeviceCountPickerProps) => {
   const { t } = useTranslation()
-  const { RiveComponent, selectedDeviceCount } = useDeviceSelectionAnimation({
-    initialIndex,
-  })
+  const { RiveComponent, selectedDeviceCount, setSelectedDeviceCount } =
+    useDeviceSelectionAnimation({ initialIndex })
+  const isDraggingSliderRef = useRef(false)
+
+  const updateSliderSelection = (event: PointerEvent<HTMLCanvasElement>) => {
+    const bounds = event.currentTarget.getBoundingClientRect()
+    const pointerY = (event.clientY - bounds.top) / bounds.height
+
+    if (pointerY < sliderMinY || pointerY > sliderMaxY) return false
+
+    setSelectedDeviceCount(((event.clientX - bounds.left) / bounds.width) * 3)
+    return true
+  }
 
   const isBelowMin = selectedDeviceCount < minSelectableIndex
 
@@ -113,7 +125,29 @@ export const DeviceCountPicker = ({
       >
         <VStack flexGrow alignItems="center" justifyContent="center">
           <AnimationContainer>
-            <RiveComponent style={{ width: '100%', height: '100%' }} />
+            <RiveComponent
+              style={{ width: '100%', height: '100%' }}
+              onPointerDown={event => {
+                if (updateSliderSelection(event)) {
+                  const canvas = event.target
+                  if (canvas instanceof HTMLCanvasElement) {
+                    canvas.setPointerCapture(event.pointerId)
+                  }
+                  isDraggingSliderRef.current = true
+                }
+              }}
+              onPointerMove={event => {
+                if (isDraggingSliderRef.current) {
+                  updateSliderSelection(event)
+                }
+              }}
+              onPointerUp={() => {
+                isDraggingSliderRef.current = false
+              }}
+              onPointerCancel={() => {
+                isDraggingSliderRef.current = false
+              }}
+            />
             {isBelowMin && renderBelowMin ? (
               <BelowMinOverlay>
                 {renderBelowMin(selectedDeviceCount)}

--- a/core/ui/vault/create/setup-vault/hooks/useDeviceSelectionAnimation.ts
+++ b/core/ui/vault/create/setup-vault/hooks/useDeviceSelectionAnimation.ts
@@ -6,7 +6,7 @@ import {
   useViewModelInstance,
   useViewModelInstanceNumber,
 } from '@rive-app/react-webgl2'
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 
 import { deviceSelectionAnimationSource } from './deviceSelectionAnimationSource'
 
@@ -15,6 +15,8 @@ const triggerHapticFeedback = () => {
     navigator.vibrate(10)
   }
 }
+
+const maxDeviceSelectionIndex = 3
 
 type UseDeviceSelectionAnimationInput = {
   /** Rive `Index` to seed the slider with once the animation loads. */
@@ -27,6 +29,9 @@ export const useDeviceSelectionAnimation = ({
   const { RiveComponent, rive } = useRive({
     src: `/core/animations/${deviceSelectionAnimationSource}.riv`,
     autoplay: true,
+    // The state-machine handlers use the default view model. Bind it before
+    // Rive exposes the interactive canvas, rather than after React effects run.
+    autoBind: true,
     stateMachines: ['State Machine 1'],
     layout: new Layout({
       fit: Fit.Layout,
@@ -42,6 +47,27 @@ export const useDeviceSelectionAnimation = ({
 
   const indexProperty = useViewModelInstanceNumber('Index', viewModelInstance)
 
+  const setSelectedDeviceCount = useCallback(
+    (count: number) => {
+      if (indexProperty.value === null) return
+
+      const selectedDeviceCount = Math.min(
+        Math.max(0, Math.round(count)),
+        maxDeviceSelectionIndex
+      )
+
+      // `autoBind` owns the instance the state machine renders. Keep its
+      // property and the React observer in sync when the slider is dragged.
+      const boundIndexProperty = rive?.viewModelInstance?.number('Index')
+      if (boundIndexProperty) {
+        boundIndexProperty.value = selectedDeviceCount
+      }
+
+      indexProperty.setValue(selectedDeviceCount)
+    },
+    [indexProperty, rive]
+  )
+
   const didSeedRef = useRef(false)
 
   useEffect(() => {
@@ -53,9 +79,16 @@ export const useDeviceSelectionAnimation = ({
       return
     }
 
+    // `autoBind` renders from Rive's bound default instance. Seed that
+    // instance too so revisiting this screen preserves the visible selection.
+    const boundIndexProperty = rive?.viewModelInstance?.number('Index')
+    if (boundIndexProperty) {
+      boundIndexProperty.value = initialIndex
+    }
+
     indexProperty.setValue(initialIndex)
     didSeedRef.current = true
-  }, [initialIndex, indexProperty])
+  }, [initialIndex, indexProperty, rive])
 
   const previousIndexRef = useRef<number | null>(null)
 
@@ -87,5 +120,6 @@ export const useDeviceSelectionAnimation = ({
   return {
     RiveComponent,
     selectedDeviceCount: indexProperty?.value ?? 0,
+    setSelectedDeviceCount,
   }
 }

--- a/core/ui/vault/create/setup-vault/hooks/useDeviceSelectionAnimation.ts
+++ b/core/ui/vault/create/setup-vault/hooks/useDeviceSelectionAnimation.ts
@@ -6,7 +6,7 @@ import {
   useViewModelInstance,
   useViewModelInstanceNumber,
 } from '@rive-app/react-webgl2'
-import { useCallback, useEffect, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 
 import { deviceSelectionAnimationSource } from './deviceSelectionAnimationSource'
 
@@ -47,26 +47,23 @@ export const useDeviceSelectionAnimation = ({
 
   const indexProperty = useViewModelInstanceNumber('Index', viewModelInstance)
 
-  const setSelectedDeviceCount = useCallback(
-    (count: number) => {
-      if (indexProperty.value === null) return
+  const setSelectedDeviceCount = (count: number) => {
+    if (indexProperty.value === null) return
 
-      const selectedDeviceCount = Math.min(
-        Math.max(0, Math.round(count)),
-        maxDeviceSelectionIndex
-      )
+    const selectedDeviceCount = Math.min(
+      Math.max(0, Math.round(count)),
+      maxDeviceSelectionIndex
+    )
 
-      // `autoBind` owns the instance the state machine renders. Keep its
-      // property and the React observer in sync when the slider is dragged.
-      const boundIndexProperty = rive?.viewModelInstance?.number('Index')
-      if (boundIndexProperty) {
-        boundIndexProperty.value = selectedDeviceCount
-      }
+    // `autoBind` owns the instance the state machine renders. Keep its
+    // property and the React observer in sync when the slider is dragged.
+    const boundIndexProperty = rive?.viewModelInstance?.number('Index')
+    if (boundIndexProperty) {
+      boundIndexProperty.value = selectedDeviceCount
+    }
 
-      indexProperty.setValue(selectedDeviceCount)
-    },
-    [indexProperty, rive]
-  )
+    indexProperty.setValue(selectedDeviceCount)
+  }
 
   const didSeedRef = useRef(false)
 

--- a/core/ui/vite/staticCopy.ts
+++ b/core/ui/vite/staticCopy.ts
@@ -9,6 +9,7 @@ const publicFolderPath = path.resolve(dirname, '../public')
 
 const wasmPaths = [
   '@trustwallet/wallet-core/dist/lib/wallet-core.wasm',
+  '@rive-app/webgl2/rive.wasm',
   '7z-wasm/7zz.wasm',
   'zxing-wasm/dist/reader/zxing_reader.wasm',
 ]


### PR DESCRIPTION
Closes #4330
Screenshot proof: real Chrome extension interaction confirms the native Rive plus control selects two devices and dragging the Rive slider selects four-plus devices, with no console errors or external Rive WASM request.

![screenshot-1](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/4330-fix-rive-device-selection/screenshot-1-1783679619989.png)
![screenshot-2](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/4330-fix-rive-device-selection/screenshot-2-1783679619989.png)
![screenshot-3](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/4330-fix-rive-device-selection/screenshot-3-1783679619989.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive device-count selection for vault setup using the Rive slider.
  * Users can select vault configurations by clicking controls or dragging the slider.
  * Added support for selecting 2-device and 4+ device vault options.

* **Bug Fixes**
  * Improved Rive animation initialization and state synchronization across desktop and extension experiences.
  * Ensured required animation resources load correctly during application startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->