### PR TITLE
fix(defi): surface RUJI bonded and auto-compounding positions separately

### DIFF
--- a/core/ui/defi/chain/config/stakeUiResolver.test.ts
+++ b/core/ui/defi/chain/config/stakeUiResolver.test.ts
@@ -32,6 +32,10 @@ describe('resolveTransferableStakeToken', () => {
     expect(
       resolveTransferableStakeToken(Chain.THORChain, 'thor-stake-rune')
     ).toBeUndefined()
+    // Bonded RUJI has no bank receipt to send (only the auto-compounding sRUJI).
+    expect(
+      resolveTransferableStakeToken(Chain.THORChain, 'thor-stake-ruji-bonded')
+    ).toBeUndefined()
   })
 
   it('returns undefined for chains with no transferable stake tokens', () => {

--- a/core/ui/defi/chain/config/stakeUiResolver.ts
+++ b/core/ui/defi/chain/config/stakeUiResolver.ts
@@ -2,6 +2,10 @@ import { Chain } from '@vultisig/core-chain/Chain'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { Coin } from '@vultisig/core-chain/coin/Coin'
 
+import {
+  rujiAutoCompoundStakePositionId,
+  rujiBondedStakePositionId,
+} from '../queries/services/thorchainStake/rujiStakeService'
 import { mayaCoin, runeCoin, thorchainTokens } from '../queries/tokens'
 import { ThorchainStakePosition } from '../queries/types'
 
@@ -47,7 +51,8 @@ const tokenById: Partial<Record<Chain, Record<string, Coin>>> = {
     'thor-stake-rune': runeCoin,
     'thor-stake-tcy': thorchainTokens.tcy,
     'thor-stake-stcy': thorchainTokens.stcy,
-    'thor-stake-ruji': thorchainTokens.ruji,
+    [rujiAutoCompoundStakePositionId]: thorchainTokens.ruji,
+    [rujiBondedStakePositionId]: thorchainTokens.ruji,
     'thor-stake-yrune': thorchainTokens.yRune,
     'thor-stake-ytcy': thorchainTokens.yTcy,
   },
@@ -157,6 +162,11 @@ export const resolveStakeTitle = ({
   if (position.type === 'index') return coin.ticker
   if (position.id === 'thor-stake-stcy') {
     return translate('compounded_token', { ticker: 'TCY' })
+  }
+  // Distinguish the two RUJI cards: the auto-compounding (sRUJI) position reads
+  // "Compounded RUJI"; the bonded position falls through to "Staked RUJI".
+  if (position.id === rujiAutoCompoundStakePositionId) {
+    return translate('compounded_token', { ticker: coin.ticker })
   }
   return `${translate('staked')} ${coin.ticker}`
 }

--- a/core/ui/defi/chain/queries/services/thorchainStake/index.ts
+++ b/core/ui/defi/chain/queries/services/thorchainStake/index.ts
@@ -7,7 +7,7 @@ import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
 import { thorchainTokens } from '../../tokens'
 import { ThorchainStakePosition } from '../../types'
 import { parseBigint } from '../../utils/parsers'
-import { fetchRujiStakePosition } from './rujiStakeService'
+import { fetchRujiStakePositions } from './rujiStakeService'
 import { fetchStcyStakePosition } from './stcyStakeService'
 import { fetchTcyStakePosition } from './tcyStakeService'
 
@@ -62,10 +62,10 @@ export const fetchStakePositions = async ({
   address,
   prices,
 }: FetchStakePositionsInput) => {
-  const [tcy, stcy, ruji, yRune, yTcy] = await Promise.all([
+  const [tcy, stcy, rujiPositions, yRune, yTcy] = await Promise.all([
     fetchTcyStakePosition({ address, prices }),
     fetchStcyStakePosition({ address, prices }),
-    fetchRujiStakePosition({ address, prices }),
+    fetchRujiStakePositions({ address, prices }),
     fetchYieldStakePosition({
       address,
       prices,
@@ -80,7 +80,7 @@ export const fetchStakePositions = async ({
     }),
   ])
 
-  const positions = [tcy, stcy, ruji, yRune, yTcy].filter(
+  const positions = [tcy, stcy, ...rujiPositions, yRune, yTcy].filter(
     (p): p is ThorchainStakePosition => p !== null
   )
   return { positions }

--- a/core/ui/defi/chain/queries/services/thorchainStake/rujiStakeService.ts
+++ b/core/ui/defi/chain/queries/services/thorchainStake/rujiStakeService.ts
@@ -90,11 +90,10 @@ const rujiReceiptDenom = shouldBePresent(
   'sRUJI receipt denom'
 )
 
-// On-chain sRUJI receipt balance — the amount the vault actually holds (and can
-// send), read the same way sTCY reads its receipt. This is deliberately kept
-// independent of the staking API's `bonded` field, which can report 0 even when
-// receipt tokens are held. Returns `null` when the request fails, so a genuine
-// zero balance stays distinct from an unknown one.
+// On-chain sRUJI receipt balance — the exact share count the vault holds, used
+// to size the `liquid.unbond` redemption (the funds it sends are receipt
+// shares, not RUJI). Read the same way sTCY reads its receipt. Returns `null`
+// when the request fails, so a genuine zero stays distinct from an unknown one.
 const fetchRujiReceiptBalance = async (
   address: string
 ): Promise<bigint | null> => {
@@ -123,7 +122,7 @@ export const rujiAutoCompoundStakePositionId = 'thor-stake-ruji'
 export const rujiBondedStakePositionId = 'thor-stake-ruji-bonded'
 
 type RujiStakeSnapshot = {
-  /** Auto-compounding (sRUJI receipt) value in RUJI base units. */
+  /** Auto-compounding position valued in RUJI base units (the API `liquidSize`). */
   autoCompoundAmount: bigint
   /** Bonded (yielding) position in RUJI base units. */
   bondedAmount: bigint
@@ -132,24 +131,20 @@ type RujiStakeSnapshot = {
   apr?: number
 }
 
-// Reads the Rujira staking API (APR, pending USDC revenue, bonded amount) and
-// the on-chain sRUJI receipt balance in one shot, deriving the two independent
-// RUJI positions. The auto-compounding value prefers the API's `liquidSize`
-// (sRUJI receipt priced in RUJI) with the raw on-chain receipt as a fallback;
-// it deliberately does NOT fall back to `bonded`, which is surfaced separately.
+// Reads the Rujira staking API (APR, pending USDC revenue, bonded + liquid
+// amounts) and derives the two independent RUJI positions. The auto-compounding
+// amount is the API's `liquidSize` — the sRUJI receipt priced in RUJI, i.e. what
+// the Rujira app shows. The raw on-chain receipt is in share units (not RUJI, so
+// not a valid display value once the share price drifts) and is read separately
+// only when building the `liquid.unbond` tx. `liquidSize` also does NOT fall
+// back to `bonded`, which is surfaced as its own position.
 const fetchRujiStakeSnapshot = async (
   address: string
 ): Promise<RujiStakeSnapshot> => {
-  const [response, heldAmount] = await Promise.all([
-    getRujiStake(address),
-    fetchRujiReceiptBalance(address),
-  ])
-  const stake = findRujiStake(response)
-  const liquidSizeAmount = parseBigint(stake?.liquidSize?.amount)
+  const stake = findRujiStake(await getRujiStake(address))
 
   return {
-    autoCompoundAmount:
-      liquidSizeAmount > 0n ? liquidSizeAmount : (heldAmount ?? 0n),
+    autoCompoundAmount: parseBigint(stake?.liquidSize?.amount),
     bondedAmount: parseBigint(stake?.bonded?.amount),
     rewardsAmount:
       parseNumber(stake?.pendingRevenue?.amount) / rujiDecimalFactor,
@@ -160,6 +155,12 @@ const fetchRujiStakeSnapshot = async (
 type FetchRujiStakePositionsInput = {
   address: string
   prices: Record<string, number>
+}
+
+type BuildPositionInput = {
+  id: string
+  amount: bigint
+  extras?: Partial<ThorchainStakePosition>
 }
 
 /**
@@ -187,11 +188,11 @@ export const fetchRujiStakePositions = async ({
   const { autoCompoundAmount, bondedAmount, rewardsAmount, apr } = snapshot.data
   const price = prices[coinKeyToString(thorchainTokens.ruji)] ?? 0
 
-  const buildPosition = (
-    id: string,
-    amount: bigint,
-    extras: Partial<ThorchainStakePosition> = {}
-  ): ThorchainStakePosition => ({
+  const buildPosition = ({
+    id,
+    amount,
+    extras = {},
+  }: BuildPositionInput): ThorchainStakePosition => ({
     id,
     ticker: thorchainTokens.ruji.ticker,
     amount,
@@ -206,20 +207,19 @@ export const fetchRujiStakePositions = async ({
   })
 
   // APR + pending USDC revenue ride on the bonded position (see the doc above).
-  const bondedPosition = buildPosition(
-    rujiBondedStakePositionId,
-    bondedAmount,
-    {
-      apr,
-      rewards: rewardsAmount,
-      rewardTicker: 'USDC',
-    }
-  )
+  const bondedPosition = buildPosition({
+    id: rujiBondedStakePositionId,
+    amount: bondedAmount,
+    extras: { apr, rewards: rewardsAmount, rewardTicker: 'USDC' },
+  })
 
   const positions: ThorchainStakePosition[] = []
   if (autoCompoundAmount > 0n) {
     positions.push(
-      buildPosition(rujiAutoCompoundStakePositionId, autoCompoundAmount)
+      buildPosition({
+        id: rujiAutoCompoundStakePositionId,
+        amount: autoCompoundAmount,
+      })
     )
   }
   // Keep the bonded card visible while its USDC revenue is claimable, so those

--- a/core/ui/defi/chain/queries/services/thorchainStake/rujiStakeService.ts
+++ b/core/ui/defi/chain/queries/services/thorchainStake/rujiStakeService.ts
@@ -107,60 +107,154 @@ const fetchRujiReceiptBalance = async (
   return 'data' in result ? parseBigint(result.data?.balance?.amount) : null
 }
 
-type FetchRujiStakePositionInput = {
+/**
+ * DeFi position id for the auto-compounding (sRUJI receipt / `liquid.unbond`)
+ * RUJI position. Kept as the original `thor-stake-ruji` id so previously stored
+ * selections keep resolving, and so a single "RUJI" manage tile gates both
+ * positions (see {@link rujiBondedStakePositionId}).
+ */
+export const rujiAutoCompoundStakePositionId = 'thor-stake-ruji'
+
+/**
+ * DeFi position id for the bonded (yielding / `account.withdraw`) RUJI position.
+ * Rendered alongside the auto-compounding card in the Staked tab; it has no
+ * manage tile of its own and is gated by the `thor-stake-ruji` selection.
+ */
+export const rujiBondedStakePositionId = 'thor-stake-ruji-bonded'
+
+type RujiStakeSnapshot = {
+  /** Auto-compounding (sRUJI receipt) value in RUJI base units. */
+  autoCompoundAmount: bigint
+  /** Bonded (yielding) position in RUJI base units. */
+  bondedAmount: bigint
+  /** Pending USDC revenue, human-readable. */
+  rewardsAmount: number
+  apr?: number
+}
+
+// Reads the Rujira staking API (APR, pending USDC revenue, bonded amount) and
+// the on-chain sRUJI receipt balance in one shot, deriving the two independent
+// RUJI positions. The auto-compounding value prefers the API's `liquidSize`
+// (sRUJI receipt priced in RUJI) with the raw on-chain receipt as a fallback;
+// it deliberately does NOT fall back to `bonded`, which is surfaced separately.
+const fetchRujiStakeSnapshot = async (
+  address: string
+): Promise<RujiStakeSnapshot> => {
+  const [response, heldAmount] = await Promise.all([
+    getRujiStake(address),
+    fetchRujiReceiptBalance(address),
+  ])
+  const stake = findRujiStake(response)
+  const liquidSizeAmount = parseBigint(stake?.liquidSize?.amount)
+
+  return {
+    autoCompoundAmount:
+      liquidSizeAmount > 0n ? liquidSizeAmount : (heldAmount ?? 0n),
+    bondedAmount: parseBigint(stake?.bonded?.amount),
+    rewardsAmount:
+      parseNumber(stake?.pendingRevenue?.amount) / rujiDecimalFactor,
+    apr: parseRujiApr(stake?.pool?.summary?.apr),
+  }
+}
+
+type FetchRujiStakePositionsInput = {
   address: string
   prices: Record<string, number>
 }
 
 /**
- * Fetches the vault's RUJI staking position, combining the Rujira staking API
- * (APR, pending USDC rewards, bonded amount) with the on-chain sRUJI receipt
- * balance. Returns the auto-compounding value in RUJI as a
- * {@link ThorchainStakePosition}, or `null` if the lookup fails.
+ * Fetches the vault's RUJI staking positions as separate
+ * {@link ThorchainStakePosition}s: an auto-compounding (sRUJI) position and a
+ * bonded position. Each is emitted only when it holds value, so a bonded-only
+ * vault shows its bonded balance and an auto-compounding vault shows only the
+ * compounded card; when neither holds value the bonded card is emitted with a
+ * zero balance as an anchor to stake into. Returns `[]` if the lookup fails.
+ *
+ * The Rujira staking API's APR and pending USDC revenue belong to the bonded
+ * position: the auto-compounding position reinvests its revenue into
+ * `liquidSize` and has no separately-claimable USDC (like sTCY). So they ride on
+ * the bonded card, and the compounded card stays stat-free.
  */
-export const fetchRujiStakePosition = async ({
+export const fetchRujiStakePositions = async ({
   address,
   prices,
-}: FetchRujiStakePositionInput): Promise<ThorchainStakePosition | null> => {
-  try {
-    const [response, heldAmount] = await Promise.all([
-      getRujiStake(address),
-      fetchRujiReceiptBalance(address),
-    ])
-    const stake = findRujiStake(response)
-    const bondedAmount = parseBigint(stake?.bonded?.amount)
-    // Display the auto-compounding value: the sRUJI receipt converted to RUJI at
-    // the pool's current share price (the API's `liquidSize`), matching what the
-    // Rujira app shows. Fall back to the raw on-chain receipt balance if the API
-    // doesn't surface it, then to the API's `bonded` amount.
-    const liquidSizeAmount = parseBigint(stake?.liquidSize?.amount)
-    const amount =
-      liquidSizeAmount > 0n ? liquidSizeAmount : (heldAmount ?? bondedAmount)
-    const rewardsAmount =
-      parseNumber(stake?.pendingRevenue?.amount) / rujiDecimalFactor
-    const apr = parseRujiApr(stake?.pool?.summary?.apr)
-    const price = prices[coinKeyToString(thorchainTokens.ruji)] ?? 0
+}: FetchRujiStakePositionsInput): Promise<ThorchainStakePosition[]> => {
+  const snapshot = await attempt(() => fetchRujiStakeSnapshot(address))
+  if ('error' in snapshot) {
+    return []
+  }
 
-    const fiatValue = getCoinValue({
+  const { autoCompoundAmount, bondedAmount, rewardsAmount, apr } = snapshot.data
+  const price = prices[coinKeyToString(thorchainTokens.ruji)] ?? 0
+
+  const buildPosition = (
+    id: string,
+    amount: bigint,
+    extras: Partial<ThorchainStakePosition> = {}
+  ): ThorchainStakePosition => ({
+    id,
+    ticker: thorchainTokens.ruji.ticker,
+    amount,
+    type: 'stake',
+    canUnstake: amount > 0n,
+    fiatValue: getCoinValue({
       amount,
       decimals: thorchainTokens.ruji.decimals,
       price,
-    })
+    }),
+    ...extras,
+  })
 
-    return {
-      id: 'thor-stake-ruji',
-      ticker: thorchainTokens.ruji.ticker,
-      amount,
-      type: 'stake',
-      canUnstake: amount > 0n,
-      fiatValue,
+  // APR + pending USDC revenue ride on the bonded position (see the doc above).
+  const bondedPosition = buildPosition(
+    rujiBondedStakePositionId,
+    bondedAmount,
+    {
       apr,
       rewards: rewardsAmount,
       rewardTicker: 'USDC',
     }
-  } catch {
-    return null
+  )
+
+  const positions: ThorchainStakePosition[] = []
+  if (autoCompoundAmount > 0n) {
+    positions.push(
+      buildPosition(rujiAutoCompoundStakePositionId, autoCompoundAmount)
+    )
   }
+  // Keep the bonded card visible while its USDC revenue is claimable, so those
+  // rewards never get stranded even when the bonded RUJI balance is 0.
+  if (bondedAmount > 0n || rewardsAmount > 0) {
+    positions.push(bondedPosition)
+  }
+  if (positions.length === 0) {
+    // Nothing staked: anchor with the bonded card, since "Stake" bonds
+    // (`account.bond`) into exactly this position.
+    positions.push(bondedPosition)
+  }
+
+  return positions
+}
+
+/** Base-unit RUJI balances available to unstake, per position. */
+export type RujiUnstakeBalances = {
+  /** Auto-compounding (sRUJI receipt) value in RUJI base units. */
+  autoCompound: bigint
+  /** Bonded (yielding) position in RUJI base units. */
+  bonded: bigint
+}
+
+/**
+ * Resolves the unstakable RUJI balances for both positions from the same source
+ * as the Staked cards, so each unstake form's ceiling matches its card.
+ */
+export const fetchRujiUnstakeBalances = async (
+  address: string
+): Promise<RujiUnstakeBalances> => {
+  const { autoCompoundAmount, bondedAmount } =
+    await fetchRujiStakeSnapshot(address)
+
+  return { autoCompound: autoCompoundAmount, bonded: bondedAmount }
 }
 
 type RujiLiquidUnbondInputs = {

--- a/core/ui/defi/chain/tabs/StakedPositions.tsx
+++ b/core/ui/defi/chain/tabs/StakedPositions.tsx
@@ -22,6 +22,10 @@ import {
   resolveTransferableStakeToken,
 } from '../config/stakeUiResolver'
 import { CosmosDelegationsView } from '../cosmos/CosmosDelegationsView'
+import {
+  rujiAutoCompoundStakePositionId,
+  rujiBondedStakePositionId,
+} from '../queries/services/thorchainStake/rujiStakeService'
 import { useDefiChainPositionsQuery } from '../queries/useDefiChainPositionsQuery'
 import { SolanaStakeDefiView } from '../solana/SolanaStakeDefiView'
 import { useCurrentDefiChain } from '../useCurrentDefiChain'
@@ -39,6 +43,14 @@ type StakeActionType =
   | 'withdraw_ruji_rewards'
   | 'add_cacao_pool'
   | 'remove_cacao_pool'
+
+// The bonded RUJI card has no manage tile of its own — it is shown whenever the
+// single "RUJI" (`thor-stake-ruji`) tile is selected. Map its position id to
+// that selection id so the selected-positions filter keeps it visible.
+const selectionIdForStakePosition = (positionId: string): string =>
+  positionId === rujiBondedStakePositionId
+    ? rujiAutoCompoundStakePositionId
+    : positionId
 
 const cosmosNativeStakingChains: readonly StakingChain[] = [
   Chain.Terra,
@@ -150,7 +162,9 @@ const ThorchainStakedPositions = () => {
 
   const selected = new Set(selectedPositions)
   const positions =
-    data?.stake?.positions.filter(position => selected.has(position.id)) ?? []
+    data?.stake?.positions.filter(position =>
+      selected.has(selectionIdForStakePosition(position.id))
+    ) ?? []
 
   if (!isPending && positions.length === 0) {
     return <DefiPositionEmptyState returnTab="staked" />
@@ -189,13 +203,23 @@ const ThorchainStakedPositions = () => {
           ? resolveStakeToken(chain, 'thor-stake-tcy')
           : token
 
+    // Both RUJI cards use the same RUJI coin; `autoCompound` selects the
+    // unstake route (auto-compounding → `liquid.unbond`, bonded →
+    // `account.withdraw`) and the balance shown, mirroring how sTCY threads it.
+    const form =
+      isStcyPosition || id === rujiAutoCompoundStakePositionId
+        ? { autoCompound: true }
+        : id === rujiBondedStakePositionId
+          ? { autoCompound: false }
+          : undefined
+
     navigate({
       id: 'deposit',
       state: {
         coin: extractCoinKey(coinForAction),
         action,
         entryPoint: 'defi',
-        form: isStcyPosition ? { autoCompound: true } : undefined,
+        form,
       },
     })
   }
@@ -260,7 +284,10 @@ const ThorchainStakedPositions = () => {
         const hideStats =
           position.id === 'thor-stake-stcy' ||
           position.id === 'thor-stake-yrune' ||
-          position.id === 'thor-stake-ytcy'
+          position.id === 'thor-stake-ytcy' ||
+          // The compounded RUJI card reinvests its revenue (like sTCY), so it
+          // has no APR/USDC claim to show — those live on the bonded card.
+          position.id === rujiAutoCompoundStakePositionId
 
         const handleNavigate = async (action: StakeActionType) => {
           if (cardActionsDisabled) return

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/UnstakeSpecific/hooks/useUnstakableRujiQuery.ts
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/UnstakeSpecific/hooks/useUnstakableRujiQuery.ts
@@ -1,16 +1,18 @@
-import { fetchRujiStakePosition } from '@core/ui/defi/chain/queries/services/thorchainStake/rujiStakeService'
-import { ThorchainStakePosition } from '@core/ui/defi/chain/queries/types'
+import {
+  fetchRujiUnstakeBalances,
+  RujiUnstakeBalances,
+} from '@core/ui/defi/chain/queries/services/thorchainStake/rujiStakeService'
 import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
 import { rujiraStakingConfig } from '@vultisig/core-chain/chains/cosmos/thor/rujira/config'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 
 /**
- * Amount of staked RUJI available to unstake. Reuses the DeFi staking service so
- * the unstake ceiling equals the amount shown on the Staked RUJI card (the
- * auto-compounding `liquidSize` value, with the on-chain receipt / `bonded` as
- * fallbacks) rather than the API's `bonded` field, which is `0` for
- * auto-compounding stakers.
+ * Amounts of staked RUJI available to unstake, per position. Reuses the DeFi
+ * staking service so each unstake ceiling equals the amount shown on its Staked
+ * RUJI card — the auto-compounding (`liquidSize`) value with the on-chain
+ * receipt as a fallback, and the bonded (`bonded`) value. The caller picks the
+ * balance matching the position being unstaked.
  */
 export const useUnstakableRujiQuery = ({
   address,
@@ -18,20 +20,19 @@ export const useUnstakableRujiQuery = ({
 }: {
   address?: string | null
   options?: Omit<
-    Partial<UseQueryOptions<ThorchainStakePosition | null>>,
+    Partial<UseQueryOptions<RujiUnstakeBalances>>,
     'queryKey' | 'queryFn' | 'select'
   >
 }) =>
   useQuery({
     queryKey: ['unstakable-ruji', address],
-    // `prices` only feeds the position's fiat value, which the unstake amount
-    // doesn't use, so an empty price map is fine here.
-    queryFn: () =>
-      fetchRujiStakePosition({ address: shouldBePresent(address), prices: {} }),
+    queryFn: () => fetchRujiUnstakeBalances(shouldBePresent(address)),
     ...options,
-    select: position => ({
-      humanReadableBalance: position
-        ? fromChainAmount(position.amount, rujiraStakingConfig.bondDecimals)
-        : 0,
+    select: ({ autoCompound, bonded }) => ({
+      autoCompound: fromChainAmount(
+        autoCompound,
+        rujiraStakingConfig.bondDecimals
+      ),
+      bonded: fromChainAmount(bonded, rujiraStakingConfig.bondDecimals),
     }),
   })

--- a/core/ui/vault/deposit/keysignPayload/build.ts
+++ b/core/ui/vault/deposit/keysignPayload/build.ts
@@ -286,12 +286,14 @@ export const buildDepositKeysignPayload = async ({
 
     let input: RujiInput | NativeTcyInput | StcyInput | null = null
 
-    // Unstaking the RUJI auto-compounding position redeems the sRUJI receipt via
-    // `liquid.unbond`, so the resolver needs the receipt shares + position value
-    // to convert the entered amount. Fetch them here (the match callbacks below
-    // are synchronous).
+    // RUJI has two independent positions unstaked via different routes: the
+    // bonded position via `account.withdraw` and the auto-compounding position
+    // via `liquid.unbond`. The card the user unstaked from sets `autocompound`
+    // (true → auto-compounding). Only the auto-compounding route needs the sRUJI
+    // receipt shares + position value to convert the entered amount, so fetch
+    // them here (the match callbacks below are synchronous).
     const rujiUnbondInputs =
-      stakeId === 'ruji' && actionAsStakeAction === 'unstake'
+      stakeId === 'ruji' && actionAsStakeAction === 'unstake' && autocompound
         ? await fetchRujiLiquidUnbondInputs(coin.address)
         : undefined
 
@@ -312,11 +314,18 @@ export const buildDepositKeysignPayload = async ({
           input = pctValid
             ? { kind: 'unstake', percentage: pct }
             : { kind: 'unstake', amount: shouldBePresent(amount) }
+        } else if (autocompound) {
+          input = {
+            kind: 'unstake',
+            position: 'liquid',
+            amount: shouldBePresent(amount),
+            ...shouldBePresent(rujiUnbondInputs),
+          }
         } else {
           input = {
             kind: 'unstake',
+            position: 'bonded',
             amount: shouldBePresent(amount),
-            ...shouldBePresent(rujiUnbondInputs),
           }
         }
       },

--- a/core/ui/vault/deposit/staking/resolvers/ruji.test.ts
+++ b/core/ui/vault/deposit/staking/resolvers/ruji.test.ts
@@ -21,7 +21,13 @@ describe('getRujiSpecific unstake', () => {
   it('redeems the full sRUJI receipt via liquid.unbond on a max unstake', () => {
     const result = getRujiSpecific({
       coin: rujiCoin,
-      input: { kind: 'unstake', amount: 1, liquidShares, liquidSize },
+      input: {
+        kind: 'unstake',
+        position: 'liquid',
+        amount: 1,
+        liquidShares,
+        liquidSize,
+      },
     })
 
     expect(result).toEqual({
@@ -35,7 +41,13 @@ describe('getRujiSpecific unstake', () => {
   it('converts a partial underlying amount to proportional receipt shares', () => {
     const result = getRujiSpecific({
       coin: rujiCoin,
-      input: { kind: 'unstake', amount: 0.5, liquidShares, liquidSize },
+      input: {
+        kind: 'unstake',
+        position: 'liquid',
+        amount: 0.5,
+        liquidShares,
+        liquidSize,
+      },
     })
 
     expect(result).toEqual({
@@ -54,6 +66,7 @@ describe('getRujiSpecific unstake', () => {
         // 1 base unit / share price 2.0 floors to 0 sRUJI shares
         input: {
           kind: 'unstake',
+          position: 'liquid',
           amount: 0.00000001,
           liquidShares,
           liquidSize,
@@ -62,14 +75,13 @@ describe('getRujiSpecific unstake', () => {
     ).toThrow()
   })
 
-  it('withdraws the bonded position when there is no liquid position', () => {
+  it('withdraws the bonded position via account.withdraw', () => {
     const result = getRujiSpecific({
       coin: rujiCoin,
       input: {
         kind: 'unstake',
+        position: 'bonded',
         amount: 0.0787,
-        liquidShares: 0n,
-        liquidSize: 0n,
       },
     })
 

--- a/core/ui/vault/deposit/staking/resolvers/ruji.ts
+++ b/core/ui/vault/deposit/staking/resolvers/ruji.ts
@@ -30,11 +30,23 @@ export function getRujiSpecific({ coin, input }: RujiPayload): StakeSpecific {
       }
     },
     unstake: () => {
-      if (!('liquidShares' in input)) {
+      if (input.kind !== 'unstake') {
         throw new Error('Invalid amount')
       }
 
       const enteredUnits = toChainAmount(input.amount, coin.decimals)
+
+      // Bonded (yielding) position: withdraw the RUJI amount directly.
+      if (input.position === 'bonded') {
+        return {
+          kind: 'wasm',
+          contract: rujiraStakingConfig.contract,
+          executeMsg: {
+            account: { withdraw: { amount: enteredUnits.toString() } },
+          },
+          funds: [],
+        }
+      }
 
       // Auto-compounding (liquid) position: redeem the sRUJI receipt via
       // `liquid.unbond`, converting the entered underlying RUJI amount into
@@ -42,34 +54,22 @@ export function getRujiSpecific({ coin, input }: RujiPayload): StakeSpecific {
       // receipt balance (avoids rounding dust and can't exceed what's held, even
       // if the share price moved since the amount was entered); below it convert
       // proportionally. The message carries no amount — the funds do.
-      if (input.liquidSize > 0n) {
-        const shares =
-          enteredUnits >= input.liquidSize
-            ? input.liquidShares
-            : (input.liquidShares * enteredUnits) / input.liquidSize
+      const shares =
+        enteredUnits >= input.liquidSize
+          ? input.liquidShares
+          : (input.liquidShares * enteredUnits) / input.liquidSize
 
-        // A tiny amount can floor to zero shares; redeeming 0 is a no-op that
-        // would fail on-chain, so reject it rather than build an empty unbond.
-        if (shares <= 0n) {
-          throw new Error('Amount too small to unstake')
-        }
-
-        return {
-          kind: 'wasm',
-          contract: rujiraStakingConfig.contract,
-          executeMsg: { liquid: { unbond: {} } },
-          funds: [{ denom: rujiShareDenom, amount: shares.toString() }],
-        }
+      // A tiny amount can floor to zero shares; redeeming 0 is a no-op that
+      // would fail on-chain, so reject it rather than build an empty unbond.
+      if (shares <= 0n) {
+        throw new Error('Amount too small to unstake')
       }
 
-      // Bonded (yielding) position: withdraw the RUJI amount directly.
       return {
         kind: 'wasm',
         contract: rujiraStakingConfig.contract,
-        executeMsg: {
-          account: { withdraw: { amount: enteredUnits.toString() } },
-        },
-        funds: [],
+        executeMsg: { liquid: { unbond: {} } },
+        funds: [{ denom: rujiShareDenom, amount: shares.toString() }],
       }
     },
     claim: () => ({

--- a/core/ui/vault/deposit/staking/types.ts
+++ b/core/ui/vault/deposit/staking/types.ts
@@ -13,6 +13,11 @@ export type StakeSpecific =
       funds: Array<{ denom: string; amount: string }>
     }
 
+/**
+ * Input for a RUJI staking op: `stake` (bond), position-specific `unstake`
+ * (auto-compounding `liquid` via `liquid.unbond` vs `bonded` via
+ * `account.withdraw`), or a rewards `claim`.
+ */
 export type RujiInput =
   | { kind: 'stake'; amount: number }
   | {

--- a/core/ui/vault/deposit/staking/types.ts
+++ b/core/ui/vault/deposit/staking/types.ts
@@ -16,10 +16,19 @@ export type StakeSpecific =
 export type RujiInput =
   | { kind: 'stake'; amount: number }
   | {
+      // Auto-compounding (sRUJI) position — redeemed via `liquid.unbond`, so the
+      // entered underlying amount is converted to receipt shares.
       kind: 'unstake'
+      position: 'liquid'
       amount: number
       liquidShares: bigint
       liquidSize: bigint
+    }
+  | {
+      // Bonded (yielding) position — withdrawn via `account.withdraw`.
+      kind: 'unstake'
+      position: 'bonded'
+      amount: number
     }
   | { kind: 'claim' }
 

--- a/core/ui/vault/deposit/staking/useStakeBalance.ts
+++ b/core/ui/vault/deposit/staking/useStakeBalance.ts
@@ -106,7 +106,9 @@ export const useStakeBalance = (): StakeBalanceResult => {
       stakeId,
     }),
     ruji: () => ({
-      balance: rujiData?.humanReadableBalance ?? 0,
+      // RUJI surfaces two positions unstaked via different routes; the card the
+      // user came from sets `autocompound` (true → auto-compounding / sRUJI).
+      balance: (autocompound ? rujiData?.autoCompound : rujiData?.bonded) ?? 0,
       isLoading: isLoadingRuji,
       stakeId,
     }),


### PR DESCRIPTION
Fixes #4372

## Problem

RUJI staking has **two independent positions** per account, exposed separately by Rujira:
- a **bonded** (yielding) position — unstaked via `account.withdraw`
- an **auto-compounding** (sRUJI receipt) position — unstaked via `liquid.unbond`

The DeFi flow only surfaced one at a time. It showed the auto-compounding balance and always routed unstaking to `liquid.unbond`, so a vault that **also** held a bonded position couldn't see or unstake it (stranded), and a bonded-only vault showed a **zero** staked balance.

Follow-up to #4366, which fixed the auto-compounding unstake but left both-positions handling open.

## Fix

Split the single RUJI card into two, both gated by the one **"RUJI"** manage tile (so a bonded-only vault sees its card just by enabling RUJI — no separate toggle to discover), each with its own balance:

| Card | Position | Unstake route |
|------|----------|---------------|
| **Compounded RUJI** | auto-compounding (`liquidSize`) | `liquid.unbond` (receipt-share conversion) |
| **Staked RUJI** | bonded (`bonded`) | `account.withdraw` |

- The unstake route **and** the displayed balance are threaded via the existing `autoCompound` form flag — the same mechanism sTCY uses.
- Each position is emitted only when it holds value: a bonded-only vault shows its bonded balance (no more zero), an auto-compounding vault shows only the compounded card, and an empty vault anchors on the bonded card (since **Stake** = `account.bond` bonds into exactly that position).
- **APR + pending USDC revenue ride on the bonded card**, and the Compounded card is stat-free like sTCY. Rationale: the auto-compounding position reinvests its revenue into `liquidSize` and has no separately-claimable USDC — that revenue (`pendingRevenue`, claimed via `account.claim`) accrues to the directly-bonded position. This also means the **Withdraw USDC** button now renders on the correct card.

Auto-compounding unstake (#4366) is unchanged. sRUJI transfer is unchanged (bonded is non-transferable — no bank receipt). Stake stays `account.bond` (out of this issue's scope, which is display + unstake routing).

## Changes

- `defi/.../thorchainStake/rujiStakeService.ts` — one fetch derives both positions; new `fetchRujiUnstakeBalances` returns both base-unit balances; APR/rewards attached to the bonded position.
- `defi/.../thorchainStake/index.ts` — spread both RUJI positions into the staked list.
- `vault/deposit/staking/types.ts` + `resolvers/ruji.ts` — unstake input discriminated `position: 'bonded' | 'liquid'` → `account.withdraw` vs `liquid.unbond`.
- `vault/deposit/keysignPayload/build.ts` — pick the route from the `autoCompound` flag; only fetch receipt-share inputs for the liquid path.
- `vault/deposit/.../useUnstakableRujiQuery.ts` + `staking/useStakeBalance.ts` — expose both balances; show the one matching the card.
- `defi/.../stakeUiResolver.ts` — bonded token mapping + "Compounded RUJI" / "Staked RUJI" titles.
- `defi/chain/tabs/StakedPositions.tsx` — bonded card gated by the RUJI selection, per-card `autoCompound` nav flag, stats hidden on the compounded card.

## Testing

- `ruji.test.ts` updated for the new input shape + a bonded `account.withdraw` case; `stakeUiResolver.test.ts` asserts bonded RUJI is non-transferable.
- Full suite: **371/371 pass**. Typecheck (root + extension ES2021), lint, and knip clean. No new i18n keys (reuses `compounded_token` / `staked`).

## Acceptance criteria

- [x] A vault holding both positions can view and unstake each independently, each producing the correct on-chain message.
- [x] A bonded-only vault shows its bonded balance and can unstake it via `account.withdraw`.
- [x] Auto-compounding unstake from #4366 is not regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RUJI staking is now displayed as separate auto-compounding and bonded positions.
  * Added dedicated unstaking flows and balance limits for each RUJI position.
  * RUJI bonded unstaking now uses the appropriate withdrawal flow, while auto-compounding uses liquid unbonding.
  * Improved RUJI position titles and navigation behavior.

* **Bug Fixes**
  * Bonded RUJI is no longer treated as a transferable stake token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->