### PR TITLE
Keep agent receipt polling status truthful

### DIFF
--- a/core/ui/agent/tools/handlers/signTx.ts
+++ b/core/ui/agent/tools/handlers/signTx.ts
@@ -1,11 +1,4 @@
 import { fromBinary } from '@bufbuild/protobuf'
-import { Chain, CosmosChain, EvmChain } from '@vultisig/core-chain/Chain'
-import { isChainOfKind } from '@vultisig/core-chain/ChainKind'
-import { getCosmosClient } from '@vultisig/core-chain/chains/cosmos/client'
-import { cosmosRpcUrl } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
-import { getEvmClient } from '@vultisig/core-chain/chains/evm/client'
-import { getSolanaClient } from '@vultisig/core-chain/chains/solana/client'
-import { getBlockchairBaseUrl } from '@vultisig/core-chain/chains/utxo/client/getBlockchairBaseUrl'
 import { getCoinType } from '@vultisig/core-chain/coin/coinType'
 import { getPublicKey } from '@vultisig/core-chain/publicKey/getPublicKey'
 import { getSignatureAlgorithm } from '@vultisig/core-chain/signing/SignatureAlgorithm'
@@ -23,6 +16,7 @@ import { z } from 'zod'
 import { fastVaultKeysign } from '../shared/fastVaultKeysign'
 import { getWalletContext } from '../shared/walletContext'
 import type { ToolHandler } from '../types'
