### PR TITLE
Fix chain identity and unknown asset decimals

### DIFF
--- a/core/ui/agent/tools/handlers/addCoin.test.ts
+++ b/core/ui/agent/tools/handlers/addCoin.test.ts
@@ -1,0 +1,81 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getStorageContext } from '../shared/storageContext'
+import type { ToolContext } from '../types'
+import { handleAddCoin } from './addCoin'
+
+vi.mock('../shared/storageContext', () => ({
+  getStorageContext: vi.fn(),
+}))
+
+const createCoin = vi.fn()
+const context: ToolContext = {
+  vaultPubKey: 'vault',
+  vaultName: 'QA vault',
+  coins: [
+    {
+      chain: Chain.Ethereum,
+      ticker: 'ETH',
+      address: '0xsender',
+      decimals: 18,
+      isNativeToken: true,
+    },
+  ],
+}
+
+describe('handleAddCoin decimal precision', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getStorageContext).mockReturnValue({ createCoin } as never)
+  })
+
+  it('refuses an unknown token without explicit decimals', async () => {
+    await expect(
+      handleAddCoin(
+        {
+          chain: Chain.Ethereum,
+          ticker: 'UNKNOWN',
+          contract_address: '0x0000000000000000000000000000000000000001',
+        },
+        context
+      )
+    ).rejects.toThrow('decimals is required for unknown token UNKNOWN')
+    expect(createCoin).not.toHaveBeenCalled()
+  })
+
+  it('persists an unknown token only with valid explicit decimals', async () => {
+    await handleAddCoin(
+      {
+        chain: Chain.Ethereum,
+        ticker: 'UNKNOWN',
+        contract_address: '0x0000000000000000000000000000000000000001',
+        decimals: 6,
+      },
+      context
+    )
+
+    expect(createCoin).toHaveBeenCalledWith(
+      expect.objectContaining({
+        coin: expect.objectContaining({ decimals: 6 }),
+      })
+    )
+  })
+
+  it.each([-1, 1.5, 256, 'not-a-number', '', null, false])(
+    'rejects invalid explicit decimals %j',
+    async decimals => {
+      await expect(
+        handleAddCoin(
+          {
+            chain: Chain.Ethereum,
+            ticker: 'UNKNOWN',
+            contract_address: '0x0000000000000000000000000000000000000001',
+            decimals,
+          },
+          context
+        )
+      ).rejects.toThrow('decimals must be an integer between 0 and 255')
+    }
+  )
+})

--- a/core/ui/agent/tools/handlers/addCoin.ts
+++ b/core/ui/agent/tools/handlers/addCoin.ts
@@ -53,7 +53,7 @@ export const handleAddCoin: ToolHandler = async (input, context) => {
     isNative = Boolean(input.is_native)
   }
 
-  let decimals = 18
+  let decimals: number | undefined
   let logo: string | undefined
   let priceProviderId: string | undefined
 
@@ -74,13 +74,31 @@ export const handleAddCoin: ToolHandler = async (input, context) => {
   }
 
   if (input.decimals !== undefined) {
-    decimals = Number(input.decimals)
+    const suppliedDecimals =
+      typeof input.decimals === 'number' ||
+      (typeof input.decimals === 'string' && input.decimals.trim() !== '')
+        ? Number(input.decimals)
+        : Number.NaN
+    if (
+      !Number.isInteger(suppliedDecimals) ||
+      suppliedDecimals < 0 ||
+      suppliedDecimals > 255
+    ) {
+      throw new Error('decimals must be an integer between 0 and 255')
+    }
+    decimals = suppliedDecimals
   }
   if (input.logo) {
     logo = String(input.logo)
   }
   if (input.price_provider_id) {
     priceProviderId = String(input.price_provider_id)
+  }
+
+  if (decimals === undefined) {
+    throw new Error(
+      `decimals is required for unknown token ${ticker} on ${chain}`
+    )
   }
 
   let existingAddress = ''

