### PR TITLE
feat(folder): align folder area visuals with Figma (PR 3/3)

### DIFF
--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -634,8 +634,7 @@ export const de = {
   normal: 'Normal',
   not_enough_funds: 'Nicht genügend Mittel',
   nothing_to_add: 'Nichts hinzuzufügen',
-  nothing_to_add_hint:
-    'Alle Ihre Tresore sind bereits sortiert. Erstellen Sie einen neuen Tresor, um ihn hier hinzuzufügen.',
+  nothing_to_add_hint: 'Alle Ihre Tresore sind bereits sortiert.',
   of: 'von',
   off: 'Aus',
   on: 'An',
@@ -1762,4 +1761,6 @@ export const de = {
     'Limit-Orders sind für THORChain vorübergehend nicht verfügbar.',
   active_vaults: 'Aktive Tresore',
   edit_folder: 'Ordner bearbeiten',
+  nothing_to_add_hint_secondary:
+    'Erstellen Sie einen neuen Tresor, um ihn hier hinzuzufügen.',
 }

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -715,8 +715,8 @@ export const en = {
   normal: 'Normal',
   not_enough_funds: 'Not enough funds',
   nothing_to_add: 'Nothing to add',
-  nothing_to_add_hint:
-    'All your vaults are already sorted. Create a new vault to add it here.',
+  nothing_to_add_hint: 'All your vaults are already sorted.',
+  nothing_to_add_hint_secondary: 'Create a new vault to add it here.',
   of: 'of',
   off: 'Off',
   on: 'On',

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -626,8 +626,7 @@ export const es = {
   normal: 'Normal',
   not_enough_funds: 'No hay fondos suficientes',
   nothing_to_add: 'Nada que añadir',
-  nothing_to_add_hint:
-    'Todas tus bóvedas ya están ordenadas. Crea una nueva bóveda para añadirla aquí.',
+  nothing_to_add_hint: 'Todas tus bóvedas ya están ordenadas.',
   of: 'de',
   off: 'Apagado',
   on: 'En',
@@ -1747,4 +1746,5 @@ export const es = {
     'Las órdenes límite no están disponibles temporalmente en THORChain',
   active_vaults: 'Bóvedas activas',
   edit_folder: 'Editar carpeta',
+  nothing_to_add_hint_secondary: 'Crea una nueva bóveda para agregarlo aquí.',
 }

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -618,8 +618,7 @@ export const hr = {
   normal: 'Normalan',
   not_enough_funds: 'Nema dovoljno sredstava',
   nothing_to_add: 'Nema što dodati',
-  nothing_to_add_hint:
-    'Svi vaši trezori su već sortirani. Izradite novi trezor da biste ga dodali ovdje.',
+  nothing_to_add_hint: 'Svi vaši trezori su već sortirani.',
   of: 'od',
   off: 'Isključeno',
   on: 'Na',
@@ -1719,4 +1718,6 @@ export const hr = {
     'Limitirani nalozi privremeno nisu dostupni na THORChain',
   active_vaults: 'Aktivni trezori',
   edit_folder: 'Uredi mapu',
+  nothing_to_add_hint_secondary:
+    'Izradite novi trezor da biste ga dodali ovdje.',
 }

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -631,8 +631,7 @@ export const it = {
   normal: 'Normale',
   not_enough_funds: 'Fondi insufficienti',
   nothing_to_add: 'Niente da aggiungere',
-  nothing_to_add_hint:
-    'Tutti i tuoi vault sono già ordinati. Crea un nuovo vault per aggiungerlo qui.',
+  nothing_to_add_hint: 'Tutti i tuoi caveau sono già stati sistemati.',
   of: 'Di',
   off: 'Spento',
   on: 'Acceso',
@@ -1753,4 +1752,5 @@ export const it = {
     'Gli ordini limite non sono temporaneamente disponibili su THORChain',
   active_vaults: 'Vault attivi',
   edit_folder: 'Modifica cartella',
+  nothing_to_add_hint_secondary: 'Crea un nuovo vault per aggiungerlo qui.',
 }

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -618,8 +618,7 @@ export const ko = {
   normal: '정상',
   not_enough_funds: '자금이 부족합니다',
   nothing_to_add: '더 이상 추가할 내용이 없습니다.',
-  nothing_to_add_hint:
-    '모든 금고가 이미 정렬되어 있습니다. 여기에 추가하려면 새 금고를 생성하세요.',
+  nothing_to_add_hint: '모든 금고가 이미 정리되었습니다.',
   of: '~의',
   off: '끄다',
   on: '~에',
@@ -1711,4 +1710,5 @@ export const ko = {
     'THORChain에 대한 지정가 주문은 일시적으로 이용할 수 없습니다.',
   active_vaults: '액티브 볼트',
   edit_folder: '폴더 편집',
+  nothing_to_add_hint_secondary: '여기에 추가하려면 새 볼트를 생성하세요.',
 }

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -621,8 +621,7 @@ export const nl = {
   normal: 'Normaal',
   not_enough_funds: 'Onvoldoende funds',
   nothing_to_add: 'Niets toe te voegen',
-  nothing_to_add_hint:
-    'Al je kluizen zijn al gesorteerd. Maak een nieuwe kluis om hem hier toe te voegen.',
+  nothing_to_add_hint: 'Al uw kluizen zijn al gesorteerd.',
   of: 'van',
   off: 'Uit',
   on: 'Aan',
@@ -1730,4 +1729,6 @@ export const nl = {
     'Limietorders zijn tijdelijk niet beschikbaar voor THORChain',
   active_vaults: 'Actieve kluizen',
   edit_folder: 'Map bewerken',
+  nothing_to_add_hint_secondary:
+    'Maak een nieuwe kluis aan om deze hier toe te voegen.',
 }

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -628,8 +628,7 @@ export const pt = {
   normal: 'Normal',
   not_enough_funds: 'Fundos insuficientes',
   nothing_to_add: 'Nada a acrescentar',
-  nothing_to_add_hint:
-    'Todos os seus cofres já estão classificados. Crie um novo cofre para adicioná-lo aqui.',
+  nothing_to_add_hint: 'Todos os seus cofres já estão organizados.',
   of: 'de',
   off: 'Desligado',
   on: 'Ligado',
@@ -1749,4 +1748,5 @@ export const pt = {
     'As ordens limitadas estão temporariamente indisponíveis em THORChain',
   active_vaults: 'Cofres ativos',
   edit_folder: 'Pasta de edição',
+  nothing_to_add_hint_secondary: 'Crie um novo cofre para adicioná-lo aqui.',
 }

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -618,8 +618,7 @@ export const ru = {
   normal: 'Обычный',
   not_enough_funds: 'Недостаточно средств',
   nothing_to_add: 'Нечего добавлять',
-  nothing_to_add_hint:
-    'Все ваши хранилища уже отсортированы. Создайте новое хранилище, чтобы добавить его сюда.',
+  nothing_to_add_hint: 'Все ваши хранилища уже рассортированы.',
   of: 'из',
   off: 'Выкл',
   on: 'Вкл',
@@ -1727,4 +1726,6 @@ export const ru = {
   swap_limit_unavailable: 'Лимитные ордера временно недоступны для THORChain',
   active_vaults: 'Активные хранилища',
   edit_folder: 'Редактировать папку',
+  nothing_to_add_hint_secondary:
+    'Создайте новое хранилище, чтобы добавить его сюда.',
 }

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -577,8 +577,7 @@ export const zh = {
   normal: '普通的',
   not_enough_funds: '资金不足',
   nothing_to_add: '没什么要补充的。',
-  nothing_to_add_hint:
-    '您的所有保险库都已整理完毕。要添加新的保险库，请在此处创建一个。',
+  nothing_to_add_hint: '您的所有保险库都已整理完毕。',
   of: '的',
   off: '离开',
   on: '在',
@@ -1607,4 +1606,5 @@ export const zh = {
   swap_limit_unavailable: 'THORChain的限价单功能暂时不可用。',
   active_vaults: '活跃金库',
   edit_folder: '编辑文件夹',
+  nothing_to_add_hint_secondary: '创建一个新的保险库，将其添加到这里。',
 }

--- a/core/ui/vaultsOrganisation/components/VaultListRow.tsx
+++ b/core/ui/vaultsOrganisation/components/VaultListRow.tsx
@@ -1,4 +1,3 @@
-import { CheckmarkIcon } from '@lib/ui/icons/CheckmarkIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -168,34 +167,10 @@ const IconBadge = styled.div.withConfig({
     const base = match(tone ?? 'neutral', {
       primary: () => theme.colors.success,
       warning: () => theme.colors.idle,
-      info: () => theme.colors.foregroundExtra,
+      info: () => theme.colors.info,
       neutral: () => theme.colors.foregroundExtra,
     })
 
     return base.withAlpha(tone === 'neutral' ? 0.18 : 0.16).toCssValue()
   }};
-`
-
-export const SelectionIndicator = () => {
-  return (
-    <SelectionBadge>
-      <CheckmarkIcon />
-    </SelectionBadge>
-  )
-}
-
-const SelectionBadge = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  border-radius: 999px;
-  background: linear-gradient(
-    135deg,
-    ${({ theme }) => theme.colors.primary.withAlpha(0.4).toCssValue()} 0%,
-    ${({ theme }) => theme.colors.primary.toCssValue()} 100%
-  );
-  color: ${getColor('contrast')};
-  font-size: 18px;
 `

--- a/core/ui/vaultsOrganisation/folder/create/index.tsx
+++ b/core/ui/vaultsOrganisation/folder/create/index.tsx
@@ -163,6 +163,7 @@ export const CreateVaultFolderPage = () => {
                       </SwitchWrapper>
                     }
                     selected={checked}
+                    dimmed={!checked}
                     onClick={() => toggleVault(vaultId)}
                   />
                 )
@@ -170,15 +171,23 @@ export const CreateVaultFolderPage = () => {
             </StyledList>
           ) : (
             <EmptyStateCard gap={12} alignItems="center">
-              <IconWrapper size={28} color="textShy">
+              <IconWrapper size={28} color="buttonPrimary">
                 <FolderLockIcon />
               </IconWrapper>
               <VStack gap={4}>
-                <Text size={16} weight={600} centerHorizontally>
+                <Text
+                  size={16}
+                  weight={600}
+                  color="contrast"
+                  centerHorizontally
+                >
                   {t('nothing_to_add')}
                 </Text>
                 <Text size={13} color="shy" centerHorizontally>
                   {t('nothing_to_add_hint')}
+                </Text>
+                <Text size={13} color="shy" centerHorizontally>
+                  {t('nothing_to_add_hint_secondary')}
                 </Text>
               </VStack>
             </EmptyStateCard>

--- a/core/ui/vaultsOrganisation/folder/index.tsx
+++ b/core/ui/vaultsOrganisation/folder/index.tsx
@@ -18,7 +18,6 @@ import { useVaultsTotalBalances } from '@core/ui/vaultsOrganisation/hooks/useVau
 import { IconButton } from '@lib/ui/buttons/IconButton'
 import { CheckIcon } from '@lib/ui/icons/CheckIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
-import { PlusIcon } from '@lib/ui/icons/PlusIcon'
 import { SquarePenIcon } from '@lib/ui/icons/SquarePenIcon'
 import { VStack } from '@lib/ui/layout/Stack'
 import { useNavigateBack } from '@lib/ui/navigation/hooks/useNavigateBack'
@@ -81,24 +80,16 @@ export const VaultFolderPage = () => {
           title={name}
           subtitle={summarySubtitle}
           actions={
-            <>
-              <IconButton
-                size="md"
-                onClick={() =>
-                  navigate({ id: 'updateVaultFolder', state: { id } })
-                }
-                aria-label={t('edit_vaults')}
-              >
-                <SquarePenIcon />
-              </IconButton>
-              <IconButton
-                size="md"
-                onClick={() => navigate({ id: 'newVault' })}
-                aria-label={t('add_new_vault')}
-              >
-                <PlusIcon />
-              </IconButton>
-            </>
+            <IconButton
+              kind="secondary"
+              size="lg"
+              onClick={() =>
+                navigate({ id: 'updateVaultFolder', state: { id } })
+              }
+              aria-label={t('edit_folder')}
+            >
+              <SquarePenIcon />
+            </IconButton>
           }
         />
         <VStack gap={16}>

--- a/core/ui/vaultsOrganisation/folder/update/index.tsx
+++ b/core/ui/vaultsOrganisation/folder/update/index.tsx
@@ -109,15 +109,18 @@ const AddVaultsToFolder = ({ totals, isTotalsPending }: AddVaultsProps) => {
   if (!vaults.length) {
     return (
       <EmptyStateCard gap={12} alignItems="center">
-        <IconWrapper size={28} color="textShy">
+        <IconWrapper size={28} color="buttonPrimary">
           <FolderLockIcon />
         </IconWrapper>
         <VStack gap={4}>
-          <Text size={16} weight={600} centerHorizontally>
+          <Text size={16} weight={600} color="contrast" centerHorizontally>
             {t('nothing_to_add')}
           </Text>
           <Text size={13} color="shy" centerHorizontally>
             {t('nothing_to_add_hint')}
+          </Text>
+          <Text size={13} color="shy" centerHorizontally>
+            {t('nothing_to_add_hint_secondary')}
           </Text>
         </VStack>
       </EmptyStateCard>

--- a/core/ui/vaultsOrganisation/index.tsx
+++ b/core/ui/vaultsOrganisation/index.tsx
@@ -161,6 +161,7 @@ export const VaultsPage = ({ onFinish }: Partial<OnFinishProp>) => {
             <>
               {totalVaultsCount > 1 && (
                 <IconButton
+                  kind="secondary"
                   size="lg"
                   onClick={handleManage}
                   aria-label={t('edit_vaults')}

--- a/core/ui/vaultsOrganisation/manage/components/VaultsSection.tsx
+++ b/core/ui/vaultsOrganisation/manage/components/VaultsSection.tsx
@@ -1,10 +1,8 @@
 import { useFormatFiatAmount } from '@core/ui/chain/hooks/useFormatFiatAmount'
-import { useCurrentVaultId } from '@core/ui/storage/currentVaultId'
 import { useFolderlessVaults } from '@core/ui/storage/vaults'
 import { useUpdateVaultMutation } from '@core/ui/vault/mutations/useUpdateVaultMutation'
 import {
   LeadingIconBadge,
-  SelectionIndicator,
   VaultListRow,
 } from '@core/ui/vaultsOrganisation/components'
 import { useVaultsTotalBalances } from '@core/ui/vaultsOrganisation/hooks/useVaultsTotalBalances'
@@ -29,7 +27,6 @@ export const VaultsSection = () => {
   const { t } = useTranslation()
   const { mutate } = useUpdateVaultMutation()
   const vaults = useFolderlessVaults()
-  const currentVaultId = useCurrentVaultId()
   const [items, setItems] = useState<Vault[]>(vaults)
   const { totals: vaultTotals, isPending: isTotalsPending } =
     useVaultsTotalBalances({ vaults })
@@ -91,9 +88,6 @@ export const VaultsSection = () => {
                 !isTotalsPending && value !== undefined
                   ? formatFiatAmount(value)
                   : undefined
-              }
-              trailing={
-                vaultId === currentVaultId ? <SelectionIndicator /> : null
               }
             />
             {status === 'overlay' && <DnDItemHighlight />}

--- a/core/ui/vaultsOrganisation/manage/index.tsx
+++ b/core/ui/vaultsOrganisation/manage/index.tsx
@@ -2,8 +2,6 @@ import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { DoneButton } from '@core/ui/vault/chain/manage/shared/DoneButton'
 import { Button } from '@lib/ui/buttons/Button'
-import { IconWrapper } from '@lib/ui/icons/IconWrapper'
-import { PlusIcon } from '@lib/ui/icons/PlusIcon'
 import { useNavigateBack } from '@lib/ui/navigation/hooks/useNavigateBack'
 import { PageContent } from '@lib/ui/page/PageContent'
 import { PageFooter } from '@lib/ui/page/PageFooter'
@@ -35,11 +33,6 @@ export const ManageVaultsPage = () => {
         <AddFolderButton
           kind="secondary"
           onClick={() => navigate({ id: 'createVaultFolder' })}
-          icon={
-            <IconWrapper size={18}>
-              <PlusIcon />
-            </IconWrapper>
-          }
         >
           {t('add_folder')}
         </AddFolderButton>
@@ -50,12 +43,11 @@ export const ManageVaultsPage = () => {
 
 const AddFolderButton = styled(Button)`
   border-radius: 40px;
-  border: 1px solid ${getColor('buttonPrimary')};
-  background: transparent;
+  border: none;
+  background: ${getColor('foreground')};
+  color: ${getColor('text')};
 
   &:hover {
-    border-color: ${({ theme }) =>
-      theme.colors.buttonPrimary.withAlpha(0.7).toCssValue()};
-    background: transparent;
+    background: ${getColor('foregroundExtra')};
   }
 `


### PR DESCRIPTION
Part of #4437 — **PR 3 of 3** (visual parity).

> Targets the integration branch `feature/4437-align-folder-screens`, not `main`.

## What this PR does

Visual-parity pass over the folder area to match the current Figma.

| # | Area | Change |
|---|------|--------|
| 1 | Vaults home + folder view | Edit icon now in a circular frame (`kind="secondary"`) matching the add button |
| 3 | Folder list badge | Visible info-tinted circle so the folder icon reads like the vault badges |
| 4 | Edit Vaults | Removed the green selection check from the vaults list |
| 5 | Add Folder | Unselected vault rows are dimmed |
| 6 | Folder view | Removed the misleading "+" (create-vault) action; kept a circular edit action that opens folder edit |
| 7 | Edit Vaults | Filled "Add folder" button, no icon |
| — | "Nothing to add" empty state | White title, `buttonPrimary` (#0b4cff) icon, hint split into two centered lines |

## Not in this PR
- **Search** (folder view search icon + vault/folder search) → separate PR (#4437 follow-up). See note below.
- Empty-state icon **shape**: still `FolderLockIcon`, not the Figma dashed circle — pending an icon decision (relates to #4383 Icons V3).

## Verification
- `yarn check` passes: typecheck (exit 0), lint (exit 0), i18n integrity check passed, no unused exports.
- `yarn translate` synced the 9 locales for the split empty-state hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
