### PR TITLE
fix(swap): render real min. payout (toAmountLimit) on swap screens

### DIFF
--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -1736,4 +1736,5 @@ export const de = {
   ripple_field_issuer: 'Emittent',
   ripple_undecoded_notice:
     'Diese Transaktion konnte nicht dekodiert werden. Bitte prüfen Sie die unten stehenden Rohdaten, bevor Sie die Transaktion genehmigen.',
+  swap_expected_payout: 'erwartete Auszahlung',
 }

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -1131,6 +1131,7 @@ export const en = {
   swap: 'Swap',
   swaps: 'Swaps',
   swap_discount: 'Swap Discount',
+  swap_expected_payout: 'expected payout',
   swap_external_recipient_warning: 'Sending to an external address',
   swap_fee: 'Swap Fee',
   swap_invalid_external_recipient:

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -1722,4 +1722,5 @@ export const es = {
   ripple_field_issuer: 'Editor',
   ripple_undecoded_notice:
     'Esta transacción no pudo ser decodificada. Revise los detalles a continuación antes de aprobar.',
+  swap_expected_payout: 'pago esperado',
 }

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -1698,4 +1698,5 @@ export const hr = {
   ripple_field_issuer: 'Izdavatelj',
   ripple_undecoded_notice:
     'Ovu transakciju nije bilo moguće dekodirati. Prije odobrenja pregledajte neobrađene podatke u nastavku.',
+  swap_expected_payout: 'očekivana isplata',
 }

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -1727,4 +1727,5 @@ export const it = {
   ripple_field_issuer: 'Emittente',
   ripple_undecoded_notice:
     'Impossibile decodificare questa transazione. Si prega di rivedere i dettagli grezzi qui sotto prima di approvare.',
+  swap_expected_payout: 'pagamento previsto',
 }

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -1688,4 +1688,5 @@ export const ko = {
   ripple_field_issuer: '발행자',
   ripple_undecoded_notice:
     '이 거래를 해독할 수 없습니다. 승인하기 전에 아래의 원본 세부 정보를 검토하십시오.',
+  swap_expected_payout: '예상 지급액',
 }

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -1706,4 +1706,5 @@ export const nl = {
   ripple_field_issuer: 'Uitgever',
   ripple_undecoded_notice:
     'Deze transactie kon niet worden gedecodeerd. Controleer de onderstaande gegevens voordat u goedkeurt.',
+  swap_expected_payout: 'verwachte uitbetaling',
 }

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -1724,4 +1724,5 @@ export const pt = {
   ripple_field_issuer: 'Emissor',
   ripple_undecoded_notice:
     'Esta transação não pôde ser decodificada. Revise os detalhes brutos abaixo antes de aprovar.',
+  swap_expected_payout: 'pagamento esperado',
 }

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -1705,4 +1705,5 @@ export const ru = {
   ripple_field_issuer: 'Эмитент',
   ripple_undecoded_notice:
     'Данная транзакция не может быть расшифрована. Перед подтверждением ознакомьтесь с приведенными ниже данными.',
+  swap_expected_payout: 'ожидаемая выплата',
 }

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -1589,4 +1589,5 @@ export const zh = {
   ripple_field_offer_sequence: '报价顺序',
   ripple_field_issuer: '发行人',
   ripple_undecoded_notice: '此交易无法解码。请在批准前查看以下原始详细信息。',
+  swap_expected_payout: '预期收益',
 }

--- a/core/ui/mpc/keysign/join/tx/JoinKeysignSwapVerify.tsx
+++ b/core/ui/mpc/keysign/join/tx/JoinKeysignSwapVerify.tsx
@@ -2,6 +2,7 @@ import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { KeysignFeeAmount } from '@core/ui/mpc/keysign/tx/FeeAmount'
 import { getSwapFeeFromPayload } from '@core/ui/mpc/keysign/tx/swap/getSwapFeeFromPayload'
 import { SwapFeeFiatValue } from '@core/ui/vault/swap/form/info/SwapTotalFeeFiatValue'
+import { getSwapToAmountLimit } from '@core/ui/vault/swap/keysignPayload/getSwapToAmountLimit'
 import {
   ContainerWrapper,
   HorizontalLine,
@@ -49,6 +50,9 @@ export const JoinKeysignSwapVerify = ({ value }: ValueProp<KeysignPayload>) => {
     fromCoin.decimals
   )
   const toAmount = Number(toAmountDecimal)
+  const toAmountLimit = toCoin
+    ? getSwapToAmountLimit({ swapPayload, toCoin })
+    : null
 
   const provider = getKeysignSwapProviderName(swapPayload)
   const swapFee = getSwapFeeFromPayload(value)
@@ -77,7 +81,7 @@ export const JoinKeysignSwapVerify = ({ value }: ValueProp<KeysignPayload>) => {
               <IconWrapper>
                 <ArrowDownIcon />
               </IconWrapper>
-              {t('to_min_payout')}
+              {t('swap_expected_payout')}
               <HorizontalLine />
             </HStack>
             {toCoin && (
@@ -88,6 +92,14 @@ export const JoinKeysignSwapVerify = ({ value }: ValueProp<KeysignPayload>) => {
                     {formatAmount(toAmount, toCoin)}
                   </Text>
                   <JoinSwapFiatAmount coin={toCoin} amount={toAmount} />
+                  {toAmountLimit !== null && (
+                    <Text size={13} color="shy">
+                      {`${t('to_min_payout')}: ${formatAmount(
+                        toAmountLimit,
+                        toCoin
+                      )}`}
+                    </Text>
+                  )}
                 </VStack>
               </HStack>
             )}

--- a/core/ui/mpc/keysign/tx/swap/SwapCoinItem.tsx
+++ b/core/ui/mpc/keysign/tx/swap/SwapCoinItem.tsx
@@ -11,9 +11,11 @@ import styled from 'styled-components'
 export const SwapCoinItem = ({
   coin,
   tokenAmount,
+  caption,
 }: {
   coin: AccountCoin
   tokenAmount: number | null
+  caption?: string
 }) => {
   const formatFiatAmount = useFormatFiatAmount()
   const coinPriceQuery = useCoinPriceQuery({
@@ -37,6 +39,11 @@ export const SwapCoinItem = ({
             </Text>
           )}
         />
+        {caption ? (
+          <Text centerHorizontally color="shy" size={12}>
+            {caption}
+          </Text>
+        ) : null}
       </div>
     </SwapVStackItem>
   )

--- a/core/ui/mpc/keysign/tx/swap/SwapKeysignTxOverview.tsx
+++ b/core/ui/mpc/keysign/tx/swap/SwapKeysignTxOverview.tsx
@@ -2,6 +2,7 @@ import { SwapCoinItem } from '@core/ui/mpc/keysign/tx/swap/SwapCoinItem'
 import { useCore } from '@core/ui/state/core'
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { SwapFeeFiatValue } from '@core/ui/vault/swap/form/info/SwapTotalFeeFiatValue'
+import { getSwapToAmountLimit } from '@core/ui/vault/swap/keysignPayload/getSwapToAmountLimit'
 import { Button } from '@lib/ui/buttons/Button'
 import { centerContent } from '@lib/ui/css/centerContent'
 import { round } from '@lib/ui/css/round'
@@ -30,6 +31,7 @@ import { fromCommCoin } from '@vultisig/core-mpc/types/utils/commCoin'
 import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
 import { getLastItem } from '@vultisig/lib-utils/array/getLastItem'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
+import { formatAmount } from '@vultisig/lib-utils/formatAmount'
 import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
 import { getRecordUnionValue } from '@vultisig/lib-utils/record/union/getRecordUnionValue'
 import { truncateId } from '@vultisig/lib-utils/string/truncate'
@@ -106,6 +108,10 @@ export const SwapKeysignTxOverview = ({
   const toCoin = potentialToCoin ? fromCommCoin(potentialToCoin) : null
   const { chain: sourceChain } = shouldBePresent(fromCoin)
 
+  const toAmountLimit = toCoin
+    ? getSwapToAmountLimit({ swapPayload, toCoin })
+    : null
+
   // Prefer the swap fee carried in the keysign payload (works for both
   // initiator and cosigner). Fall back to the SwapQuote provider for older
   // payloads built before the SDK populated the swap-fee fields — only the
@@ -169,6 +175,14 @@ export const SwapKeysignTxOverview = ({
               <SwapCoinItem
                 coin={toCoin}
                 tokenAmount={parseFloat(toAmountDecimal)}
+                caption={
+                  toAmountLimit !== null
+                    ? `${t('to_min_payout')}: ${formatAmount(
+                        toAmountLimit,
+                        toCoin
+                      )}`
+                    : undefined
+                }
               />
             )}
             <IconWrapper alignItems="center" justifyContent="center">

--- a/core/ui/transaction-history/core.ts
+++ b/core/ui/transaction-history/core.ts
@@ -52,6 +52,10 @@ export type SwapTransactionData = {
   fromDecimals: number
   toToken: string
   toAmount: string
+  /** Guaranteed on-chain minimum output ("min. payout"). Present only for
+   * native (THORChain/MayaChain) swaps, whose signed payload carries a real
+   * `to_amount_limit`. General aggregator swaps expose no separate floor. */
+  toAmountLimit?: string
   toChain: Chain
   toTokenLogo: string
   toTokenId?: string

--- a/core/ui/transaction-history/detail/TransactionDetailPage.tsx
+++ b/core/ui/transaction-history/detail/TransactionDetailPage.tsx
@@ -14,6 +14,7 @@ import {
 import { useTransactionStatusPolling } from '@core/ui/transaction-history/status/useTransactionStatusPolling'
 import { TransactionHistoryTag } from '@core/ui/transaction-history/TransactionHistoryTag'
 import { useCurrentVaultCoins } from '@core/ui/vault/state/currentVaultCoins'
+import { toNativeSwapLimitAmount } from '@core/ui/vault/swap/keysignPayload/getSwapToAmountLimit'
 import { Button } from '@lib/ui/buttons/Button'
 import { centerContent } from '@lib/ui/css/centerContent'
 import { round } from '@lib/ui/css/round'
@@ -208,11 +209,16 @@ const SendDetailPanel = ({ record }: { record: SendTransactionRecord }) => {
 }
 
 const SwapAmountDisplay = ({ record }: { record: SwapTransactionRecord }) => {
+  const { t } = useTranslation()
   const { data } = record
   const fromCryptoAmount = Number(
     fromChainAmount(safeBigInt(data.fromAmount), data.fromDecimals)
   )
   const toCryptoAmount = parseFloat(data.toAmount)
+  const toAmountLimit = toNativeSwapLimitAmount({
+    rawLimit: data.toAmountLimit,
+    toCoin: { chain: data.toChain, id: data.toTokenId },
+  })
   const fromFiat = useFiatFromPrice({
     coin: { chain: data.fromChain, id: data.fromTokenId },
     fiatValue: record.fiatValue,
@@ -277,6 +283,13 @@ const SwapAmountDisplay = ({ record }: { record: SwapTransactionRecord }) => {
           {toFiat && (
             <Text size={12} color="supporting" centerHorizontally>
               {toFiat}
+            </Text>
+          )}
+          {toAmountLimit !== null && (
+            <Text size={12} color="shy" centerHorizontally>
+              {`${t('to_min_payout')}: ${formatAmount(toAmountLimit, {
+                precision: 'high',
+              })} ${data.toToken}`}
             </Text>
           )}
         </VStack>

--- a/core/ui/transaction-history/progress/PendingTransactionProgressCard.tsx
+++ b/core/ui/transaction-history/progress/PendingTransactionProgressCard.tsx
@@ -5,6 +5,7 @@ import { useFormatFiatAmount } from '@core/ui/chain/hooks/useFormatFiatAmount'
 import { getChainLogoSrc } from '@core/ui/chain/metadata/getChainLogoSrc'
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { useCurrentVaultCoins } from '@core/ui/vault/state/currentVaultCoins'
+import { toNativeSwapLimitAmount } from '@core/ui/vault/swap/keysignPayload/getSwapToAmountLimit'
 import { ArrowDownIcon } from '@lib/ui/icons/ArrowDownIcon'
 import { WalletIcon } from '@lib/ui/icons/WalletIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -129,6 +130,10 @@ const SwapProgressContent = ({ record }: { record: SwapTransactionRecord }) => {
     fromChainAmount(safeBigInt(data.fromAmount), data.fromDecimals)
   )
   const toAmount = parseFloat(data.toAmount)
+  const toAmountLimit = toNativeSwapLimitAmount({
+    rawLimit: data.toAmountLimit,
+    toCoin: { chain: data.toChain, id: data.toTokenId },
+  })
   const fromFiat = useFiatValue(
     { chain: data.fromChain, id: data.fromTokenId },
     fromAmount
@@ -189,7 +194,7 @@ const SwapProgressContent = ({ record }: { record: SwapTransactionRecord }) => {
           )}
           <VStack gap={2}>
             <Text size={11} color="shy">
-              {t('to_min_payout')}
+              {t('swap_expected_payout')}
             </Text>
             <Text size={16} weight={600}>
               {formatAmount(toAmount, { precision: 'high' })} {data.toToken}
@@ -197,6 +202,13 @@ const SwapProgressContent = ({ record }: { record: SwapTransactionRecord }) => {
             {toFiat && (
               <Text size={12} color="supporting">
                 {toFiat}
+              </Text>
+            )}
+            {toAmountLimit !== null && (
+              <Text size={12} color="shy">
+                {`${t('to_min_payout')}: ${formatAmount(toAmountLimit, {
+                  precision: 'high',
+                })} ${data.toToken}`}
               </Text>
             )}
           </VStack>

--- a/core/ui/transaction-history/record/createTransactionRecord.ts
+++ b/core/ui/transaction-history/record/createTransactionRecord.ts
@@ -82,6 +82,7 @@ const createSwapData = (payload: KeysignPayload): SwapTransactionData => {
         fromDecimals: from.decimals,
         toToken: to.token,
         toAmount: native.toAmountDecimal,
+        toAmountLimit: native.toAmountLimit,
         toChain: to.chain,
         toTokenLogo: to.tokenLogo,
         toTokenId: to.tokenId,

--- a/core/ui/vault/swap/keysignPayload/getSwapToAmountLimit.ts
+++ b/core/ui/vault/swap/keysignPayload/getSwapToAmountLimit.ts
@@ -1,0 +1,59 @@
+import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
+import { CoinKey } from '@vultisig/core-chain/coin/Coin'
+import { getNativeSwapDecimals } from '@vultisig/core-chain/swap/native/utils/getNativeSwapDecimals'
+import { KeysignSwapPayload } from '@vultisig/core-mpc/keysign/swap/KeysignSwapPayload'
+import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
+
+type ToNativeSwapLimitAmountInput = {
+  rawLimit: string | null | undefined
+  toCoin: CoinKey
+}
+
+/**
+ * Converts a raw native-swap limit into a positive human decimal amount.
+ *
+ * `to_amount_limit` is stored in the swap API's base units (THORChain's 8-decimal
+ * standard, or MayaChain's native precision) — the same precision that produced
+ * `toAmountDecimal` — so it must be scaled by `getNativeSwapDecimals`, not shown
+ * raw. Returns `null` when the limit is absent, zero, or unparseable, so callers
+ * can hide the "min. payout" row.
+ */
+export const toNativeSwapLimitAmount = ({
+  rawLimit,
+  toCoin,
+}: ToNativeSwapLimitAmountInput): number | null => {
+  if (!rawLimit) {
+    return null
+  }
+
+  const amount = fromChainAmount(rawLimit, getNativeSwapDecimals(toCoin))
+
+  return amount > 0 ? amount : null
+}
+
+type GetSwapToAmountLimitInput = {
+  swapPayload: KeysignSwapPayload
+  toCoin: CoinKey
+}
+
+/**
+ * Resolves the guaranteed minimum swap output ("min. payout") as a human decimal
+ * number. Only native (THORChain/MayaChain) swaps carry a real floor —
+ * `to_amount_limit` in the signed payload, derived from the slippage tolerance
+ * sent with the quote. General aggregator swaps (1inch, SwapKit, CowSwap) expose
+ * no separate limit, so this returns `null` for them.
+ */
+export const getSwapToAmountLimit = ({
+  swapPayload,
+  toCoin,
+}: GetSwapToAmountLimitInput): number | null => {
+  const rawLimit = matchRecordUnion<KeysignSwapPayload, string | null>(
+    swapPayload,
+    {
+      native: ({ toAmountLimit }) => toAmountLimit,
+      general: () => null,
+    }
+  )
+
+  return toNativeSwapLimitAmount({ rawLimit, toCoin })
+}

--- a/core/ui/vault/swap/verify/SwapVerify/index.tsx
+++ b/core/ui/vault/swap/verify/SwapVerify/index.tsx
@@ -5,6 +5,7 @@ import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { useCurrentVaultCoin } from '@core/ui/vault/state/currentVaultCoins'
 import { SwapFiatAmount } from '@core/ui/vault/swap/form/amount/SwapFiatAmount'
 import { VerifySwapFees } from '@core/ui/vault/swap/form/info/VerifySwapFees'
+import { getSwapToAmountLimit } from '@core/ui/vault/swap/keysignPayload/getSwapToAmountLimit'
 import { useSwapKeysignPayloadQuery } from '@core/ui/vault/swap/keysignPayload/query'
 import { useFromAmount } from '@core/ui/vault/swap/state/fromAmount'
 import { useSwapFromCoin } from '@core/ui/vault/swap/state/fromCoin'
@@ -97,7 +98,7 @@ export const SwapVerify = ({ swapQuote, onBack }: SwapVerifyProps) => {
                 <IconWrapper>
                   <ArrowDownIcon />
                 </IconWrapper>
-                {t('to_min_payout')}
+                {t('swap_expected_payout')}
                 <HorizontalLine />
               </HStack>
               <HStack gap={12} alignItems="center">
@@ -112,6 +113,10 @@ export const SwapVerify = ({ swapQuote, onBack }: SwapVerifyProps) => {
                       'swap payload'
                     )
                     const { toAmountDecimal } = getRecordUnionValue(swapPayload)
+                    const toAmountLimit = getSwapToAmountLimit({
+                      swapPayload,
+                      toCoin,
+                    })
 
                     return (
                       <VStack gap={2}>
@@ -124,6 +129,14 @@ export const SwapVerify = ({ swapQuote, onBack }: SwapVerifyProps) => {
                             amount: parseFloat(toAmountDecimal),
                           }}
                         />
+                        {toAmountLimit !== null && (
+                          <Text size={13} color="shy">
+                            {`${t('to_min_payout')}: ${formatAmount(
+                              toAmountLimit,
+                              toCoin
+                            )}`}
+                          </Text>
+                        )}
                       </VStack>
                     )
                   }}


### PR DESCRIPTION
## Problem

The swap verify screen, **every co-signer's** verify screen, and the swap transaction history all label a value **"min. payout"** while rendering `toAmountDecimal` — the *expected* output, not the minimum. The real floor (`toAmountLimit`, derived from the slippage tolerance Windows sends) was never shown.

Windows is the only Vultisig client that sends a slippage tolerance and gets a real `LIM` into the signed memo, so it's the one app with genuine on-chain protection — and it was displaying the wrong number for it, on the screen where the user consents to and a co-signer approves the transaction. Classic WYSIWYS gap.

Closes #4392

## What changed

- **Relabel** the existing expected amount as **"expected payout"** (new `swap_expected_payout` key, translated to all 9 locales).
- **Add a "min. payout" line** rendering `toAmountLimit`, **native (THORChain/MayaChain) swaps only** — general aggregator swaps (1inch, SwapKit, CowSwap) expose no separate floor, so the line is hidden for them.
- **Unit fix:** `toAmountLimit` is stored in the swap API's base units (THORChain's 8-decimal standard / MayaChain native precision), so it's converted with `getNativeSwapDecimals` — the *same* precision used for `toAmountDecimal` — instead of being shown as the raw integer. Without this it rendered e.g. `1,615 BTC` instead of `0.00001615 BTC`.
- **Persist `toAmountLimit`** on `SwapTransactionData` so the history card and detail page can show it for **new** native swaps.

Shared helper `getSwapToAmountLimit` / `toNativeSwapLimitAmount` centralizes the native-only extraction + base-unit conversion, so every swap surface stays consistent.

## Screens affected

| Screen | File | Behavior |
|---|---|---|
| Swap verify (initiator) | `SwapVerify/index.tsx` | expected + min line |
| Swap verify (co-signer) | `JoinKeysignSwapVerify.tsx` | expected + min line (reads the signed payload — the real floor the co-signer approves) |
| Transaction successful (keysign result) | `SwapKeysignTxOverview.tsx` / `SwapCoinItem.tsx` | min line under the destination amount |
| History card | `PendingTransactionProgressCard.tsx` | expected + min line |
| Transaction detail | `TransactionDetailPage.tsx` | min line under the "to" amount |

## Screenshots

| Swap confirmation | Transaction successful |
|---|---|
| <img width="300" height="508" alt="1" src="https://github.com/user-attachments/assets/917fb7b4-86c5-4d2c-ae02-e2b7d354c84b" /> | <img width="300" height="516" alt="2" src="https://github.com/user-attachments/assets/28210ece-f48b-44db-ba31-10649569c2ca" />|

| Co-signer Swap confirmation | Co-signer Transaction successful |
|---|---|
| <img width="300" height="509" alt="11" src="https://github.com/user-attachments/assets/f8d0e2d1-22f6-4eb4-a8ac-0142011957c6" /> | <img width="300" height="527" alt="22" src="https://github.com/user-attachments/assets/cae7ba8c-20cc-4ff7-9df3-03fe2f7bb73c" /> |

### Transaction history screen
<img width="300" height="379" alt="3" src="https://github.com/user-attachments/assets/ca12dc94-5b7c-422a-88cf-f4020a6e93f7" />

## Scope / notes

- Only **native (THORChain/Maya)** swaps show a min. payout; general swaps show only "expected payout" (they have no floor to display).
- History card and detail page show the min line only for swaps signed **after** this change — older records don't carry `toAmountLimit`. Verify screens work for any swap since they read the live payload.
- Out of scope: the issue's secondary note about surfacing the inbound vault address.

## Validation

- `yarn typecheck` ✓ · `tsc -b` ✓ · `yarn lint` ✓ · `yarn knip` ✓
- `createTransactionRecord` unit tests ✓ (4/4)
- Extension builds clean (`yarn build:extension`, exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Swap screens now show the expected payout and guaranteed minimum payout when available.
  * Minimum payout amounts are displayed in the destination token across swap verification, transaction details, and pending transaction views.
  * Added localized expected-payout text for supported languages.
  * General aggregator swaps no longer display an unavailable minimum payout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->