### PR TITLE
feat(deposit): add bRUNE stake / ybRUNE unstake flow

### DIFF
--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/StakeForm.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/StakeForm.tsx
@@ -63,7 +63,11 @@ export const StakeForm = ({
   useEffect(() => {
     if (stakeId === 'stcy') {
       setValue('autoCompound', true, { shouldValidate: false })
-    } else if (stakeId === 'native-tcy' || stakeId === 'ruji') {
+    } else if (
+      stakeId === 'native-tcy' ||
+      stakeId === 'ruji' ||
+      stakeId === 'brune'
+    ) {
       setValue('autoCompound', false, { shouldValidate: false })
     }
   }, [stakeId, setValue])

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/UnstakeSpecific/UnstakeSpecific.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/UnstakeSpecific/UnstakeSpecific.tsx
@@ -67,6 +67,7 @@ export const UnstakeSpecific = () => {
               TCY={() => <UnstakeTCYSpecific />}
               RUJI={() => null}
               GRAM={() => null}
+              bRUNE={() => null}
             />
           </>
         )}

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/UnstakeSpecific/hooks/useUnstakableBruneQuery.ts
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/UnstakeSpecific/hooks/useUnstakableBruneQuery.ts
@@ -1,0 +1,36 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
+import { cosmosRpcUrl } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
+import { bruneBondConfig } from '@vultisig/core-chain/chains/cosmos/thor/brune-bond/config'
+import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+
+const bankApiBase = `${cosmosRpcUrl.THORChain}/cosmos/bank/v1beta1`
+
+type BankBalanceResponse = {
+  balance?: { denom?: string; amount?: string }
+}
+
+export const useUnstakableBruneQuery = ({
+  address,
+  options,
+}: {
+  address?: string | null
+  options?: Partial<UseQueryOptions<bigint>>
+}) =>
+  useQuery({
+    queryKey: ['unstakable-brune', address],
+    queryFn: async () => {
+      const denom = encodeURIComponent(bruneBondConfig.shareDenom)
+      const url = `${bankApiBase}/balances/${address}/by_denom?denom=${denom}`
+      const { balance } = await queryUrl<BankBalanceResponse>(url)
+      return BigInt(balance?.amount ?? '0')
+    },
+    ...options,
+    select: (data = 0n) => ({
+      chainBalance: data,
+      humanReadableBalance: fromChainAmount(
+        data,
+        bruneBondConfig.shareDecimals
+      ),
+    }),
+  })

--- a/core/ui/vault/deposit/config.ts
+++ b/core/ui/vault/deposit/config.ts
@@ -6,7 +6,7 @@ export const mayachainPoolsEndpoint = `${mayachainApiBaseUrl}/pools`
 
 const stakeableChains = [Chain.Ton, Chain.THORChain] as const
 export type StakeableChain = (typeof stakeableChains)[number]
-export const stakeableAssetsTickers = ['TCY', 'RUJI', 'GRAM'] as const
+export const stakeableAssetsTickers = ['TCY', 'RUJI', 'GRAM', 'bRUNE'] as const
 export type StakeableAssetTicker = (typeof stakeableAssetsTickers)[number]
 
 export const isStakeableChain = (c: Chain): c is StakeableChain =>

--- a/core/ui/vault/deposit/keysignPayload/build.ts
+++ b/core/ui/vault/deposit/keysignPayload/build.ts
@@ -73,6 +73,7 @@ import {
 } from '../ChainAction'
 import { resolvers, selectStakeId } from '../staking/resolvers'
 import {
+  BruneInput,
   NativeTcyInput,
   RujiInput,
   StakeKind,
@@ -284,7 +285,7 @@ export const buildDepositKeysignPayload = async ({
 
     const stakeSpecific = resolvers[stakeId]
 
-    let input: RujiInput | NativeTcyInput | StcyInput | null = null
+    let input: RujiInput | NativeTcyInput | StcyInput | BruneInput | null = null
 
     // RUJI has two independent positions unstaked via different routes: the
     // bonded position via `account.withdraw` and the auto-compounding position
@@ -302,7 +303,7 @@ export const buildDepositKeysignPayload = async ({
         input = { kind: 'stake', amount: shouldBePresent(amount) }
       },
       unstake: () => {
-        if (stakeId === 'stcy') {
+        if (stakeId === 'stcy' || stakeId === 'brune') {
           input = { kind: 'unstake', amount: shouldBePresent(amount) }
         } else if (stakeId === 'native-tcy') {
           const raw = depositData['percentage']

--- a/core/ui/vault/deposit/staking/config.ts
+++ b/core/ui/vault/deposit/staking/config.ts
@@ -4,4 +4,5 @@ export const stakeModeById: { [K in StakeId]: StakeContract } = {
   ruji: 'wasm',
   'native-tcy': 'memo',
   stcy: 'wasm',
+  brune: 'wasm',
 }

--- a/core/ui/vault/deposit/staking/resolvers/brune.ts
+++ b/core/ui/vault/deposit/staking/resolvers/brune.ts
@@ -1,0 +1,47 @@
+import { toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'
+import { bruneBondConfig } from '@vultisig/core-chain/chains/cosmos/thor/brune-bond/config'
+import { match } from '@vultisig/lib-utils/match'
+
+import type { BrunePayload, StakeSpecific } from '../types'
+
+/**
+ * bRUNE staking via Rujira liquid bonding — a wasm `MsgExecuteContract` on the
+ * `bruneBondConfig` contract. Architecturally identical to the STCY
+ * auto-compounder: `stake` bonds bRUNE (`liquid.bond`, funds in `x/brune`) to
+ * mint the auto-compounding ybRUNE receipt; `unstake` redeems ybRUNE shares
+ * (`liquid.unbond`, funds in `x/staking-x/brune`) back to bRUNE.
+ */
+export const getBruneSpecific = ({ input }: BrunePayload): StakeSpecific => {
+  return match<BrunePayload['input']['kind'], StakeSpecific>(input.kind, {
+    stake: () => {
+      if (!('amount' in input)) throw new Error('Invalid amount')
+
+      const units = toChainAmount(
+        input.amount,
+        bruneBondConfig.depositDecimals
+      ).toString()
+
+      return {
+        kind: 'wasm',
+        contract: bruneBondConfig.contract,
+        executeMsg: { liquid: { bond: {} } },
+        funds: [{ denom: bruneBondConfig.depositDenom, amount: units }],
+      }
+    },
+    unstake: () => {
+      if (!('amount' in input)) throw new Error('Invalid amount')
+
+      const units = toChainAmount(
+        input.amount,
+        bruneBondConfig.shareDecimals
+      ).toString()
+
+      return {
+        kind: 'wasm',
+        contract: bruneBondConfig.contract,
+        executeMsg: { liquid: { unbond: {} } },
+        funds: [{ denom: bruneBondConfig.shareDenom, amount: units }],
+      }
+    },
+  })
+}

--- a/core/ui/vault/deposit/staking/resolvers/index.ts
+++ b/core/ui/vault/deposit/staking/resolvers/index.ts
@@ -1,4 +1,5 @@
 import { CosmosChain } from '@vultisig/core-chain/Chain'
+import { bruneBondConfig } from '@vultisig/core-chain/chains/cosmos/thor/brune-bond/config'
 import { rujiraStakingConfig } from '@vultisig/core-chain/chains/cosmos/thor/rujira/config'
 import type { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
 import { CoinKey } from '@vultisig/core-chain/coin/Coin'
@@ -6,6 +7,7 @@ import { knownCosmosTokens } from '@vultisig/core-chain/coin/knownTokens/cosmos'
 import { getDenom } from '@vultisig/core-chain/coin/utils/getDenom'
 
 import type { StakeId, StakeResolverMap } from '../types'
+import { getBruneSpecific } from './brune'
 import { getRujiSpecific } from './ruji'
 import { getStcySpecific } from './stcy-auto'
 import { getNativeTcySpecific } from './tcy-native'
@@ -14,6 +16,7 @@ export const resolvers = {
   ruji: getRujiSpecific,
   'native-tcy': getNativeTcySpecific,
   stcy: getStcySpecific,
+  brune: getBruneSpecific,
 } as const satisfies StakeResolverMap
 
 export const selectStakeId = (
@@ -37,6 +40,16 @@ export const selectStakeId = (
     coin.id === rujiraStakingConfig.bondDenom
 
   if (rujiByTicker || rujiByDenom) return 'ruji'
+
+  const bruneByTicker =
+    coin.ticker?.toUpperCase() ===
+    knownCosmosTokens['THORChain']['x/brune'].ticker.toUpperCase()
+
+  const bruneByDenom =
+    denom === bruneBondConfig.depositDenom ||
+    coin.id === bruneBondConfig.depositDenom
+
+  if (bruneByTicker || bruneByDenom) return 'brune'
 
   throw new Error(`No staking provider found for ${coin.chain}:${coin.ticker}`)
 }

--- a/core/ui/vault/deposit/staking/types.ts
+++ b/core/ui/vault/deposit/staking/types.ts
@@ -2,7 +2,7 @@ import type { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
 import type { Resolver } from '@vultisig/lib-utils/types/Resolver'
 
 export type StakeKind = 'stake' | 'unstake' | 'claim'
-export type StakeId = 'ruji' | 'native-tcy' | 'stcy'
+export type StakeId = 'ruji' | 'native-tcy' | 'stcy' | 'brune'
 
 export type StakeSpecific =
   | { kind: 'memo'; memo: string; toAddress?: string; toAmount?: string }
@@ -46,14 +46,25 @@ export type StcyInput =
   | { kind: 'stake'; amount: number }
   | { kind: 'unstake'; amount: number }
 
+/**
+ * Input for a bRUNE staking op via Rujira liquid bonding: `stake` bonds bRUNE
+ * (`liquid.bond`) to receive the auto-compounding ybRUNE receipt; `unstake`
+ * redeems ybRUNE shares (`liquid.unbond`) back to bRUNE. Amount-based, like STCY.
+ */
+export type BruneInput =
+  | { kind: 'stake'; amount: number }
+  | { kind: 'unstake'; amount: number }
+
 export type RujiPayload = { coin: AccountCoin; input: RujiInput }
 export type NativeTcyPayload = { coin: AccountCoin; input: NativeTcyInput }
 export type StcyPayload = { input: StcyInput }
+export type BrunePayload = { input: BruneInput }
 
 type StakePayloadById = {
   ruji: RujiPayload
   'native-tcy': NativeTcyPayload
   stcy: StcyPayload
+  brune: BrunePayload
 }
 
 export type StakeResolverMap = {

--- a/core/ui/vault/deposit/staking/useStakeBalance.ts
+++ b/core/ui/vault/deposit/staking/useStakeBalance.ts
@@ -7,6 +7,7 @@ import { attempt } from '@vultisig/lib-utils/attempt'
 import { match } from '@vultisig/lib-utils/match'
 import { useMemo } from 'react'
 
+import { useUnstakableBruneQuery } from '../DepositForm/ActionSpecific/StakeSpecific/UnstakeSpecific/hooks/useUnstakableBruneQuery'
 import { useUnstakableRujiQuery } from '../DepositForm/ActionSpecific/StakeSpecific/UnstakeSpecific/hooks/useUnstakableRujiQuery'
 import { useUnstakableStcyQuery } from '../DepositForm/ActionSpecific/StakeSpecific/UnstakeSpecific/hooks/useUnstakableSTcyQuery'
 import { useUnstakableTcyQuery } from '../DepositForm/ActionSpecific/StakeSpecific/UnstakeSpecific/hooks/useUnstakableTcyQuery'
@@ -68,6 +69,16 @@ export const useStakeBalance = (): StakeBalanceResult => {
     },
   })
 
+  const { data: bruneData, isLoading: isLoadingBrune } =
+    useUnstakableBruneQuery({
+      address: thorchainVaultAddress,
+      options: {
+        enabled: Boolean(
+          thorchainVaultAddress && isUnstake && stakeId === 'brune'
+        ),
+      },
+    })
+
   const { data: tonBalance, isLoading: isLoadingTon } = useTonUnstakableQuery({
     address: tonVaultAddress,
     options: {
@@ -110,6 +121,13 @@ export const useStakeBalance = (): StakeBalanceResult => {
       // user came from sets `autocompound` (true → auto-compounding / sRUJI).
       balance: (autocompound ? rujiData?.autoCompound : rujiData?.bonded) ?? 0,
       isLoading: isLoadingRuji,
+      stakeId,
+    }),
+    brune: () => ({
+      // Unstake redeems the ybRUNE receipt, so the available balance is the
+      // vault's `x/staking-x/brune` bank balance.
+      balance: bruneData?.humanReadableBalance ?? 0,
+      isLoading: isLoadingBrune,
       stakeId,
     }),
   })

--- a/core/ui/vault/deposit/utils/getDepositFormConfig.ts
+++ b/core/ui/vault/deposit/utils/getDepositFormConfig.ts
@@ -608,7 +608,7 @@ export const getDepositFormConfig = ({
         ? z.never()
         : match(chain, {
             THORChain: () =>
-              coin.ticker === 'RUJI'
+              coin.ticker === 'RUJI' || coin.ticker === 'bRUNE'
                 ? z.object({
                     amount: positiveAmountSchema(totalAmountAvailable, t),
                   })
@@ -657,7 +657,7 @@ export const getDepositFormConfig = ({
               },
             ],
             [Chain.THORChain]: () =>
-              coin.ticker === 'RUJI'
+              coin.ticker === 'RUJI' || coin.ticker === 'bRUNE'
                 ? [
                     {
                       name: 'amount',
@@ -683,7 +683,7 @@ export const getDepositFormConfig = ({
         ? z.never()
         : match(chain, {
             THORChain: () =>
-              coin.ticker === 'RUJI'
+              coin.ticker === 'RUJI' || coin.ticker === 'bRUNE'
                 ? z.object({
                     amount: positiveAmountSchema(totalAmountAvailable, t),
                   })

--- a/core/ui/vault/deposit/utils/memoGenerator/index.ts
+++ b/core/ui/vault/deposit/utils/memoGenerator/index.ts
@@ -78,6 +78,14 @@ export const generateMemo = ({
             return `bond:${rujiraStakingConfig.bondDenom}:${chainAmount}`
           }
 
+          // bRUNE bonds via a wasm MsgExecuteContract, not a memo. The keysign
+          // build sets contractPayload + an empty memo directly, but this
+          // generator still runs on every form render (useDepositMemo); return
+          // an empty memo so it doesn't throw before the wasm build takes over.
+          if (coin.ticker === 'bRUNE') {
+            return ''
+          }
+
           throw new Error(
             `Unsupported chain and token for staking memo: ${chain}`
           )
@@ -108,6 +116,13 @@ export const generateMemo = ({
             }
             const chainAmount = toChainAmount(amtNum, coin.decimals).toString()
             return `withdraw:${rujiraStakingConfig.bondDenom}:${chainAmount}`
+          }
+
+          // ybRUNE unbonds via a wasm MsgExecuteContract, not a memo. See the
+          // stake path above — return an empty memo so this generator doesn't
+          // throw before the wasm keysign build runs.
+          if (coin.ticker === 'bRUNE') {
+            return ''
           }
 
           throw new Error(


### PR DESCRIPTION
## Summary

Adds the **bRUNE stake / ybRUNE unstake** transaction flow via Rujira liquid bonding, wired into the existing deposit → keysign → broadcast pipeline. This is architecturally identical to the existing TCY→sTCY auto-compounder (same `{"liquid":{"bond":{}}}` / `{"liquid":{"unbond":{}}}` wasm `MsgExecuteContract` messages) — only the contract and denoms differ, and those already ship in `@vultisig/core-chain` 2.26.0 as `bruneBondConfig`.

- **Stake**: bonds bRUNE (`liquid.bond`, funds in `x/brune`) → mints the auto-compounding ybRUNE receipt.
- **Unstake**: redeems ybRUNE shares (`liquid.unbond`, funds in `x/staking-x/brune`) → back to bRUNE.

Closes #4395.

## Changes

| File | Change |
|------|--------|
| `staking/types.ts` | `brune` in `StakeId` + `BruneInput`/`BrunePayload` + `StakePayloadById` |
| `staking/config.ts` | `stakeModeById.brune = 'wasm'` |
| `staking/resolvers/brune.ts` *(new)* | wasm bond/unbond resolver (modeled on `stcy-auto`) |
| `staking/resolvers/index.ts` | register resolver + `selectStakeId` mapping for `x/brune`/`bRUNE` |
| `.../hooks/useUnstakableBruneQuery.ts` *(new)* | reads the `x/staking-x/brune` bank balance |
| `staking/useStakeBalance.ts` | `brune` case + query wiring |
| `deposit/config.ts` | add `bRUNE` to `stakeableAssetsTickers` (surfaces it in the Select-token modal) |
| `keysignPayload/build.ts` | `BruneInput` in the input union + unstake branch |
| `utils/memoGenerator/index.ts` | **bRUNE guard returning `''`** in both THORChain stake/unstake paths — it previously `throw`w for any ticker other than TCY/RUJI, crashing the form (`useDepositMemo` runs on every render) before the wasm build takes over |
| `utils/getDepositFormConfig.ts` | amount-based schema/fields for bRUNE (like RUJI) |
| `StakeForm.tsx` | `brune` → `autoCompound=false` |
| `UnstakeSpecific.tsx` | exhaustive `bRUNE` branch in the ticker `Match` |

The wasm keysign→sign→broadcast pipeline (THORChain `MsgExecuteContract`) already exists and is used by sTCY/RUJI today, so this is declarative wiring plus the one required memo-generator guard.

## Out of scope (follow-up sub-issue)

- ybRUNE **DeFi staked-position card** with NAV-based fiat value (the `DeFi → Staked → Manage positions` catalog in `storage/defiPositions.tsx` is intentionally untouched).
- The joiner Verify screen shows `0 bRUNE` / empty "To" for the bond tx — this is **pre-existing** behavior for all wasm stakes (sTCY, RUJI): `toAddress`/`toAmount` are empty by design, the real destination + amount live in `contractPayload.wasmExecuteContractPayload`. Not a regression from this PR.

## Testing

- `yarn typecheck` ✓ · `yarn lint` ✓ · `yarn knip` ✓ · deposit-scoped `vitest` ✓
- Built the extension (`yarn build:extension`) and verified the bRUNE resolver, `selectStakeId` mapping, `unstakable-brune` query, and the `bruneBondConfig` contract are all present in the output bundle.
- Manual: from a vault holding bRUNE, **THORChain → Function → Stake** now surfaces bRUNE and builds a `{"liquid":{"bond":{}}}` wasm tx; **Unstake** reads the ybRUNE balance and builds `{"liquid":{"unbond":{}}}`; the form no longer throws in the memo generator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for staking and unstaking bRUNE through the deposit form.
  * Added bRUNE balance retrieval and display for unstaking.
  * Added validation, transaction handling, and form configuration for bRUNE operations.
  * bRUNE is now recognized as a supported stakeable asset.

* **Bug Fixes**
  * Prevented unsupported unstaking controls and memo-generation errors for bRUNE.
  * Ensured auto-compounding is disabled for bRUNE positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->