### PR TITLE
feat(folder): prevent removing the last vault from a folder (PR 2/3)

### DIFF
--- a/core/ui/vaultsOrganisation/folder/update/index.tsx
+++ b/core/ui/vaultsOrganisation/folder/update/index.tsx
@@ -38,6 +38,7 @@ import { PageFooter } from '@lib/ui/page/PageFooter'
 import { PageHeader } from '@lib/ui/page/PageHeader'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
+import { useToast } from '@lib/ui/toast/ToastProvider'
 import { getVaultId } from '@vultisig/core-mpc/vault/Vault'
 import { sortEntitiesWithOrder } from '@vultisig/lib-utils/entities/EntityWithOrder'
 import { getNewOrder } from '@vultisig/lib-utils/order/getNewOrder'
@@ -182,6 +183,7 @@ const ManageFolderVaults = ({
   const { mutate: remove } = useRemoveVaultFromFolderMutation()
   const { mutate: updateVault } = useUpdateVaultMutation()
   const formatFiatAmount = useFormatFiatAmount()
+  const { addToast } = useToast()
 
   useEffect(() => setItems(vaults), [vaults])
 
@@ -228,7 +230,14 @@ const ManageFolderVaults = ({
         const { tone, icon } = getVaultSecurityTone(item)
         const value = totals?.[vaultId]
 
-        const handleRemove = () => remove({ vaultId })
+        const handleRemove = () => {
+          if (items.length <= 1) {
+            addToast({ message: t('folder_at_least_one_vault_required') })
+            return
+          }
+
+          remove({ vaultId })
+        }
 
         return (
           <DnDItemContainer key={vaultId} {...draggableProps} status={status}>


### PR DESCRIPTION
Part of #4437 — **PR 2 of 3** (last-vault guard).

> Targets the integration branch `feature/4437-align-folder-screens`, not `main`.
> Independent of PR 1 (#4438) — different lines in `update/index.tsx`, no conflict.

## What this PR does

Prevents a folder from becoming empty. In the Edit Folder screen, toggling off the **last remaining vault** no longer removes it — it surfaces a toast (`At least one vault is required`) and leaves the vault in place.

Matches the Android behaviour (`CreateFolderViewModel.canRemoveVaultFromFolder`: removal is only allowed while more than one vault remains).

```ts
const handleRemove = () => {
  if (items.length <= 1) {
    addToast({ message: t('folder_at_least_one_vault_required') })
    return
  }
  remove({ vaultId })
}
```

Reuses the existing `folder_at_least_one_vault_required` string and the existing `useToast` toast pattern (same one the Delete Folder flow uses) — no new i18n keys, no new deps.

## Verification
- `yarn check` passes: typecheck (exit 0), lint (exit 0), i18n integrity check passed.

## Manual test
1. Open a folder with a single vault → Edit.
2. Toggle off that vault → it stays, and a toast shows "At least one vault is required".
3. In a folder with 2+ vaults, removing still works normally down to the last one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
