### PR TITLE
fix(extension): set build.minify explicitly so TLA plugin can't discard it

### DIFF
--- a/clients/extension/vite.config.ts
+++ b/clients/extension/vite.config.ts
@@ -145,6 +145,7 @@ export default defineConfig(async ({ mode }) => {
         copyPublicDir: false,
         emptyOutDir: false,
         manifest: false,
+        minify: 'esbuild' as const,
         ...devBuildOptions,
         rollupOptions: {
           input: {
@@ -190,6 +191,7 @@ export default defineConfig(async ({ mode }) => {
         target: 'esnext',
         emptyOutDir: false,
         manifest: false,
+        minify: 'esbuild' as const,
         ...devBuildOptions,
         rollupOptions: {
           input: {


### PR DESCRIPTION
## Summary
- `vite-plugin-top-level-await@1.6.0` silently discards esbuild's minification: it reads `minify = !!config.build.minify` in its `config()` hook — which runs **before Vite applies defaults** — then re-prints every top-level-await chunk via `SWC.printSync(ast, { minify })` in `generateBundle` (`enforce: "post"`, runs last).
- Our config never set `build.minify`, relying on Vite's `'esbuild'` default → the plugin captured `false` → TLA chunks shipped **un-minified**.
- Result: `assets/vendor-app--vultisig-sdk.js` hit **5.28 MB**, over addons.mozilla.org's hard **5 MB per-file parse limit** → `Add-on failed validation` → the Firefox listing is blocked. Setting `minify` explicitly drops it to **2.76 MB**.

## Changes
| File | Change |
|------|--------|
| `clients/extension/vite.config.ts` | `minify: 'esbuild' as const,` added before `...devBuildOptions` in both build branches (chunk branch + app branch) |

## Context

Found while packaging the first AMO submission. The AMO validator returned exactly one error:

> **File is too large to parse** — `assets/vendor-app--vultisig-sdk.js` — *"Files larger than 5MB will not be parsed."*

The plugin's code:
```js
enforce: "post",
config(config, env) { minify = !!config.build.minify },        // user config, pre-defaults
async generateBundle(...) { SWC.printSync(newAst, { minify }) } // re-prints TLA chunks
```

Everything fits: the shipped chunk had **mangled-but-pretty-printed** code (esbuild minified it; SWC re-printed it), and **only TLA-containing chunks** were affected — `ethers`/`trustwallet` stayed minified, which is why this never looked like a global "minify is off".

Two details worth knowing for review:
- **`as const` is required.** Bare `minify: 'esbuild'` widens to `string`, which isn't assignable to Vite's `boolean | 'terser' | 'esbuild'` → `TS2769` and the whole config stops matching `UserConfig`. This matches the existing `minify: false as const` idiom at line 98.
- **Order matters.** `minify` must precede `...devBuildOptions` so the dev path (`VITE_DEV_RELOAD`) still overrides it to `false`.

`1.6.0` is the latest published plugin version and still contains the read — there's no upstream fix to wait for.

**Follow-ups filed (not in this PR):**
- #4385 — `clients/desktop` has the identical bug (uses `getCommonPlugins()` → `topLevelAwait()`, never sets `minify`) and ships unminified TLA chunks. Not bundled here: desktop is manual-QA-only (Wails blocks automation), so it needs its own PR + QA rather than riding an AMO blocker fix.
- #4384 — whether the plugin is needed at all where `target: 'esnext'` already supports TLA natively.

## Test plan
- [x] `tsc -b` clean (exit 0) — catches the `as const` widening class
- [x] `eslint` clean on the changed file (exit 0)
- [x] `yarn build:app` (firefox target) exit 0; chunk < 5 MB and minified
- [x] full `yarn build:firefox` exit 0; **no JS chunk ≥ 5 MB**; Firefox manifest transforms intact
- [x] `yarn build:extension` (Chrome target) exit 0, output minified
- [x] Extension e2e suite green against the minified build — no regression vs baseline
- [ ] Re-submit to AMO (blocked on this merging or being cherry-picked into the release build)

## receipts

Gate — **RED before / GREEN after**, same command (also reproduces on `origin/main`, not just the v1.0.68 tag):
```
$ # before the fix
Error: FAIL chunk 5541156 >= 5MB AMO limit
gate exit: 1

$ # after the fix
build:app exit: 0        (tsc -b clean)
GATE PASS: 2892086 bytes, minified
gate exit: 0
```

Full Firefox build:
```
$ yarn build:firefox
✓ built ... Extension brand assertion passed for vultisig.
build:firefox exit: 0
✅ no JS file >= 5MB — AMO per-file limit satisfied
gecko.id: vultisig-extension@vultisig.com | background: ['scripts','type'] | data_collection: True
```

Output actually changes shape (not just size):
```
before:  import { B as WU, p as D1, a as Ue } from "./vendor-app-vite-plugin-node-polyfills.js";
after:   import{B as WU,p as D1,a as Ue}from"./vendor-app-vite-plugin-node-polyfills.js";
```

Extension e2e against the **minified** build (`ENABLE_TX_SIGNING_TESTS=false`):
```
228 total | 152 passed | 4 failed | 72 skipped  (3.6m)
```
Identical to the pre-change baseline (228/152/4/72). All 4 failures are known pre-existing non-app issues, unchanged: 2× `dapp-provider` (test helper `waitForApprovalPopup` called positionally → `undefined.pages()`) and 2× push-notification mock-wiring.

Measured impact:
| | Before | After |
|---|---|---|
| `vendor-app--vultisig-sdk.js` | 5.54 MB | **2.89 MB** |
| total Firefox dist | 128 M | 123 M |

(The whole package only drops ~5 M — it's dominated by WASM/images, not JS. The TLA-affected JS chunks are what roughly halve.)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production build optimization by ensuring generated extension bundles use esbuild minification.
  * Development builds remain unminified for easier debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->