### PR TITLE
fix(swap): make chain switch responsive

### DIFF
--- a/core/ui/chain/coin/queries/useWhitelistedCoinsQuery.ts
+++ b/core/ui/chain/coin/queries/useWhitelistedCoinsQuery.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { Chain } from '@vultisig/core-chain/Chain'
 
 import { fetchWhitelistedCoins } from './fetchWhitelistedCoins'
@@ -8,5 +8,6 @@ export const useWhitelistedCoinsQuery = (chain: Chain, enabled?: boolean) => {
     queryKey: ['whitelistedCoins', chain],
     enabled,
     queryFn: () => fetchWhitelistedCoins(chain),
+    placeholderData: keepPreviousData,
   })
 }

--- a/core/ui/vault/swap/form/SwapCoinsExplorer.tsx
+++ b/core/ui/vault/swap/form/SwapCoinsExplorer.tsx
@@ -16,7 +16,7 @@ import { knownTokens } from '@vultisig/core-chain/coin/knownTokens'
 import { isFeeCoin } from '@vultisig/core-chain/coin/utils/isFeeCoin'
 import { isOneOf } from '@vultisig/lib-utils/array/isOneOf'
 import { withoutDuplicates } from '@vultisig/lib-utils/array/withoutDuplicates'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useDeferredValue, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
@@ -45,16 +45,21 @@ export const SwapCoinsExplorer = ({
   const { mutateAsync: createCoin } = useCreateCoinMutation()
   const currentChain = side === 'from' ? fromCoinKey.chain : currentToCoin.chain
 
-  const { data: whitelisted } = useWhitelistedCoinsQuery(currentChain)
+  // The carousel/highlight tracks the live `currentChain` so the selection
+  // feels instant, while the heavy token list re-renders off `deferredChain`
+  // in a low-priority pass, so switching chains never blocks on the list.
+  const deferredChain = useDeferredValue(currentChain)
 
-  const sortedSwapCoins = useSortedByBalanceCoins(currentChain)
+  const { data: whitelisted } = useWhitelistedCoinsQuery(deferredChain)
+
+  const sortedSwapCoins = useSortedByBalanceCoins(deferredChain)
   const options = useMemo(() => {
-    const vaultCoinsForChain = coins.filter(c => c.chain === currentChain)
+    const vaultCoinsForChain = coins.filter(c => c.chain === deferredChain)
 
     const allOptions = withoutDuplicates(
       [
         ...sortedSwapCoins,
-        ...(knownTokens[currentChain] ?? []).filter(
+        ...(knownTokens[deferredChain] ?? []).filter(
           coin => !vaultCoinsForChain.some(vc => areEqualCoins(vc, coin))
         ),
         ...(whitelisted ?? []).filter(
@@ -64,7 +69,7 @@ export const SwapCoinsExplorer = ({
       areEqualCoins
     )
 
-    if (currentChain === Chain.Solana) {
+    if (deferredChain === Chain.Solana) {
       const hasNativeSol = allOptions.some(
         coin => coin.chain === Chain.Solana && !coin.id && isFeeCoin(coin)
       )
@@ -81,7 +86,7 @@ export const SwapCoinsExplorer = ({
     }
 
     return allOptions
-  }, [currentChain, sortedSwapCoins, whitelisted, coins])
+  }, [deferredChain, sortedSwapCoins, whitelisted, coins])
 
   const { t } = useTranslation()
 


### PR DESCRIPTION
Follow-up to #4357 / issue #4348.

## Problem
After the ring rework in #4357, switching the swap **Select chain** pill still had a residual lag: the token list visibly reloaded/flashed to empty, so the switch felt like *"coins load, then the chain switches."* Two causes:

1. **Query dropped to loading on every chain change.** `useWhitelistedCoinsQuery` had no `placeholderData`, so on a chain change `whitelisted` became `undefined`; the `options` list was recomputed **without** the whitelisted coins, rendered, then recomputed **again** when the fetch resolved — a double render + visible flash.
2. **The heavy token-list re-render was coupled to the chain switch** in the same commit — the ~20 virtualized rows re-rendered synchronously on the frame that should be updating the carousel.

## Fix (pure UI/perf, no behavior change)
- **`placeholderData: keepPreviousData`** on `useWhitelistedCoinsQuery` — the list keeps the previous chain's data until the new one loads, so it never flashes to empty.
- **`useDeferredValue`** in `SwapCoinsExplorer`: the token-list path (whitelist query, sorted-by-balance coins, `options` filter/dedup/Solana branch) is fed off `deferredChain`, while the **carousel** (`useCenteredSnapCarousel({ chain: currentChain })`) and the pill `isActive` highlight stay on the **live** `currentChain`. The pill updates immediately; the list re-renders in a low-priority, interruptible pass.

### Left as-is
`useBalancesQuery` (via `useSortedByBalanceCoins`): the visible coin list comes synchronously from vault state — balances only affect **sort order**, not presence, so there's no flash to fix. Its per-coin query keys also change entirely between chains, so `keepPreviousData` wouldn't apply.

## Scope
Shared `core/ui` (desktop + extension). No swap business logic, chain enablement, or coin-fetch semantics changed. No new user-facing strings.

## Testing
- `yarn typecheck` and `yarn eslint` pass on the changed files.
- Manual: open the swap asset picker and switch between a light chain and a token-heavy chain (e.g. Ethereum) via click, scroll-snap, and arrow keys — pill highlight/centering updates immediately, the token list updates in place without flashing to empty, and the "coins load, then chain switches" ordering is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coin and token browsing during chain changes by keeping existing results visible while updated data loads.
  * Reduced interface flickering and maintained smoother swap-token exploration when switching networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->