### PR TITLE
fix(send): show expected address format on invalid recipient

### DIFF
--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -1744,7 +1744,7 @@ export const de = {
   send_receiver_format_hint_evm:
     'Geben Sie eine EVM-Adresse ein, die mit 0x beginnt und 40 Hexadezimalzeichen hat.',
   send_receiver_format_hint_qbtc:
-    'Geben Sie eine QBTC -Adresse ein, die mit qbtc beginnt.',
+    'Geben Sie eine QBTC-Adresse ein, die mit qbtc beginnt.',
   send_receiver_format_hint_ripple:
     'Geben Sie eine XRP-Adresse ein, die mit dem Buchstaben r beginnt.',
   send_receiver_format_hint_solana:
@@ -1753,9 +1753,9 @@ export const de = {
     'Geben Sie eine SS58-codierte Adresse für dieses Netzwerk ein.',
   send_receiver_format_hint_sui:
     'Geben Sie eine Sui-Adresse ein, die mit 0x beginnt und 64 Hexadezimalzeichen enthält.',
-  send_receiver_format_hint_ton: 'Geben Sie eine gültige TON -Adresse ein.',
+  send_receiver_format_hint_ton: 'Geben Sie eine gültige TON-Adresse ein.',
   send_receiver_format_hint_tron:
-    'Geben Sie eine TRON -Adresse ein, die mit dem Buchstaben T beginnt.',
+    'Geben Sie eine TRON-Adresse ein, die mit dem Buchstaben T beginnt.',
   send_receiver_format_hint_utxo:
     'Geben Sie eine gültige Adresse für dieses Netzwerk ein (Bech32- oder Legacy-Format).',
 }

--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -1737,4 +1737,25 @@ export const de = {
   ripple_undecoded_notice:
     'Diese Transaktion konnte nicht dekodiert werden. Bitte prüfen Sie die unten stehenden Rohdaten, bevor Sie die Transaktion genehmigen.',
   swap_expected_payout: 'erwartete Auszahlung',
+  send_receiver_format_hint_cardano:
+    'Geben Sie eine Cardano-Adresse ein, die mit addr1 beginnt.',
+  send_receiver_format_hint_cosmos:
+    'Geben Sie eine Bech32-Adresse ein, die mit dem Präfix {{prefix}} beginnt.',
+  send_receiver_format_hint_evm:
+    'Geben Sie eine EVM-Adresse ein, die mit 0x beginnt und 40 Hexadezimalzeichen hat.',
+  send_receiver_format_hint_qbtc:
+    'Geben Sie eine QBTC -Adresse ein, die mit qbtc beginnt.',
+  send_receiver_format_hint_ripple:
+    'Geben Sie eine XRP-Adresse ein, die mit dem Buchstaben r beginnt.',
+  send_receiver_format_hint_solana:
+    'Geben Sie eine Base58-kodierte Solana-Adresse ein, üblicherweise 32 bis 44 Zeichen lang.',
+  send_receiver_format_hint_ss58:
+    'Geben Sie eine SS58-codierte Adresse für dieses Netzwerk ein.',
+  send_receiver_format_hint_sui:
+    'Geben Sie eine Sui-Adresse ein, die mit 0x beginnt und 64 Hexadezimalzeichen enthält.',
+  send_receiver_format_hint_ton: 'Geben Sie eine gültige TON -Adresse ein.',
+  send_receiver_format_hint_tron:
+    'Geben Sie eine TRON -Adresse ein, die mit dem Buchstaben T beginnt.',
+  send_receiver_format_hint_utxo:
+    'Geben Sie eine gültige Adresse für dieses Netzwerk ein (Bech32- oder Legacy-Format).',
 }

--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -1758,4 +1758,5 @@ export const de = {
     'Geben Sie eine TRON-Adresse ein, die mit dem Buchstaben T beginnt.',
   send_receiver_format_hint_utxo:
     'Geben Sie eine gültige Adresse für dieses Netzwerk ein (Bech32- oder Legacy-Format).',
+  send_invalid_receiver_address_with_hint: '{{error}}. {{hint}}',
 }

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -1009,6 +1009,7 @@ export const en = {
   sends: 'Sends',
   send_amount_exceeds_balance: 'Amount exceeds balance',
   send_invalid_receiver_address: 'Wrong address for selected chain',
+  send_invalid_receiver_address_with_hint: '{{error}}. {{hint}}',
   send_overview: 'Send Overview',
   send_receiver_address_same_as_sender:
     'Receiver address cannot be the same as sender address',

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -1012,6 +1012,26 @@ export const en = {
   send_overview: 'Send Overview',
   send_receiver_address_same_as_sender:
     'Receiver address cannot be the same as sender address',
+  send_receiver_format_hint_cardano:
+    'Enter a Cardano address that starts with addr1.',
+  send_receiver_format_hint_cosmos:
+    'Enter a Bech32 address that starts with the {{prefix}} prefix.',
+  send_receiver_format_hint_evm:
+    'Enter an EVM address that starts with 0x and has 40 hexadecimal characters.',
+  send_receiver_format_hint_qbtc: 'Enter a QBTC address that starts with qbtc.',
+  send_receiver_format_hint_ripple:
+    'Enter an XRP address that starts with the letter r.',
+  send_receiver_format_hint_solana:
+    'Enter a Base58-encoded Solana address, usually 32 to 44 characters.',
+  send_receiver_format_hint_ss58:
+    'Enter an SS58-encoded address for this network.',
+  send_receiver_format_hint_sui:
+    'Enter a Sui address that starts with 0x and has 64 hexadecimal characters.',
+  send_receiver_format_hint_ton: 'Enter a valid TON address.',
+  send_receiver_format_hint_tron:
+    'Enter a TRON address that starts with the letter T.',
+  send_receiver_format_hint_utxo:
+    'Enter a valid address for this network (bech32 or legacy format).',
   send_terms_0: "I'm sending to the right address",
   send_terms_1: 'The amount is correct',
   send_to: 'Send to',

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -1723,4 +1723,25 @@ export const es = {
   ripple_undecoded_notice:
     'Esta transacción no pudo ser decodificada. Revise los detalles a continuación antes de aprobar.',
   swap_expected_payout: 'pago esperado',
+  send_receiver_format_hint_cardano:
+    'Introduce una dirección de Cardano que empiece por addr1.',
+  send_receiver_format_hint_cosmos:
+    'Introduzca una dirección Bech32 que comience con el prefijo {{prefix}} .',
+  send_receiver_format_hint_evm:
+    'Introduzca una dirección EVM que comience con 0x y tenga 40 caracteres hexadecimales.',
+  send_receiver_format_hint_qbtc:
+    'Introduzca una dirección QBTC que comience con qbtc.',
+  send_receiver_format_hint_ripple:
+    'Introduce una dirección XRP que empiece por la letra r.',
+  send_receiver_format_hint_solana:
+    'Introduzca una dirección Solana codificada en Base58, normalmente de entre 32 y 44 caracteres.',
+  send_receiver_format_hint_ss58:
+    'Introduzca una dirección codificada en SS58 para esta red.',
+  send_receiver_format_hint_sui:
+    'Introduzca una dirección Sui que comience con 0x y tenga 64 caracteres hexadecimales.',
+  send_receiver_format_hint_ton: 'Introduzca una dirección TON válida.',
+  send_receiver_format_hint_tron:
+    'Introduzca una dirección TRON que comience con la letra T.',
+  send_receiver_format_hint_utxo:
+    'Introduzca una dirección válida para esta red (formato bech32 o heredado).',
 }

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -1744,4 +1744,5 @@ export const es = {
     'Introduzca una dirección TRON que comience con la letra T.',
   send_receiver_format_hint_utxo:
     'Introduzca una dirección válida para esta red (formato bech32 o heredado).',
+  send_invalid_receiver_address_with_hint: '{{error}}. {{hint}}',
 }

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -1726,7 +1726,7 @@ export const es = {
   send_receiver_format_hint_cardano:
     'Introduce una dirección de Cardano que empiece por addr1.',
   send_receiver_format_hint_cosmos:
-    'Introduzca una dirección Bech32 que comience con el prefijo {{prefix}} .',
+    'Introduzca una dirección Bech32 que comience con el prefijo {{prefix}}.',
   send_receiver_format_hint_evm:
     'Introduzca una dirección EVM que comience con 0x y tenga 40 caracteres hexadecimales.',
   send_receiver_format_hint_qbtc:

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -1702,7 +1702,7 @@ export const hr = {
   send_receiver_format_hint_cardano:
     'Unesite Cardano adresu koja počinje s addr1.',
   send_receiver_format_hint_cosmos:
-    'Unesite Bech32 adresu koja počinje s prefiksom {{prefix}} .',
+    'Unesite Bech32 adresu koja počinje s prefiksom {{prefix}}.',
   send_receiver_format_hint_evm:
     'Unesite EVM adresu koja počinje s 0x i ima 40 heksadecimalnih znakova.',
   send_receiver_format_hint_qbtc: 'Unesite adresu QBTC koja počinje s qbtc.',
@@ -1712,7 +1712,7 @@ export const hr = {
   send_receiver_format_hint_ss58: 'Unesite adresu kodiranu SS58 za ovu mrežu.',
   send_receiver_format_hint_sui:
     'Unesite Sui adresu koja počinje s 0x i ima 64 heksadecimalna znaka.',
-  send_receiver_format_hint_ton: 'Unesite valjanu adresu TON .',
+  send_receiver_format_hint_ton: 'Unesite valjanu adresu TON.',
   send_receiver_format_hint_tron: 'Unesite adresu TRON koja počinje slovom T.',
   send_receiver_format_hint_utxo:
     'Unesite valjanu adresu za ovu mrežu (bech32 ili stariji format).',

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -1716,4 +1716,5 @@ export const hr = {
   send_receiver_format_hint_tron: 'Unesite adresu TRON koja počinje slovom T.',
   send_receiver_format_hint_utxo:
     'Unesite valjanu adresu za ovu mrežu (bech32 ili stariji format).',
+  send_invalid_receiver_address_with_hint: '{{error}}. {{hint}}',
 }

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -1699,4 +1699,21 @@ export const hr = {
   ripple_undecoded_notice:
     'Ovu transakciju nije bilo moguće dekodirati. Prije odobrenja pregledajte neobrađene podatke u nastavku.',
   swap_expected_payout: 'očekivana isplata',
+  send_receiver_format_hint_cardano:
+    'Unesite Cardano adresu koja počinje s addr1.',
+  send_receiver_format_hint_cosmos:
+    'Unesite Bech32 adresu koja počinje s prefiksom {{prefix}} .',
+  send_receiver_format_hint_evm:
+    'Unesite EVM adresu koja počinje s 0x i ima 40 heksadecimalnih znakova.',
+  send_receiver_format_hint_qbtc: 'Unesite adresu QBTC koja počinje s qbtc.',
+  send_receiver_format_hint_ripple: 'Unesite XRP adresu koja počinje slovom r.',
+  send_receiver_format_hint_solana:
+    'Unesite Solana adresu kodiranu Base58, obično od 32 do 44 znaka.',
+  send_receiver_format_hint_ss58: 'Unesite adresu kodiranu SS58 za ovu mrežu.',
+  send_receiver_format_hint_sui:
+    'Unesite Sui adresu koja počinje s 0x i ima 64 heksadecimalna znaka.',
+  send_receiver_format_hint_ton: 'Unesite valjanu adresu TON .',
+  send_receiver_format_hint_tron: 'Unesite adresu TRON koja počinje slovom T.',
+  send_receiver_format_hint_utxo:
+    'Unesite valjanu adresu za ovu mrežu (bech32 ili stariji format).',
 }

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -1728,4 +1728,25 @@ export const it = {
   ripple_undecoded_notice:
     'Impossibile decodificare questa transazione. Si prega di rivedere i dettagli grezzi qui sotto prima di approvare.',
   swap_expected_payout: 'pagamento previsto',
+  send_receiver_format_hint_cardano:
+    'Inserisci un indirizzo Cardano che inizia con addr1.',
+  send_receiver_format_hint_cosmos:
+    'Inserisci un indirizzo Bech32 che inizia con il prefisso {{prefix}} .',
+  send_receiver_format_hint_evm:
+    'Inserisci un indirizzo EVM che inizi con 0x e abbia 40 caratteri esadecimali.',
+  send_receiver_format_hint_qbtc:
+    'Inserisci un indirizzo QBTC che inizia con qbtc.',
+  send_receiver_format_hint_ripple:
+    'Inserisci un indirizzo XRP che inizia con la lettera r.',
+  send_receiver_format_hint_solana:
+    'Inserisci un indirizzo Solana codificato in Base58, solitamente da 32 a 44 caratteri.',
+  send_receiver_format_hint_ss58:
+    'Inserisci un indirizzo codificato SS58 per questa rete.',
+  send_receiver_format_hint_sui:
+    'Inserisci un indirizzo SUI che inizia con 0x e ha 64 caratteri esadecimali.',
+  send_receiver_format_hint_ton: 'Inserisci un indirizzo TON valido.',
+  send_receiver_format_hint_tron:
+    'Inserisci un indirizzo TRON che inizia con la lettera T.',
+  send_receiver_format_hint_utxo:
+    'Inserisci un indirizzo valido per questa rete (formato bech32 o legacy).',
 }

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -1731,7 +1731,7 @@ export const it = {
   send_receiver_format_hint_cardano:
     'Inserisci un indirizzo Cardano che inizia con addr1.',
   send_receiver_format_hint_cosmos:
-    'Inserisci un indirizzo Bech32 che inizia con il prefisso {{prefix}} .',
+    'Inserisci un indirizzo Bech32 che inizia con il prefisso {{prefix}}.',
   send_receiver_format_hint_evm:
     'Inserisci un indirizzo EVM che inizi con 0x e abbia 40 caratteri esadecimali.',
   send_receiver_format_hint_qbtc:

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -1749,4 +1749,5 @@ export const it = {
     'Inserisci un indirizzo TRON che inizia con la lettera T.',
   send_receiver_format_hint_utxo:
     'Inserisci un indirizzo valido per questa rete (formato bech32 o legacy).',
+  send_invalid_receiver_address_with_hint: '{{error}}. {{hint}}',
 }

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -1689,4 +1689,23 @@ export const ko = {
   ripple_undecoded_notice:
     '이 거래를 해독할 수 없습니다. 승인하기 전에 아래의 원본 세부 정보를 검토하십시오.',
   swap_expected_payout: '예상 지급액',
+  send_receiver_format_hint_cardano:
+    'addr1로 시작하는 카르다노 주소를 입력하세요.',
+  send_receiver_format_hint_cosmos:
+    '{{prefix}} 접두사로 시작하는 Bech32 주소를 입력하십시오.',
+  send_receiver_format_hint_evm:
+    '0x로 시작하고 40자의 16진수로 구성된 EVM 주소를 입력하십시오.',
+  send_receiver_format_hint_qbtc: 'qbtc로 시작하는 QBTC 주소를 입력하십시오.',
+  send_receiver_format_hint_ripple:
+    '문자 &#39;r&#39;로 시작하는 XRP 주소를 입력하세요.',
+  send_receiver_format_hint_solana:
+    'Base58로 인코딩된 Solana 주소를 입력하십시오. 일반적으로 32~44자입니다.',
+  send_receiver_format_hint_ss58:
+    '이 네트워크에 대한 SS58로 인코딩된 주소를 입력하십시오.',
+  send_receiver_format_hint_sui:
+    '0x로 시작하고 64자리의 16진수로 구성된 Sui 주소를 입력하십시오.',
+  send_receiver_format_hint_ton: '유효한 TON 주소를 입력하십시오.',
+  send_receiver_format_hint_tron: '문자 T로 시작하는 TRON 주소를 입력하십시오.',
+  send_receiver_format_hint_utxo:
+    '이 네트워크에 사용할 유효한 주소를 입력하십시오(bech32 또는 기존 형식).',
 }

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -1696,8 +1696,7 @@ export const ko = {
   send_receiver_format_hint_evm:
     '0x로 시작하고 40자의 16진수로 구성된 EVM 주소를 입력하십시오.',
   send_receiver_format_hint_qbtc: 'qbtc로 시작하는 QBTC 주소를 입력하십시오.',
-  send_receiver_format_hint_ripple:
-    '문자 r로 시작하는 XRP 주소를 입력하세요.',
+  send_receiver_format_hint_ripple: '문자 r로 시작하는 XRP 주소를 입력하세요.',
   send_receiver_format_hint_solana:
     'Base58로 인코딩된 Solana 주소를 입력하십시오. 일반적으로 32~44자입니다.',
   send_receiver_format_hint_ss58:
@@ -1708,4 +1707,5 @@ export const ko = {
   send_receiver_format_hint_tron: '문자 T로 시작하는 TRON 주소를 입력하십시오.',
   send_receiver_format_hint_utxo:
     '이 네트워크에 사용할 유효한 주소를 입력하십시오(bech32 또는 기존 형식).',
+  send_invalid_receiver_address_with_hint: '{{error}}. {{hint}}',
 }

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -1697,7 +1697,7 @@ export const ko = {
     '0x로 시작하고 40자의 16진수로 구성된 EVM 주소를 입력하십시오.',
   send_receiver_format_hint_qbtc: 'qbtc로 시작하는 QBTC 주소를 입력하십시오.',
   send_receiver_format_hint_ripple:
-    '문자 &#39;r&#39;로 시작하는 XRP 주소를 입력하세요.',
+    '문자 r로 시작하는 XRP 주소를 입력하세요.',
   send_receiver_format_hint_solana:
     'Base58로 인코딩된 Solana 주소를 입력하십시오. 일반적으로 32~44자입니다.',
   send_receiver_format_hint_ss58:

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -1710,11 +1710,11 @@ export const nl = {
   send_receiver_format_hint_cardano:
     'Voer een Cardano-adres in dat begint met addr1.',
   send_receiver_format_hint_cosmos:
-    'Voer een Bech32-adres in dat begint met het voorvoegsel {{prefix}} .',
+    'Voer een Bech32-adres in dat begint met het voorvoegsel {{prefix}}.',
   send_receiver_format_hint_evm:
     'Voer een EVM-adres in dat begint met 0x en 40 hexadecimale tekens bevat.',
   send_receiver_format_hint_qbtc:
-    'Voer een QBTC -adres in dat begint met qbtc.',
+    'Voer een QBTC-adres in dat begint met qbtc.',
   send_receiver_format_hint_ripple:
     'Voer een XRP-adres in dat begint met de letter r.',
   send_receiver_format_hint_solana:
@@ -1723,9 +1723,9 @@ export const nl = {
     'Voer een SS58-gecodeerd adres in voor dit netwerk.',
   send_receiver_format_hint_sui:
     'Voer een SUI-adres in dat begint met 0x en 64 hexadecimale tekens bevat.',
-  send_receiver_format_hint_ton: 'Voer een geldig TON -adres in.',
+  send_receiver_format_hint_ton: 'Voer een geldig TON-adres in.',
   send_receiver_format_hint_tron:
-    'Voer een TRON -adres in dat begint met de letter T.',
+    'Voer een TRON-adres in dat begint met de letter T.',
   send_receiver_format_hint_utxo:
     'Voer een geldig adres in voor dit netwerk (bech32- of legacy-formaat).',
 }

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -1713,8 +1713,7 @@ export const nl = {
     'Voer een Bech32-adres in dat begint met het voorvoegsel {{prefix}}.',
   send_receiver_format_hint_evm:
     'Voer een EVM-adres in dat begint met 0x en 40 hexadecimale tekens bevat.',
-  send_receiver_format_hint_qbtc:
-    'Voer een QBTC-adres in dat begint met qbtc.',
+  send_receiver_format_hint_qbtc: 'Voer een QBTC-adres in dat begint met qbtc.',
   send_receiver_format_hint_ripple:
     'Voer een XRP-adres in dat begint met de letter r.',
   send_receiver_format_hint_solana:
@@ -1728,4 +1727,5 @@ export const nl = {
     'Voer een TRON-adres in dat begint met de letter T.',
   send_receiver_format_hint_utxo:
     'Voer een geldig adres in voor dit netwerk (bech32- of legacy-formaat).',
+  send_invalid_receiver_address_with_hint: '{{error}}. {{hint}}',
 }

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -1707,4 +1707,25 @@ export const nl = {
   ripple_undecoded_notice:
     'Deze transactie kon niet worden gedecodeerd. Controleer de onderstaande gegevens voordat u goedkeurt.',
   swap_expected_payout: 'verwachte uitbetaling',
+  send_receiver_format_hint_cardano:
+    'Voer een Cardano-adres in dat begint met addr1.',
+  send_receiver_format_hint_cosmos:
+    'Voer een Bech32-adres in dat begint met het voorvoegsel {{prefix}} .',
+  send_receiver_format_hint_evm:
+    'Voer een EVM-adres in dat begint met 0x en 40 hexadecimale tekens bevat.',
+  send_receiver_format_hint_qbtc:
+    'Voer een QBTC -adres in dat begint met qbtc.',
+  send_receiver_format_hint_ripple:
+    'Voer een XRP-adres in dat begint met de letter r.',
+  send_receiver_format_hint_solana:
+    'Voer een Base58-gecodeerd Solana-adres in, meestal 32 tot 44 tekens lang.',
+  send_receiver_format_hint_ss58:
+    'Voer een SS58-gecodeerd adres in voor dit netwerk.',
+  send_receiver_format_hint_sui:
+    'Voer een SUI-adres in dat begint met 0x en 64 hexadecimale tekens bevat.',
+  send_receiver_format_hint_ton: 'Voer een geldig TON -adres in.',
+  send_receiver_format_hint_tron:
+    'Voer een TRON -adres in dat begint met de letter T.',
+  send_receiver_format_hint_utxo:
+    'Voer een geldig adres in voor dit netwerk (bech32- of legacy-formaat).',
 }

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -1728,7 +1728,7 @@ export const pt = {
   send_receiver_format_hint_cardano:
     'Insira um endereço Cardano que comece com addr1.',
   send_receiver_format_hint_cosmos:
-    'Insira um endereço Bech32 que comece com o prefixo {{prefix}} .',
+    'Insira um endereço Bech32 que comece com o prefixo {{prefix}}.',
   send_receiver_format_hint_evm:
     'Insira um endereço EVM que comece com 0x e tenha 40 caracteres hexadecimais.',
   send_receiver_format_hint_qbtc:

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -1746,4 +1746,5 @@ export const pt = {
     'Insira um endereço TRON que comece com a letra T.',
   send_receiver_format_hint_utxo:
     'Insira um endereço válido para esta rede (formato bech32 ou legado).',
+  send_invalid_receiver_address_with_hint: '{{error}}. {{hint}}',
 }

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -1725,4 +1725,25 @@ export const pt = {
   ripple_undecoded_notice:
     'Esta transação não pôde ser decodificada. Revise os detalhes brutos abaixo antes de aprovar.',
   swap_expected_payout: 'pagamento esperado',
+  send_receiver_format_hint_cardano:
+    'Insira um endereço Cardano que comece com addr1.',
+  send_receiver_format_hint_cosmos:
+    'Insira um endereço Bech32 que comece com o prefixo {{prefix}} .',
+  send_receiver_format_hint_evm:
+    'Insira um endereço EVM que comece com 0x e tenha 40 caracteres hexadecimais.',
+  send_receiver_format_hint_qbtc:
+    'Insira um endereço QBTC que comece com qbtc.',
+  send_receiver_format_hint_ripple:
+    'Insira um endereço XRP que comece com a letra r.',
+  send_receiver_format_hint_solana:
+    'Insira um endereço Solana codificado em Base58, geralmente com 32 a 44 caracteres.',
+  send_receiver_format_hint_ss58:
+    'Insira um endereço codificado em SS58 para esta rede.',
+  send_receiver_format_hint_sui:
+    'Insira um endereço Sui que comece com 0x e tenha 64 caracteres hexadecimais.',
+  send_receiver_format_hint_ton: 'Insira um endereço TON válido.',
+  send_receiver_format_hint_tron:
+    'Insira um endereço TRON que comece com a letra T.',
+  send_receiver_format_hint_utxo:
+    'Insira um endereço válido para esta rede (formato bech32 ou legado).',
 }

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -1721,8 +1721,8 @@ export const ru = {
   send_receiver_format_hint_sui:
     'Введите адрес Sui, начинающийся с 0x и содержащий 64 шестнадцатеричных символа.',
   send_receiver_format_hint_ton: 'Введите действительный адрес TON.',
-  send_receiver_format_hint_tron:
-    'Введите адрес TRON, начинающийся с буквы T.',
+  send_receiver_format_hint_tron: 'Введите адрес TRON, начинающийся с буквы T.',
   send_receiver_format_hint_utxo:
     'Введите действительный адрес для этой сети (формат bech32 или устаревший).',
+  send_invalid_receiver_address_with_hint: '{{error}}. {{hint}}',
 }

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -1706,4 +1706,23 @@ export const ru = {
   ripple_undecoded_notice:
     'Данная транзакция не может быть расшифрована. Перед подтверждением ознакомьтесь с приведенными ниже данными.',
   swap_expected_payout: 'ожидаемая выплата',
+  send_receiver_format_hint_cardano:
+    'Введите адрес Cardano, начинающийся с addr1.',
+  send_receiver_format_hint_cosmos:
+    'Введите адрес Bech32, начинающийся с префикса {{prefix}} .',
+  send_receiver_format_hint_evm:
+    'Введите адрес EVM, начинающийся с 0x и содержащий 40 шестнадцатеричных символов.',
+  send_receiver_format_hint_qbtc: 'Введите адрес QBTC , начинающийся с qbtc.',
+  send_receiver_format_hint_ripple:
+    'Введите XRP-адрес, начинающийся с буквы «r».',
+  send_receiver_format_hint_solana:
+    'Введите адрес Solana, закодированный в Base58, обычно от 32 до 44 символов.',
+  send_receiver_format_hint_ss58: 'Введите адрес в формате SS58 для этой сети.',
+  send_receiver_format_hint_sui:
+    'Введите адрес Sui, начинающийся с 0x и содержащий 64 шестнадцатеричных символа.',
+  send_receiver_format_hint_ton: 'Введите действительный адрес TON .',
+  send_receiver_format_hint_tron:
+    'Введите адрес TRON , начинающийся с буквы T.',
+  send_receiver_format_hint_utxo:
+    'Введите действительный адрес для этой сети (формат bech32 или устаревший).',
 }

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -1709,10 +1709,10 @@ export const ru = {
   send_receiver_format_hint_cardano:
     'Введите адрес Cardano, начинающийся с addr1.',
   send_receiver_format_hint_cosmos:
-    'Введите адрес Bech32, начинающийся с префикса {{prefix}} .',
+    'Введите адрес Bech32, начинающийся с префикса {{prefix}}.',
   send_receiver_format_hint_evm:
     'Введите адрес EVM, начинающийся с 0x и содержащий 40 шестнадцатеричных символов.',
-  send_receiver_format_hint_qbtc: 'Введите адрес QBTC , начинающийся с qbtc.',
+  send_receiver_format_hint_qbtc: 'Введите адрес QBTC, начинающийся с qbtc.',
   send_receiver_format_hint_ripple:
     'Введите XRP-адрес, начинающийся с буквы «r».',
   send_receiver_format_hint_solana:
@@ -1720,9 +1720,9 @@ export const ru = {
   send_receiver_format_hint_ss58: 'Введите адрес в формате SS58 для этой сети.',
   send_receiver_format_hint_sui:
     'Введите адрес Sui, начинающийся с 0x и содержащий 64 шестнадцатеричных символа.',
-  send_receiver_format_hint_ton: 'Введите действительный адрес TON .',
+  send_receiver_format_hint_ton: 'Введите действительный адрес TON.',
   send_receiver_format_hint_tron:
-    'Введите адрес TRON , начинающийся с буквы T.',
+    'Введите адрес TRON, начинающийся с буквы T.',
   send_receiver_format_hint_utxo:
     'Введите действительный адрес для этой сети (формат bech32 или устаревший).',
 }

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -1605,4 +1605,5 @@ export const zh = {
   send_receiver_format_hint_tron: '输入以字母 T 开头的TRON地址。',
   send_receiver_format_hint_utxo:
     '请输入此网络的有效地址（bech32 或传统格式）。',
+  send_invalid_receiver_address_with_hint: '{{error}}. {{hint}}',
 }

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -1590,4 +1590,19 @@ export const zh = {
   ripple_field_issuer: '发行人',
   ripple_undecoded_notice: '此交易无法解码。请在批准前查看以下原始详细信息。',
   swap_expected_payout: '预期收益',
+  send_receiver_format_hint_cardano: '输入以addr1开头的Cardano地址。',
+  send_receiver_format_hint_cosmos: '输入以{{prefix}}为前缀的 Bech32 地址。',
+  send_receiver_format_hint_evm:
+    '输入一个以 0x 开头且长度为 40 个十六进制字符的 EVM 地址。',
+  send_receiver_format_hint_qbtc: '输入以 qbtc 开头的QBTC地址。',
+  send_receiver_format_hint_ripple: '输入一个以字母 r 开头的 XRP 地址。',
+  send_receiver_format_hint_solana:
+    '输入一个 Base58 编码的 Solana 地址，通常为 32 到 44 个字符。',
+  send_receiver_format_hint_ss58: '请输入此网络的 SS58 编码地址。',
+  send_receiver_format_hint_sui:
+    '输入一个以 0x 开头且长度为 64 个十六进制字符的 Sui 地址。',
+  send_receiver_format_hint_ton: '请输入有效的TON地址。',
+  send_receiver_format_hint_tron: '输入以字母 T 开头的TRON地址。',
+  send_receiver_format_hint_utxo:
+    '请输入此网络的有效地址（bech32 或传统格式）。',
 }

--- a/core/ui/vault/send/form/getReceiverAddressFormatHint.ts
+++ b/core/ui/vault/send/form/getReceiverAddressFormatHint.ts
@@ -1,0 +1,48 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { ChainKind, getChainKind } from '@vultisig/core-chain/ChainKind'
+import { TFunction } from 'i18next'
+
+type GetReceiverAddressFormatHintInput = {
+  chain: Chain
+  senderAddress: string
+  t: TFunction
+}
+
+// Bech32 addresses are `<hrp>1<data>`; the human-readable prefix never contains
+// the `1` separator, so the first segment is the expected chain prefix. The
+// sender is always a valid address on the same chain, making it a reliable
+// source for the receiver's expected prefix.
+const getBech32Prefix = (address: string): string =>
+  address.trim().split('1')[0]
+
+/**
+ * Returns a human-readable hint describing the recipient address format expected
+ * for the given chain. Used to explain why a recipient was rejected so the user
+ * can correct it. Resolved per chain kind so every supported chain surfaces
+ * guidance without per-chain branching.
+ */
+export const getReceiverAddressFormatHint = ({
+  chain,
+  senderAddress,
+  t,
+}: GetReceiverAddressFormatHintInput): string => {
+  const hintByKind: Record<ChainKind, () => string> = {
+    evm: () => t('send_receiver_format_hint_evm'),
+    utxo: () => t('send_receiver_format_hint_utxo'),
+    cosmos: () =>
+      t('send_receiver_format_hint_cosmos', {
+        prefix: getBech32Prefix(senderAddress),
+      }),
+    solana: () => t('send_receiver_format_hint_solana'),
+    sui: () => t('send_receiver_format_hint_sui'),
+    polkadot: () => t('send_receiver_format_hint_ss58'),
+    bittensor: () => t('send_receiver_format_hint_ss58'),
+    ton: () => t('send_receiver_format_hint_ton'),
+    ripple: () => t('send_receiver_format_hint_ripple'),
+    tron: () => t('send_receiver_format_hint_tron'),
+    cardano: () => t('send_receiver_format_hint_cardano'),
+    qbtc: () => t('send_receiver_format_hint_qbtc'),
+  }
+
+  return hintByKind[getChainKind(chain)]()
+}

--- a/core/ui/vault/send/form/getReceiverAddressFormatHint.ts
+++ b/core/ui/vault/send/form/getReceiverAddressFormatHint.ts
@@ -8,12 +8,15 @@ type GetReceiverAddressFormatHintInput = {
   t: TFunction
 }
 
-// Bech32 addresses are `<hrp>1<data>`; the human-readable prefix never contains
-// the `1` separator, so the first segment is the expected chain prefix. The
-// sender is always a valid address on the same chain, making it a reliable
-// source for the receiver's expected prefix.
-const getBech32Prefix = (address: string): string =>
-  address.trim().split('1')[0]
+// Bech32 addresses are `<hrp>1<data>`. The data part excludes `1`, so the last
+// `1` is always the separator — even when the human-readable prefix itself
+// contains a `1` (BIP-173). The sender is always a valid address on the same
+// chain, making it a reliable source for the receiver's expected prefix.
+const getBech32Prefix = (address: string): string => {
+  const trimmed = address.trim()
+  const separatorIndex = trimmed.lastIndexOf('1')
+  return separatorIndex === -1 ? trimmed : trimmed.slice(0, separatorIndex)
+}
 
 /**
  * Returns a human-readable hint describing the recipient address format expected

--- a/core/ui/vault/send/form/validateSendForm.test.ts
+++ b/core/ui/vault/send/form/validateSendForm.test.ts
@@ -174,4 +174,75 @@ describe('validateSendReceiver', () => {
     ).toBe('send_receiver_address_same_as_sender')
     expect(isValidAddress).not.toHaveBeenCalled()
   })
+
+  it('requires a recipient before format validation', () => {
+    expect(
+      validateSendReceiver({
+        receiverAddress: '',
+        senderAddress: '0xsender',
+        chain: Chain.Ethereum,
+        walletCore,
+        t,
+      })
+    ).toBe('enter_address')
+    expect(isValidAddress).not.toHaveBeenCalled()
+  })
+
+  it('appends the chain-specific format hint when the address is invalid', () => {
+    vi.mocked(isValidAddress).mockReturnValue(false)
+
+    expect(
+      validateSendReceiver({
+        receiverAddress:
+          '0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b',
+        senderAddress: '0xsender',
+        chain: Chain.Ethereum,
+        walletCore,
+        t,
+      })
+    ).toBe('send_invalid_receiver_address. send_receiver_format_hint_evm')
+  })
+
+  it('surfaces the sender bech32 prefix in the Cosmos hint', () => {
+    vi.mocked(isValidAddress).mockReturnValue(false)
+
+    const cosmosT = ((key: string, options?: { prefix?: string }) =>
+      key === 'send_receiver_format_hint_cosmos'
+        ? `starts with ${options?.prefix}`
+        : key) as TFunction
+
+    expect(
+      validateSendReceiver({
+        receiverAddress: 'not-an-address',
+        senderAddress: 'thor1abcdefg',
+        chain: Chain.THORChain,
+        walletCore,
+        t: cosmosT,
+      })
+    ).toBe('send_invalid_receiver_address. starts with thor')
+  })
+
+  it('resolves a format hint for every acceptance-criteria chain family', () => {
+    vi.mocked(isValidAddress).mockReturnValue(false)
+
+    const chains = [
+      Chain.Ethereum,
+      Chain.Cosmos,
+      Chain.Bitcoin,
+      Chain.Solana,
+      Chain.Ripple,
+    ]
+
+    for (const chain of chains) {
+      const error = validateSendReceiver({
+        receiverAddress: 'invalid',
+        senderAddress: 'sender1xyz',
+        chain,
+        walletCore,
+        t,
+      })
+      expect(error).toContain('send_invalid_receiver_address')
+      expect(error).toContain('send_receiver_format_hint_')
+    }
+  })
 })

--- a/core/ui/vault/send/form/validateSendForm.test.ts
+++ b/core/ui/vault/send/form/validateSendForm.test.ts
@@ -19,7 +19,17 @@ vi.mock(
   })
 )
 
-const t = ((key: string) => key) as TFunction
+// Minimal interpolating stub so the composed error+hint message is exercised.
+const t = ((key: string, options?: Record<string, unknown>) => {
+  const template =
+    key === 'send_invalid_receiver_address_with_hint'
+      ? '{{error}}. {{hint}}'
+      : key
+  if (!options) return template
+  return template.replace(/{{(\w+)}}/g, (_, name) =>
+    String(options[name] ?? `{{${name}}}`)
+  )
+}) as TFunction
 const walletCore = {} as WalletCore
 
 const nativeCoin = (chain: Chain): Coin =>
@@ -206,10 +216,18 @@ describe('validateSendReceiver', () => {
   it('surfaces the sender bech32 prefix in the Cosmos hint', () => {
     vi.mocked(isValidAddress).mockReturnValue(false)
 
-    const cosmosT = ((key: string, options?: { prefix?: string }) =>
-      key === 'send_receiver_format_hint_cosmos'
-        ? `starts with ${options?.prefix}`
-        : key) as TFunction
+    const cosmosT = ((
+      key: string,
+      options?: { prefix?: string; error?: string; hint?: string }
+    ) => {
+      if (key === 'send_invalid_receiver_address_with_hint') {
+        return `${options?.error}. ${options?.hint}`
+      }
+      if (key === 'send_receiver_format_hint_cosmos') {
+        return `starts with ${options?.prefix}`
+      }
+      return key
+    }) as TFunction
 
     expect(
       validateSendReceiver({

--- a/core/ui/vault/send/form/validateSendForm.ts
+++ b/core/ui/vault/send/form/validateSendForm.ts
@@ -37,9 +37,10 @@ export const validateSendReceiver = ({
   }
 
   if (!isValidAddress({ address: receiverAddress, chain, walletCore })) {
-    return `${t('send_invalid_receiver_address')}. ${getReceiverAddressFormatHint(
-      { chain, senderAddress, t }
-    )}`
+    return t('send_invalid_receiver_address_with_hint', {
+      error: t('send_invalid_receiver_address'),
+      hint: getReceiverAddressFormatHint({ chain, senderAddress, t }),
+    })
   }
 }
 

--- a/core/ui/vault/send/form/validateSendForm.ts
+++ b/core/ui/vault/send/form/validateSendForm.ts
@@ -8,6 +8,7 @@ import { areLowerCaseEqual } from '@vultisig/lib-utils/string/areLowerCaseEqual'
 import { TFunction } from 'i18next'
 
 import { SendFormShape, ValidationResult } from './formShape'
+import { getReceiverAddressFormatHint } from './getReceiverAddressFormatHint'
 
 type ValidateSendReceiverInput = {
   receiverAddress: string
@@ -36,7 +37,9 @@ export const validateSendReceiver = ({
   }
 
   if (!isValidAddress({ address: receiverAddress, chain, walletCore })) {
-    return t('send_invalid_receiver_address')
+    return `${t('send_invalid_receiver_address')}. ${getReceiverAddressFormatHint(
+      { chain, senderAddress, t }
+    )}`
   }
 }
 


### PR DESCRIPTION
## Summary

When an invalid recipient is entered in the Send flow, the app previously showed only `Wrong address for selected chain` with no guidance on what a valid address looks like. This PR appends a **chain-aware expected-format hint** to that error.

- New `getReceiverAddressFormatHint` resolves the hint per `ChainKind` (resolver pattern, no chain `switch`), covering EVM, UTXO, Cosmos, Solana, Sui, SS58 (Polkadot/Bittensor), TON, Ripple, Tron, Cardano, QBTC.
- For Cosmos chains the expected bech32 prefix (e.g. `cosmos`, `thor`) is derived from the sender address.
- The hint is composed inside the shared `validateSendForm` output, so it appears in **both existing surfaces automatically**: the inline error under the recipient field and the disabled Continue button's reason tooltip. No new UI location was required.

Example (Ethereum/USDC with a txid pasted):
> Wrong address for selected chain. Enter an EVM address that starts with 0x and has 40 hexadecimal characters.

## Issue

Closes #4416

## Test Plan

- [x] `yarn check` (typecheck + lint + knip) passes
- [x] Unit tests in `validateSendForm.test.ts` cover the invalid path, the Cosmos prefix derivation, and all five acceptance-criteria chain families (Ethereum, Cosmos, UTXO, Solana, XRP)
- [x] Verified live rendering of all five messages through the real `validateSendReceiver` path (real WalletCore + i18n)
- [x] `yarn translate` propagated the 11 new keys to all 9 other locales; `i18n:check-integrity` passes
- [ ] Manual: Send → paste an invalid recipient per chain → inline error + Continue tooltip both show the format hint; a valid address re-enables the flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * When a receiver address is invalid, the send flow now shows an error plus a localized, network-specific format hint.
  * Hints include the expected prefix/encoding, typical length, and examples for many networks (e.g., Cardano, Cosmos/Bech32, EVM, Solana, TON, TRON, and generic UTXO).
  * Cosmos hints dynamically reflect the Bech32 prefix derived from the sender address.
* **Tests**
  * Expanded validation test coverage to verify the composed error + hint behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->