### PR TITLE
fix(vault): collapsed header border flush, no longer cuts action buttons (#4266)

### DIFF
--- a/core/ui/vault/page/components/VaultPageHeader.tsx
+++ b/core/ui/vault/page/components/VaultPageHeader.tsx
@@ -20,20 +20,19 @@ import { VaultSelector } from './VaultSelector'
 const HeaderContainer = styled.div`
   position: sticky;
   top: 0;
+  z-index: 1;
+  display: grid;
   background: ${getColor('background')};
 `
 
 const CollapsedContent = styled(HStack)<{ isVisible: boolean }>`
   ${horizontalPadding(pageConfig.horizontalPadding)};
   ${verticalPadding(pageConfig.verticalPadding)};
+  grid-area: 1 / 1;
   min-height: 60px;
   border-bottom: 1px solid ${getColor('foregroundExtra')};
   justify-content: space-between;
   align-items: center;
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
   background: ${getColor('background')};
   opacity: ${({ isVisible }) => (isVisible ? 1 : 0)};
   pointer-events: ${({ isVisible }) => (isVisible ? 'auto' : 'none')};
@@ -41,6 +40,7 @@ const CollapsedContent = styled(HStack)<{ isVisible: boolean }>`
 `
 
 const NormalContent = styled.div<{ isVisible: boolean }>`
+  grid-area: 1 / 1;
   opacity: ${({ isVisible }) => (isVisible ? 1 : 0)};
   pointer-events: ${({ isVisible }) => (isVisible ? 'auto' : 'none')};
   transition: opacity 0.25s ease-in-out;


### PR DESCRIPTION
## Summary

Fixes #4266 — on the vault main view, once you scroll slightly the collapsed header band (vault selector + "Portfolio Balance") overlaid the primary actions and its 1px bottom border sliced across the Swap / Send / Buy / Receive icons.

## Root cause

In `VaultPageHeader.tsx`, `CollapsedContent` was `position: absolute; top: 0` with `min-height: 60px`, while `HeaderContainer` only reserved the height of the shorter `NormalContent` (`PageHeader`). Because the collapsed band renders two stacked text lines (portfolio label + balance) it grows past 60px, so the band and its `border-bottom` spilled below the header container onto the scrolling content beneath — cutting the action buttons.

## Fix

Stack both header states in the same CSS grid cell (`grid-area: 1 / 1`) instead of absolutely positioning the collapsed band:

- `HeaderContainer` → `display: grid` + `z-index: 1`
- `CollapsedContent` / `NormalContent` → `grid-area: 1 / 1` (removed `position: absolute` and its offsets)

The container now always reserves the taller state's height, so the collapsed band's border sits flush at the container's own bottom edge, and the `z-index` ensures the opaque band reliably occludes content scrolling underneath. The opacity cross-fade between states is unchanged.

This is shared `core/ui`, so it fixes both the extension and the desktop app.

## Testing

- `yarn typecheck` ✅
- `yarn eslint` on the changed file ✅
- Built the desktop app and verified visually: scrolling on the vault main view now shows the collapsed header border flush against its own edge, no longer intersecting the action buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the vault page header layout and transitions between collapsed and expanded states.
  * Preserved smooth visibility changes while improving content alignment and layering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->