--- a/core/ui/agent/tools/shared/assetResolution.test.ts
+++ b/core/ui/agent/tools/shared/assetResolution.test.ts
@@ -1,0 +1,33 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { knownTokensIndex } from '@vultisig/core-chain/coin/knownTokens'
+import { describe, expect, it } from 'vitest'
+
+import { formatHumanAmount } from './assetResolution'
+
+describe('formatHumanAmount', () => {
+  it('formats a known native asset with canonical precision', () => {
+    expect(formatHumanAmount('123456789', Chain.Bitcoin, '')).toBe('1.23456789')
+  })
+
+  it('formats a known token with registry precision', () => {
+    const [address, token] = Object.entries(
+      knownTokensIndex[Chain.Ethereum]!
+    )[0]!
+    const baseUnits = `1${'0'.repeat(token.decimals)}`
+
+    expect(formatHumanAmount(baseUnits, Chain.Ethereum, address)).toBe('1')
+  })
+
+  it.each([
+    ['unknown chain', 'NotAChain', ''],
+    [
+      'unknown token',
+      Chain.Ethereum,
+      '0x0000000000000000000000000000000000000000',
+    ],
+  ])('refuses to guess precision for an %s', (_, chain, tokenAddress) => {
+    expect(formatHumanAmount('1000000000000000000', chain, tokenAddress)).toBe(
+      null
+    )
+  })
+})

