### PR TITLE
fix(keysign): show real amount on success screen for wasm stake/unstake

### DIFF
--- a/core/ui/mpc/keysign/tx/TxSuccess.tsx
+++ b/core/ui/mpc/keysign/tx/TxSuccess.tsx
@@ -41,6 +41,7 @@ import styled from 'styled-components'
 import { useTxHash } from '../../../chain/state/txHash'
 import { useCore } from '../../../state/core'
 import { getTxSuccessAmountPresentation } from './getTxSuccessAmountPresentation'
+import { getWasmExecuteTxDisplay } from './getWasmExecuteTxDisplay'
 import { TransactionStatusAnimation } from './TransactionStatusAnimation'
 import { TxStatusTracker } from './TxStatusTracker'
 
@@ -58,11 +59,17 @@ export const TxSuccess = ({
   const [, copyToClipboard] = useCopyToClipboard()
   const { openUrl } = useCore()
 
-  const formattedToAmount = useMemo(() => {
-    if (!toAmount) return 0
+  // A wasm contract execute (stake/unstake) is signed entirely from
+  // `contractPayload`; its `toAmount` is empty, so derive the amount + asset
+  // from that same payload (mirrors KeysignTxOverview / the details screen)
+  // instead of showing `0`.
+  const wasmDisplay = getWasmExecuteTxDisplay(value)
 
-    return fromChainAmount(BigInt(toAmount), coin.decimals)
-  }, [toAmount, coin.decimals])
+  const formattedToAmount = wasmDisplay
+    ? fromChainAmount(BigInt(wasmDisplay.fundAmount), wasmDisplay.coin.decimals)
+    : toAmount
+      ? fromChainAmount(BigInt(toAmount), coin.decimals)
+      : 0
 
   const txAction = useMemo(
     () => getSignDataTxAction(value, formattedToAmount),
@@ -170,7 +177,8 @@ export const TxSuccess = ({
     return { coin: sendChange.coin, amount: sendChange.amount }
   }, [blockaidSimulationQuery.data])
 
-  const displayCoin = simulationSend?.coin ?? resolvedToken?.coin ?? coin
+  const displayCoin =
+    simulationSend?.coin ?? resolvedToken?.coin ?? wasmDisplay?.coin ?? coin
   const displayAmount = simulationSend
     ? Number(formatUnits(simulationSend.amount, simulationSend.coin.decimals))
     : (resolvedToken?.amount ??


### PR DESCRIPTION
## Summary

Fixes the **"0 bRUNE"** amount on the keysign success ("Transaction successful" / Done) screen for **wasm contract-execute** transactions (bRUNE stake/unstake, and equally sTCY / RUJI).

The Done hero read the sent amount from `toAmount`, which the keysign builder leaves empty (`'0'`) for wasm executes (the real funds live in `contractPayload`). So the hero showed `0 bRUNE` even though the tx was correct — and the **Transaction Details** screen of the *same* tx already showed the right amount (`0.5 bRUNE`, `$0.22`).

Closes #4412.

## Root cause

`KeysignTxOverview.tsx` (the Details screen) derives its amount/asset from the signed `contractPayload` via `getWasmExecuteTxDisplay(payload)`. `TxSuccess.tsx` (the Done hero) did **not** — it relied on `toAmount` (empty for wasm) / `getSignDataTxAction` (returns no amount for an in-app wasm execute), so it fell back to `0`.

## Fix

In `TxSuccess.tsx`, reuse the same `getWasmExecuteTxDisplay(value)` helper for the hero `displayCoin` / `displayAmount`, mirroring `KeysignTxOverview`. One file, +13/−5:

- `formattedToAmount` now uses the wasm `fundAmount` + fund-coin decimals when the tx is a wasm execute; otherwise the existing `toAmount` path.
- `displayCoin` falls back to `wasmDisplay?.coin` (the resolved fund asset) before the sender coin.

Non-wasm txs and fundless wasm executes (e.g. RUJI withdraw, whose amount lives inside the execute message — `getWasmExecuteTxDisplay` returns `null` there) keep the existing behavior. The "Sent" label and zero-amount handling are unchanged.

This is a **display-only** change in `core/ui/mpc/keysign/tx/` — it does not touch the `core/mpc/` crypto boundary or the wasm keysign/broadcast pipeline.

##
<img width="300" height="461" alt="2026-07-21 12 26 20" src="https://github.com/user-attachments/assets/c185acbd-fc87-45a9-8c02-728f9b79c9d7" />

## Testing

- `eslint core/ui/mpc/keysign/tx/TxSuccess.tsx` ✓ (clean)
- `tsgo --noEmit` — the changed file is error-free (the sole remaining error is a pre-existing, unrelated `core/inpage-provider/bridge` overload artifact in this environment, not touched by this PR).
- Manual expectation: after a bRUNE stake of `0.5`, the Done hero shows `0.5 bRUNE` (matching Transaction Details), not `0 bRUNE`; same for bRUNE unstake, sTCY and RUJI stakes; native sends / THORChain deposits unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction success screens for WASM contract executions.
  * Displays the correct asset, amount, and coin details when contract execution transfers funds.
  * Preserves fallback behavior for standard transactions when WASM-specific information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->