### PR TITLE
feat(extension): add GemWallet-compatible provider for XRPL dApps (#4087)

### DIFF
--- a/clients/extension/index.d.ts
+++ b/clients/extension/index.d.ts
@@ -20,6 +20,7 @@ interface Window {
   getOfflineSignerAuto: any
   station: any
   terra: any
+  gemWallet?: boolean
   isTerraExtensionAvailable?: boolean
   isStationExtensionAvailable?: boolean
   terraWallets?: Array<{ name: string; identifier: string; icon: string }>

--- a/clients/extension/package.json
+++ b/clients/extension/package.json
@@ -80,6 +80,7 @@
     "@core/ui": "workspace:^",
     "@fontsource/montserrat": "^5.2.8",
     "@fontsource/roboto-mono": "^5.2.9",
+    "@gemwallet/api": "^3.8.0",
     "@keplr-wallet/types": "^0.13.38",
     "@lib/ui": "workspace:^",
     "@playwright/test": "^1.60.0",

--- a/clients/extension/src/inpage/providers/gemWallet/handlers.ts
+++ b/clients/extension/src/inpage/providers/gemWallet/handlers.ts
@@ -1,0 +1,50 @@
+import { OtherChain } from '@vultisig/core-chain/Chain'
+
+import { requestAccount } from '../core/requestAccount'
+import { GemWalletRequestType, GemWalletResponseBody } from './protocol'
+
+/**
+ * We only ever derive XRPL mainnet accounts, so the network answer is constant.
+ * `websocket` is the public mainnet cluster the SDK's own constants point at —
+ * dApps read it back to open their own `xrpl.js` client.
+ */
+const xrplMainnet = {
+  chain: 'XRPL',
+  network: 'Mainnet',
+  websocket: 'wss://xrplcluster.com',
+}
+
+const getRippleAccount = () => requestAccount(OtherChain.Ripple)
+
+/**
+ * Resolvers for the GemWallet request types this bridge implements.
+ *
+ * `getAddress` and `getPublicKey` go through `requestAccount`, so an
+ * unauthorized origin gets the standard grant-access popup and no address
+ * leaves the wallet until the user approves. `isInstalled` and `getNetwork`
+ * expose nothing vault-specific and answer without a prompt.
+ */
+export const gemWalletHandlers: Record<
+  GemWalletRequestType,
+  () => Promise<GemWalletResponseBody>
+> = {
+  'REQUEST_IS_INSTALLED/V3': async () => ({
+    // The shipped SDK reads a flat `isInstalled`, while its published types
+    // declare it nested under `result`. Answer both so either reader is happy.
+    isInstalled: true,
+    result: { isInstalled: true },
+  }),
+  'REQUEST_GET_ADDRESS/V3': async () => {
+    const { address } = await getRippleAccount()
+
+    return { result: { address } }
+  },
+  'REQUEST_GET_PUBLIC_KEY/V3': async () => {
+    const { address, publicKey } = await getRippleAccount()
+
+    // XRPL tooling emits account public keys as uppercase hex, and dApps feed
+    // this straight back into `xrpl.js`.
+    return { result: { address, publicKey: publicKey.toUpperCase() } }
+  },
+  'REQUEST_GET_NETWORK/V3': async () => ({ result: xrplMainnet }),
+}

--- a/clients/extension/src/inpage/providers/gemWallet/index.ts
+++ b/clients/extension/src/inpage/providers/gemWallet/index.ts
@@ -1,0 +1,83 @@
+import { attempt } from '@vultisig/lib-utils/attempt'
+
+import { EIP1193Error } from '../../../background/handlers/errorHandler'
+import { gemWalletHandlers } from './handlers'
+import {
+  buildGemWalletResponse,
+  GemWalletResponseBody,
+  isGemWalletRequestType,
+  parseGemWalletRequest,
+} from './protocol'
+
+const userRejectedCode = new EIP1193Error('UserRejectedRequest').code
+
+/**
+ * The SDK turns a result-less response into `{ type: 'reject' }` and a
+ * serialized error into a thrown `Error`. dApps branch on the former when the
+ * user declines, so a rejection must not reach them as a throw.
+ */
+const toErrorBody = (error: unknown): GemWalletResponseBody => {
+  if (error instanceof EIP1193Error && error.code === userRejectedCode) {
+    return { result: undefined }
+  }
+
+  const { name, message, stack } =
+    error instanceof Error ? error : new Error(String(error))
+
+  return { error: { name, message, stack } }
+}
+
+const resolveGemWalletRequest = async (
+  type: string
+): Promise<GemWalletResponseBody> => {
+  if (!isGemWalletRequestType(type)) {
+    // Answer rather than stay silent. Only `isInstalled` has a timeout on the
+    // SDK side, so ignoring anything else leaves the dApp's promise pending
+    // forever — an explicit refusal at least lets it surface a failure.
+    return toErrorBody(
+      new EIP1193Error(
+        'UnsupportedMethod',
+        `GemWallet method ${type} is not supported`
+      )
+    )
+  }
+
+  const result = await attempt(gemWalletHandlers[type]())
+  if ('error' in result) return toErrorBody(result.error)
+
+  return result.data
+}
+
+/**
+ * Installs the GemWallet-compatible `postMessage` bridge, making XRPL dApps
+ * built on `@gemwallet/api` able to detect this wallet and read the active
+ * vault's XRP account.
+ *
+ * GemWallet is an injected protocol rather than an object API, so — like the
+ * Keplr proxy — it installs as a window listener instead of going through
+ * `createProviders`. Setting `window.gemWallet` is what the SDK's
+ * `isInstalled()` probes first, and it also gates its own request path: every
+ * other method rejects locally with "GemWallet needs to be installed" unless
+ * the flag is set, so detection is a prerequisite for connecting, not just a
+ * nicety.
+ */
+export const installGemWalletBridge = () => {
+  window.gemWallet = true
+
+  window.addEventListener('message', async (event: MessageEvent) => {
+    // Same-window only. A message from an embedded frame arrives with that
+    // frame's window as `source`, and must not be able to request the top
+    // frame's account.
+    if (event.source !== window) return
+
+    const request = parseGemWalletRequest(event.data)
+    if (!request) return
+
+    const body = await resolveGemWalletRequest(request.type)
+
+    window.postMessage(
+      buildGemWalletResponse(request.messageId, body),
+      window.location.origin
+    )
+  })
+}

--- a/clients/extension/src/inpage/providers/gemWallet/protocol.ts
+++ b/clients/extension/src/inpage/providers/gemWallet/protocol.ts
@@ -1,0 +1,107 @@
+/**
+ * Wire format spoken by the `@gemwallet/api` SDK.
+ *
+ * XRPL dApps reach GemWallet through that SDK, which talks to the wallet over a
+ * bespoke `window.postMessage` protocol rather than an injected object API. The
+ * envelopes below are therefore a hard contract: they are reproduced from the
+ * shipped SDK, and anything that drifts from them makes us undetectable.
+ */
+
+/** `app` tag the SDK stamps on every request it emits. */
+export const gemWalletApp = 'gem-wallet'
+
+/** `source` tag on dApp → wallet messages. */
+export const gemWalletRequestSource = 'GEM_WALLET_MSG_REQUEST'
+
+/** `source` tag on wallet → dApp messages. */
+export const gemWalletResponseSource = 'GEM_WALLET_MSG_RESPONSE'
+
+/**
+ * Request types this bridge answers: detection and account reads only. Signing
+ * is deliberately absent — see `resolveGemWalletRequest` for how the rest are
+ * turned away.
+ */
+export const gemWalletRequestTypes = [
+  'REQUEST_IS_INSTALLED/V3',
+  'REQUEST_GET_ADDRESS/V3',
+  'REQUEST_GET_PUBLIC_KEY/V3',
+  'REQUEST_GET_NETWORK/V3',
+] as const
+
+export type GemWalletRequestType = (typeof gemWalletRequestTypes)[number]
+
+/** A `GEM_WALLET_MSG_REQUEST` envelope, narrowed to the fields we act on. */
+type GemWalletRequest = {
+  messageId: number
+  type: string
+}
+
+/** Error shape the SDK hands to `deserializeError` and rethrows to the dApp. */
+export type GemWalletSerializedError = {
+  name: string
+  message: string
+  stack?: string
+}
+
+/**
+ * Body merged into the response envelope. `result: undefined` is not a no-op:
+ * the SDK maps a result-less response to `{ type: 'reject' }`, which is the
+ * branch dApps take when the user declines.
+ */
+export type GemWalletResponseBody =
+  | { isInstalled: true; result: { isInstalled: true } }
+  | { result: { address: string } }
+  | { result: { address: string; publicKey: string } }
+  | { result: { chain: string; network: string; websocket: string } }
+  | { result: undefined }
+  | { error: GemWalletSerializedError }
+
+const supportedRequestTypes: readonly string[] = gemWalletRequestTypes
+
+/** Narrows a raw `type` string to a request type this bridge implements. */
+export const isGemWalletRequestType = (
+  type: string
+): type is GemWalletRequestType => supportedRequestTypes.includes(type)
+
+/**
+ * Validates an inbound `message` payload as a GemWallet request, returning
+ * `null` for anything else on the page — including our own responses, which
+ * land back on this same listener.
+ */
+export const parseGemWalletRequest = (
+  data: unknown
+): GemWalletRequest | null => {
+  if (typeof data !== 'object' || data === null) return null
+  if (
+    !(
+      'source' in data &&
+      'app' in data &&
+      'messageId' in data &&
+      'type' in data
+    )
+  )
+    return null
+
+  const { source, app, messageId, type } = data
+
+  if (source !== gemWalletRequestSource || app !== gemWalletApp) return null
+  if (typeof messageId !== 'number' || typeof type !== 'string') return null
+
+  return { messageId, type }
+}
+
+/**
+ * Builds the response envelope.
+ *
+ * The correlation key really is `messagedId`. It is a typo baked into the
+ * SDK's own wire format (it posts `messageId` and filters replies on
+ * `messagedId`), so spelling it correctly here would strand every request.
+ */
+export const buildGemWalletResponse = (
+  messageId: number,
+  body: GemWalletResponseBody
+) => ({
+  source: gemWalletResponseSource,
+  messagedId: messageId,
+  ...body,
+})

--- a/clients/extension/src/inpage/utils/windowInjector.ts
+++ b/clients/extension/src/inpage/utils/windowInjector.ts
@@ -9,6 +9,7 @@ import { announceProvider, EIP1193Provider } from 'mipd'
 import { v4 as uuidv4 } from 'uuid'
 
 import { currentExtensionBrandConfig } from '../../brand/extensionBrandConfig'
+import { installGemWalletBridge } from '../providers/gemWallet'
 import { installKeplrProxyBridge } from '../providers/keplrProxyBridge'
 import { Solana } from '../providers/solana'
 import { registerWallet } from '../providers/solana/register'
@@ -196,6 +197,15 @@ export const injectToWindow = () => {
   // `window.station` is present.
   attempt(() => pushToWalletArray('terraWallets'))
   attempt(() => pushToWalletArray('interchainWallets'))
+
+  // GemWallet is the injectable API XRPL dApps integrate against. Like Keplr
+  // above, it must be synchronous: dApps snapshot the installed wallets on
+  // first render, so deferring behind the async background round-trip below
+  // would hide us from the picker. The guard defers to a real GemWallet that
+  // already claimed the page.
+  if (!window.gemWallet) {
+    attempt(() => installGemWalletBridge())
+  }
 
   setupContentScriptMessenger(providers)
 }

--- a/clients/extension/tests/unit/gemWallet-provider.test.ts
+++ b/clients/extension/tests/unit/gemWallet-provider.test.ts
@@ -1,0 +1,203 @@
+// @vitest-environment happy-dom
+
+/**
+ * Protocol contract for the GemWallet-compatible bridge.
+ *
+ * These tests drive the real `@gemwallet/api` SDK — the same package XRPL dApps
+ * import — against our injected bridge, so any drift in the wire format (the
+ * `messagedId` correlation key, the response envelope, the reject shape) fails
+ * here rather than silently making us undetectable.
+ */
+import { EIP1193Error } from '@clients/extension/src/background/handlers/errorHandler'
+import { installGemWalletBridge } from '@clients/extension/src/inpage/providers/gemWallet'
+import {
+  gemWalletApp,
+  gemWalletRequestSource,
+  gemWalletResponseSource,
+} from '@clients/extension/src/inpage/providers/gemWallet/protocol'
+import {
+  getAddress,
+  getNetwork,
+  getPublicKey,
+  isInstalled,
+} from '@gemwallet/api'
+import { OtherChain } from '@vultisig/core-chain/Chain'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockRequestAccount = vi.fn()
+
+vi.mock('@clients/extension/src/inpage/providers/core/requestAccount', () => ({
+  requestAccount: (...args: unknown[]) => mockRequestAccount(...args),
+}))
+
+const address = 'rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH'
+const publicKey =
+  '0330e7fc9d56bb25d6893ba3f317ae5bcf33b3291bd63db32654a313222f7fd020'
+
+/**
+ * happy-dom delivers `postMessage` with a `source` of its own and on its own
+ * schedule. Both details are load-bearing here:
+ *
+ * - `source` must be the posting window, because the SDK (and our bridge) drop
+ *   any message that fails that same-window check.
+ * - delivery must be asynchronous, because the SDK posts its request *before*
+ *   registering the listener that awaits the reply. A synchronous dispatch
+ *   would answer into the void and every call would hang.
+ *
+ * Re-dispatching this way is what a real browser does, so the round-trip under
+ * test is the real one.
+ */
+const installBrowserFaithfulPostMessage = () => {
+  vi.spyOn(window, 'postMessage').mockImplementation((message: unknown) => {
+    setTimeout(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: message,
+          origin: window.location.origin,
+          source: window,
+        })
+      )
+    }, 0)
+  })
+}
+
+/** Posts a raw envelope the way the SDK does, for types it has no helper for. */
+const sendRawRequest = (type: string) =>
+  new Promise<Record<string, unknown>>(resolve => {
+    const messageId = Date.now() + Math.random()
+
+    window.addEventListener('message', function listener(event: MessageEvent) {
+      if (event.data?.source !== gemWalletResponseSource) return
+      if (event.data?.messagedId !== messageId) return
+
+      window.removeEventListener('message', listener)
+      resolve(event.data)
+    })
+
+    window.postMessage(
+      { source: gemWalletRequestSource, messageId, app: gemWalletApp, type },
+      window.location.origin
+    )
+  })
+
+describe('GemWallet-compatible provider', () => {
+  beforeAll(() => {
+    installBrowserFaithfulPostMessage()
+    installGemWalletBridge()
+  })
+
+  beforeEach(() => {
+    mockRequestAccount.mockReset()
+    mockRequestAccount.mockResolvedValue({ address, publicKey })
+    window.gemWallet = true
+  })
+
+  describe('detection', () => {
+    it('is detected through the window flag the SDK probes first', async () => {
+      await expect(isInstalled()).resolves.toEqual({
+        result: { isInstalled: true },
+      })
+    })
+
+    it('is detected over the message protocol when the flag is absent', async () => {
+      // The flag short-circuits `isInstalled()`, so drop it to force the SDK
+      // down its postMessage path — the one that actually pins the envelope.
+      delete window.gemWallet
+
+      await expect(isInstalled()).resolves.toEqual({
+        result: { isInstalled: true },
+      })
+    })
+  })
+
+  describe('connect', () => {
+    it('getAddress returns the vault XRP address after authorization', async () => {
+      await expect(getAddress()).resolves.toEqual({
+        type: 'response',
+        result: { address },
+      })
+
+      expect(mockRequestAccount).toHaveBeenCalledWith(OtherChain.Ripple)
+    })
+
+    it('getPublicKey returns the address and uppercase public key', async () => {
+      await expect(getPublicKey()).resolves.toEqual({
+        type: 'response',
+        result: { address, publicKey: publicKey.toUpperCase() },
+      })
+    })
+
+    it('getNetwork returns the XRPL mainnet descriptor without prompting', async () => {
+      await expect(getNetwork()).resolves.toEqual({
+        type: 'response',
+        result: {
+          chain: 'XRPL',
+          network: 'Mainnet',
+          websocket: 'wss://xrplcluster.com',
+        },
+      })
+
+      expect(mockRequestAccount).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('failures', () => {
+    it('reports a declined grant as a reject, not a throw', async () => {
+      mockRequestAccount.mockRejectedValue(
+        new EIP1193Error('UserRejectedRequest')
+      )
+
+      await expect(getAddress()).resolves.toEqual({
+        type: 'reject',
+        result: undefined,
+      })
+    })
+
+    it('surfaces a genuine failure as a thrown error', async () => {
+      mockRequestAccount.mockRejectedValue(new Error('vault is locked'))
+
+      await expect(getAddress()).rejects.toThrow('vault is locked')
+    })
+
+    it('answers unsupported methods instead of hanging the dApp', async () => {
+      const response = await sendRawRequest('REQUEST_SIGN_TRANSACTION/V3')
+
+      expect(response.error).toMatchObject({
+        message: expect.stringContaining('not supported'),
+      })
+    })
+
+    it('ignores messages that are not GemWallet requests', async () => {
+      const responses: unknown[] = []
+      window.addEventListener('message', (event: MessageEvent) => {
+        if (event.data?.source === gemWalletResponseSource)
+          responses.push(event.data)
+      })
+
+      window.postMessage({ source: 'SOME_OTHER_WALLET' }, '*')
+      await new Promise(resolve => setTimeout(resolve, 20))
+
+      expect(responses).toHaveLength(0)
+    })
+  })
+
+  it('correlates concurrent requests by message id', async () => {
+    // Resolve the address slowly so its reply lands after getNetwork's. If the
+    // bridge dropped the id correlation, the SDK would hand the network payload
+    // to the address caller.
+    mockRequestAccount.mockImplementation(
+      () =>
+        new Promise(resolve =>
+          setTimeout(() => resolve({ address, publicKey }), 30)
+        )
+    )
+
+    const [addressResponse, networkResponse] = await Promise.all([
+      getAddress(),
+      getNetwork(),
+    ])
+
+    expect(addressResponse.result).toEqual({ address })
+    expect(networkResponse.result).toMatchObject({ chain: 'XRPL' })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -757,6 +757,7 @@ __metadata:
     "@cosmjs/stargate": "npm:^0.39.0"
     "@fontsource/montserrat": "npm:^5.2.8"
     "@fontsource/roboto-mono": "npm:^5.2.9"
+    "@gemwallet/api": "npm:^3.8.0"
     "@hookform/resolvers": "npm:^5.4.0"
     "@keplr-wallet/provider": "npm:^0.13.38"
     "@keplr-wallet/types": "npm:^0.13.38"
@@ -2198,6 +2199,13 @@ __metadata:
   dependencies:
     "@formatjs/fast-memoize": "npm:3.1.6"
   checksum: 10c0/4c84b70c48ddd47c86087666b8dd7524f263cbbe8825341745db2416441907b6354509f3439a08f373f374442c8abc1e1d53662c2a6d8ef7a5e7385be10e1619
+  languageName: node
+  linkType: hard
+
+"@gemwallet/api@npm:^3.8.0":
+  version: 3.8.0
+  resolution: "@gemwallet/api@npm:3.8.0"
+  checksum: 10c0/4aaceeb1cd7433283e21e617f424a36d802865e90ce734ce9f27a03855bc33d93d7b8041eb3716884164d9c3dab5390b9f56a690ef1fc2f8bba87d63508caff8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #4087

## Problem

XRPL dApps reach wallets through the GemWallet SDK (`@gemwallet/api`), which talks to the wallet over a bespoke `window.postMessage` protocol rather than an injected object API. We inject `window.vultisig.ripple`, which that SDK cannot see — so we were invisible to this part of the ecosystem.

## Solution

A GemWallet-compatible bridge covering the detection and connect surface.

**Detection** works two ways, because the SDK uses both:
- `window.gemWallet = true` — the flag `isInstalled()` probes first. This is a **prerequisite for connecting**, not just a detection nicety: every other SDK method self-rejects locally with *"GemWallet needs to be installed"* unless the flag is set.
- A `postMessage` listener answering `REQUEST_IS_INSTALLED/V3` — the fallback probe, which has a 1s timeout on the SDK side.

Injection is synchronous, alongside Keplr/Station: dApps snapshot installed wallets on first render, so deferring behind the async background round-trip would hide us from the picker.

**Connect** — `getAddress()`, `getPublicKey()`, and `getNetwork()` round-trip. Authorization is unchanged: the first two ride the existing `requestAccount` rail, so an unauthorized origin still gets the normal grant-access popup and no address leaves the wallet until the user approves. `getNetwork()` exposes nothing vault-specific and answers without a prompt.

The SDK sends a page-supplied `payload: { url, title, favicon }`. We deliberately ignore it — the background derives the real origin from the message sender, which a page cannot spoof.

## The `messagedId` quirk

The SDK posts requests carrying `messageId` but filters replies on **`messagedId`** — a typo baked into its own wire format. Responses reproduce it verbatim; spelling it correctly would strand every request forever. It's commented in the source so it doesn't get "fixed" later.

## Scope

Signing, submission, payments, trustlines, message signing, and event emission (`networkChanged` / `walletChanged` / `logout`) are all out of scope per the issue. Unsupported request types get an **explicit refusal** rather than silence: the SDK has no timeout on anything but `isInstalled`, so staying quiet would leave the dApp's promise pending forever.

Existing `window.vultisig.ripple` behavior and every other provider are untouched.

## Testing

`yarn check:all` passes (0 errors; 331 + 477 + 20 tests).

The contract test drives the **real `@gemwallet/api` package** — the same one dApps import — rather than a hand-rolled mock, so protocol drift fails here instead of silently making us undetectable. It's a devDependency with zero transitive deps and is never bundled into the extension.

Two fidelity details were load-bearing, and without them the test would have been silently vacuous: the SDK posts its request *before* registering the reply listener (so delivery must be async, as in a real browser), and happy-dom doesn't set `event.source` (which both the SDK and our bridge hard-filter on). Both are shimmed to real browser semantics.

I verified the suite isn't vacuous by mutation: correcting the `messagedId` typo fails 8 of 10 tests. The 2 survivors are exactly the cases that don't cross the wire — the `window.gemWallet` short-circuit and the "ignore foreign messages" case.

Also confirmed the bridge survives minification into the shipped `dist/inpage.js`.

**Not verified end-to-end:** the real-browser round-trip against a live dApp, which needs the built extension loaded in Chrome with a vault holding XRP. Worth a manual pass on the `getAddress` grant-access flow before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GemWallet compatibility for XRPL dApps.
  * dApps can detect the wallet and request XRP addresses, public keys, and network details.
  * Added support for authorization prompts and clear responses for declined or unsupported requests.
  * Added concurrent request handling to ensure responses are matched correctly.

* **Bug Fixes**
  * Prevented unrelated messages from being processed by the wallet bridge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->