+import { pollTxReceipt } from './txReceiptPolling'
 
 const signTxInputSchema = z.object({
   keysign_payload: z.string(),
@@ -115,7 +109,7 @@ export const handleSignTx: ToolHandler = async (input, context) => {
     await broadcastTx({ chain, tx: signingOutput })
 
     if (conversationId && emitEvent) {
-      pollTxReceipt({ chain, txHash, conversationId, label, emitEvent })
+      void pollTxReceipt({ chain, txHash, conversationId, label, emitEvent })
     }
 
     txResults.push({ label, tx_hash: txHash })
@@ -130,230 +124,4 @@ export const handleSignTx: ToolHandler = async (input, context) => {
   }
 
   return { data: result }
-}
-
-type EmitFn = (event: string, data: Record<string, unknown>) => void
-
-function emitTxStatus(params: {
-  emitEvent: EmitFn
-  conversationId: string
-  txHash: string
-  chain: string
-  status: 'pending' | 'confirmed' | 'failed'
-  label: string
-}) {
-  const { emitEvent, conversationId, txHash, chain, status, label } = params
-  emitEvent('tx_status', { conversationId, txHash, chain, status, label })
-}
-
-function pollTxReceipt(params: {
-  chain: Chain
-  txHash: string
-  conversationId: string
-  label: string
-  emitEvent: EmitFn
-}) {
-  const { chain, txHash, conversationId, label, emitEvent } = params
-  emitTxStatus({
-    emitEvent,
-    conversationId,
-    txHash,
-    chain,
-    status: 'pending',
-    label,
-  })
-
-  if (isChainOfKind(chain, 'evm')) {
-    pollEvmReceipt({ chain, txHash, conversationId, label, emitEvent })
-  } else if (isChainOfKind(chain, 'cosmos')) {
-    pollCosmosReceipt({ chain, txHash, conversationId, label, emitEvent })
-  } else if (isChainOfKind(chain, 'utxo')) {
-    pollUtxoReceipt({ chain, txHash, conversationId, label, emitEvent })
-  } else if (isChainOfKind(chain, 'solana')) {
-    pollSolanaReceipt({ txHash, conversationId, label, emitEvent })
-  }
-}
-
-function pollEvmReceipt(params: {
-  chain: EvmChain
-  txHash: string
-  conversationId: string
-  label: string
-  emitEvent: EmitFn
-}) {
-  const { chain, txHash, conversationId, label, emitEvent } = params
-  const client = getEvmClient(chain)
-  const hash = txHash as `0x${string}`
-
-  client
-    .waitForTransactionReceipt({ hash, timeout: 180_000 })
-    .then(receipt => {
-      const status = receipt.status === 'success' ? 'confirmed' : 'failed'
-      emitTxStatus({ emitEvent, conversationId, txHash, chain, status, label })
-    })
-    .catch(() => {
-      emitTxStatus({
-        emitEvent,
-        conversationId,
-        txHash,
-        chain,
-        status: 'failed',
-        label,
-      })
-    })
-}
-
-function pollCosmosReceipt(params: {
-  chain: CosmosChain
-  txHash: string
-  conversationId: string
-  label: string
-  emitEvent: EmitFn
-}) {
-  const { chain, txHash, conversationId, label, emitEvent } = params
-  const isThorMaya = chain === Chain.THORChain || chain === Chain.MayaChain
-  const pollInterval = isThorMaya ? 6_000 : 8_000
-  const maxAttempts = 30
-
-  const poll = async () => {
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      await new Promise(r => setTimeout(r, pollInterval))
-      try {
-        if (isThorMaya) {
-          const prefix = chain === Chain.THORChain ? 'thorchain' : 'mayachain'
-          const url = `${cosmosRpcUrl[chain]}/${prefix}/tx/${txHash}`
-          const resp = await fetch(url)
-          if (resp.ok) {
-            emitTxStatus({
-              emitEvent,
-              conversationId,
-              txHash,
-              chain,
-              status: 'confirmed',
-              label,
-            })
-            return
-          }
-        } else {
-          const client = await getCosmosClient(chain)
-          const tx = await client.getTx(txHash)
-          if (tx) {
-            const status = tx.code === 0 ? 'confirmed' : 'failed'
-            emitTxStatus({
-              emitEvent,
-              conversationId,
-              txHash,
-              chain,
-              status,
-              label,
-            })
-            return
-          }
-        }
-      } catch {
-        // not indexed yet
-      }
-    }
-    emitTxStatus({
-      emitEvent,
-      conversationId,
-      txHash,
-      chain,
-      status: 'failed',
-      label,
-    })
-  }
-  poll().catch(() => {})
-}
-
-function pollUtxoReceipt(params: {
-  chain: Chain
-  txHash: string
-  conversationId: string
-  label: string
-  emitEvent: EmitFn
-}) {
-  const { chain, txHash, conversationId, label, emitEvent } = params
-  const pollInterval = 15_000
-  const maxAttempts = 12
-
-  const poll = async () => {
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      await new Promise(r => setTimeout(r, pollInterval))
-      try {
-        const url = `${getBlockchairBaseUrl(chain as any)}/dashboards/transaction/${txHash}`
-        const resp = await fetch(url)
-        if (resp.ok) {
-          const body = await resp.json()
-          if (body?.data?.[txHash]) {
-            emitTxStatus({
-              emitEvent,
-              conversationId,
-              txHash,
-              chain,
-              status: 'confirmed',
-              label,
-            })
-            return
-          }
-        }
-      } catch {
-        // not confirmed yet
-      }
-    }
-    emitTxStatus({
-      emitEvent,
-      conversationId,
-      txHash,
-      chain,
-      status: 'failed',
-      label,
-    })
-  }
-  poll().catch(() => {})
-}
-
-function pollSolanaReceipt(params: {
-  txHash: string
-  conversationId: string
-  label: string
-  emitEvent: EmitFn
-}) {
-  const { txHash, conversationId, label, emitEvent } = params
-  const pollInterval = 5_000
-  const maxAttempts = 36
-
-  const poll = async () => {
-    const client = getSolanaClient()
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      await new Promise(r => setTimeout(r, pollInterval))
-      try {
-        const result = await client.getSignatureStatuses([txHash])
-        const sigStatus = result?.value?.[0]
-        if (sigStatus) {
-          const status = sigStatus.err ? 'failed' : 'confirmed'
-          emitTxStatus({
-            emitEvent,
-            conversationId,
-            txHash,
-            chain: Chain.Solana,
-            status,
-            label,
-          })
-          return
-        }
-      } catch {
-        // not confirmed yet
-      }
-    }
-    emitTxStatus({
-      emitEvent,
-      conversationId,
-      txHash,
-      chain: Chain.Solana,
-      status: 'failed',
-      label,
-    })
-  }
-  poll().catch(() => {})
 }

