### PR TITLE
feat(defi): Send for sRUJI staking receipt + fix RUJI staked amount

### DIFF
--- a/core/ui/defi/chain/config/stakeUiResolver.test.ts
+++ b/core/ui/defi/chain/config/stakeUiResolver.test.ts
@@ -1,0 +1,42 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { describe, expect, it } from 'vitest'
+
+import { resolveTransferableStakeToken } from './stakeUiResolver'
+
+describe('resolveTransferableStakeToken', () => {
+  it('sends the sRUJI receipt (not liquid RUJI) for the RUJI stake position', () => {
+    const coin = resolveTransferableStakeToken(
+      Chain.THORChain,
+      'thor-stake-ruji'
+    )
+
+    expect(coin?.ticker).toBe('sRUJI')
+    expect(coin?.id).toBe('x/staking-x/ruji')
+    expect(coin?.chain).toBe(Chain.THORChain)
+  })
+
+  it('sends the sTCY receipt for the sTCY stake position', () => {
+    const coin = resolveTransferableStakeToken(
+      Chain.THORChain,
+      'thor-stake-stcy'
+    )
+
+    expect(coin?.ticker).toBe('sTCY')
+    expect(coin?.id).toBe('x/staking-tcy')
+  })
+
+  it('returns undefined for non-transferable positions', () => {
+    expect(
+      resolveTransferableStakeToken(Chain.THORChain, 'thor-bond-rune')
+    ).toBeUndefined()
+    expect(
+      resolveTransferableStakeToken(Chain.THORChain, 'thor-stake-rune')
+    ).toBeUndefined()
+  })
+
+  it('returns undefined for chains with no transferable stake tokens', () => {
+    expect(
+      resolveTransferableStakeToken(Chain.MayaChain, 'maya-stake-cacao')
+    ).toBeUndefined()
+  })
+})

--- a/core/ui/defi/chain/config/stakeUiResolver.ts
+++ b/core/ui/defi/chain/config/stakeUiResolver.ts
@@ -79,6 +79,33 @@ export const resolveStakeToken = (chain: Chain, positionId: string) => {
   return { ...chainFeeCoin[chain], chain }
 }
 
+/**
+ * DeFi staking positions whose on-chain receipt is a transferable bank denom,
+ * mapped to the coin that should actually be sent. This is intentionally the
+ * receipt token the vault holds (e.g. `sRUJI` / `x/staking-x/ruji`), not the
+ * liquid asset used for stake/unstake (`resolveStakeToken` returns the latter).
+ *
+ * Positions absent from this list are treated as non-transferable (e.g. bonded
+ * RUNE), so they get no Send button. Add an entry here — the single source of
+ * truth — to enable Send for a new receipt token.
+ */
+const transferableStakeTokenById: Partial<Record<Chain, Record<string, Coin>>> =
+  {
+    [Chain.THORChain]: {
+      'thor-stake-stcy': thorchainTokens.stcy,
+      'thor-stake-ruji': thorchainTokens.sruji,
+    },
+  }
+
+/**
+ * Returns the coin to send for a transferable stake position, or `undefined`
+ * when the position's receipt is not transferable.
+ */
+export const resolveTransferableStakeToken = (
+  chain: Chain,
+  positionId: string
+): Coin | undefined => transferableStakeTokenById[chain]?.[positionId]
+
 export const resolveStakeActions = ({
   chain,
   position,

--- a/core/ui/defi/chain/queries/services/thorchainStake/rujiStakeService.ts
+++ b/core/ui/defi/chain/queries/services/thorchainStake/rujiStakeService.ts
@@ -1,5 +1,8 @@
+import { cosmosRpcUrl } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
 import { coinKeyToString } from '@vultisig/core-chain/coin/Coin'
 import { getCoinValue } from '@vultisig/core-chain/coin/utils/getCoinValue'
+import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
+import { attempt } from '@vultisig/lib-utils/attempt'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
 import { rujiStakeApiUrl } from '../../constants'
@@ -48,6 +51,25 @@ const getRujiStake = (address: string) => {
   })
 }
 
