### PR TITLE
fix(extension): raise Firefox strict_min_version to 140

### DIFF
--- a/clients/extension/scripts/prepare-firefox-build.mjs
+++ b/clients/extension/scripts/prepare-firefox-build.mjs
@@ -50,7 +50,7 @@ manifest.web_accessible_resources = manifest.web_accessible_resources.map(
 manifest.browser_specific_settings = {
   gecko: {
     id: 'vultisig-extension@vultisig.com',
-    strict_min_version: '139.0',
+    strict_min_version: '140.0',
     data_collection_permissions: {
       required: ['financialAndPaymentInfo', 'websiteActivity'],
     },


### PR DESCRIPTION
## Summary
- The Firefox build declares `browser_specific_settings.gecko.data_collection_permissions` but sets `strict_min_version: '139.0'`.
- That manifest key was only introduced in **Firefox 140** — on FF 139 it is silently ignored, so the data-collection consent never appears.
- Raises the floor to `140.0` so the declared consent for `financialAndPaymentInfo` + `websiteActivity` is actually honored.

## Changes
| File | Change |
|------|--------|
| `clients/extension/scripts/prepare-firefox-build.mjs` | `strict_min_version` `'139.0'` → `'140.0'` |

## Context
Found via `web-ext lint` (AMO's own linter) while packaging the **first AMO submission** from tag `v1.0.68`:

> `KEY_FIREFOX_UNSUPPORTED_BY_MIN_VERSION`: "strict_min_version" requires Firefox 139, which was released before version 140 introduced support for "browser_specific_settings.gecko.data_collection_permissions".

This matters beyond a lint warning: Vultisig is a funds-moving wallet declaring financial-data collection, so a version floor that silently drops the consent prompt is a disclosure gap. FF 140 vs 139 is a negligible user-base difference.

Remaining (not addressed here, deliberately): `KEY_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION` — the key needs Firefox for Android 142. Moot for a desktop-targeted add-on, and bumping the shared desktop floor to 142 would needlessly exclude FF 140–141 desktop users.

## Test plan
- [x] `node --check` passes
- [x] `yarn build:firefox` succeeds end-to-end (exit 0, brand assertion passed)
- [x] Emitted `dist/manifest.json` shows `strict_min_version: 140.0`
- [x] `web-ext lint` desktop min-version warning cleared
- [x] `eslint` clean on the changed file

## receipts

Build with the change:
```
$ yarn build:firefox
✓ built in 50.93s
Extension brand assertion passed for vultisig.
build exit: 0
```

Emitted manifest:
```
$ python3 -c "import json; g=json.load(open('dist/manifest.json'))['browser_specific_settings']['gecko']; print(g)"
strict_min_version: 140.0
gecko.id: vultisig-extension@vultisig.com
data_collection_permissions: {'required': ['financialAndPaymentInfo', 'websiteActivity']}
```

web-ext lint, before → after:
```
BEFORE: warnings include KEY_FIREFOX_UNSUPPORTED_BY_MIN_VERSION (desktop) + KEY_FIREFOX_ANDROID_UNSUPPORTED_BY_MIN_VERSION
AFTER:  SUMMARY: {'errors': 1, 'notices': 0, 'warnings': 53}
        min-version warnings remaining: 1  (Android-only, see Context)
```
(The 1 remaining `error` is `FILE_TOO_LARGE` on the 5.3 MB `vendor-app--vultisig-sdk.js` bundle — a linter parse-size limit, pre-existing and unrelated to this change.)

eslint:
```
$ npx eslint clients/extension/scripts/prepare-firefox-build.mjs
eslint exit code: 0
```

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum supported Firefox version to 140.0 for the extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->