--- a/core/ui/agent/tools/handlers/txReceiptPolling.test.ts
+++ b/core/ui/agent/tools/handlers/txReceiptPolling.test.ts
@@ -1,0 +1,151 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { describe, expect, it, vi } from 'vitest'
+
+import { pollTxReceipt } from './txReceiptPolling'
+
+const schedule = {
+  cosmos: { pollInterval: 0, maxAttempts: 2 },
+  thorMaya: { pollInterval: 0, maxAttempts: 2 },
+  utxo: { pollInterval: 0, maxAttempts: 2 },
+  solana: { pollInterval: 0, maxAttempts: 2 },
+}
+
+const createDependencies = () => ({
+  sleep: vi.fn().mockResolvedValue(undefined),
+  waitForEvmReceipt: vi.fn().mockResolvedValue('confirmed' as const),
+  getCosmosReceiptStatus: vi.fn().mockResolvedValue(null),
+  getUtxoReceiptStatus: vi.fn().mockResolvedValue(null),
+  getSolanaReceiptStatus: vi.fn().mockResolvedValue(null),
+})
+
+const getStatuses = (emitEvent: ReturnType<typeof vi.fn>) =>
+  emitEvent.mock.calls.map(([, data]) => data.status)
+
+describe('pollTxReceipt', () => {
+  it('keeps an EVM transaction pending when receipt polling rejects', async () => {
+    const emitEvent = vi.fn()
+    const dependencies = createDependencies()
+    dependencies.waitForEvmReceipt.mockRejectedValue(new Error('timeout'))
+
+    await pollTxReceipt(
+      {
+        chain: Chain.Ethereum,
+        txHash: '0xabc',
+        conversationId: 'conversation',
+        label: 'transfer',
+        emitEvent,
+      },
+      dependencies,
+      schedule
+    )
+
+    expect(getStatuses(emitEvent)).toEqual(['pending'])
+  })
+
+  it.each([
+    ['Cosmos', Chain.Cosmos, 'getCosmosReceiptStatus'],
+    ['UTXO', Chain.Bitcoin, 'getUtxoReceiptStatus'],
+    ['Solana', Chain.Solana, 'getSolanaReceiptStatus'],
+  ] as const)(
+    'keeps a %s transaction pending after the observation window expires',
+    async (_, chain, observerName) => {
+      const emitEvent = vi.fn()
+      const dependencies = createDependencies()
+
+      await pollTxReceipt(
+        {
+          chain,
+          txHash: 'tx-hash',
+          conversationId: 'conversation',
+          label: 'transfer',
+          emitEvent,
+        },
+        dependencies,
+        schedule
+      )
+
+      expect(getStatuses(emitEvent)).toEqual(['pending'])
+      expect(dependencies[observerName]).toHaveBeenCalledTimes(2)
+    }
+  )
+
+  it.each([
+    ['Cosmos', Chain.Cosmos, 'getCosmosReceiptStatus'],
+    ['UTXO', Chain.Bitcoin, 'getUtxoReceiptStatus'],
+    ['Solana', Chain.Solana, 'getSolanaReceiptStatus'],
+  ] as const)(
+    'keeps a %s transaction pending through transport errors',
+    async (_, chain, observerName) => {
+      const emitEvent = vi.fn()
+      const dependencies = createDependencies()
+      dependencies[observerName].mockRejectedValue(new Error('transport'))
+
+      await pollTxReceipt(
+        {
+          chain,
+          txHash: 'tx-hash',
+          conversationId: 'conversation',
+          label: 'transfer',
+          emitEvent,
+        },
+        dependencies,
+        schedule
+      )
+
+      expect(getStatuses(emitEvent)).toEqual(['pending'])
+    }
+  )
+
+  it.each([
+    ['EVM', Chain.Ethereum, 'waitForEvmReceipt'],
+    ['Cosmos', Chain.Cosmos, 'getCosmosReceiptStatus'],
+    ['UTXO', Chain.Bitcoin, 'getUtxoReceiptStatus'],
+    ['Solana', Chain.Solana, 'getSolanaReceiptStatus'],
+  ] as const)(
+    'emits failed for a positive %s chain failure',
+    async (_, chain, observerName) => {
+      const emitEvent = vi.fn()
+      const dependencies = createDependencies()
+      dependencies[observerName].mockResolvedValue('failed')
+
+      await pollTxReceipt(
+        {
+          chain,
+          txHash: 'tx-hash',
+          conversationId: 'conversation',
+          label: 'transfer',
+          emitEvent,
+        },
+        dependencies,
+        schedule
+      )
+
+      expect(getStatuses(emitEvent)).toEqual(['pending', 'failed'])
+    }
+  )
+
+  it('emits confirmed with the original transaction context', async () => {
+    const emitEvent = vi.fn()
+    const dependencies = createDependencies()
+
+    await pollTxReceipt(
+      {
+        chain: Chain.Ethereum,
+        txHash: '0xabc',
+        conversationId: 'conversation',
+        label: 'swap',
+        emitEvent,
+      },
+      dependencies,
+      schedule
+    )
+
+    expect(emitEvent).toHaveBeenLastCalledWith('tx_status', {
+      conversationId: 'conversation',
+      txHash: '0xabc',
+      chain: Chain.Ethereum,
+      status: 'confirmed',
+      label: 'swap',
+    })
+  })
+})

