### PR TITLE
fix(defi): show sRUJI auto-compounding value, not receipt shares

### DIFF
--- a/core/ui/defi/chain/queries/services/thorchainStake/rujiStakeService.ts
+++ b/core/ui/defi/chain/queries/services/thorchainStake/rujiStakeService.ts
@@ -21,6 +21,7 @@ const getRujiStake = (address: string) => {
         ... on Account {
           stakingV2 {
             bonded { amount asset { metadata { symbol } } }
+            liquidSize { amount }
             pendingRevenue { amount asset { metadata { symbol } } }
             pool { summary { apr { value } } }
           }
@@ -36,6 +37,7 @@ const getRujiStake = (address: string) => {
             amount?: string
             asset?: { metadata?: { symbol?: string } | null } | null
           } | null
+          liquidSize?: { amount?: string } | null
           pendingRevenue?: {
             amount?: string
             asset?: { metadata?: { symbol?: string } | null } | null
@@ -87,12 +89,21 @@ export const fetchRujiStakePosition = async ({
       getRujiStake(address),
       fetchRujiReceiptBalance(address),
     ])
-    const stake = response?.data?.node?.stakingV2?.[0]
+    // `stakingV2` can contain entries for multiple pools; the first entry is not
+    // guaranteed to be RUJI. Match iOS and select the RUJI pool by its bond asset
+    // symbol so the APR, rewards and bonded amount come from the right pool
+    // (blindly taking [0] can surface a different pool's APR entirely).
+    const stake = response?.data?.node?.stakingV2?.find(
+      entry => entry?.bonded?.asset?.metadata?.symbol?.toUpperCase() === 'RUJI'
+    )
     const bondedAmount = parseBigint(stake?.bonded?.amount)
-    // Prefer the on-chain receipt balance (source of truth for what the vault
-    // holds and can send); a successful zero stays zero. Fall back to the API's
-    // `bonded` amount only when the balance request failed (heldAmount is null).
-    const amount = heldAmount ?? bondedAmount
+    // Display the auto-compounding value: the sRUJI receipt converted to RUJI at
+    // the pool's current share price (the API's `liquidSize`), matching what the
+    // Rujira app shows. Fall back to the raw on-chain receipt balance if the API
+    // doesn't surface it, then to the API's `bonded` amount.
+    const liquidSizeAmount = parseBigint(stake?.liquidSize?.amount)
+    const amount =
+      liquidSizeAmount > 0n ? liquidSizeAmount : (heldAmount ?? bondedAmount)
     const rewardsAmount =
       parseNumber(stake?.pendingRevenue?.amount) / rujiDecimalFactor
     const aprValue = parseNumber(stake?.pool?.summary?.apr?.value)

--- a/core/ui/defi/chain/queries/services/thorchainStake/rujiStakeService.ts
+++ b/core/ui/defi/chain/queries/services/thorchainStake/rujiStakeService.ts
@@ -80,6 +80,12 @@ type FetchRujiStakePositionInput = {
   prices: Record<string, number>
 }
 
+/**
+ * Fetches the vault's RUJI staking position, combining the Rujira staking API
+ * (APR, pending USDC rewards, bonded amount) with the on-chain sRUJI receipt
+ * balance. Returns the auto-compounding value in RUJI as a
+ * {@link ThorchainStakePosition}, or `null` if the lookup fails.
+ */
 export const fetchRujiStakePosition = async ({
   address,
   prices,


### PR DESCRIPTION
## Problem

The **Staked RUJI** (sRUJI) card showed the raw sRUJI receipt balance — a *share count* — instead of the auto-compounding value in RUJI that the Rujira app shows for the position. sRUJI is an auto-compounding vault receipt: rewards compound into the share price, so one sRUJI is worth progressively more than one RUJI. The card therefore understated the staked RUJI value, and its fiat figure was off by the same factor.

## Fix

Read the RUJI pool's **`liquidSize`** from the staking API — the receipt converted to RUJI at the current share price — and display that as the staked amount (verified against live accounts to match the Rujira app's auto-compounding figure). Falls back to the on-chain receipt balance, then to `bonded`, if the API doesn't surface `liquidSize`.

Selecting the RUJI `stakingV2` entry by bond-asset symbol (instead of blind `[0]`) is required so `liquidSize` is read from the correct pool — for accounts that also hold other staking positions, `[0]` can be a different pool.

## Changes

- `core/ui/defi/chain/queries/services/thorchainStake/rujiStakeService.ts`
  - Fetch `liquidSize { amount }` in the GraphQL query (and in the response type).
  - Display `liquidSize` (auto-compounding RUJI value) instead of the raw receipt share count; keep on-chain receipt / `bonded` as fallbacks.
  - Select the RUJI `stakingV2` entry by symbol.

## Scope

- Shows the **auto-compounding value only** — the separate yielding/bonded portion is intentionally not summed in.


## Testing

- `yarn check` — typecheck, lint, i18n, knip all pass
- `yarn vitest run core/ui/defi/chain` — 4/4 pass
- Verified against live Rujira API + on-chain balances: the displayed amount now equals the pool's `liquidSize` (auto-compounding RUJI value) rather than the receipt share count

Fixes #4355

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RUJI staking balance accuracy by selecting the correct pool and prioritizing its current liquid stake value.
  * Added fallback handling to display the on-chain receipt balance or bonded amount when the liquid stake value is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->