### PR TITLE
fix(defi): show "Amount must be positive" instead of "Invalid input" on Stake/Bond/Unbond amount fields

### DIFF
--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/BondSpecific/BondForm.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/BondSpecific/BondForm.tsx
@@ -98,10 +98,11 @@ export const BondForm = ({ balance, errors, formValues }: BondFormProps) => {
     enabled: shouldShowFeePreview,
   })
 
+  // Schema messages are already translated (see getDepositFormConfig), so we
+  // render them directly. Re-running them through t() would find no matching
+  // key and collapse every error to the generic default_validation fallback.
   const formatError = (message?: string) =>
-    message
-      ? t(message, { defaultValue: t('chainFunctions.default_validation') })
-      : undefined
+    message || t('chainFunctions.default_validation')
 
   const parsedAmount =
     typeof amountValue === 'number'

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/StakeForm.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/StakeForm.tsx
@@ -96,10 +96,11 @@ export const StakeForm = ({
 
   const formattedBalance = formatAmount(balance, { ticker: coin.ticker })
 
+  // Schema messages are already translated (see getDepositFormConfig), so we
+  // render them directly. Re-running them through t() would find no matching
+  // key and collapse every error to the generic default_validation fallback.
   const formatError = (message?: string) =>
-    message
-      ? t(message, { defaultValue: t('chainFunctions.default_validation') })
-      : undefined
+    message || t('chainFunctions.default_validation')
 
   return (
     <VStack flexGrow gap={16}>

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/UnbondSpecific/UnbondForm.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/UnbondSpecific/UnbondForm.tsx
@@ -83,10 +83,11 @@ export const UnbondForm = ({
     enabled: shouldShowFeePreview,
   })
 
+  // Schema messages are already translated (see getDepositFormConfig), so we
+  // render them directly. Re-running them through t() would find no matching
+  // key and collapse every error to the generic default_validation fallback.
   const formatError = (message?: string) =>
-    message
-      ? t(message, { defaultValue: t('chainFunctions.default_validation') })
-      : undefined
+    message || t('chainFunctions.default_validation')
 
   const parsedAmount =
     typeof amountValue === 'number'

--- a/core/ui/vault/deposit/utils/validationHelpers.ts
+++ b/core/ui/vault/deposit/utils/validationHelpers.ts
@@ -22,7 +22,10 @@ export const positiveAmountSchema = (
   z.preprocess(
     toRequiredNumber,
     z
-      .number()
+      // An empty/undefined amount becomes NaN via toRequiredNumber; without a
+      // custom message Zod emits its raw invalid_type error instead of the
+      // translated "amount must be positive" one.
+      .number({ error: t('amount_must_be_positive') })
       .gt(0, t('amount_must_be_positive'))
       .max(
         maxValue > 0 ? maxValue : Number.POSITIVE_INFINITY,


### PR DESCRIPTION
## Problem

On the DeFi amount screens — **Stake/Unstake (TCY, RUJI, TON, sTCY mint/redeem)**, **Bond RUNE**, and **Unbond RUNE** — the amount field showed the generic **"Invalid input"** message on first entry (before typing anything). The intended message is **"Amount must be positive"**. The same wrong text also appeared for every other amount error on these screens (e.g. "amount exceeded", "insufficient balance").

| Before | After |
|--------|-------|
| First entry → `Invalid input` | First entry → `Amount must be positive` |

## Root cause

Two stacked bugs, both needed to be fixed:

**1. The schema emitted a raw type error for an empty amount.**
The amount field starts as `undefined` (no default value) and the form validates on mount (`mode: 'onChange'` + a `trigger()` effect). `positiveAmountSchema` preprocesses the value with `toRequiredNumber`, which turns `undefined`/`''` into `NaN`. Zod v4's `z.number()` rejects `NaN` with its built-in `invalid_type` error ("Invalid input: expected number, received NaN") **before** the `.gt(0, 'amount_must_be_positive')` rule can run — so the intended message was never produced.

**2. The renderer double-translated an already-translated message.**
This project is **translation-based**: schemas call `t('key')` and store the *already-translated string* as the error message; renderers display `errors.x.message` directly (30+ other forms do exactly this). But `formatError` in `StakeForm`/`BondForm`/`UnbondForm` re-ran the message through `t()`:

```ts
t(message, { defaultValue: t('chainFunctions.default_validation') })
```

The key `amount_must_be_positive` **exists** in `en.ts`, but by this point `message` is the *sentence* "Amount must be positive", not the key. i18next can't find a key by that sentence, so it falls back to `default_validation` = **"Invalid input"** — collapsing every amount error to that one string.

## Fix

1. **`positiveAmountSchema`** (`validationHelpers.ts`): give `z.number()` a custom error so the empty/`NaN` case yields the intended message instead of Zod's raw type error:
   ```ts
   z.number({ error: t('amount_must_be_positive') })
   ```
   `.gt()` / `.max()` / `insufficient_balance` keep their own messages — the schema-level `error` only fills in the `invalid_type` case.

2. **`formatError`** in `StakeForm`, `BondForm`, `UnbondForm`: render the already-translated message directly (translation-based convention), keeping `default_validation` only as a fallback when no message is present:
   ```ts
   message || t('chainFunctions.default_validation')
   ```

No default value was added to the `amount` field, and no translation key was created — `amount_must_be_positive` already exists. The `undefined`→`NaN` value still flows through; the schema now just handles it with the correct message.

## Files changed

- `core/ui/vault/deposit/utils/validationHelpers.ts` — schema `error` message
- `core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/StakeForm.tsx` — `formatError`
- `core/ui/vault/deposit/DepositForm/ActionSpecific/BondSpecific/BondForm.tsx` — `formatError`
- `core/ui/vault/deposit/DepositForm/ActionSpecific/UnbondSpecific/UnbondForm.tsx` — `formatError`

## Verification

- `yarn typecheck` ✅, `yarn eslint` (changed files) ✅, deposit-form tests ✅ (8 passed)
- End-to-end simulation of the exact flow (schema → RHF error → `formatError`):
  - first entry (undefined) → `Amount must be positive`
  - zero → `Amount must be positive`
  - valid amount → no error
  - exceeds balance → `Amount exceeded` (previously also collapsed to "Invalid input")
- Rebuilt the extension app bundle and verified on the Stake TCY, Bond RUNE, and Unbond RUNE screens.

Closes #4373

🤖 Generated with [Claude Code](https://claude.com/claude-code)