--- a/core/ui/agent/tools/handlers/txReceiptPolling.test.ts
+++ b/core/ui/agent/tools/handlers/txReceiptPolling.test.ts
@@ -1,7 +1,16 @@
 import { Chain } from '@vultisig/core-chain/Chain'
+import { getSolanaClient } from '@vultisig/core-chain/chains/solana/client'
 import { describe, expect, it, vi } from 'vitest'
 
 import { pollTxReceipt } from './txReceiptPolling'
+
+const { getSignatureStatuses } = vi.hoisted(() => ({
+  getSignatureStatuses: vi.fn(),
+}))
+
+vi.mock('@vultisig/core-chain/chains/solana/client', () => ({
+  getSolanaClient: vi.fn(() => ({ getSignatureStatuses })),
+}))
 
 const schedule = {
   cosmos: { pollInterval: 0, maxAttempts: 2 },
@@ -9,6 +18,9 @@ const schedule = {
   utxo: { pollInterval: 0, maxAttempts: 2 },
   solana: { pollInterval: 0, maxAttempts: 2 },
 }
+
+const evmTxHash =
+  '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 
 const createDependencies = () => ({
   sleep: vi.fn().mockResolvedValue(undefined),
@@ -27,17 +39,15 @@ describe('pollTxReceipt', () => {
     const dependencies = createDependencies()
     dependencies.waitForEvmReceipt.mockRejectedValue(new Error('timeout'))
 
-    await pollTxReceipt(
-      {
-        chain: Chain.Ethereum,
-        txHash: '0xabc',
-        conversationId: 'conversation',
-        label: 'transfer',
-        emitEvent,
-      },
+    await pollTxReceipt({
+      chain: Chain.Ethereum,
+      txHash: evmTxHash,
+      conversationId: 'conversation',
+      label: 'transfer',
+      emitEvent,
       dependencies,
-      schedule
-    )
+      schedule,
+    })
 
     expect(getStatuses(emitEvent)).toEqual(['pending'])
   })
@@ -52,17 +62,15 @@ describe('pollTxReceipt', () => {
       const emitEvent = vi.fn()
       const dependencies = createDependencies()
 
-      await pollTxReceipt(
-        {
-          chain,
-          txHash: 'tx-hash',
-          conversationId: 'conversation',
-          label: 'transfer',
-          emitEvent,
-        },
+      await pollTxReceipt({
+        chain,
+        txHash: 'tx-hash',
+        conversationId: 'conversation',
+        label: 'transfer',
+        emitEvent,
         dependencies,
-        schedule
-      )
+        schedule,
+      })
 
       expect(getStatuses(emitEvent)).toEqual(['pending'])
       expect(dependencies[observerName]).toHaveBeenCalledTimes(2)
@@ -80,17 +88,15 @@ describe('pollTxReceipt', () => {
       const dependencies = createDependencies()
       dependencies[observerName].mockRejectedValue(new Error('transport'))
 
-      await pollTxReceipt(
-        {
-          chain,
-          txHash: 'tx-hash',
-          conversationId: 'conversation',
-          label: 'transfer',
-          emitEvent,
-        },
+      await pollTxReceipt({
+        chain,
+        txHash: 'tx-hash',
+        conversationId: 'conversation',
+        label: 'transfer',
+        emitEvent,
         dependencies,
-        schedule
-      )
+        schedule,
+      })
 
       expect(getStatuses(emitEvent)).toEqual(['pending'])
     }
@@ -107,18 +113,17 @@ describe('pollTxReceipt', () => {
       const emitEvent = vi.fn()
       const dependencies = createDependencies()
       dependencies[observerName].mockResolvedValue('failed')
+      const txHash = chain === Chain.Ethereum ? evmTxHash : 'tx-hash'
 
-      await pollTxReceipt(
-        {
-          chain,
-          txHash: 'tx-hash',
-          conversationId: 'conversation',
-          label: 'transfer',
-          emitEvent,
-        },
+      await pollTxReceipt({
+        chain,
+        txHash,
+        conversationId: 'conversation',
+        label: 'transfer',
+        emitEvent,
         dependencies,
-        schedule
-      )
+        schedule,
+      })
 
       expect(getStatuses(emitEvent)).toEqual(['pending', 'failed'])
     }
@@ -128,24 +133,59 @@ describe('pollTxReceipt', () => {
     const emitEvent = vi.fn()
     const dependencies = createDependencies()
 
-    await pollTxReceipt(
-      {
-        chain: Chain.Ethereum,
-        txHash: '0xabc',
-        conversationId: 'conversation',
-        label: 'swap',
-        emitEvent,
-      },
+    await pollTxReceipt({
+      chain: Chain.Ethereum,
+      txHash: evmTxHash,
+      conversationId: 'conversation',
+      label: 'swap',
+      emitEvent,
       dependencies,
-      schedule
-    )
+      schedule,
+    })
 
     expect(emitEvent).toHaveBeenLastCalledWith('tx_status', {
       conversationId: 'conversation',
-      txHash: '0xabc',
+      txHash: evmTxHash,
       chain: Chain.Ethereum,
       status: 'confirmed',
       label: 'swap',
     })
+  })
+
+  it('does not query an EVM receipt for an invalid hash', async () => {
+    const emitEvent = vi.fn()
+    const dependencies = createDependencies()
+
+    await pollTxReceipt({
+      chain: Chain.Ethereum,
+      txHash: '0xabc',
+      conversationId: 'conversation',
+      label: 'transfer',
+      emitEvent,
+      dependencies,
+      schedule,
+    })
+
+    expect(dependencies.waitForEvmReceipt).not.toHaveBeenCalled()
+    expect(getStatuses(emitEvent)).toEqual(['pending'])
+  })
+
+  it('keeps a processed Solana transaction pending', async () => {
+    const emitEvent = vi.fn()
+    getSignatureStatuses.mockResolvedValue({
+      value: [{ err: null, confirmationStatus: 'processed' }],
+    })
+
+    await pollTxReceipt({
+      chain: Chain.Solana,
+      txHash: 'signature',
+      conversationId: 'conversation',
+      label: 'transfer',
+      emitEvent,
+      schedule,
+    })
+
+    expect(getSolanaClient).toHaveBeenCalled()
+    expect(getStatuses(emitEvent)).toEqual(['pending'])
   })
 })

--- a/core/ui/agent/tools/handlers/txReceiptPolling.ts
+++ b/core/ui/agent/tools/handlers/txReceiptPolling.ts
@@ -1,0 +1,201 @@
+import {
+  Chain,
+  CosmosChain,
+  EvmChain,
+  UtxoBasedChain,
+} from '@vultisig/core-chain/Chain'
+import { isChainOfKind } from '@vultisig/core-chain/ChainKind'
+import { getCosmosClient } from '@vultisig/core-chain/chains/cosmos/client'
+import { cosmosRpcUrl } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
+import { getEvmClient } from '@vultisig/core-chain/chains/evm/client'
+import { getSolanaClient } from '@vultisig/core-chain/chains/solana/client'
+import { getBlockchairBaseUrl } from '@vultisig/core-chain/chains/utxo/client/getBlockchairBaseUrl'
+
+type TxStatus = 'pending' | 'confirmed' | 'failed'
+type TerminalTxStatus = Exclude<TxStatus, 'pending'>
+type EmitFn = (event: string, data: Record<string, unknown>) => void
+
+type ReceiptPollingDependencies = {
+  sleep: (duration: number) => Promise<void>
+  waitForEvmReceipt: (
+    chain: EvmChain,
+    txHash: string
+  ) => Promise<TerminalTxStatus>
+  getCosmosReceiptStatus: (
+    chain: CosmosChain,
+    txHash: string
+  ) => Promise<TerminalTxStatus | null>
+  getUtxoReceiptStatus: (
+    chain: UtxoBasedChain,
+    txHash: string
+  ) => Promise<TerminalTxStatus | null>
+  getSolanaReceiptStatus: (txHash: string) => Promise<TerminalTxStatus | null>
+}
+
+type ReceiptPollingSchedule = {
+  cosmos: { pollInterval: number; maxAttempts: number }
+  thorMaya: { pollInterval: number; maxAttempts: number }
+  utxo: { pollInterval: number; maxAttempts: number }
+  solana: { pollInterval: number; maxAttempts: number }
+}
+
+const defaultSchedule: ReceiptPollingSchedule = {
+  cosmos: { pollInterval: 8_000, maxAttempts: 30 },
+  thorMaya: { pollInterval: 6_000, maxAttempts: 30 },
+  utxo: { pollInterval: 15_000, maxAttempts: 12 },
+  solana: { pollInterval: 5_000, maxAttempts: 36 },
+}
+
+const sleep = (duration: number) =>
+  new Promise<void>(resolve => setTimeout(resolve, duration))
+
+const defaultDependencies: ReceiptPollingDependencies = {
+  sleep,
+  waitForEvmReceipt: async (chain, txHash) => {
+    const client = getEvmClient(chain)
+    const hash = txHash as `0x${string}`
+    const receipt = await client.waitForTransactionReceipt({
+      hash,
+      timeout: 180_000,
+    })
+
+    return receipt.status === 'success' ? 'confirmed' : 'failed'
+  },
+  getCosmosReceiptStatus: async (chain, txHash) => {
+    const isThorMaya = chain === Chain.THORChain || chain === Chain.MayaChain
+    if (isThorMaya) {
+      const prefix = chain === Chain.THORChain ? 'thorchain' : 'mayachain'
+      const url = `${cosmosRpcUrl[chain]}/${prefix}/tx/${txHash}`
+      const response = await fetch(url)
+
+      return response.ok ? 'confirmed' : null
+    }
+
+    const client = await getCosmosClient(chain)
+    const tx = await client.getTx(txHash)
+
+    if (!tx) return null
+
+    return tx.code === 0 ? 'confirmed' : 'failed'
+  },
+  getUtxoReceiptStatus: async (chain, txHash) => {
+    const url = `${getBlockchairBaseUrl(chain)}/dashboards/transaction/${txHash}`
+    const response = await fetch(url)
+    if (!response.ok) return null
+
+    const body = await response.json()
+
+    return body?.data?.[txHash] ? 'confirmed' : null
+  },
+  getSolanaReceiptStatus: async txHash => {
+    const client = getSolanaClient()
+    const result = await client.getSignatureStatuses([txHash])
+    const signatureStatus = result?.value?.[0]
+
+    if (!signatureStatus) return null
+
+    return signatureStatus.err ? 'failed' : 'confirmed'
+  },
+}
+
+const emitTxStatus = (params: {
+  emitEvent: EmitFn
+  conversationId: string
+  txHash: string
+  chain: Chain
+  status: TxStatus
+  label: string
+}) => {
+  const { emitEvent, conversationId, txHash, chain, status, label } = params
+  emitEvent('tx_status', { conversationId, txHash, chain, status, label })
+}
+
+const pollRepeatedly = async (params: {
+  observe: () => Promise<TerminalTxStatus | null>
+  sleep: ReceiptPollingDependencies['sleep']
+  pollInterval: number
+  maxAttempts: number
+}) => {
+  const { observe, sleep, pollInterval, maxAttempts } = params
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    await sleep(pollInterval)
+    try {
+      const status = await observe()
+      if (status) return status
+    } catch {
+      // A transport error does not prove that the transaction failed.
+    }
+  }
+
+  return null
+}
+
+export const pollTxReceipt = async (
+  params: {
+    chain: Chain
+    txHash: string
+    conversationId: string
+    label: string
+    emitEvent: EmitFn
+  },
+  dependencies: ReceiptPollingDependencies = defaultDependencies,
+  schedule: ReceiptPollingSchedule = defaultSchedule
+) => {
+  const { chain, txHash, conversationId, label, emitEvent } = params
+  const emitTerminalStatus = (status: TerminalTxStatus) =>
+    emitTxStatus({
+      emitEvent,
+      conversationId,
+      txHash,
+      chain,
+      status,
+      label,
+    })
+
+  emitTxStatus({
+    emitEvent,
+    conversationId,
+    txHash,
+    chain,
+    status: 'pending',
+    label,
+  })
+
+  if (isChainOfKind(chain, 'evm')) {
+    try {
+      emitTerminalStatus(await dependencies.waitForEvmReceipt(chain, txHash))
+    } catch {
+      // Timeout or transport failure leaves the last truthful status pending.
+    }
+    return
+  }
+
+  let status: TerminalTxStatus | null = null
+
+  if (isChainOfKind(chain, 'cosmos')) {
+    const pollingSchedule =
+      chain === Chain.THORChain || chain === Chain.MayaChain
+        ? schedule.thorMaya
+        : schedule.cosmos
+    status = await pollRepeatedly({
+      observe: () => dependencies.getCosmosReceiptStatus(chain, txHash),
+      sleep: dependencies.sleep,
+      ...pollingSchedule,
+    })
+  } else if (isChainOfKind(chain, 'utxo')) {
+    status = await pollRepeatedly({
+      observe: () => dependencies.getUtxoReceiptStatus(chain, txHash),
+      sleep: dependencies.sleep,
+      ...schedule.utxo,
+    })
+  } else if (isChainOfKind(chain, 'solana')) {
+    status = await pollRepeatedly({
+      observe: () => dependencies.getSolanaReceiptStatus(txHash),
+      sleep: dependencies.sleep,
+      ...schedule.solana,
+    })
+  }
+
+  if (status) emitTerminalStatus(status)
+}

--- a/core/ui/agent/tools/handlers/txReceiptPolling.ts
+++ b/core/ui/agent/tools/handlers/txReceiptPolling.ts
@@ -10,26 +10,45 @@ import { cosmosRpcUrl } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
 import { getEvmClient } from '@vultisig/core-chain/chains/evm/client'
 import { getSolanaClient } from '@vultisig/core-chain/chains/solana/client'
 import { getBlockchairBaseUrl } from '@vultisig/core-chain/chains/utxo/client/getBlockchairBaseUrl'
+import { type Hash, isHash } from 'viem'
 
 type TxStatus = 'pending' | 'confirmed' | 'failed'
 type TerminalTxStatus = Exclude<TxStatus, 'pending'>
 type EmitFn = (event: string, data: Record<string, unknown>) => void
 
+type WaitForEvmReceiptInput = {
+  chain: EvmChain
+  txHash: Hash
+}
+
+type GetCosmosReceiptStatusInput = {
+  chain: CosmosChain
+  txHash: string
+}
+
+type GetUtxoReceiptStatusInput = {
+  chain: UtxoBasedChain
+  txHash: string
+}
+
+type GetSolanaReceiptStatusInput = {
+  txHash: string
+}
+
 type ReceiptPollingDependencies = {
   sleep: (duration: number) => Promise<void>
   waitForEvmReceipt: (
-    chain: EvmChain,
-    txHash: string
+    input: WaitForEvmReceiptInput
   ) => Promise<TerminalTxStatus>
   getCosmosReceiptStatus: (
-    chain: CosmosChain,
-    txHash: string
+    input: GetCosmosReceiptStatusInput
   ) => Promise<TerminalTxStatus | null>
   getUtxoReceiptStatus: (
-    chain: UtxoBasedChain,
-    txHash: string
+    input: GetUtxoReceiptStatusInput
   ) => Promise<TerminalTxStatus | null>
-  getSolanaReceiptStatus: (txHash: string) => Promise<TerminalTxStatus | null>
+  getSolanaReceiptStatus: (
+    input: GetSolanaReceiptStatusInput
+  ) => Promise<TerminalTxStatus | null>
 }
 
 type ReceiptPollingSchedule = {
@@ -51,17 +70,16 @@ const sleep = (duration: number) =>
 
 const defaultDependencies: ReceiptPollingDependencies = {
   sleep,
-  waitForEvmReceipt: async (chain, txHash) => {
+  waitForEvmReceipt: async ({ chain, txHash }) => {
     const client = getEvmClient(chain)
-    const hash = txHash as `0x${string}`
     const receipt = await client.waitForTransactionReceipt({
-      hash,
+      hash: txHash,
       timeout: 180_000,
     })
 
     return receipt.status === 'success' ? 'confirmed' : 'failed'
   },
-  getCosmosReceiptStatus: async (chain, txHash) => {
+  getCosmosReceiptStatus: async ({ chain, txHash }) => {
     const isThorMaya = chain === Chain.THORChain || chain === Chain.MayaChain
     if (isThorMaya) {
       const prefix = chain === Chain.THORChain ? 'thorchain' : 'mayachain'
@@ -78,7 +96,7 @@ const defaultDependencies: ReceiptPollingDependencies = {
 
     return tx.code === 0 ? 'confirmed' : 'failed'
   },
-  getUtxoReceiptStatus: async (chain, txHash) => {
+  getUtxoReceiptStatus: async ({ chain, txHash }) => {
     const url = `${getBlockchairBaseUrl(chain)}/dashboards/transaction/${txHash}`
     const response = await fetch(url)
     if (!response.ok) return null
@@ -87,14 +105,19 @@ const defaultDependencies: ReceiptPollingDependencies = {
 
     return body?.data?.[txHash] ? 'confirmed' : null
   },
-  getSolanaReceiptStatus: async txHash => {
+  getSolanaReceiptStatus: async ({ txHash }) => {
     const client = getSolanaClient()
     const result = await client.getSignatureStatuses([txHash])
     const signatureStatus = result?.value?.[0]
 
     if (!signatureStatus) return null
 
-    return signatureStatus.err ? 'failed' : 'confirmed'
+    if (signatureStatus.err) return 'failed'
+
+    return signatureStatus.confirmationStatus === 'confirmed' ||
+      signatureStatus.confirmationStatus === 'finalized'
+      ? 'confirmed'
+      : null
   },
 }
 
@@ -131,18 +154,29 @@ const pollRepeatedly = async (params: {
   return null
 }
 
-export const pollTxReceipt = async (
-  params: {
-    chain: Chain
-    txHash: string
-    conversationId: string
-    label: string
-    emitEvent: EmitFn
-  },
-  dependencies: ReceiptPollingDependencies = defaultDependencies,
-  schedule: ReceiptPollingSchedule = defaultSchedule
-) => {
-  const { chain, txHash, conversationId, label, emitEvent } = params
+type PollTxReceiptInput = {
+  chain: Chain
+  txHash: string
+  conversationId: string
+  label: string
+  emitEvent: EmitFn
+  dependencies?: ReceiptPollingDependencies
+  schedule?: ReceiptPollingSchedule
+}
+
+/**
+ * Emits pending immediately and a terminal status only on positive chain evidence.
+ * @param input Transaction context, event sink, and optional polling controls.
+ */
+export const pollTxReceipt = async ({
+  chain,
+  txHash,
+  conversationId,
+  label,
+  emitEvent,
+  dependencies = defaultDependencies,
+  schedule = defaultSchedule,
+}: PollTxReceiptInput) => {
   const emitTerminalStatus = (status: TerminalTxStatus) =>
     emitTxStatus({
       emitEvent,
@@ -163,8 +197,12 @@ export const pollTxReceipt = async (
   })
 
   if (isChainOfKind(chain, 'evm')) {
+    if (!isHash(txHash)) return
+
     try {
-      emitTerminalStatus(await dependencies.waitForEvmReceipt(chain, txHash))
+      emitTerminalStatus(
+        await dependencies.waitForEvmReceipt({ chain, txHash })
+      )
     } catch {
       // Timeout or transport failure leaves the last truthful status pending.
     }
@@ -179,19 +217,19 @@ export const pollTxReceipt = async (
         ? schedule.thorMaya
         : schedule.cosmos
     status = await pollRepeatedly({
-      observe: () => dependencies.getCosmosReceiptStatus(chain, txHash),
+      observe: () => dependencies.getCosmosReceiptStatus({ chain, txHash }),
       sleep: dependencies.sleep,
       ...pollingSchedule,
     })
   } else if (isChainOfKind(chain, 'utxo')) {
     status = await pollRepeatedly({
-      observe: () => dependencies.getUtxoReceiptStatus(chain, txHash),
+      observe: () => dependencies.getUtxoReceiptStatus({ chain, txHash }),
       sleep: dependencies.sleep,
       ...schedule.utxo,
     })
   } else if (isChainOfKind(chain, 'solana')) {
     status = await pollRepeatedly({
-      observe: () => dependencies.getSolanaReceiptStatus(txHash),
+      observe: () => dependencies.getSolanaReceiptStatus({ txHash }),
       sleep: dependencies.sleep,
       ...schedule.solana,
     })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized transaction receipt polling that emits real-time `tx_status` updates for EVM, Cosmos, UTXO, and Solana.
  * Statuses now consistently transition from `pending` to `confirmed` or `failed` when chain evidence is available.

* **Bug Fixes**
  * Improved reliability for timeouts, invalid transaction hashes, and transport/observation errors—when confirmations can’t be determined in time, transactions remain `pending`.

* **Tests**
  * Expanded automated coverage for polling behavior across all supported networks and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->