+const rujiReceiptDenom = shouldBePresent(
+  thorchainTokens.sruji.id,
+  'sRUJI receipt denom'
+)
+
+// On-chain sRUJI receipt balance — the amount the vault actually holds (and can
+// send), read the same way sTCY reads its receipt. This is deliberately kept
+// independent of the staking API's `bonded` field, which can report 0 even when
+// receipt tokens are held.
+const fetchRujiReceiptBalance = async (address: string): Promise<bigint> => {
+  const result = await attempt(() =>
+    queryUrl<{ balance?: { amount?: string } }>(
+      `${cosmosRpcUrl.THORChain}/cosmos/bank/v1beta1/balances/${address}/by_denom?denom=${encodeURIComponent(rujiReceiptDenom)}`
+    )
+  )
+
+  return 'data' in result ? parseBigint(result.data?.balance?.amount) : 0n
+}
+
 type FetchRujiStakePositionInput = {
   address: string
   prices: Record<string, number>
@@ -58,16 +80,22 @@ export const fetchRujiStakePosition = async ({
   prices,
 }: FetchRujiStakePositionInput): Promise<ThorchainStakePosition | null> => {
   try {
-    const response = await getRujiStake(address)
+    const [response, heldAmount] = await Promise.all([
+      getRujiStake(address),
+      fetchRujiReceiptBalance(address),
+    ])
     const stake = response?.data?.node?.stakingV2?.[0]
     const bondedAmount = parseBigint(stake?.bonded?.amount)
+    // Prefer the held receipt balance; fall back to the API's `bonded` amount
+    // only when nothing is held (e.g. the balance request failed).
+    const amount = heldAmount > 0n ? heldAmount : bondedAmount
     const rewardsAmount =
       parseNumber(stake?.pendingRevenue?.amount) / rujiDecimalFactor
     const aprValue = parseNumber(stake?.pool?.summary?.apr?.value)
     const price = prices[coinKeyToString(thorchainTokens.ruji)] ?? 0
 
     const fiatValue = getCoinValue({
-      amount: bondedAmount,
+      amount,
       decimals: thorchainTokens.ruji.decimals,
       price,
     })
@@ -75,9 +103,9 @@ export const fetchRujiStakePosition = async ({
     return {
       id: 'thor-stake-ruji',
       ticker: thorchainTokens.ruji.ticker,
-      amount: bondedAmount,
+      amount,
       type: 'stake',
-      canUnstake: bondedAmount > 0n,
+      canUnstake: amount > 0n,
       fiatValue,
       apr: aprValue * 100,
       rewards: rewardsAmount,

--- a/core/ui/defi/chain/queries/services/thorchainStake/rujiStakeService.ts
+++ b/core/ui/defi/chain/queries/services/thorchainStake/rujiStakeService.ts
@@ -59,15 +59,18 @@ const rujiReceiptDenom = shouldBePresent(
 // On-chain sRUJI receipt balance — the amount the vault actually holds (and can
 // send), read the same way sTCY reads its receipt. This is deliberately kept
 // independent of the staking API's `bonded` field, which can report 0 even when
-// receipt tokens are held.
-const fetchRujiReceiptBalance = async (address: string): Promise<bigint> => {
+// receipt tokens are held. Returns `null` when the request fails, so a genuine
+// zero balance stays distinct from an unknown one.
+const fetchRujiReceiptBalance = async (
+  address: string
+): Promise<bigint | null> => {
   const result = await attempt(() =>
     queryUrl<{ balance?: { amount?: string } }>(
       `${cosmosRpcUrl.THORChain}/cosmos/bank/v1beta1/balances/${address}/by_denom?denom=${encodeURIComponent(rujiReceiptDenom)}`
     )
   )
 
-  return 'data' in result ? parseBigint(result.data?.balance?.amount) : 0n
+  return 'data' in result ? parseBigint(result.data?.balance?.amount) : null
 }
 
 type FetchRujiStakePositionInput = {
@@ -86,9 +89,10 @@ export const fetchRujiStakePosition = async ({
     ])
     const stake = response?.data?.node?.stakingV2?.[0]
     const bondedAmount = parseBigint(stake?.bonded?.amount)
-    // Prefer the held receipt balance; fall back to the API's `bonded` amount
-    // only when nothing is held (e.g. the balance request failed).
-    const amount = heldAmount > 0n ? heldAmount : bondedAmount
+    // Prefer the on-chain receipt balance (source of truth for what the vault
+    // holds and can send); a successful zero stays zero. Fall back to the API's
+    // `bonded` amount only when the balance request failed (heldAmount is null).
+    const amount = heldAmount ?? bondedAmount
     const rewardsAmount =
       parseNumber(stake?.pendingRevenue?.amount) / rujiDecimalFactor
     const aprValue = parseNumber(stake?.pool?.summary?.apr?.value)

--- a/core/ui/defi/chain/queries/tokens.ts
+++ b/core/ui/defi/chain/queries/tokens.ts
@@ -27,6 +27,12 @@ export const thorchainTokens: Record<string, Coin> = {
     id: 'x/ruji',
     ticker: 'RUJI',
   },
+  sruji: {
+    ...knownCosmosTokens[Chain.THORChain]['x/staking-x/ruji'],
+    chain: Chain.THORChain,
+    id: 'x/staking-x/ruji',
+    ticker: 'sRUJI',
+  },
   yRune: {
     ...yieldBearingThorChainTokens[
       'x/nami-index-nav-thor1mlphkryw5g54yfkrp6xpqzlpv4f8wh6hyw27yyg4z2els8a9gxpqhfhekt-rcpt'

--- a/core/ui/defi/chain/tabs/StakedPositions.tsx
+++ b/core/ui/defi/chain/tabs/StakedPositions.tsx
@@ -22,6 +22,7 @@ import {
   resolveStakeActions,
   resolveStakeTitle,
   resolveStakeToken,
+  resolveTransferableStakeToken,
 } from '../config/stakeUiResolver'
 import { CosmosDelegationsView } from '../cosmos/CosmosDelegationsView'
 import { useDefiChainPositionsQuery } from '../queries/useDefiChainPositionsQuery'
@@ -279,17 +280,21 @@ const ThorchainStakedPositions = () => {
           navigateTo(position.id, action, false)
         }
 
+        const transferToken = resolveTransferableStakeToken(chain, position.id)
+        const canTransfer = transferToken !== undefined && position.amount > 0n
+
         const handleTransfer = async () => {
-          if (position.id === 'thor-stake-stcy') {
-            const stcyCoin = resolveStakeToken(chain, position.id)
-            if (!hasRequiredCoin && supportsAutoEnable) {
-              await autoEnableCoinIfNeeded(position.id, stcyCoin)
-            }
-            navigate({
-              id: 'send',
-              state: { coin: extractCoinKey(stcyCoin) },
-            })
+          if (!transferToken) return
+          const hasTransferCoin = vaultCoins.some(current =>
+            areEqualCoins(current, transferToken)
+          )
+          if (!hasTransferCoin && supportsAutoEnable) {
+            await autoEnableCoinIfNeeded(position.id, transferToken)
           }
+          navigate({
+            id: 'send',
+            state: { coin: extractCoinKey(transferToken) },
+          })
         }
 
         return (
@@ -326,9 +331,7 @@ const ThorchainStakedPositions = () => {
             infoUrl={
               position.id === 'thor-stake-stcy' ? stcyInfoUrl : undefined
             }
-            onTransfer={
-              position.id === 'thor-stake-stcy' ? handleTransfer : undefined
-            }
+            onTransfer={canTransfer ? handleTransfer : undefined}
           />
         )
       })}


### PR DESCRIPTION
## What & why
Resolves #4329. Rather than adding the `sRUJI` receipt to the wallet token list (which would break the intentional DeFi/wallet separation and parity with Android), this adds a **Send** action to the DeFi staking card for transferable receipts, and fixes the RUJI staked amount so the receipt balance is actually reflected.

## Changes
- **Send on DeFi staking cards** — `sTCY`/`sRUJI` now expose a Send/Transfer button, driven by an explicit `resolveTransferableStakeToken` allowlist instead of the previous hardcoded `thor-stake-stcy` check. New receipts opt in with a single entry.
- **Send the receipt coin** — the button sends the actual receipt (`sRUJI` = `x/staking-x/ruji`), not the liquid `RUJI` used for stake/unstake.
- **Fix RUJI staked amount** — read the on-chain `x/staking-x/ruji` balance directly (like sTCY) and prefer it over the Rujira staking API's `bonded` field, which can report `0` even when receipts are held. This makes the Staked RUJI card show the real balance and the Send button appear.

## Notes
- The `sRUJI` receipt stays hidden from the wallet token list (unchanged), consistent with Android; only its Send path is added under DeFi.
- Follow-ups found while implementing: DeFi error-state styling (#4335) and the iOS equivalent of the staked-amount bug (vultisig/vultisig-ios#4794).

## Testing
- `yarn typecheck` + `yarn lint` clean; unit tests for `resolveTransferableStakeToken` pass (4/4).
- Built the extension and verified the change is bundled in DeFi → THORChain → Staked.

Closes #4329

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for transferring eligible THORChain staking receipt tokens, including sRUJI and sTCY.
  - Transfer actions now dynamically select and enable the correct receipt token when available.
- **Bug Fixes**
  - Updated RUJI staking balances, fiat values, and unstaking availability to reflect on-chain receipt token holdings when present (with safe fallback).
- **Tests**
  - Added coverage for transferable-stake token resolution, including non-transferable positions and non-supported cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->