### PR TITLE
fix(swap): use computed network fee for Solana swaps (#4381)

### DIFF
--- a/core/ui/vault/swap/queries/resolveSwapFees.test.ts
+++ b/core/ui/vault/swap/queries/resolveSwapFees.test.ts
@@ -1,0 +1,78 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { CoinKey } from '@vultisig/core-chain/coin/Coin'
+import { SwapQuoteResult } from '@vultisig/core-chain/swap/quote/SwapQuote'
+import { SwapFee } from '@vultisig/core-chain/swap/SwapFee'
+import { describe, expect, it } from 'vitest'
+
+import { resolveSwapFees } from './resolveSwapFees'
+
+// The network fee computed up front from the keysign payload — the real cost.
+const computedNetworkFee: SwapFee = {
+  chain: Chain.Solana,
+  amount: 5000n,
+  decimals: 9,
+}
+
+const providerSwapFee: SwapFee = {
+  chain: Chain.Solana,
+  amount: 12_345n,
+  decimals: 9,
+}
+
+const toCoinKey: CoinKey = { chain: Chain.Ethereum }
+
+describe('resolveSwapFees', () => {
+  it('keeps the computed network fee for a Solana general swap even when the provider reports networkFee 0 (#4381)', () => {
+    const quote: SwapQuoteResult = {
+      general: {
+        dstAmount: '1000000',
+        provider: 'swapkit',
+        tx: {
+          solana: {
+            data: '',
+            // Provider omits the network-fee entry -> SDK returns 0n here.
+            networkFee: 0n,
+            swapFee: providerSwapFee,
+          },
+        },
+      },
+    }
+
+    const result = resolveSwapFees({
+      quote,
+      network: computedNetworkFee,
+      toCoinKey,
+      fromCoin: undefined,
+    })
+
+    // Regression: the solana branch used to override this with the provider's 0n.
+    expect(result.network).toBe(computedNetworkFee)
+    expect(result.network.amount).toBe(5000n)
+    expect(result.swap).toBe(providerSwapFee)
+  })
+
+  it('threads the computed network fee through the transfer branch', () => {
+    const quote: SwapQuoteResult = {
+      general: {
+        dstAmount: '1000000',
+        provider: 'swapkit',
+        tx: {
+          transfer: {
+            to: 'recipient-address',
+            amount: 1000n,
+          },
+        },
+      },
+    }
+
+    const result = resolveSwapFees({
+      quote,
+      network: computedNetworkFee,
+      toCoinKey,
+      fromCoin: undefined,
+    })
+
+    expect(result.network).toBe(computedNetworkFee)
+    expect(result.swap).toBeUndefined()
+  })
+})

--- a/core/ui/vault/swap/queries/resolveSwapFees.test.ts
+++ b/core/ui/vault/swap/queries/resolveSwapFees.test.ts
@@ -46,9 +46,36 @@ describe('resolveSwapFees', () => {
     })
 
     // Regression: the solana branch used to override this with the provider's 0n.
-    expect(result.network).toBe(computedNetworkFee)
     expect(result.network.amount).toBe(5000n)
+    expect(result.network.chain).toBe(Chain.Solana)
     expect(result.swap).toBe(providerSwapFee)
+  })
+
+  it('uses the provider network fee for a Solana swap when it exceeds the computed one', () => {
+    const quote: SwapQuoteResult = {
+      general: {
+        dstAmount: '1000000',
+        provider: 'swapkit',
+        tx: {
+          solana: {
+            data: '',
+            // Provider reports a higher fee than we computed.
+            networkFee: 8000n,
+            swapFee: providerSwapFee,
+          },
+        },
+      },
+    }
+
+    const result = resolveSwapFees({
+      quote,
+      network: computedNetworkFee,
+      toCoinKey,
+      fromCoin: undefined,
+    })
+
+    expect(result.network.amount).toBe(8000n)
+    expect(result.network.decimals).toBe(computedNetworkFee.decimals)
   })
 
   it('threads the computed network fee through the transfer branch', () => {

--- a/core/ui/vault/swap/queries/resolveSwapFees.ts
+++ b/core/ui/vault/swap/queries/resolveSwapFees.ts
@@ -3,6 +3,7 @@ import { getNativeSwapDecimals } from '@vultisig/core-chain/swap/native/utils/ge
 import { SwapQuoteResult } from '@vultisig/core-chain/swap/quote/SwapQuote'
 import { SwapFee, SwapFees } from '@vultisig/core-chain/swap/SwapFee'
 import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
+import { maxBigInt } from '@vultisig/lib-utils/math/maxBigInt'
 
 /** Input for {@link resolveSwapFees}. */
 type ResolveSwapFeesInput = {
@@ -16,10 +17,11 @@ type ResolveSwapFeesInput = {
  * Maps a swap quote to its network + swap fee breakdown.
  *
  * Every branch keeps the caller-computed `network` fee. In particular the
- * `solana` branch must not fall back to the provider's `networkFee`, which is
+ * `solana` branch must not blindly trust the provider's `networkFee`, which is
  * `0n` whenever the quote carries no network-fee entry (e.g. SwapKit
- * CHAINFLIP_STREAMING) — the computed value from the keysign payload is the
- * real on-chain cost. See vultisig-windows#4381.
+ * CHAINFLIP_STREAMING); it takes the larger of the computed keysign-payload fee
+ * and the provider's value, so the displayed fee is never below the real
+ * on-chain cost. See vultisig-windows#4381.
  */
 export const resolveSwapFees = ({
   quote,
@@ -42,8 +44,11 @@ export const resolveSwapFees = ({
           network,
           ...(affiliateFee ? { swap: affiliateFee } : {}),
         }),
-        solana: ({ swapFee }) => ({
-          network,
+        solana: ({ networkFee, swapFee }) => ({
+          network: {
+            ...network,
+            amount: maxBigInt(network.amount, networkFee),
+          },
           swap: swapFee,
         }),
         transfer: () => ({ network }),

--- a/core/ui/vault/swap/queries/resolveSwapFees.ts
+++ b/core/ui/vault/swap/queries/resolveSwapFees.ts
@@ -1,0 +1,68 @@
+import { Coin, CoinKey } from '@vultisig/core-chain/coin/Coin'
+import { getNativeSwapDecimals } from '@vultisig/core-chain/swap/native/utils/getNativeSwapDecimals'
+import { SwapQuoteResult } from '@vultisig/core-chain/swap/quote/SwapQuote'
+import { SwapFee, SwapFees } from '@vultisig/core-chain/swap/SwapFee'
+import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
+
+/** Input for {@link resolveSwapFees}. */
+type ResolveSwapFeesInput = {
+  quote: SwapQuoteResult
+  network: SwapFee
+  toCoinKey: CoinKey
+  fromCoin: Coin | undefined
+}
+
+/**
+ * Maps a swap quote to its network + swap fee breakdown.
+ *
+ * Every branch keeps the caller-computed `network` fee. In particular the
+ * `solana` branch must not fall back to the provider's `networkFee`, which is
+ * `0n` whenever the quote carries no network-fee entry (e.g. SwapKit
+ * CHAINFLIP_STREAMING) — the computed value from the keysign payload is the
+ * real on-chain cost. See vultisig-windows#4381.
+ */
+export const resolveSwapFees = ({
+  quote,
+  network,
+  toCoinKey,
+  fromCoin,
+}: ResolveSwapFeesInput): SwapFees =>
+  matchRecordUnion<SwapQuoteResult, SwapFees>(quote, {
+    native: ({ fees }) => ({
+      swap: {
+        ...toCoinKey,
+        amount: BigInt(fees.total),
+        decimals: getNativeSwapDecimals(toCoinKey),
+      },
+      network,
+    }),
+    general: ({ tx }) =>
+      matchRecordUnion(tx, {
+        evm: ({ affiliateFee }) => ({
+          network,
+          ...(affiliateFee ? { swap: affiliateFee } : {}),
+        }),
+        solana: ({ swapFee }) => ({
+          network,
+          swap: swapFee,
+        }),
+        transfer: () => ({ network }),
+        cowswap_order: ({ feeAmount }) => {
+          const swapAmount = BigInt(feeAmount)
+
+          return {
+            network,
+            ...(swapAmount > 0n && fromCoin
+              ? {
+                  swap: {
+                    chain: fromCoin.chain,
+                    id: fromCoin.id,
+                    amount: swapAmount,
+                    decimals: fromCoin.decimals,
+                  },
+                }
+              : {}),
+          }
+        },
+      }),
+  })

--- a/core/ui/vault/swap/queries/useSwapFeesQuery.ts
+++ b/core/ui/vault/swap/queries/useSwapFeesQuery.ts
@@ -1,14 +1,9 @@
 import { useTransformQueryDataAsync } from '@lib/ui/query/hooks/useTransformQueryData'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { areEqualCoins } from '@vultisig/core-chain/coin/Coin'
-import { getNativeSwapDecimals } from '@vultisig/core-chain/swap/native/utils/getNativeSwapDecimals'
-import {
-  SwapQuote,
-  SwapQuoteResult,
-} from '@vultisig/core-chain/swap/quote/SwapQuote'
+import { SwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
 import { SwapFees } from '@vultisig/core-chain/swap/SwapFee'
 import { getFeeAmount } from '@vultisig/core-mpc/keysign/fee'
-import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
 import { useCallback, useMemo } from 'react'
 
 import { useAssertWalletCore } from '../../../chain/providers/WalletCoreProvider'
@@ -17,6 +12,7 @@ import { useCurrentVaultCoins } from '../../state/currentVaultCoins'
 import { useSwapKeysignPayloadQuery } from '../keysignPayload/query'
 import { useSwapFromCoin } from '../state/fromCoin'
 import { useSwapToCoin } from '../state/toCoin'
+import { resolveSwapFees } from './resolveSwapFees'
 
 export const useSwapFeesQuery = (swapQuote: SwapQuote) => {
   const [fromCoinKey] = useSwapFromCoin()
@@ -47,53 +43,11 @@ export const useSwapFeesQuery = (swapQuote: SwapQuote) => {
           decimals: fromFeeCoin.decimals,
         }
 
-        return matchRecordUnion<SwapQuoteResult, SwapFees>(swapQuote.quote, {
-          native: ({ fees }) => {
-            const swapAmount = BigInt(fees.total)
-
-            return {
-              swap: {
-                ...toCoinKey,
-                amount: swapAmount,
-                decimals: getNativeSwapDecimals(toCoinKey),
-              },
-              network,
-            }
-          },
-          general: ({ tx }) => {
-            return matchRecordUnion(tx, {
-              evm: ({ affiliateFee }) => ({
-                network,
-                ...(affiliateFee ? { swap: affiliateFee } : {}),
-              }),
-              solana: ({ networkFee, swapFee }) => ({
-                network: {
-                  chain: chain,
-                  amount: BigInt(networkFee),
-                  decimals: fromFeeCoin.decimals,
-                },
-                swap: swapFee,
-              }),
-              transfer: () => ({ network }),
-              cowswap_order: ({ feeAmount }) => {
-                const swapAmount = BigInt(feeAmount)
-
-                return {
-                  network,
-                  ...(swapAmount > 0n && fromCoin
-                    ? {
-                        swap: {
-                          chain: fromCoin.chain,
-                          id: fromCoin.id,
-                          amount: swapAmount,
-                          decimals: fromCoin.decimals,
-                        },
-                      }
-                    : {}),
-                }
-              },
-            })
-          },
+        return resolveSwapFees({
+          quote: swapQuote.quote,
+          network,
+          toCoinKey,
+          fromCoin,
         })
       },
       [fromCoin, fromCoinKey, publicKey, swapQuote.quote, toCoinKey, walletCore]


### PR DESCRIPTION
## Problem

Solana swaps showed **`Network Fee: 0 SOL`** (e.g. `1000 SOL → USDC` via SwapKit `CHAINFLIP_STREAMING`). Impossible — every Solana tx costs at least the base fee.

## Cause

The `solana` fee branch used the provider's `networkFee`, which is `0n` when the quote has no network-fee entry — discarding the fee we compute from the keysign payload. Every other branch keeps the computed one.

## Fix

The `solana` branch now takes the **larger** of the computed fee and the provider's value, so the displayed fee is never below the real on-chain cost:

```ts
solana: ({ networkFee, swapFee }) => ({
  network: { ...network, amount: maxBigInt(network.amount, networkFee) },
  swap: swapFee,
}),
```

Mapping extracted into a pure `resolveSwapFees` for testability.

## Tests

`resolveSwapFees.test.ts` — provider `0n` → computed fee; provider higher → provider fee; `transfer` threads the fee through. `yarn typecheck` / `eslint` / tests all pass.

Display-only; tx construction unchanged.

Closes #4381

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap fee calculations for Solana quotes, ensuring displayed network fees never drop below the real computed on-chain cost.
  * When a Solana provider reports a higher network fee, the amount and displayed decimals now match the correct calculation.
  * Corrected fee breakdown for transfer-based swaps so only the network fee is shown (no incorrect swap fee).
* **Tests**
  * Added new test coverage for Solana fee-resolution edge cases and the transfer-branch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->