### PR TITLE
fix(defi): correct sRUJI staking APR value

### DIFF
--- a/core/ui/defi/chain/queries/services/thorchainStake/rujiStakeService.ts
+++ b/core/ui/defi/chain/queries/services/thorchainStake/rujiStakeService.ts
@@ -13,6 +13,22 @@ import { encodeBase64, parseBigint, parseNumber } from '../../utils/parsers'
 
 const rujiDecimalFactor = toDecimalFactor(thorchainTokens.ruji.decimals)
 
+// The Rujira staking API returns APR as a Bigint fixed-point rate scaled to 12
+// decimal places: divide by 10^12 for the fractional rate (e.g. 37176753737 =>
+// 0.0372 => 3.72%). `status` is only meaningful when 'AVAILABLE'; any other
+// status (NOT_APPLICABLE, SOON) means no APR to show.
+const rujiRateDecimalFactor = toDecimalFactor(12)
+
+const parseRujiApr = (
+  apr?: { value?: string | null; status?: string | null } | null
+): number | undefined => {
+  if (!apr || (apr.status && apr.status !== 'AVAILABLE')) {
+    return undefined
+  }
+
+  return (parseNumber(apr.value) / rujiRateDecimalFactor) * 100
+}
+
 const getRujiStake = (address: string) => {
   const variables = { id: encodeBase64(`Account:${address}`) }
   const query = `
@@ -22,7 +38,7 @@ const getRujiStake = (address: string) => {
           stakingV2 {
             bonded { amount asset { metadata { symbol } } }
             pendingRevenue { amount asset { metadata { symbol } } }
-            pool { summary { apr { value } } }
+            pool { summary { apr { value status } } }
           }
         }
       }
@@ -41,7 +57,9 @@ const getRujiStake = (address: string) => {
             asset?: { metadata?: { symbol?: string } | null } | null
           } | null
           pool?: {
-            summary?: { apr?: { value?: string | null } | null } | null
+            summary?: {
+              apr?: { value?: string | null; status?: string | null } | null
+            } | null
           } | null
         } | null> | null
       } | null
@@ -87,7 +105,13 @@ export const fetchRujiStakePosition = async ({
       getRujiStake(address),
       fetchRujiReceiptBalance(address),
     ])
-    const stake = response?.data?.node?.stakingV2?.[0]
+    // `stakingV2` can contain entries for multiple pools; the first entry is not
+    // guaranteed to be RUJI. Match iOS and select the RUJI pool by its bond asset
+    // symbol so the APR, rewards and bonded amount come from the right pool
+    // (blindly taking [0] can surface a different pool's APR entirely).
+    const stake = response?.data?.node?.stakingV2?.find(
+      entry => entry?.bonded?.asset?.metadata?.symbol?.toUpperCase() === 'RUJI'
+    )
     const bondedAmount = parseBigint(stake?.bonded?.amount)
     // Prefer the on-chain receipt balance (source of truth for what the vault
     // holds and can send); a successful zero stays zero. Fall back to the API's
@@ -95,7 +119,7 @@ export const fetchRujiStakePosition = async ({
     const amount = heldAmount ?? bondedAmount
     const rewardsAmount =
       parseNumber(stake?.pendingRevenue?.amount) / rujiDecimalFactor
-    const aprValue = parseNumber(stake?.pool?.summary?.apr?.value)
+    const apr = parseRujiApr(stake?.pool?.summary?.apr)
     const price = prices[coinKeyToString(thorchainTokens.ruji)] ?? 0
 
     const fiatValue = getCoinValue({
@@ -111,7 +135,7 @@ export const fetchRujiStakePosition = async ({
       type: 'stake',
       canUnstake: amount > 0n,
       fiatValue,
-      apr: aprValue * 100,
+      apr,
       rewards: rewardsAmount,
       rewardTicker: 'USDC',
     }

--- a/core/ui/defi/chain/queries/services/thorchainStake/rujiStakeService.ts
+++ b/core/ui/defi/chain/queries/services/thorchainStake/rujiStakeService.ts
@@ -19,8 +19,11 @@ const rujiDecimalFactor = toDecimalFactor(thorchainTokens.ruji.decimals)
 // status (NOT_APPLICABLE, SOON) means no APR to show.
 const rujiRateDecimalFactor = toDecimalFactor(12)
 
+// The Rujira staking API's `AprStatus` enum; only `AVAILABLE` yields an APR.
+type RujiAprStatus = 'AVAILABLE' | 'NOT_APPLICABLE' | 'SOON'
+
 const parseRujiApr = (
-  apr?: { value?: string | null; status?: string | null } | null
+  apr?: { value?: string | null; status?: RujiAprStatus | null } | null
 ): number | undefined => {
   if (!apr || (apr.status && apr.status !== 'AVAILABLE')) {
     return undefined
@@ -58,7 +61,10 @@ const getRujiStake = (address: string) => {
           } | null
           pool?: {
             summary?: {
-              apr?: { value?: string | null; status?: string | null } | null
+              apr?: {
+                value?: string | null
+                status?: RujiAprStatus | null
+              } | null
             } | null
           } | null
         } | null> | null


### PR DESCRIPTION
## Problem

The **Staked RUJI** (sRUJI) card in the THORChain DeFi → Staked tab showed a wrong APR, in two ways:

1. An **astronomically large** value, e.g. `5765836505900.00%`.
2. A **plausible-but-wrong** value, e.g. `5.77%` while iOS and the Rujira app showed `3.73%` for the same pool at the same time — and this survived reloads (not a caching artifact).

Verified against the live Rujira GraphQL API (both the Vultisig proxy and Rujira's own endpoint return identical values), on-chain balances, and the iOS reference implementation.

## Root causes & fixes

**1. Missing fixed-point scaling.** The API returns `pool.summary.apr.value` as a `Bigint` scaled to **12 decimals** (e.g. `37176753737` = `0.0372` = `3.72%`). The code did `value * 100` with no `/ 1e12`, inflating the result by ~1e12. Now divides by the 1e12 scale, and honors the `status` field — a non-`AVAILABLE` status (`SOON` / `NOT_APPLICABLE`) shows `—` instead of a bogus number (matching iOS).

**2. Wrong pool selection.** `stakingV2` can contain entries for multiple pools; the code took `stakingV2[0]` by blind index. For accounts that also hold a bonded/yielding position, `[0]` resolved to a *different* pool whose APR was ~5.77%, not the RUJI pool (3.73%). Now selects the RUJI entry by bond-asset symbol (`bonded.asset.metadata.symbol === 'RUJI'`), exactly like iOS's `THORChainStakingService`. This also corrects the rewards and bonded amount, which are read from the same entry.

## Changes

- `core/ui/defi/chain/queries/services/thorchainStake/rujiStakeService.ts`
  - Add `parseRujiApr` helper: `/ 1e12` scaling + `status` gating.
  - Fetch `apr.status` in the GraphQL query (and in the response type).
  - Select the RUJI `stakingV2` entry by symbol instead of `[0]`.

Scope is limited to the APR fix for #4353. The separate staked-amount discrepancy (receipt shares vs. RUJI value / bonded total) is intentionally **not** included here.

## Testing

- `yarn check` — typecheck, lint, i18n, knip all pass
- `yarn vitest run core/ui/defi/chain` — 4/4 pass
- Confirmed with live API data: `apr.value` for the RUJI pool → `3.73%` after the fix

Fixes #4353

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rujira staking APR display by correctly interpreting fixed-point API values.
  * APR is now shown only when the staking service reports it as available.
  * Ensured staking positions use the correct RUJI pool when multiple pools are returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->