### PR TITLE
fix(defi): show sRUJI send balance instead of NaN

### DIFF
--- a/core/ui/chain/coin/thorchain/withThorchainNativeCoinMetadata.test.ts
+++ b/core/ui/chain/coin/thorchain/withThorchainNativeCoinMetadata.test.ts
@@ -4,46 +4,44 @@ import { describe, expect, it } from 'vitest'
 
 import { withThorchainNativeCoinMetadata } from './withThorchainNativeCoinMetadata'
 
-const srujiKey = {
+// A coin persisted before the fix has no `decimals` at runtime. `NaN` is a
+// type-safe stand-in that hits the same `Number.isFinite` guard — `undefined`
+// can't be assigned to the required `decimals: number` without an `as` cast.
+const srujiStored: AccountCoin = {
   chain: Chain.THORChain,
   id: 'x/staking-x/ruji',
   address: 'thor1test',
+  ticker: 'sRUJI',
+  decimals: NaN,
 }
 
 describe('withThorchainNativeCoinMetadata', () => {
   it('backfills decimals and logo for a stored sRUJI coin missing them', () => {
-    // Reproduces the persisted-coin bug: decimals is undefined at runtime even
-    // though the type says `number`, so the send flow renders a NaN balance.
-    const stored = { ...srujiKey, ticker: 'sRUJI' } as unknown as AccountCoin
-
-    const result = withThorchainNativeCoinMetadata(stored)
+    const result = withThorchainNativeCoinMetadata(srujiStored)
 
     expect(result.decimals).toBe(8)
     expect(result.logo).toBe('ruji')
   })
 
   it('leaves a coin that already has decimals unchanged', () => {
-    const complete: AccountCoin = {
-      ...srujiKey,
-      ticker: 'sRUJI',
-      decimals: 8,
-      logo: 'ruji',
-    }
+    const complete: AccountCoin = { ...srujiStored, decimals: 8, logo: 'ruji' }
 
     expect(withThorchainNativeCoinMetadata(complete)).toBe(complete)
   })
 
-  it('passes through a coin that is not a known THORChain native token', () => {
-    const unknown = {
-      chain: Chain.THORChain,
+  it('passes through a THORChain coin that is not a known native token', () => {
+    const unknown: AccountCoin = {
+      ...srujiStored,
       id: 'x/not-a-real-denom',
-      address: 'thor1test',
       ticker: 'FOO',
-    } as unknown as AccountCoin
+    }
 
-    const result = withThorchainNativeCoinMetadata(unknown)
+    expect(withThorchainNativeCoinMetadata(unknown)).toBe(unknown)
+  })
 
-    expect(result).toBe(unknown)
-    expect(result.decimals).toBeUndefined()
+  it('does not backfill a non-THORChain coin even when its id is a known THORChain denom', () => {
+    const cosmosCoin: AccountCoin = { ...srujiStored, chain: Chain.Cosmos }
+
+    expect(withThorchainNativeCoinMetadata(cosmosCoin)).toBe(cosmosCoin)
   })
 })

--- a/core/ui/chain/coin/thorchain/withThorchainNativeCoinMetadata.test.ts
+++ b/core/ui/chain/coin/thorchain/withThorchainNativeCoinMetadata.test.ts
@@ -1,0 +1,49 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+import { describe, expect, it } from 'vitest'
+
+import { withThorchainNativeCoinMetadata } from './withThorchainNativeCoinMetadata'
+
+const srujiKey = {
+  chain: Chain.THORChain,
+  id: 'x/staking-x/ruji',
+  address: 'thor1test',
+}
+
+describe('withThorchainNativeCoinMetadata', () => {
+  it('backfills decimals and logo for a stored sRUJI coin missing them', () => {
+    // Reproduces the persisted-coin bug: decimals is undefined at runtime even
+    // though the type says `number`, so the send flow renders a NaN balance.
+    const stored = { ...srujiKey, ticker: 'sRUJI' } as unknown as AccountCoin
+
+    const result = withThorchainNativeCoinMetadata(stored)
+
+    expect(result.decimals).toBe(8)
+    expect(result.logo).toBe('ruji')
+  })
+
+  it('leaves a coin that already has decimals unchanged', () => {
+    const complete: AccountCoin = {
+      ...srujiKey,
+      ticker: 'sRUJI',
+      decimals: 8,
+      logo: 'ruji',
+    }
+
+    expect(withThorchainNativeCoinMetadata(complete)).toBe(complete)
+  })
+
+  it('passes through a coin that is not a known THORChain native token', () => {
+    const unknown = {
+      chain: Chain.THORChain,
+      id: 'x/not-a-real-denom',
+      address: 'thor1test',
+      ticker: 'FOO',
+    } as unknown as AccountCoin
+
+    const result = withThorchainNativeCoinMetadata(unknown)
+
+    expect(result).toBe(unknown)
+    expect(result.decimals).toBeUndefined()
+  })
+})

--- a/core/ui/chain/coin/thorchain/withThorchainNativeCoinMetadata.ts
+++ b/core/ui/chain/coin/thorchain/withThorchainNativeCoinMetadata.ts
@@ -1,0 +1,25 @@
+import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+import { thorchainNativeTokensMetadata } from '@vultisig/core-chain/coin/knownTokens/thorchain'
+
+/**
+ * Backfills `decimals` (and `logo`) for a stored coin whose metadata is known in
+ * `thorchainNativeTokensMetadata` but was persisted incomplete. Some receipt
+ * coins (e.g. sRUJI) were stored without `decimals` — which renders a `NaN`
+ * balance in the send flow — so this repairs them on read. Coins that already
+ * carry a finite `decimals`, or that aren't known THORChain native tokens, pass
+ * through unchanged.
+ */
+export const withThorchainNativeCoinMetadata = (
+  coin: AccountCoin
+): AccountCoin => {
+  if (!coin.id || Number.isFinite(coin.decimals)) {
+    return coin
+  }
+
+  const known = thorchainNativeTokensMetadata[coin.id]
+  if (!known) {
+    return coin
+  }
+
+  return { ...coin, decimals: known.decimals, logo: coin.logo ?? known.logo }
+}

--- a/core/ui/chain/coin/thorchain/withThorchainNativeCoinMetadata.ts
+++ b/core/ui/chain/coin/thorchain/withThorchainNativeCoinMetadata.ts
@@ -1,3 +1,4 @@
+import { Chain } from '@vultisig/core-chain/Chain'
 import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
 import { thorchainNativeTokensMetadata } from '@vultisig/core-chain/coin/knownTokens/thorchain'
 
@@ -12,7 +13,11 @@ import { thorchainNativeTokensMetadata } from '@vultisig/core-chain/coin/knownTo
 export const withThorchainNativeCoinMetadata = (
   coin: AccountCoin
 ): AccountCoin => {
-  if (!coin.id || Number.isFinite(coin.decimals)) {
+  if (
+    coin.chain !== Chain.THORChain ||
+    !coin.id ||
+    Number.isFinite(coin.decimals)
+  ) {
     return coin
   }
 

--- a/core/ui/defi/chain/queries/tokens.ts
+++ b/core/ui/defi/chain/queries/tokens.ts
@@ -3,6 +3,7 @@ import { yieldBearingThorChainTokens } from '@vultisig/core-chain/chains/cosmos/
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { Coin } from '@vultisig/core-chain/coin/Coin'
 import { knownCosmosTokens } from '@vultisig/core-chain/coin/knownTokens/cosmos'
+import { thorchainNativeTokensMetadata } from '@vultisig/core-chain/coin/knownTokens/thorchain'
 
 export const runeCoin: Coin = {
   ...chainFeeCoin[Chain.THORChain],
@@ -28,7 +29,10 @@ export const thorchainTokens: Record<string, Coin> = {
     ticker: 'RUJI',
   },
   sruji: {
-    ...knownCosmosTokens[Chain.THORChain]['x/staking-x/ruji'],
+    // sRUJI lives in `thorchainNativeTokensMetadata`, not `knownCosmosTokens`
+    // (indexing the latter yields `undefined` at runtime, leaving the coin with
+    // no `decimals` and rendering a `NaN` balance in the send flow).
+    ...thorchainNativeTokensMetadata['x/staking-x/ruji'],
     chain: Chain.THORChain,
     id: 'x/staking-x/ruji',
     ticker: 'sRUJI',

--- a/core/ui/storage/vaults.tsx
+++ b/core/ui/storage/vaults.tsx
@@ -1,3 +1,4 @@
+import { withThorchainNativeCoinMetadata } from '@core/ui/chain/coin/thorchain/withThorchainNativeCoinMetadata'
 import { useCore } from '@core/ui/state/core'
 import { useCombineQueries } from '@lib/ui/query/hooks/useCombineQueries'
 import { useRefetchQueries } from '@lib/ui/query/hooks/useRefetchQueries'
@@ -56,7 +57,9 @@ const mergeVaultsWithCoins = ({ vaults, coins }: MergeVaultsWithCoinsInput) => {
 
     return {
       ...vault,
-      coins: vaultCoins.filter(coin => vaultChains.includes(coin.chain)),
+      coins: vaultCoins
+        .filter(coin => vaultChains.includes(coin.chain))
+        .map(withThorchainNativeCoinMetadata),
     }
   })
 }

--- a/core/ui/storage/vaults.tsx
+++ b/core/ui/storage/vaults.tsx
@@ -1,4 +1,3 @@
-import { withThorchainNativeCoinMetadata } from '@core/ui/chain/coin/thorchain/withThorchainNativeCoinMetadata'
 import { useCore } from '@core/ui/state/core'
 import { useCombineQueries } from '@lib/ui/query/hooks/useCombineQueries'
 import { useRefetchQueries } from '@lib/ui/query/hooks/useRefetchQueries'
@@ -16,6 +15,7 @@ import { withoutDuplicates } from '@vultisig/lib-utils/array/withoutDuplicates'
 import { sortEntitiesWithOrder } from '@vultisig/lib-utils/entities/EntityWithOrder'
 import { useMemo } from 'react'
 
+import { withThorchainNativeCoinMetadata } from '../chain/coin/thorchain/withThorchainNativeCoinMetadata'
 import { StorageKey } from './StorageKey'
 
 export type UpdateVaultInput = {


### PR DESCRIPTION
## Problem

Tapping **Transfer** on the Staked RUJI card opens the Send screen for the sRUJI receipt token, but "Balance available" showed `NaN sRUJI` (and the asset icon was missing), so the vault's sRUJI couldn't be seen or transferred.

**Root cause:** the `sruji` coin was built by spreading `knownCosmosTokens[Chain.THORChain]['x/staking-x/ruji']` — but that key only exists in `thorchainNativeTokensMetadata`, **not** in `knownCosmosTokens`. At runtime the spread was `undefined`, so the coin carried no `decimals` (nor `logo`). The send screen then computed `fromChainAmount(amount, undefined)` = `Number(amount) / 10 ** undefined` = **`NaN`**. TypeScript didn't catch it because indexing a `Record<string, CoinMetadata>` yields a non-`undefined` type.

Confirmed the balance itself is fine: the on-chain sRUJI amount is fetched correctly (e.g. `41952462` for a real staker); only the decimals-based formatting was broken.

## Fix

1. **Source fix** — `sruji` now takes its metadata from `thorchainNativeTokensMetadata['x/staking-x/ruji']` (`decimals: 8`, `logo: 'ruji'`), so newly-enabled coins are complete.
2. **Repair already-stored coins** — coins persisted before the fix were saved without `decimals`, and the send screen reads the *stored* coin. `mergeVaultsWithCoins` now maps each coin through `withThorchainNativeCoinMetadata`, which backfills `decimals`/`logo` from `thorchainNativeTokensMetadata` when they're missing. This repairs existing coins on read — no storage migration — and fixes every consumer (balance display and the send amount → chain-amount conversion), not just the label.

## Changes

- `core/ui/defi/chain/queries/tokens.ts` — source `sruji` metadata from the correct registry.
- `core/ui/chain/coin/thorchain/withThorchainNativeCoinMetadata.ts` — pure helper that backfills missing `decimals`/`logo` for known THORChain native-token coins.
- `core/ui/storage/vaults.tsx` — apply the helper in `mergeVaultsWithCoins` (single read chokepoint for all vault coins).
- `…/withThorchainNativeCoinMetadata.test.ts` — unit tests (backfill / already-complete / unknown-coin).

## Testing

- `yarn check` — typecheck, lint, i18n, knip all pass
- New unit test + `core/ui/chain/coin` and `core/ui/storage` suites — 31 passing
- Verified against live data: with the backfill, a stored sRUJI coin resolves `decimals: 8`, so the send balance renders `0.41952462 sRUJI` instead of `NaN`

Fixes #4368

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved THORChain native token “repair on read” to consistently backfill missing `decimals` and logo for known tokens.
  * Ensured vault coin data uses the enriched THORChain metadata when available.
  * Corrected sRUJI token metadata sourcing to use the native THORChain metadata source for more reliable runtime fields.
* **Tests**
  * Added a new test suite covering metadata backfill, value preservation, and safe pass-through for unrecognized/non-THORChain coins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->