### PR TITLE
fix(price): value THORChain secured assets from pool oracle

### DIFF
--- a/core/ui/chain/coin/price/queries/useCoinPricesQuery.ts
+++ b/core/ui/chain/coin/price/queries/useCoinPricesQuery.ts
@@ -26,6 +26,10 @@ import {
   MayaPoolPricedTokenId,
   mayaPoolPricedTokens,
 } from '../maya/mayaPoolPricedTokens'
+import {
+  getThorchainSecuredAssetPrices,
+  isThorchainSecuredAssetDenom,
+} from '../thor/getThorchainSecuredAssetPrices'
 
 type GetCoinPricesQueryKeysInput = {
   coins: CoinKey[]
@@ -66,6 +70,7 @@ export function useCoinPricesQuery(
   const coinsWithPriceProviderId: (CoinKey & { priceProviderId: string })[] = []
   const erc20sWithoutPriceProviderId: Token<CoinKey<EvmChain>>[] = []
   const yieldBearingTokens: Token<CoinKey<CosmosChain>>[] = []
+  const thorSecuredTokens: Token<CoinKey<CosmosChain>>[] = []
   const mayaPoolTokens: (Token<CoinKey> & {
     poolTokenId: MayaPoolPricedTokenId
   })[] = []
@@ -89,6 +94,12 @@ export function useCoinPricesQuery(
       isChainOfKind(chain, 'cosmos')
     ) {
       yieldBearingTokens.push({ id, chain })
+    } else if (
+      chain === Chain.THORChain &&
+      id &&
+      isThorchainSecuredAssetDenom(id)
+    ) {
+      thorSecuredTokens.push({ id, chain })
     } else if (isChainOfKind(chain, 'evm') && id) {
       erc20sWithoutPriceProviderId.push({ id, chain })
     } else if (!eager) {
@@ -199,6 +210,28 @@ export function useCoinPricesQuery(
             result[coinKeyToString(coin)] = nav
           }
         }
+        return result
+      },
+      ...persistQueryOptions,
+    })
+  }
+
+  if (!isEmpty(thorSecuredTokens)) {
+    const denoms = thorSecuredTokens.map(coin => shouldBePresent(coin.id))
+
+    queries.push({
+      queryKey: ['thorchainSecuredAssetPrices', denoms],
+      queryFn: async () => {
+        const prices = await getThorchainSecuredAssetPrices(denoms)
+
+        const result: Record<string, number> = {}
+        for (const coin of thorSecuredTokens) {
+          const price = prices[shouldBePresent(coin.id)]
+          if (price != null) {
+            result[coinKeyToString(coin)] = price
+          }
+        }
+
         return result
       },
       ...persistQueryOptions,

--- a/core/ui/chain/coin/price/queries/useCoinPricesQuery.ts
+++ b/core/ui/chain/coin/price/queries/useCoinPricesQuery.ts
@@ -31,6 +31,12 @@ import {
   isThorchainSecuredAssetDenom,
 } from '../thor/getThorchainSecuredAssetPrices'
 
+// USD stablecoin used to convert USD-denominated prices (e.g. THORChain pool
+// `asset_tor_price`) into the selected fiat: its price in `fiatCurrency` is the
+// USD -> fiat rate.
+const usdAnchorPriceProviderId = 'usd-coin'
+const usdFiatCurrency: FiatCurrency = 'usd'
+
 type GetCoinPricesQueryKeysInput = {
   coins: CoinKey[]
   fiatCurrency: FiatCurrency
@@ -220,15 +226,25 @@ export function useCoinPricesQuery(
     const denoms = thorSecuredTokens.map(coin => shouldBePresent(coin.id))
 
     queries.push({
-      queryKey: ['thorchainSecuredAssetPrices', denoms],
+      queryKey: ['thorchainSecuredAssetPrices', denoms, fiatCurrency],
       queryFn: async () => {
-        const prices = await getThorchainSecuredAssetPrices(denoms)
+        const usdPrices = await getThorchainSecuredAssetPrices(denoms)
+
+        // Pool prices are USD-denominated; convert to the selected fiat.
+        let usdToFiatRate = 1
+        if (fiatCurrency !== usdFiatCurrency) {
+          const anchorPrices = await getCoinPrices({
+            ids: [usdAnchorPriceProviderId],
+            fiatCurrency,
+          })
+          usdToFiatRate = anchorPrices[usdAnchorPriceProviderId] ?? 1
+        }
 
         const result: Record<string, number> = {}
         for (const coin of thorSecuredTokens) {
-          const price = prices[shouldBePresent(coin.id)]
-          if (price != null) {
-            result[coinKeyToString(coin)] = price
+          const usdPrice = usdPrices[shouldBePresent(coin.id)]
+          if (usdPrice != null) {
+            result[coinKeyToString(coin)] = usdPrice * usdToFiatRate
           }
         }
 

--- a/core/ui/chain/coin/price/queries/useCoinPricesQuery.ts
+++ b/core/ui/chain/coin/price/queries/useCoinPricesQuery.ts
@@ -27,15 +27,9 @@ import {
   mayaPoolPricedTokens,
 } from '../maya/mayaPoolPricedTokens'
 import {
-  getThorchainSecuredAssetPrices,
+  getThorchainSecuredAssetFiatPrices,
   isThorchainSecuredAssetDenom,
 } from '../thor/getThorchainSecuredAssetPrices'
-
-// USD stablecoin used to convert USD-denominated prices (e.g. THORChain pool
-// `asset_tor_price`) into the selected fiat: its price in `fiatCurrency` is the
-// USD -> fiat rate.
-const usdAnchorPriceProviderId = 'usd-coin'
-const usdFiatCurrency: FiatCurrency = 'usd'
 
 type GetCoinPricesQueryKeysInput = {
   coins: CoinKey[]
@@ -228,23 +222,16 @@ export function useCoinPricesQuery(
     queries.push({
       queryKey: ['thorchainSecuredAssetPrices', denoms, fiatCurrency],
       queryFn: async () => {
-        const usdPrices = await getThorchainSecuredAssetPrices(denoms)
-
-        // Pool prices are USD-denominated; convert to the selected fiat.
-        let usdToFiatRate = 1
-        if (fiatCurrency !== usdFiatCurrency) {
-          const anchorPrices = await getCoinPrices({
-            ids: [usdAnchorPriceProviderId],
-            fiatCurrency,
-          })
-          usdToFiatRate = anchorPrices[usdAnchorPriceProviderId] ?? 1
-        }
+        const prices = await getThorchainSecuredAssetFiatPrices({
+          denoms,
+          fiatCurrency,
+        })
 
         const result: Record<string, number> = {}
         for (const coin of thorSecuredTokens) {
-          const usdPrice = usdPrices[shouldBePresent(coin.id)]
-          if (usdPrice != null) {
-            result[coinKeyToString(coin)] = usdPrice * usdToFiatRate
+          const price = prices[shouldBePresent(coin.id)]
+          if (price != null) {
+            result[coinKeyToString(coin)] = price
           }
         }
 

--- a/core/ui/chain/coin/price/thor/getThorchainSecuredAssetPrices.test.ts
+++ b/core/ui/chain/coin/price/thor/getThorchainSecuredAssetPrices.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockQueryUrl } = vi.hoisted(() => ({
+  mockQueryUrl: vi.fn(),
+}))
+
+vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
+  queryUrl: mockQueryUrl,
+}))
+
+import {
+  getThorchainSecuredAssetPrices,
+  isThorchainSecuredAssetDenom,
+  securedAssetDenomToPoolAsset,
+} from './getThorchainSecuredAssetPrices'
+
+describe('isThorchainSecuredAssetDenom', () => {
+  it('accepts hyphenated secured-asset denoms', () => {
+    expect(isThorchainSecuredAssetDenom('btc-btc')).toBe(true)
+    expect(isThorchainSecuredAssetDenom('gaia-atom')).toBe(true)
+    expect(
+      isThorchainSecuredAssetDenom(
+        'eth-usdc-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+      )
+    ).toBe(true)
+  })
+
+  it('rejects native, factory, LP and dotted denoms', () => {
+    expect(isThorchainSecuredAssetDenom('rune')).toBe(false)
+    expect(isThorchainSecuredAssetDenom('x/ruji')).toBe(false)
+    expect(isThorchainSecuredAssetDenom('x/brune')).toBe(false)
+    expect(isThorchainSecuredAssetDenom('thor.lqdy')).toBe(false)
+    expect(
+      isThorchainSecuredAssetDenom(
+        'x/bow-xyk-gaia-atom-eth-usdc-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+      )
+    ).toBe(false)
+  })
+})
+
+describe('securedAssetDenomToPoolAsset', () => {
+  it('uppercases and turns only the leading chain hyphen into a dot', () => {
+    expect(securedAssetDenomToPoolAsset('btc-btc')).toBe('BTC.BTC')
+    expect(securedAssetDenomToPoolAsset('gaia-atom')).toBe('GAIA.ATOM')
+    expect(
+      securedAssetDenomToPoolAsset(
+        'eth-usdc-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+      )
+    ).toBe('ETH.USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48')
+  })
+})
+
+describe('getThorchainSecuredAssetPrices', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('maps denoms to pool asset_tor_price scaled down by 10^8', async () => {
+    mockQueryUrl.mockResolvedValue([
+      { asset: 'BTC.BTC', asset_tor_price: '6417195738200' },
+      { asset: 'GAIA.ATOM', asset_tor_price: '153753700' },
+      {
+        asset: 'ETH.XRUNE-0X69FA0FEE221AD11012BAB0FDB45D444D3D2CE71C',
+        asset_tor_price: '69927',
+      },
+    ])
+
+    const prices = await getThorchainSecuredAssetPrices([
+      'btc-btc',
+      'gaia-atom',
+      'eth-xrune-0x69fa0fee221ad11012bab0fdb45d444d3d2ce71c',
+    ])
+
+    expect(prices['btc-btc']).toBeCloseTo(64171.957382, 4)
+    expect(prices['gaia-atom']).toBeCloseTo(1.537537, 4)
+    expect(
+      prices['eth-xrune-0x69fa0fee221ad11012bab0fdb45d444d3d2ce71c']
+    ).toBeCloseTo(0.00069927, 8)
+  })
+
+  it('omits denoms without an available pool and zero-priced pools', async () => {
+    mockQueryUrl.mockResolvedValue([
+      { asset: 'BTC.BTC', asset_tor_price: '6417195738200' },
+      { asset: 'ETH.ETH', asset_tor_price: '0' },
+    ])
+
+    const prices = await getThorchainSecuredAssetPrices([
+      'btc-btc',
+      'eth-eth',
+      'ltc-ltc',
+    ])
+
+    expect(prices['btc-btc']).toBeGreaterThan(0)
+    expect('eth-eth' in prices).toBe(false)
+    expect('ltc-ltc' in prices).toBe(false)
+  })
+
+  it('returns an empty map when the pools request fails', async () => {
+    mockQueryUrl.mockRejectedValue(new Error('network'))
+
+    const prices = await getThorchainSecuredAssetPrices(['btc-btc'])
+
+    expect(prices).toEqual({})
+  })
+})

--- a/core/ui/chain/coin/price/thor/getThorchainSecuredAssetPrices.test.ts
+++ b/core/ui/chain/coin/price/thor/getThorchainSecuredAssetPrices.test.ts
@@ -1,14 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockQueryUrl } = vi.hoisted(() => ({
+const { mockQueryUrl, mockGetCoinPrices } = vi.hoisted(() => ({
   mockQueryUrl: vi.fn(),
+  mockGetCoinPrices: vi.fn(),
 }))
 
 vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
   queryUrl: mockQueryUrl,
 }))
 
+vi.mock('@vultisig/core-chain/coin/price/getCoinPrices', () => ({
+  getCoinPrices: mockGetCoinPrices,
+}))
+
 import {
+  getThorchainSecuredAssetFiatPrices,
   getThorchainSecuredAssetPrices,
   isThorchainSecuredAssetDenom,
   securedAssetDenomToPoolAsset,
@@ -99,6 +105,55 @@ describe('getThorchainSecuredAssetPrices', () => {
     mockQueryUrl.mockRejectedValue(new Error('network'))
 
     const prices = await getThorchainSecuredAssetPrices(['btc-btc'])
+
+    expect(prices).toEqual({})
+  })
+})
+
+describe('getThorchainSecuredAssetFiatPrices', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns USD pool prices unchanged for USD without fetching an anchor', async () => {
+    mockQueryUrl.mockResolvedValue([
+      { asset: 'BTC.BTC', asset_tor_price: '6417195738200' },
+    ])
+
+    const prices = await getThorchainSecuredAssetFiatPrices({
+      denoms: ['btc-btc'],
+      fiatCurrency: 'usd',
+    })
+
+    expect(prices['btc-btc']).toBeCloseTo(64171.957382, 4)
+    expect(mockGetCoinPrices).not.toHaveBeenCalled()
+  })
+
+  it('converts USD pool prices to the selected fiat via the usd-coin anchor', async () => {
+    mockQueryUrl.mockResolvedValue([
+      { asset: 'BTC.BTC', asset_tor_price: '6417195738200' },
+    ])
+    mockGetCoinPrices.mockResolvedValue({ 'usd-coin': 0.9 })
+
+    const prices = await getThorchainSecuredAssetFiatPrices({
+      denoms: ['btc-btc'],
+      fiatCurrency: 'eur',
+    })
+
+    expect(prices['btc-btc']).toBeCloseTo(64171.957382 * 0.9, 2)
+  })
+
+  it('returns no prices when the usd anchor is missing for a non-USD currency', async () => {
+    mockQueryUrl.mockResolvedValue([
+      { asset: 'BTC.BTC', asset_tor_price: '6417195738200' },
+    ])
+    // Successful response that does not include the usd-coin anchor.
+    mockGetCoinPrices.mockResolvedValue({})
+
+    const prices = await getThorchainSecuredAssetFiatPrices({
+      denoms: ['btc-btc'],
+      fiatCurrency: 'eur',
+    })
 
     expect(prices).toEqual({})
   })

--- a/core/ui/chain/coin/price/thor/getThorchainSecuredAssetPrices.ts
+++ b/core/ui/chain/coin/price/thor/getThorchainSecuredAssetPrices.ts
@@ -1,0 +1,60 @@
+import { cosmosRpcUrl } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
+import { attempt } from '@vultisig/lib-utils/attempt'
+import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+
+// THORChain reports pool prices in TOR, a USD-pegged unit scaled by 10^8.
+const torPriceDecimals = 8
+
+type ThorchainPool = {
+  asset: string
+  asset_tor_price?: string
+}
+
+/**
+ * THORChain secured-asset bank denoms are lowercase and hyphen-separated
+ * (`btc-btc`, `gaia-atom`, `eth-usdc-0x…`). Native-token denoms instead use
+ * `x/…`, `factory/…`, `ibc/…`, or a dotted form (`thor.lqdy`) and are not
+ * pooled, so we exclude them here.
+ */
+export const isThorchainSecuredAssetDenom = (denom: string): boolean =>
+  !denom.includes('/') && !denom.includes('.') && denom.includes('-')
+
+/**
+ * Maps a secured-asset bank denom to its THORChain pool id: uppercase the
+ * denom and turn the leading chain segment's hyphen into a dot
+ * (`eth-usdc-0x…` → `ETH.USDC-0X…`, `btc-btc` → `BTC.BTC`).
+ */
+export const securedAssetDenomToPoolAsset = (denom: string): string =>
+  denom.toUpperCase().replace('-', '.')
+
+/**
+ * Prices THORChain secured assets from THORChain's own pool oracle
+ * (`asset_tor_price`). Returns USD prices keyed by the input denom; denoms
+ * without an available pool price are omitted.
+ */
+export const getThorchainSecuredAssetPrices = async (
+  denoms: string[]
+): Promise<Record<string, number>> => {
+  const result = await attempt(() =>
+    queryUrl<ThorchainPool[]>(`${cosmosRpcUrl.THORChain}/thorchain/pools`)
+  )
+  if ('error' in result) return {}
+
+  const priceByPoolAsset: Record<string, number> = {}
+  for (const pool of result.data) {
+    const torPrice = Number(pool.asset_tor_price)
+    if (Number.isFinite(torPrice) && torPrice > 0) {
+      priceByPoolAsset[pool.asset] = torPrice / 10 ** torPriceDecimals
+    }
+  }
+
+  const prices: Record<string, number> = {}
+  for (const denom of denoms) {
+    const price = priceByPoolAsset[securedAssetDenomToPoolAsset(denom)]
+    if (price != null) {
+      prices[denom] = price
+    }
+  }
+
+  return prices
+}

--- a/core/ui/chain/coin/price/thor/getThorchainSecuredAssetPrices.ts
+++ b/core/ui/chain/coin/price/thor/getThorchainSecuredAssetPrices.ts
@@ -1,9 +1,16 @@
 import { cosmosRpcUrl } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
+import { getCoinPrices } from '@vultisig/core-chain/coin/price/getCoinPrices'
+import { FiatCurrency } from '@vultisig/core-config/FiatCurrency'
 import { attempt } from '@vultisig/lib-utils/attempt'
 import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 
 // THORChain reports pool prices in TOR, a USD-pegged unit scaled by 10^8.
 const torPriceDecimals = 8
+
+// USD stablecoin anchor: its price in a given fiat currency is the USD -> fiat
+// rate used to convert USD-denominated pool prices.
+const usdAnchorPriceProviderId = 'usd-coin'
+const usdFiatCurrency: FiatCurrency = 'usd'
 
 type ThorchainPool = {
   asset: string
@@ -54,6 +61,48 @@ export const getThorchainSecuredAssetPrices = async (
     if (price != null) {
       prices[denom] = price
     }
+  }
+
+  return prices
+}
+
+type GetThorchainSecuredAssetFiatPricesInput = {
+  denoms: string[]
+  fiatCurrency: FiatCurrency
+}
+
+/**
+ * THORChain pool prices are USD-denominated (`asset_tor_price`). Converts them
+ * to `fiatCurrency` using a USD stablecoin anchor (its price in that currency
+ * is the USD -> fiat rate). Returns prices keyed by denom.
+ *
+ * When the anchor quote is unavailable for a non-USD currency, returns no
+ * prices rather than mislabeling raw USD values as the selected fiat.
+ */
+export const getThorchainSecuredAssetFiatPrices = async ({
+  denoms,
+  fiatCurrency,
+}: GetThorchainSecuredAssetFiatPricesInput): Promise<
+  Record<string, number>
+> => {
+  let usdToFiatRate = 1
+  if (fiatCurrency !== usdFiatCurrency) {
+    const anchorPrices = await getCoinPrices({
+      ids: [usdAnchorPriceProviderId],
+      fiatCurrency,
+    })
+    const anchorRate = anchorPrices[usdAnchorPriceProviderId]
+    if (anchorRate == null) {
+      return {}
+    }
+    usdToFiatRate = anchorRate
+  }
+
+  const usdPrices = await getThorchainSecuredAssetPrices(denoms)
+
+  const prices: Record<string, number> = {}
+  for (const [denom, usdPrice] of Object.entries(usdPrices)) {
+    prices[denom] = usdPrice * usdToFiatRate
   }
 
   return prices


### PR DESCRIPTION
Closes #4375

## Problem
On a THORChain (`thor1…`) account, **secured assets** — bank denoms like `btc-btc`, `eth-eth`, `eth-usdc-0x…`, `eth-xrune-0x…`, `gaia-atom`, `ltc-ltc`, `xrp-xrp`, `bsc-bnb` — are auto-discovered from balances and show the right ticker/amount, but always render **`$0.00`**. They never receive a `priceProviderId` during discovery, so `useCoinPricesQuery` has no branch that prices them and defaults them to `0`. This under-reports the vault total for anyone holding secured assets. (RUNE/TCY/RUJI/KUJI/sTCY and yield-bearing yRUNE/yTCY are unaffected — they price via the existing whitelist / NAV paths.)

## Fix
Price secured assets from THORChain's own pool oracle (`asset_tor_price`, a USD value scaled by `10^8`) — mirroring the existing MAYAChain pool-pricing path. Each secured-asset denom is mapped to its pool id (`eth-usdc-0x…` → `ETH.USDC-0X…`) and priced from the pools endpoint. This is self-maintaining (new secured assets are covered automatically) and needs no CoinGecko whitelist entries.

The change lives entirely in the extension's `core/ui` and reuses already-published SDK primitives, so no `@vultisig/core-chain` release is required.

- `core/ui/chain/coin/price/thor/getThorchainSecuredAssetPrices.ts` — new helper (denom→pool mapping + pool-oracle lookup)
- `core/ui/chain/coin/price/queries/useCoinPricesQuery.ts` — route THORChain secured assets to the new pool-price query
- unit tests for the mapping, predicate, and pricing/fallback behavior

Tokens with no pool (LQDY `thor.lqdy`, BRUNE `x/brune`, LP receipts) have no public price source and stay gracefully unpriced.

## Verification
Ran the fix logic against a real THORChain account's live balances + live pools. Assets that were `$0.00` now resolve to correct market values:

| Token | Now priced |
|---|---|
| BTC (`btc-btc`) | ✅ |
| XRP (`xrp-xrp`) | ✅ |
| BNB (`bsc-bnb`) | ✅ |
| XRUNE (`eth-xrune-0x…`) | ✅ |
| ETH (`eth-eth`) | ✅ |
| LTC (`ltc-ltc`) | ✅ |
| USDC (`eth-usdc-0x…`) | ✅ |
| ATOM (`gaia-atom`) | ✅ |

- `yarn check` (typecheck + lint + knip + i18n): green
- `yarn vitest run core/ui/chain/coin/price/thor`: 6/6 passing

## Test plan
- [ ] Open a vault with a THORChain address holding secured assets; confirm the token list shows non-zero USD values and the vault total reflects them.
- [ ] Confirm already-priced tokens (RUNE/TCY/RUJI/KUJI/sTCY/yRUNE/yTCY) are unchanged.
- [ ] `yarn check:all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added THORChain secured-asset price support alongside existing pricing providers.
  * Secured-asset prices can now be returned in the requested fiat currency (with USD-based conversion when needed).
* **Bug Fixes**
  * Assets without valid pool pricing or with zero/invalid prices are omitted without impacting other coin prices.
* **Tests**
  * Added coverage for secured-asset denom validation, price mapping/scaling, and fiat conversion behavior (including missing-anchor cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->