### PR TITLE
feat(folder): add vault & folder search (PR 4)

### DIFF
--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -1763,4 +1763,5 @@ export const de = {
   edit_folder: 'Ordner bearbeiten',
   nothing_to_add_hint_secondary:
     'Erstellen Sie einen neuen Tresor, um ihn hier hinzuzufügen.',
+  no_results_found: 'Keine Ergebnisse gefunden',
 }

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -714,6 +714,7 @@ export const en = {
   node_address: 'Node Address',
   normal: 'Normal',
   not_enough_funds: 'Not enough funds',
+  no_results_found: 'No results found',
   nothing_to_add: 'Nothing to add',
   nothing_to_add_hint: 'All your vaults are already sorted.',
   nothing_to_add_hint_secondary: 'Create a new vault to add it here.',

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -1747,4 +1747,5 @@ export const es = {
   active_vaults: 'Bóvedas activas',
   edit_folder: 'Editar carpeta',
   nothing_to_add_hint_secondary: 'Crea una nueva bóveda para agregarlo aquí.',
+  no_results_found: 'No se encontraron resultados',
 }

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -1720,4 +1720,5 @@ export const hr = {
   edit_folder: 'Uredi mapu',
   nothing_to_add_hint_secondary:
     'Izradite novi trezor da biste ga dodali ovdje.',
+  no_results_found: 'Nisu pronađeni rezultati',
 }

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -1753,4 +1753,5 @@ export const it = {
   active_vaults: 'Vault attivi',
   edit_folder: 'Modifica cartella',
   nothing_to_add_hint_secondary: 'Crea un nuovo vault per aggiungerlo qui.',
+  no_results_found: 'Nessun risultato trovato',
 }

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -1711,4 +1711,5 @@ export const ko = {
   active_vaults: '액티브 볼트',
   edit_folder: '폴더 편집',
   nothing_to_add_hint_secondary: '여기에 추가하려면 새 볼트를 생성하세요.',
+  no_results_found: '검색 결과가 없습니다.',
 }

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -1731,4 +1731,5 @@ export const nl = {
   edit_folder: 'Map bewerken',
   nothing_to_add_hint_secondary:
     'Maak een nieuwe kluis aan om deze hier toe te voegen.',
+  no_results_found: 'Geen resultaten gevonden',
 }

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -1749,4 +1749,5 @@ export const pt = {
   active_vaults: 'Cofres ativos',
   edit_folder: 'Pasta de edição',
   nothing_to_add_hint_secondary: 'Crie um novo cofre para adicioná-lo aqui.',
+  no_results_found: 'Nenhum resultado encontrado',
 }

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -1728,4 +1728,5 @@ export const ru = {
   edit_folder: 'Редактировать папку',
   nothing_to_add_hint_secondary:
     'Создайте новое хранилище, чтобы добавить его сюда.',
+  no_results_found: 'Результаты не найдены',
 }

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -1607,4 +1607,5 @@ export const zh = {
   active_vaults: '活跃金库',
   edit_folder: '编辑文件夹',
   nothing_to_add_hint_secondary: '创建一个新的保险库，将其添加到这里。',
+  no_results_found: '未找到结果',
 }

--- a/core/ui/vaultsOrganisation/components/VaultSearchField.tsx
+++ b/core/ui/vaultsOrganisation/components/VaultSearchField.tsx
@@ -1,0 +1,44 @@
+import { IconButton } from '@lib/ui/buttons/IconButton'
+import { CircleICloseIcon } from '@lib/ui/icons/CircleICloseIcon'
+import { HStack } from '@lib/ui/layout/Stack'
+import { SearchField } from '@lib/ui/search/SearchField'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+
+type VaultSearchFieldProps = {
+  value: string
+  onChange: (query: string) => void
+  onClose: () => void
+}
+
+export const VaultSearchField = ({
+  value,
+  onChange,
+  onClose,
+}: VaultSearchFieldProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <Wrapper gap={8} alignItems="center">
+      <FieldSlot>
+        <SearchField value={value} onSearch={onChange} />
+      </FieldSlot>
+      <IconButton
+        kind="link"
+        size="lg"
+        onClick={onClose}
+        aria-label={t('cancel')}
+      >
+        <CircleICloseIcon />
+      </IconButton>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled(HStack)`
+  width: 100%;
+`
+
+const FieldSlot = styled.div`
+  flex: 1;
+`

--- a/core/ui/vaultsOrganisation/components/index.ts
+++ b/core/ui/vaultsOrganisation/components/index.ts
@@ -1,4 +1,5 @@
 export * from './SectionHeader'
 export * from './VaultListItem'
 export * from './VaultListRow'
+export * from './VaultSearchField'
 export * from './VaultSignersPill'

--- a/core/ui/vaultsOrganisation/folder/index.tsx
+++ b/core/ui/vaultsOrganisation/folder/index.tsx
@@ -12,12 +12,14 @@ import {
   LeadingIconBadge,
   SectionHeader,
   VaultListRow,
+  VaultSearchField,
 } from '@core/ui/vaultsOrganisation/components'
 import { useCurrentVaultFolder } from '@core/ui/vaultsOrganisation/folder/state/currentVaultFolder'
 import { useVaultsTotalBalances } from '@core/ui/vaultsOrganisation/hooks/useVaultsTotalBalances'
 import { IconButton } from '@lib/ui/buttons/IconButton'
 import { CheckIcon } from '@lib/ui/icons/CheckIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
+import { SearchIcon } from '@lib/ui/icons/SearchIcon'
 import { SquarePenIcon } from '@lib/ui/icons/SquarePenIcon'
 import { VStack } from '@lib/ui/layout/Stack'
 import { useNavigateBack } from '@lib/ui/navigation/hooks/useNavigateBack'
@@ -25,7 +27,7 @@ import { PageContent } from '@lib/ui/page/PageContent'
 import { PageHeader } from '@lib/ui/page/PageHeader'
 import { Text } from '@lib/ui/text'
 import { getVaultId } from '@vultisig/core-mpc/vault/Vault'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { getVaultSecurityTone } from '../utils/getVaultSecurityTone'
@@ -39,6 +41,8 @@ export const VaultFolderPage = () => {
   const { id, name } = useCurrentVaultFolder()
   const vaults = useFolderVaults(id)
   const currentVaultId = useCurrentVaultId()
+  const [isSearchOpen, setIsSearchOpen] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
 
   const { totals: vaultTotals, isPending: isTotalsPending } =
     useVaultsTotalBalances({ vaults })
@@ -68,6 +72,18 @@ export const VaultFolderPage = () => {
       onSuccess: () => navigate({ id: 'vault' }),
     })
 
+  const openSearch = () => setIsSearchOpen(true)
+  const closeSearch = () => {
+    setIsSearchOpen(false)
+    setSearchQuery('')
+  }
+
+  const normalizedQuery = searchQuery.trim().toLowerCase()
+  const isSearching = normalizedQuery.length > 0
+  const displayedVaults = isSearching
+    ? vaults.filter(vault => vault.name.toLowerCase().includes(normalizedQuery))
+    : vaults
+
   return (
     <VStack fullHeight>
       <PageHeader
@@ -80,54 +96,79 @@ export const VaultFolderPage = () => {
           title={name}
           subtitle={summarySubtitle}
           actions={
-            <IconButton
-              kind="secondary"
-              size="lg"
-              onClick={() =>
-                navigate({ id: 'updateVaultFolder', state: { id } })
-              }
-              aria-label={t('edit_folder')}
-            >
-              <SquarePenIcon />
-            </IconButton>
+            <>
+              <IconButton
+                kind="secondary"
+                size="lg"
+                onClick={openSearch}
+                aria-label={t('search_field_placeholder')}
+              >
+                <SearchIcon />
+              </IconButton>
+              <IconButton
+                kind="secondary"
+                size="lg"
+                onClick={() =>
+                  navigate({ id: 'updateVaultFolder', state: { id } })
+                }
+                aria-label={t('edit_folder')}
+              >
+                <SquarePenIcon />
+              </IconButton>
+            </>
           }
         />
-        <VStack gap={16}>
-          <Text size={13} weight={600} color="shy">
-            {t('vaults')}
-          </Text>
-          <VStack gap={12}>
-            {vaults.map(vault => {
-              const vaultId = getVaultId(vault)
-              const { tone, icon } = getVaultSecurityTone(vault)
-              const value = vaultTotals?.[vaultId]
-
-              return (
-                <VaultListRow
-                  key={vaultId}
-                  leading={
-                    <LeadingIconBadge tone={tone}>{icon}</LeadingIconBadge>
-                  }
-                  title={vault.name}
-                  subtitle={
-                    !isTotalsPending && value !== undefined
-                      ? formatFiatAmount(value)
-                      : undefined
-                  }
-                  meta={<VaultSigners vault={vault} />}
-                  trailing={
-                    vaultId === currentVaultId ? (
-                      <IconWrapper size={20} color="success">
-                        <CheckIcon />
-                      </IconWrapper>
-                    ) : null
-                  }
-                  onClick={() => handleSelectVault(vaultId)}
-                />
-              )
-            })}
+        {isSearchOpen && (
+          <VaultSearchField
+            value={searchQuery}
+            onChange={setSearchQuery}
+            onClose={closeSearch}
+          />
+        )}
+        {isSearching && displayedVaults.length === 0 ? (
+          <VStack gap={12} alignItems="center" justifyContent="center">
+            <Text size={16} weight={500} centerHorizontally>
+              {t('no_results_found')}
+            </Text>
           </VStack>
-        </VStack>
+        ) : (
+          <VStack gap={16}>
+            <Text size={13} weight={600} color="shy">
+              {t('vaults')}
+            </Text>
+            <VStack gap={12}>
+              {displayedVaults.map(vault => {
+                const vaultId = getVaultId(vault)
+                const { tone, icon } = getVaultSecurityTone(vault)
+                const value = vaultTotals?.[vaultId]
+
+                return (
+                  <VaultListRow
+                    key={vaultId}
+                    leading={
+                      <LeadingIconBadge tone={tone}>{icon}</LeadingIconBadge>
+                    }
+                    title={vault.name}
+                    subtitle={
+                      !isTotalsPending && value !== undefined
+                        ? formatFiatAmount(value)
+                        : undefined
+                    }
+                    meta={<VaultSigners vault={vault} />}
+                    trailing={
+                      vaultId === currentVaultId ? (
+                        <IconWrapper size={20} color="success">
+                          <CheckIcon />
+                        </IconWrapper>
+                      ) : null
+                    }
+                    onClick={() => handleSelectVault(vaultId)}
+                  />
+                )
+              })}
+            </VStack>
+          </VStack>
+        )}
       </PageContent>
     </VStack>
   )

--- a/core/ui/vaultsOrganisation/index.tsx
+++ b/core/ui/vaultsOrganisation/index.tsx
@@ -13,6 +13,7 @@ import {
   SectionHeader,
   VaultListItem,
   VaultListRow,
+  VaultSearchField,
 } from '@core/ui/vaultsOrganisation/components'
 import { useVaultsTotalBalances } from '@core/ui/vaultsOrganisation/hooks/useVaultsTotalBalances'
 import { IconButton } from '@lib/ui/buttons/IconButton'
@@ -20,6 +21,7 @@ import { ChevronRightIcon } from '@lib/ui/icons/ChevronRightIcon'
 import { FolderIcon } from '@lib/ui/icons/FolderIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { PlusIcon } from '@lib/ui/icons/PlusIcon'
+import { SearchIcon } from '@lib/ui/icons/SearchIcon'
 import { SquarePenIcon } from '@lib/ui/icons/SquarePenIcon'
 import { VStack } from '@lib/ui/layout/Stack'
 import { useNavigateBack } from '@lib/ui/navigation/hooks/useNavigateBack'
@@ -28,7 +30,7 @@ import { PageHeader } from '@lib/ui/page/PageHeader'
 import { OnFinishProp } from '@lib/ui/props'
 import { Text } from '@lib/ui/text'
 import { getVaultId } from '@vultisig/core-mpc/vault/Vault'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { useCore } from '../state/core'
@@ -61,6 +63,8 @@ export const VaultsPage = ({ onFinish }: Partial<OnFinishProp>) => {
   const folders = useVaultFolders()
   const vaults = useVaults()
   const folderlessVaults = useFolderlessVaults()
+  const [isSearchOpen, setIsSearchOpen] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
 
   const folderEntries = useMemo<FolderEntry[]>(() => {
     return folders.map(folder => {
@@ -144,6 +148,27 @@ export const VaultsPage = ({ onFinish }: Partial<OnFinishProp>) => {
       onSuccess: onFinish ?? goHome,
     })
 
+  const openSearch = () => setIsSearchOpen(true)
+  const closeSearch = () => {
+    setIsSearchOpen(false)
+    setSearchQuery('')
+  }
+
+  const normalizedQuery = searchQuery.trim().toLowerCase()
+  const isSearching = normalizedQuery.length > 0
+
+  const displayedFolders = isSearching
+    ? folderEntries.filter(folder =>
+        folder.name.toLowerCase().includes(normalizedQuery)
+      )
+    : folderEntries
+  const displayedVaults = isSearching
+    ? vaults.filter(vault => vault.name.toLowerCase().includes(normalizedQuery))
+    : folderlessVaults
+
+  const hasNoSearchResults =
+    isSearching && displayedFolders.length === 0 && displayedVaults.length === 0
+
   return (
     <VStack fullHeight>
       <PageHeader
@@ -159,6 +184,16 @@ export const VaultsPage = ({ onFinish }: Partial<OnFinishProp>) => {
           subtitle={summarySubtitle}
           actions={
             <>
+              {totalVaultsCount > 1 && (
+                <IconButton
+                  kind="secondary"
+                  size="lg"
+                  onClick={openSearch}
+                  aria-label={t('search_field_placeholder')}
+                >
+                  <SearchIcon />
+                </IconButton>
+              )}
               {totalVaultsCount > 1 && (
                 <IconButton
                   kind="secondary"
@@ -181,9 +216,17 @@ export const VaultsPage = ({ onFinish }: Partial<OnFinishProp>) => {
           }
         />
 
-        {folderEntries.length > 0 && (
+        {isSearchOpen && (
+          <VaultSearchField
+            value={searchQuery}
+            onChange={setSearchQuery}
+            onClose={closeSearch}
+          />
+        )}
+
+        {displayedFolders.length > 0 && (
           <VStack gap={12}>
-            {folderEntries.map(folder => {
+            {displayedFolders.map(folder => {
               const subtitle = folder.activeVaultName
                 ? `✓ '${folder.activeVaultName}' ${t('active')}`
                 : t('vault_count', { count: folder.vaultCount })
@@ -222,13 +265,13 @@ export const VaultsPage = ({ onFinish }: Partial<OnFinishProp>) => {
           </VStack>
         )}
 
-        {folderlessVaults.length > 0 && (
+        {displayedVaults.length > 0 && (
           <VStack gap={16}>
             <Text size={13} weight={600} color="shy">
               {t('vaults')}
             </Text>
             <VStack gap={12}>
-              {folderlessVaults.map(vault => {
+              {displayedVaults.map(vault => {
                 const vaultId = getVaultId(vault)
                 const value =
                   !skipBalanceFetch &&
@@ -251,13 +294,23 @@ export const VaultsPage = ({ onFinish }: Partial<OnFinishProp>) => {
           </VStack>
         )}
 
-        {folderEntries.length === 0 && folderlessVaults.length === 0 && (
+        {!isSearching &&
+          folderEntries.length === 0 &&
+          folderlessVaults.length === 0 && (
+            <VStack gap={12} alignItems="center" justifyContent="center">
+              <Text size={16} weight={500}>
+                {t('no_vaults')}
+              </Text>
+              <Text size={13} color="shy" centerHorizontally>
+                {t('create_new_vault')}
+              </Text>
+            </VStack>
+          )}
+
+        {hasNoSearchResults && (
           <VStack gap={12} alignItems="center" justifyContent="center">
-            <Text size={16} weight={500}>
-              {t('no_vaults')}
-            </Text>
-            <Text size={13} color="shy" centerHorizontally>
-              {t('create_new_vault')}
+            <Text size={16} weight={500} centerHorizontally>
+              {t('no_results_found')}
             </Text>
           </VStack>
         )}


### PR DESCRIPTION
Part of #4437 — search follow-up (implements the search from #4422 item 2).

> Targets the integration branch `feature/4437-align-folder-screens`, not `main`.

## Context

The Figma design has a search in the vault list and inside folders. **There is no Android reference** — the Android vault list (`VaultListViewModel`/`VaultListScreen`) has folders, vaults, reorder and create, but no folder/vault search. So this was built fresh from the Figma intent, reusing the shared `SearchField`.

## What this PR does

- **New `VaultSearchField`** shared component (wraps `SearchField` + a close button).
- **Vaults home:** a circular search icon (matching the edit/add buttons) reveals a search field. Filters folders by name **and** all vaults by name — a matching vault inside a folder surfaces directly in a flat results list. "No results found" empty state.
- **Folder view:** a circular search icon filters that folder's vaults by name. "No results found" empty state. This completes the search half of PR3's item 6 (the folder header now has search + edit).

## Verification
- `yarn check` passes: typecheck (exit 0), lint (exit 0), i18n integrity check passed.
- No new `useMemo` (React Compiler), no hardcoded hex; `yarn translate` synced the 9 locales for `no_results_found`.

## Manual test
1. Vaults home → tap search → type a folder name (filters folders) or a vault name (surfaces the vault flat, even from inside a folder).
2. Open a folder → tap search → filters that folder's vaults.
3. Type gibberish → "No results found". Tap ✕ → search closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