--- a/core/ui/agent/tools/shared/assetResolution.ts
+++ b/core/ui/agent/tools/shared/assetResolution.ts
@@ -171,9 +171,9 @@ export function resolveTickerByChainAndToken(
 function resolveDecimalsByChainAndToken(
   chain: string,
   tokenAddress: string
-): number {
+): number | null {
   const resolved = getChainFromString(chain)
-  if (!resolved) return 18
+  if (!resolved) return null
 
   if (!tokenAddress) {
     return chainFeeCoin[resolved].decimals
@@ -185,15 +185,16 @@ function resolveDecimalsByChainAndToken(
     if (token) return token.decimals
   }
 
-  return 18
+  return null
 }
 
 export function formatHumanAmount(
   smallestUnit: string,
   chain: string,
   tokenAddress: string
-): string {
+): string | null {
   const decimals = resolveDecimalsByChainAndToken(chain, tokenAddress)
+  if (decimals === null) return null
   if (decimals === 0) return smallestUnit
 
   const sanitized = smallestUnit.trim()

--- a/core/ui/agent/tools/shared/policyHelpers.test.ts
+++ b/core/ui/agent/tools/shared/policyHelpers.test.ts
@@ -1,0 +1,28 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { describe, expect, it } from 'vitest'
+
+import { enrichPolicyFields } from './policyHelpers'
+
+describe('enrichPolicyFields amount precision', () => {
+  it('renders a known native amount', () => {
+    const policy: Record<string, unknown> = {}
+
+    enrichPolicyFields(policy, {
+      asset: { chain: Chain.Bitcoin, token: '' },
+      recipients: [{ amount: '123456789' }],
+    })
+
+    expect(policy.amount).toBe('1.23456789')
+  })
+
+  it('omits an amount when asset precision cannot be resolved', () => {
+    const policy: Record<string, unknown> = {}
+
+    enrichPolicyFields(policy, {
+      asset: { chain: 'NotAChain', token: '' },
+      recipients: [{ amount: '1000000000000000000' }],
+    })
+
+    expect(policy).not.toHaveProperty('amount')
+  })
+})

--- a/core/ui/agent/tools/shared/policyHelpers.test.ts
+++ b/core/ui/agent/tools/shared/policyHelpers.test.ts
@@ -15,12 +15,23 @@ describe('enrichPolicyFields amount precision', () => {
     expect(policy.amount).toBe('1.23456789')
   })
 
-  it('omits an amount when asset precision cannot be resolved', () => {
-    const policy: Record<string, unknown> = {}
+  it('clears a stale recipient amount when precision cannot be resolved', () => {
+    const policy: Record<string, unknown> = { amount: 'stale' }
 
     enrichPolicyFields(policy, {
       asset: { chain: 'NotAChain', token: '' },
       recipients: [{ amount: '1000000000000000000' }],
+    })
+
+    expect(policy).not.toHaveProperty('amount')
+  })
+
+  it('clears a stale transfer amount when precision cannot be resolved', () => {
+    const policy: Record<string, unknown> = { amount: 'stale' }
+
+    enrichPolicyFields(policy, {
+      from: { chain: 'NotAChain', token: '' },
+      fromAmount: '1000000000000000000',
     })
 
     expect(policy).not.toHaveProperty('amount')

--- a/core/ui/agent/tools/shared/policyHelpers.ts
+++ b/core/ui/agent/tools/shared/policyHelpers.ts
@@ -50,7 +50,8 @@ export function enrichPolicyFields(
         policy.to_address = String(r.toAddress)
       }
       if (r.amount != null) {
-        policy.amount = formatHumanAmount(String(r.amount), chain, token)
+        const amount = formatHumanAmount(String(r.amount), chain, token)
+        if (amount !== null) policy.amount = amount
       }
     }
   } else {
@@ -69,11 +70,12 @@ export function enrichPolicyFields(
     }
 
     if (config.fromAmount != null) {
-      policy.amount = formatHumanAmount(
+      const amount = formatHumanAmount(
         String(config.fromAmount),
         from.chain,
         from.token
       )
+      if (amount !== null) policy.amount = amount
     }
   }
 

--- a/core/ui/agent/tools/shared/policyHelpers.ts
+++ b/core/ui/agent/tools/shared/policyHelpers.ts
@@ -51,7 +51,11 @@ export function enrichPolicyFields(
       }
       if (r.amount != null) {
         const amount = formatHumanAmount(String(r.amount), chain, token)
-        if (amount !== null) policy.amount = amount
+        if (amount !== null) {
+          policy.amount = amount
+        } else {
+          delete policy.amount
+        }
       }
     }
   } else {
@@ -75,7 +79,11 @@ export function enrichPolicyFields(
         from.chain,
         from.token
       )
-      if (amount !== null) policy.amount = amount
+      if (amount !== null) {
+        policy.amount = amount
+      } else {
+        delete policy.amount
+      }
     }
   }
 

--- a/core/ui/vault/settings/referral/components/EditReferral/EditReferralForm/config.test.ts
+++ b/core/ui/vault/settings/referral/components/EditReferral/EditReferralForm/config.test.ts
@@ -1,0 +1,27 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { describe, expect, it } from 'vitest'
+
+import { normaliseChainToMatchPoolChain } from './config'
+
+describe('normaliseChainToMatchPoolChain', () => {
+  it.each([
+    ['AVAX', Chain.Avalanche],
+    ['BASE', Chain.Base],
+    ['BCH', Chain.BitcoinCash],
+    ['BTC', Chain.Bitcoin],
+    ['DOGE', Chain.Dogecoin],
+    ['ETH', Chain.Ethereum],
+    ['GAIA', Chain.Cosmos],
+    ['LTC', Chain.Litecoin],
+    ['THOR', Chain.THORChain],
+    ['XRP', Chain.Ripple],
+  ])('maps pool alias %s to canonical chain %s', (poolAlias, chain) => {
+    expect(normaliseChainToMatchPoolChain(poolAlias)).toBe(
+      normaliseChainToMatchPoolChain(chain)
+    )
+  })
+
+  it('normalizes Bitcoin Cash with the canonical ASCII hyphen', () => {
+    expect(normaliseChainToMatchPoolChain('BCH')).toBe('BITCOIN-CASH')
+  })
+})

--- a/core/ui/vault/settings/referral/components/EditReferral/EditReferralForm/config.ts
+++ b/core/ui/vault/settings/referral/components/EditReferral/EditReferralForm/config.ts
@@ -1,14 +1,16 @@
-const poolChainMap: Record<string, string> = {
-  AVAX: 'Avalanche',
-  BASE: 'Base',
-  BCH: 'Bitcoin‑Cash',
-  BTC: 'Bitcoin',
-  DOGE: 'Dogecoin',
-  ETH: 'Ethereum',
-  GAIA: 'Cosmos',
-  LTC: 'Litecoin',
-  THOR: 'THORChain',
-  XRP: 'XRP Ledger',
+import { Chain } from '@vultisig/core-chain/Chain'
+
+const poolChainMap: Record<string, Chain> = {
+  AVAX: Chain.Avalanche,
+  BASE: Chain.Base,
+  BCH: Chain.BitcoinCash,
+  BTC: Chain.Bitcoin,
+  DOGE: Chain.Dogecoin,
+  ETH: Chain.Ethereum,
+  GAIA: Chain.Cosmos,
+  LTC: Chain.Litecoin,
+  THOR: Chain.THORChain,
+  XRP: Chain.Ripple,
 }
 
 export const normaliseChainToMatchPoolChain = (c: string) =>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -50,7 +50,7 @@ const noUnicodeDashLiterals = {
             if (typeof node.value === 'string') reportIfNeeded(node, node.value)
           },
           TemplateElement(node) {
-            reportIfNeeded(node, node.value.raw)
+            reportIfNeeded(node, node.value.cooked ?? node.value.raw)
           },
           JSXText(node) {
             reportIfNeeded(node, node.value)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,6 +26,41 @@ const compat = new FlatCompat({
   allConfig: js.configs.all,
 })
 
+const unicodeDashPattern = /\S[\u2011\u2013\u2014]\S/u
+const noUnicodeDashLiterals = {
+  rules: {
+    'no-unicode-dash-literals': {
+      meta: {
+        type: 'problem',
+        schema: [],
+        messages: {
+          forbidden:
+            'Use an ASCII hyphen inside identifier-like source text; Unicode dashes can break identity matching.',
+        },
+      },
+      create(context) {
+        const reportIfNeeded = (node, value) => {
+          if (unicodeDashPattern.test(value)) {
+            context.report({ node, messageId: 'forbidden' })
+          }
+        }
+
+        return {
+          Literal(node) {
+            if (typeof node.value === 'string') reportIfNeeded(node, node.value)
+          },
+          TemplateElement(node) {
+            reportIfNeeded(node, node.value.raw)
+          },
+          JSXText(node) {
+            reportIfNeeded(node, node.value)
+          },
+        }
+      },
+    },
+  },
+}
+
 export default [
   {
     ignores: [
@@ -58,6 +93,7 @@ export default [
       'unused-imports': fixupPluginRules(unusedImportsPlugin),
       storybook,
       'react-compiler': reactCompiler,
+      local: noUnicodeDashLiterals,
     },
 
     languageOptions: {
@@ -120,8 +156,15 @@ export default [
         },
       ],
       '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
+      'local/no-unicode-dash-literals': 'error',
     },
   }, // Override for declaration files where interfaces are required for module augmentation
+  {
+    files: ['core/ui/i18n/locales/**/*.{ts,tsx}'],
+    rules: {
+      'local/no-unicode-dash-literals': 'off',
+    },
+  },
   {
     files: ['**/*.d.ts'],
     rules: {

--- a/lib/ui/layout/LineSeparator/LineSeparator.stories.tsx
+++ b/lib/ui/layout/LineSeparator/LineSeparator.stories.tsx
@@ -20,7 +20,7 @@ const DemoBlock = styled.div<{ width?: number }>`
 `
 
 export const FullWidth: Story = {
-  name: 'Full‑width separator',
+  name: 'Full-width separator',
   render: () => (
     <DemoBlock>
       <LineSeparator />
@@ -29,7 +29,7 @@ export const FullWidth: Story = {
 }
 
 export const InNarrowContainer: Story = {
-  name: 'Inside 240‑px container',
+  name: 'Inside 240-px container',
   render: () => (
     <DemoBlock width={240}>
       <LineSeparator />

--- a/lib/ui/status/InfoBlock/InfoBlock.stories.tsx
+++ b/lib/ui/status/InfoBlock/InfoBlock.stories.tsx
@@ -24,7 +24,7 @@ export const Default: Story = {}
 export const WithTooltip: Story = {
   name: 'With tooltip on icon',
   args: {
-    iconTooltipContent: 'Auto‑save runs every 30 seconds as well.',
+    iconTooltipContent: 'Auto-save runs every 30 seconds as well.',
   },
 }
 

--- a/lib/ui/toast/Toast.stories.tsx
+++ b/lib/ui/toast/Toast.stories.tsx
@@ -26,7 +26,7 @@ export const LongMessage: Story = {
   name: 'Long text message',
   args: {
     children:
-      'Your settings have been synced across all logged‑in devices. You can safely close this window.',
+      'Your settings have been synced across all logged-in devices. You can safely close this window.',
   },
 }
 

--- a/lib/ui/tooltips/Tooltip.stories.tsx
+++ b/lib/ui/tooltips/Tooltip.stories.tsx
@@ -39,10 +39,10 @@ export const RichContent: Story = {
 }
 
 export const LongText: Story = {
-  name: 'Long text auto‑wrap',
+  name: 'Long text auto-wrap',
   render: () => (
     <Tooltip
-      content="This tooltip has a lot of text to demonstrate how it wraps within the max‑width constraint. The quick brown fox jumps over the lazy dog."
+      content="This tooltip has a lot of text to demonstrate how it wraps within the max-width constraint. The quick brown fox jumps over the lazy dog."
       renderOpener={props => <button {...props}>Hover me</button>}
     />
   ),

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "quality:audit": "node scripts/quality-audit.mjs",
     "quality:complexity": "eslint --config .config/eslint-health.config.mjs 'clients/desktop/src/**/*.{js,jsx,ts,tsx}' 'clients/extension/src/**/*.{js,jsx,ts,tsx}' 'clients/desktop/vite.config.mts' 'clients/extension/vite.config.ts' 'core/**/*.{js,jsx,ts,tsx}' 'lib/**/*.{js,jsx,ts,tsx}'",
     "quality:docs": "yarn quality:docs:markdown && yarn quality:docs:links",
-    "quality:docs:links": "git ls-files -z '*.md' ':!.agents/**' ':!.claude/**' ':!.cursor/**' ':!.codex/**' ':!tasks/**' ':!clients/extension/tests/e2e/playwright-report/**' | xargs -0 -n 1 sh -c 'if test -f \"$1\"; then markdown-link-check -q -c .config/markdown-link-check.json \"$1\"; else case \"$1\" in AGENTS.md|CLAUDE.md) ;; *) echo \"missing tracked Markdown: $1\" >&2; exit 1 ;; esac; fi' _",
+    "quality:docs:links": "git ls-files -z '*.md' ':!.agents/**' ':!.claude/**' ':!.cursor/**' ':!.codex/**' ':!tasks/**' ':!clients/extension/tests/e2e/playwright-report/**' | xargs -0 -n 1 sh -c 'if test \"$#\" -eq 0; then exit 0; fi; if test -f \"$1\"; then markdown-link-check -q -c .config/markdown-link-check.json \"$1\"; else case \"$1\" in AGENTS.md|CLAUDE.md) ;; *) echo \"missing tracked Markdown: $1\" >&2; exit 1 ;; esac; fi' _",
     "quality:docs:markdown": "markdownlint-cli2 --config .config/markdownlint-cli2.jsonc",
     "quality:duplication": "jscpd --config .config/jscpd.json clients core lib scripts app.go main.go install_marker.go notification_darwin.go notification_linux.go notification_windows.go mediator relay storage tss utils",
     "quality:go": "go test ./mediator ./relay ./storage ./tss ./utils",


### PR DESCRIPTION
Closes #4393
Refs #4393

Uses canonical chain identities for referral pool matching, including Bitcoin Cash, and makes unresolved token precision fail closed in agent policy formatting and add-coin persistence. The executable modules were exercised against the canonical chain/token registries: BCH normalization matched, known Bitcoin precision remained correct, unknown precision stayed omitted or was rejected before storage, and explicit decimals persisted exactly once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unknown tokens no longer fall back to a default decimal precision; decimals are required and validated.
  * Invalid `decimals` inputs are rejected with clear errors.
  * Asset amounts are no longer shown when precision can’t be resolved.
* **Improvements**
  * Referral chain aliases now normalize consistently to canonical chains.
  * Standardized hyphen formatting across UI examples to avoid typographic dash issues.
  * Documentation link checks now fail more safely when files are missing.
* **Tests**
  * Added coverage for decimal precision, formatting, and policy amount behavior.
* **Chores**
  * Added an ESLint rule to prevent non-ASCII dash characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->