### PR TITLE
fix(defi): styled error state with retry for position tabs

### DIFF
--- a/core/ui/defi/chain/tabs/BondedPositions.tsx
+++ b/core/ui/defi/chain/tabs/BondedPositions.tsx
@@ -7,7 +7,6 @@ import { Button } from '@lib/ui/buttons/Button'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
 import { ArrowUpRightIcon } from '@lib/ui/icons/ArrowUpRightIcon'
 import { ChevronDownIcon } from '@lib/ui/icons/ChevronDownIcon'
-import { CenterAbsolutely } from '@lib/ui/layout/CenterAbsolutely'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Skeleton } from '@lib/ui/loaders/Skeleton'
 import { Text } from '@lib/ui/text'
@@ -16,7 +15,6 @@ import { Chain } from '@vultisig/core-chain/Chain'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { extractCoinKey } from '@vultisig/core-chain/coin/Coin'
 import { sum } from '@vultisig/lib-utils/array/sum'
-import { extractErrorMsg } from '@vultisig/lib-utils/error/extractErrorMsg'
 import { AnimatePresence, motion } from 'framer-motion'
 import { ReactNode, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -27,6 +25,7 @@ import { BondNodeItem } from '../components/bond/BondNodeItem'
 import { useDefiChainPositionsQuery } from '../queries/useDefiChainPositionsQuery'
 import { useCurrentDefiChain } from '../useCurrentDefiChain'
 import { DefiPositionEmptyState } from './DefiPositionEmptyState'
+import { DefiPositionErrorState } from './DefiPositionErrorState'
 
 const collapsibleTransition = {
   duration: 0.35,
@@ -98,7 +97,7 @@ const Collapsible = ({ isOpen, children }: CollapsibleProps) => (
 export const BondedPositions = () => {
   const chain = useCurrentDefiChain()
   const selectedPositions = useDefiPositions(chain)
-  const { data, isPending, error } = useDefiChainPositionsQuery(chain)
+  const { data, isPending, error, refetch } = useDefiChainPositionsQuery(chain)
   const navigate = useCoreNavigate()
   const { t } = useTranslation()
   const [activeNodesOpen, setActiveNodesOpen] = useState(true)
@@ -123,11 +122,7 @@ export const BondedPositions = () => {
   }
 
   if (error) {
-    return (
-      <CenterAbsolutely>
-        <Text color="danger">{extractErrorMsg(error)}</Text>
-      </CenterAbsolutely>
-    )
+    return <DefiPositionErrorState onRetry={refetch} />
   }
 
   if (
@@ -136,11 +131,7 @@ export const BondedPositions = () => {
     !data?.bond &&
     selectedPositions.length > 0
   ) {
-    return (
-      <CenterAbsolutely>
-        <Text color="danger">{t('failed_to_load')}</Text>
-      </CenterAbsolutely>
-    )
+    return <DefiPositionErrorState onRetry={refetch} />
   }
 
   if (selectedPositions.length === 0) {

--- a/core/ui/defi/chain/tabs/DefiPositionErrorState.stories.tsx
+++ b/core/ui/defi/chain/tabs/DefiPositionErrorState.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { DefiPositionErrorState } from './DefiPositionErrorState'
+
+const meta = {
+  title: 'DeFi/DefiPositionErrorState',
+} satisfies Meta
+
+export default meta
+type Story = StoryObj
+
+const Frame = ({ onRetry }: { onRetry: () => Promise<unknown> }) => (
+  <div style={{ width: 380 }}>
+    <DefiPositionErrorState onRetry={onRetry} />
+  </div>
+)
+
+export const Default: Story = {
+  render: () => <Frame onRetry={async () => {}} />,
+}
+
+// Retry resolves after a delay so the button's loading spinner is visible.
+export const SlowRetry: Story = {
+  render: () => (
+    <Frame onRetry={() => new Promise(resolve => setTimeout(resolve, 2000))} />
+  ),
+}

--- a/core/ui/defi/chain/tabs/DefiPositionErrorState.tsx
+++ b/core/ui/defi/chain/tabs/DefiPositionErrorState.tsx
@@ -1,0 +1,66 @@
+import { Button } from '@lib/ui/buttons/Button'
+import { IconWrapper } from '@lib/ui/icons/IconWrapper'
+import { TriangleAlertIcon } from '@lib/ui/icons/TriangleAlertIcon'
+import { VStack } from '@lib/ui/layout/Stack'
+import { Text } from '@lib/ui/text'
+import { getColor } from '@lib/ui/theme/getters'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+
+type DefiPositionErrorStateProps = {
+  onRetry: () => Promise<unknown>
+}
+
+/**
+ * Styled error state for the DeFi position tabs (Bonded / Staked / LPs). Shows a
+ * friendly message and a Retry button instead of dumping the raw error string
+ * (which previously leaked the failing endpoint URL into the UI).
+ */
+export const DefiPositionErrorState = ({
+  onRetry,
+}: DefiPositionErrorStateProps) => {
+  const { t } = useTranslation()
+  const [isRetrying, setIsRetrying] = useState(false)
+
+  const handleRetry = async () => {
+    setIsRetrying(true)
+    try {
+      await onRetry()
+    } finally {
+      setIsRetrying(false)
+    }
+  }
+
+  return (
+    <ErrorWrapper>
+      <VStack gap={12} alignItems="center">
+        <IconWrapper size={24} color="danger">
+          <TriangleAlertIcon />
+        </IconWrapper>
+        <Text centerHorizontally size={17} weight="600">
+          {t('failed_to_load')}
+        </Text>
+      </VStack>
+      <CtaWrapper>
+        <Button loading={isRetrying} onClick={handleRetry}>
+          {t('retry')}
+        </Button>
+      </CtaWrapper>
+    </ErrorWrapper>
+  )
+}
+
+const ErrorWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  padding: 40px 20px;
+  background-color: ${getColor('foreground')};
+  border-radius: 12px;
+`
+
+const CtaWrapper = styled.div`
+  width: fit-content;
+`

--- a/core/ui/defi/chain/tabs/LpPositions.tsx
+++ b/core/ui/defi/chain/tabs/LpPositions.tsx
@@ -29,6 +29,7 @@ import { useMayaLpPositionsQuery } from '../queries/useMayaLpPositionsQuery'
 import { useThorchainLpPositionsQuery } from '../queries/useThorchainLpPositionsQuery'
 import { useCurrentDefiChain } from '../useCurrentDefiChain'
 import { DefiPositionEmptyState } from './DefiPositionEmptyState'
+import { DefiPositionErrorState } from './DefiPositionErrorState'
 
 const Card = styled(Panel)`
   padding: 20px;
@@ -265,6 +266,10 @@ export const LpPositions = () => {
 
   if (selectedPositions.length === 0) {
     return <DefiPositionEmptyState returnTab="lps" />
+  }
+
+  if (lpQuery.error) {
+    return <DefiPositionErrorState onRetry={lpQuery.refetch} />
   }
 
   const lpDataMap = new Map((lpQuery.data ?? []).map(d => [d.position.id, d]))

--- a/core/ui/defi/chain/tabs/StakedPositions.tsx
+++ b/core/ui/defi/chain/tabs/StakedPositions.tsx
@@ -4,14 +4,11 @@ import { useRemoveFromCoinFinderIgnoreMutation } from '@core/ui/storage/coinFind
 import { useCreateCoinMutation } from '@core/ui/storage/coins'
 import { useDefiPositions } from '@core/ui/storage/defiPositions'
 import { useCurrentVaultCoins } from '@core/ui/vault/state/currentVaultCoins'
-import { CenterAbsolutely } from '@lib/ui/layout/CenterAbsolutely'
 import { VStack } from '@lib/ui/layout/Stack'
 import { Spinner } from '@lib/ui/loaders/Spinner'
-import { Text } from '@lib/ui/text'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { StakingChain } from '@vultisig/core-chain/chains/cosmos/staking/lcdQueries'
 import { areEqualCoins, extractCoinKey } from '@vultisig/core-chain/coin/Coin'
-import { extractErrorMsg } from '@vultisig/lib-utils/error/extractErrorMsg'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -28,6 +25,7 @@ import { useDefiChainPositionsQuery } from '../queries/useDefiChainPositionsQuer
 import { SolanaStakeDefiView } from '../solana/SolanaStakeDefiView'
 import { useCurrentDefiChain } from '../useCurrentDefiChain'
 import { DefiPositionEmptyState } from './DefiPositionEmptyState'
+import { DefiPositionErrorState } from './DefiPositionErrorState'
 
 const stcyInfoUrl =
   'https://docs.rujira.network/ecosystem-products/tcy-autocompounder'
@@ -113,7 +111,7 @@ export const StakedPositions = () => {
 const ThorchainStakedPositions = () => {
   const chain = useCurrentDefiChain()
   const selectedPositions = useDefiPositions(chain)
-  const { data, isPending, error } = useDefiChainPositionsQuery(chain)
+  const { data, isPending, error, refetch } = useDefiChainPositionsQuery(chain)
   const navigate = useCoreNavigate()
   const vaultCoins = useCurrentVaultCoins()
   const createCoin = useCreateCoinMutation()
@@ -138,19 +136,11 @@ const ThorchainStakedPositions = () => {
   )
 
   if (error) {
-    return (
-      <CenterAbsolutely>
-        <Text color="danger">{extractErrorMsg(error)}</Text>
-      </CenterAbsolutely>
-    )
+    return <DefiPositionErrorState onRetry={refetch} />
   }
 
   if (!isPending && !data?.stake && selectedPositions.length > 0) {
-    return (
-      <CenterAbsolutely>
-        <Text color="danger">{t('failed_to_load')}</Text>
-      </CenterAbsolutely>
-    )
+    return <DefiPositionErrorState onRetry={refetch} />
   }
 
   if (selectedPositions.length === 0) {


### PR DESCRIPTION
## What & why
Closes #4335. The DeFi position tabs (Bonded / Staked / LPs) rendered a failed request as raw red text via `extractErrorMsg(error)` — leaking the endpoint URL (e.g. `https://gateway.liquify.com/...`) into the UI, with no card, icon, or way to recover.

## Changes
- **New shared component** `DefiPositionErrorState` — warning icon, plain-language `Failed to load` message (no URL), and a **Retry** button wired to the query's `refetch` with an inline loading state. Styled to match the existing `DefiPositionEmptyState` card.
- **Bonded / Staked** — both error branches now render the shared component instead of raw text; unused imports removed.
- **LPs** — previously had *no* error handling at all; an error branch is added for consistency.
- **Storybook** — `DefiPositionErrorState.stories.tsx` with `Default` and `SlowRetry` (shows the button's loading spinner).

## Before / after
| | |
|---|---|
| **Before** | Raw red string, full URL wrapping across lines, no retry |
| **After** | Styled card · warning icon · "Failed to load" · Retry |

Verified in Storybook (`DeFi/DefiPositionErrorState`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consistent DeFi position error state with a clear failure message and retry button.
  * Added retry support for bonded, liquidity pool, and staked position loading errors.
  * Added loading feedback while retrying.

* **Bug Fixes**
  * Improved handling of missing or failed DeFi position data.

* **Tests**
  * Added Storybook scenarios for the default and delayed retry states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->