### PR TITLE
Limit Station defaults to Terra chains

### DIFF
--- a/core/ui/vault/chains/defaultVaultChains.test.ts
+++ b/core/ui/vault/chains/defaultVaultChains.test.ts
@@ -8,12 +8,10 @@ describe('getDefaultVaultChains', () => {
     expect(getDefaultVaultChains('vultisig')).toEqual(defaultChains)
   })
 
-  it('adds Terra and Terra Classic for Station vaults', () => {
-    const chains = getDefaultVaultChains('station')
-
-    expect(chains).toEqual(
-      expect.arrayContaining([Chain.Terra, Chain.TerraClassic])
-    )
-    expect(chains).toEqual([...new Set(chains)])
+  it('enables only Terra and Terra Classic for new Station vaults', () => {
+    expect(getDefaultVaultChains('station')).toEqual([
+      Chain.Terra,
+      Chain.TerraClassic,
+    ])
   })
 })

--- a/core/ui/vault/chains/defaultVaultChains.ts
+++ b/core/ui/vault/chains/defaultVaultChains.ts
@@ -2,17 +2,17 @@ import { Chain, defaultChains } from '@vultisig/core-chain/Chain'
 
 import { ProductBrand } from '../../product/brand'
 
-const stationDefaultChains = [...defaultChains, Chain.Terra, Chain.TerraClassic]
+const stationDefaultChains = [Chain.Terra, Chain.TerraClassic]
 
 /**
  * Resolves default vault chains for the selected product brand.
  *
- * @param productBrand Product brand that controls included default chains.
- * @returns Deduplicated default chains for vault creation.
+ * @param productBrand Product brand that controls the initial chain set.
+ * @returns Default chains for vault creation.
  */
 export const getDefaultVaultChains = (productBrand: ProductBrand): Chain[] => {
   const chains =
     productBrand === 'station' ? stationDefaultChains : defaultChains
 
-  return [...new Set(chains)]
+  return [...chains]
 }


### PR DESCRIPTION
Station was including the regular Vultisig default chains alongside Terra and Terra Classic. Fresh non-key-import Station vaults now start with only Terra and Terra Classic, while existing and imported vaults and the regular Vultisig defaults remain unchanged. Built-extension QA persisted and reopened a fresh Station vault with exactly the two Terra-family chain rows and confirmed the equivalent Vultisig flow retains its normal five defaults.

![screenshot-1](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/station-terra-only-defaults/screenshot-1-1784958380020.png)
![screenshot-2](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/station-terra-only-defaults/screenshot-2-1784958380020.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default chain selection for Station vaults to include only Terra and Terra Classic.
  * Ensured returned chain lists preserve the configured selection without adding unrelated default chains.
* **Tests**
  * Updated coverage to verify the exact expected chain set for Station vaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->