### PR TITLE
fix(backup): prevent Fast Vault backup email from being sent twice on double-click

### DIFF
--- a/core/ui/vault/backup/fast/request/RequestFastVaultBackupForm.tsx
+++ b/core/ui/vault/backup/fast/request/RequestFastVaultBackupForm.tsx
@@ -10,7 +10,7 @@ import { resendVaultShare } from '@vultisig/core-mpc/fast/api/resendVaultShare'
 import { getVaultId } from '@vultisig/core-mpc/vault/Vault'
 import { isInError } from '@vultisig/lib-utils/error/isInError'
 import { TFunction } from 'i18next'
-import { useMemo } from 'react'
+import { useMemo, useRef } from 'react'
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { z } from 'zod'
@@ -33,6 +33,12 @@ const RequestFastVaultBackupFormContent = ({ onFinish }: OnFinishProp) => {
 
   const schema = useMemo(() => getSchema(t), [t])
 
+  // Synchronous in-flight guard: `isPending` only disables the submit button
+  // after a re-render, so a fast double-submit can fire two /resend requests
+  // (two backup emails) before that commits. A ref blocks the second submit in
+  // the same tick, before any render happens.
+  const isRequestingRef = useRef(false)
+
   const { mutate, isPending, error } = useMutation({
     mutationFn: ({ email, password }: Schema) =>
       resendVaultShare({
@@ -41,7 +47,18 @@ const RequestFastVaultBackupFormContent = ({ onFinish }: OnFinishProp) => {
         password,
       }),
     onSuccess: onFinish,
+    onSettled: () => {
+      isRequestingRef.current = false
+    },
   })
+
+  const requestBackup = (values: Schema) => {
+    if (isRequestingRef.current) {
+      return
+    }
+    isRequestingRef.current = true
+    mutate(values)
+  }
 
   const {
     register,
@@ -75,9 +92,7 @@ const RequestFastVaultBackupFormContent = ({ onFinish }: OnFinishProp) => {
       justifyContent="space-between"
       scrollable
       gap={40}
-      onSubmit={handleSubmit(({ email, password }) =>
-        mutate({ email, password })
-      )}
+      onSubmit={handleSubmit(requestBackup)}
     >
       <VStack gap={16}>
         {errorMessage && <ErrorBlock>{errorMessage}</ErrorBlock>}
@@ -94,7 +109,11 @@ const RequestFastVaultBackupFormContent = ({ onFinish }: OnFinishProp) => {
           error={errors.password?.message}
         />
       </VStack>
-      <Button disabled={!isValid} loading={isPending} type="submit">
+      <Button
+        disabled={!isValid || isPending}
+        loading={isPending}
+        type="submit"
+      >
         {t('get_started')}
       </Button>
     </ActionForm>


### PR DESCRIPTION
## Problem

Closes #4342.

On the Fast Vault server-backup request screen, the "Get Started" submit button stayed interactive while the request was in flight. On the shared `Button`, `loading` is purely cosmetic (it only swaps in a spinner — `lib/ui/buttons/Button/index.tsx` wires the native `disabled` attribute solely from the `disabled` prop), and here `disabled={!isValid}` ignored the pending state. So a fast double-submit fired the mutation twice → two `resendVaultShare()` → `POST /resend` calls → **two backup-share emails** sent.

Same bug class as the vault backup double-download (#4286).

## Fix

- `RequestFastVaultBackupForm.tsx` → `disabled={!isValid || isPending}`.
- Added a **synchronous `useRef` in-flight guard** around the submit so a same-tick second submit is a no-op (reset in `onSettled`). This is necessary because `disabled={isPending}` alone only takes effect after a re-render and still loses the render-gap race to a very fast double-click — mirrors the guard added in `useBackupVaultMutation.ts`.

## Validation

- `yarn typecheck` — passes
- `yarn eslint` on the file — passes
- Normal single submit unchanged; 429 / bad-request errors still surface via the existing `error` handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate resend-backup requests from rapid repeated submissions.
  * Disabled the submit button while a backup request is in progress.
  * Preserved loading feedback during request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->