### PR TITLE
fix(solana): guard delegate against over-balance stake

### DIFF
--- a/core/ui/chain/solana/staking/getSolanaStakingFee.test.ts
+++ b/core/ui/chain/solana/staking/getSolanaStakingFee.test.ts
@@ -1,0 +1,43 @@
+import { solanaConfig } from '@vultisig/core-chain/chains/solana/solanaConfig'
+import { describe, expect, it } from 'vitest'
+
+import {
+  getSolanaStakingFee,
+  solanaStakingFloorFee,
+} from './getSolanaStakingFee'
+
+describe('getSolanaStakingFee', () => {
+  it('adds the prioritization fee to the per-signature base fee', () => {
+    // 1_000_000 µ-lamports/CU × 100_000 CU = 100_000 lamports.
+    expect(
+      getSolanaStakingFee({
+        priorityFeePrice: 1_000_000n,
+        priorityFeeLimit: 100_000,
+      })
+    ).toBe(BigInt(solanaConfig.baseFee) + 100_000n)
+  })
+
+  it('rounds the prioritization fee up, like the runtime does', () => {
+    expect(
+      getSolanaStakingFee({ priorityFeePrice: 1n, priorityFeeLimit: 1 })
+    ).toBe(BigInt(solanaConfig.baseFee) + 1n)
+  })
+
+  it('falls back to the base fee when no priority fee is charged', () => {
+    expect(
+      getSolanaStakingFee({ priorityFeePrice: 0n, priorityFeeLimit: 100_000 })
+    ).toBe(BigInt(solanaConfig.baseFee))
+  })
+
+  it('exposes the floor fee the delegate form budgets with', () => {
+    expect(solanaStakingFloorFee).toBe(
+      getSolanaStakingFee({
+        priorityFeePrice: BigInt(solanaConfig.priorityFeePrice),
+        priorityFeeLimit: solanaConfig.priorityFeeLimit,
+      })
+    )
+    // Reserving only `baseFee` leaves a max-sized stake short by the
+    // prioritization fee — the regression this constant closes.
+    expect(solanaStakingFloorFee).toBeGreaterThan(BigInt(solanaConfig.baseFee))
+  })
+})

--- a/core/ui/chain/solana/staking/getSolanaStakingFee.ts
+++ b/core/ui/chain/solana/staking/getSolanaStakingFee.ts
@@ -1,0 +1,38 @@
+import { solanaConfig } from '@vultisig/core-chain/chains/solana/solanaConfig'
+
+const microLamportsPerLamport = 1_000_000n
+
+const ceilDiv = (dividend: bigint, divisor: bigint) =>
+  (dividend + divisor - 1n) / divisor
+
+type GetSolanaStakingFeeInput = {
+  /** Priority-fee price, in micro-lamports per compute unit. */
+  priorityFeePrice: bigint
+  /** Compute-unit limit the staking transaction requests. */
+  priorityFeeLimit: number
+}
+
+/**
+ * Lamports a Solana staking transaction costs its sender: the per-signature
+ * base fee plus the prioritization fee `buildUnsignedStakingTx` always attaches
+ * (price × compute-unit limit, rounded up like the runtime does). Budgeting for
+ * the base fee alone leaves a max-sized stake ~0.0001 SOL short and the network
+ * rejects it at simulation.
+ */
+export const getSolanaStakingFee = ({
+  priorityFeePrice,
+  priorityFeeLimit,
+}: GetSolanaStakingFeeInput) =>
+  BigInt(solanaConfig.baseFee) +
+  ceilDiv(priorityFeePrice * BigInt(priorityFeeLimit), microLamportsPerLamport)
+
+/**
+ * The staking fee at the configured priority-fee floor. The live per-slot price
+ * is only known once the keysign payload's chain-specific data is fetched, so
+ * the delegate form budgets with the floor and the pre-sign funding guard
+ * re-checks against the price actually encoded into the transaction.
+ */
+export const solanaStakingFloorFee = getSolanaStakingFee({
+  priorityFeePrice: BigInt(solanaConfig.priorityFeePrice),
+  priorityFeeLimit: solanaConfig.priorityFeeLimit,
+})

--- a/core/ui/chain/solana/staking/queries/useSolanaRentReserveQuery.ts
+++ b/core/ui/chain/solana/staking/queries/useSolanaRentReserveQuery.ts
@@ -2,16 +2,27 @@ import { useQuery } from '@tanstack/react-query'
 import { solanaStakingConfig } from '@vultisig/core-chain/chains/solana/staking/config'
 import { fetchSolanaRentReserve } from '@vultisig/core-chain/chains/solana/staking/rpc'
 
+type UseSolanaRentReserveQueryInput = {
+  /**
+   * Keeps the Solana RPC read from firing on non-Solana screens that still call
+   * the hook unconditionally. The placeholder below is served either way.
+   */
+  enabled?: boolean
+}
+
 /**
  * The rent-exempt reserve for a 200-byte stake account, in lamports. Changes
  * rarely, so it is cached 24h and seeded with the deterministic
  * `rentExemptReserveLamports` default so the delegate form can subtract the
  * reserve from the stakeable max before the live read returns.
  */
-export const useSolanaRentReserveQuery = () =>
+export const useSolanaRentReserveQuery = ({
+  enabled = true,
+}: UseSolanaRentReserveQueryInput = {}) =>
   useQuery({
     queryKey: ['solanaRentReserve'] as const,
     queryFn: fetchSolanaRentReserve,
     staleTime: 24 * 60 * 60 * 1000,
     placeholderData: solanaStakingConfig.rentExemptReserveLamports,
+    enabled,
   })

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/SolanaStakingSpecific/SolanaDelegateSpecific.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/SolanaStakingSpecific/SolanaDelegateSpecific.tsx
@@ -1,18 +1,16 @@
-import { useBalanceQuery } from '@core/ui/chain/coin/queries/useBalanceQuery'
 import { SolanaValidatorPickerField } from '@core/ui/chain/solana/staking/components/SolanaValidatorPickerField'
-import { useSolanaRentReserveQuery } from '@core/ui/chain/solana/staking/queries/useSolanaRentReserveQuery'
+import { useSolanaStakeableBalance } from '@core/ui/vault/deposit/hooks/useSolanaStakeableBalance'
 import { useDepositCoin } from '@core/ui/vault/deposit/providers/DepositCoinProvider'
 import { useDepositFormHandlers } from '@core/ui/vault/deposit/providers/DepositFormHandlersProvider'
+import { getFieldErrorMessage } from '@core/ui/vault/deposit/utils/getFieldErrorMessage'
 import { PercentageSelector } from '@lib/ui/inputs/PercentageSelector'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
 import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
-import { solanaConfig } from '@vultisig/core-chain/chains/solana/solanaConfig'
-import { extractAccountCoinKey } from '@vultisig/core-chain/coin/AccountCoin'
 import { attempt } from '@vultisig/lib-utils/attempt'
 import { decimalStringToBigInt } from '@vultisig/lib-utils/bigint/decimalStringToBigInt'
-import { Controller } from 'react-hook-form'
+import { Controller, useFormState } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
@@ -31,15 +29,12 @@ export const SolanaDelegateSpecific = () => {
   const { t } = useTranslation()
   const [{ control, setValue }] = useDepositFormHandlers()
   const [coin] = useDepositCoin()
-  const balanceQuery = useBalanceQuery(extractAccountCoinKey(coin))
-  const rentReserveQuery = useSolanaRentReserveQuery()
+  const { errors } = useFormState({ control })
+  const { rentReserve, stakeable: stakeableUnits } = useSolanaStakeableBalance()
 
-  const balanceUnits = balanceQuery.data ?? 0n
-  const rentReserve = rentReserveQuery.data ?? 0n
-  const reserved = rentReserve + BigInt(solanaConfig.baseFee)
-  const stakeableUnits = balanceUnits > reserved ? balanceUnits - reserved : 0n
   const stakeableUi = fromChainAmount(stakeableUnits, coin.decimals)
   const rentReserveUi = fromChainAmount(rentReserve, coin.decimals)
+  const amountError = getFieldErrorMessage(errors, 'amount')
 
   return (
     <Layout>
@@ -60,6 +55,11 @@ export const SolanaDelegateSpecific = () => {
             )}
           />
         </CenteredAmount>
+        {amountError ? (
+          <Text size={13} color="danger" centerHorizontally>
+            {amountError}
+          </Text>
+        ) : null}
         <Controller
           control={control}
           name="amount"

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/SolanaStakingSpecific/SolanaStakingFooterButton.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/SolanaStakingSpecific/SolanaStakingFooterButton.tsx
@@ -1,13 +1,10 @@
 import { SolanaValidatorPickerSheet } from '@core/ui/chain/solana/staking/components/SolanaValidatorPickerSheet'
 import { useDepositCoin } from '@core/ui/vault/deposit/providers/DepositCoinProvider'
 import { useDepositFormHandlers } from '@core/ui/vault/deposit/providers/DepositFormHandlersProvider'
+import { getFieldErrorMessage } from '@core/ui/vault/deposit/utils/getFieldErrorMessage'
 import { Opener } from '@lib/ui/base/Opener'
 import { Button } from '@lib/ui/buttons/Button'
-import {
-  solanaStakingConfig,
-  solDecimals,
-} from '@vultisig/core-chain/chains/solana/staking/config'
-import { Controller, useWatch } from 'react-hook-form'
+import { Controller, useFormState, useWatch } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 
 /**
@@ -24,21 +21,22 @@ type SolanaStakingFooterButtonProps = {
   action: (typeof solanaValidatorPickerActions)[number]
 }
 
-// Solana Stake program minimum active delegation, in whole SOL (1 SOL on
-// mainnet). A DelegateStake below it reverts on-chain with
-// StakeError.InsufficientDelegation, so the CTA gates on it up front.
-const minDelegationSol =
-  Number(solanaStakingConfig.minDelegationFloorLamports) / 10 ** solDecimals
-
 /**
  * Page-bottom CTA for the Solana forms that pick a validator. States, in order:
  *   1. Amount not set → "Enter Amount", disabled. Delegate only — a move sends
  *      the whole stake account, so it has no amount to enter.
- *   2. Amount below the 1 SOL program minimum → disabled minimum-delegation hint.
+ *   2. Amount rejected by the form schema (below the 1 SOL program minimum,
+ *      or above the stakeable balance) → that message, disabled.
  *   3. Validator not picked → "Select Validator", opens the picker sheet (the
  *      same sheet the inline validator field opens; both keep `validatorAddress`
  *      in sync via react-hook-form).
- *   4. Everything set → "Continue" (`type=submit`).
+ *   4. Everything set → "Continue" (`type=submit`), disabled while the form is
+ *      invalid.
+ *
+ * The amount states read `formState` rather than re-deriving their own bounds:
+ * gating on locally computed rules alone let an over-balance delegate reach the
+ * keysign ceremony, which then signed a transaction the network rejects at
+ * simulation ("insufficient lamports").
  *
  * Lives at the page footer so it stays pinned outside the scrollable form,
  * mirroring `CosmosStakingFooterButton`. The ops that carry a prefilled
@@ -50,6 +48,7 @@ export const SolanaStakingFooterButton = ({
   const { t } = useTranslation()
   const [{ control }] = useDepositFormHandlers()
   const [coin] = useDepositCoin()
+  const { errors, isValid } = useFormState({ control })
 
   // Form values are loosely typed (`Record<string, any>`), so narrow rather
   // than assert: typing into the amount input emits a string while the
@@ -66,7 +65,7 @@ export const SolanaStakingFooterButton = ({
   const requiresAmount = action === 'solana_delegate'
   const numericAmount = Number(amount ?? 0)
   const amountSet = Number.isFinite(numericAmount) && numericAmount > 0
-  const belowMinimum = amountSet && numericAmount < minDelegationSol
+  const amountError = getFieldErrorMessage(errors, 'amount')
   const validatorPicked = Boolean(validatorAddress)
 
   if (requiresAmount && !amountSet) {
@@ -77,19 +76,20 @@ export const SolanaStakingFooterButton = ({
     )
   }
 
-  if (requiresAmount && belowMinimum) {
+  if (requiresAmount && amountError) {
     return (
       <Button disabled type="button">
-        {t('solana_staking_min_delegation', {
-          amount: minDelegationSol,
-          ticker: coin.ticker,
-        })}
+        {amountError}
       </Button>
     )
   }
 
   if (validatorPicked) {
-    return <Button type="submit">{t('continue')}</Button>
+    return (
+      <Button disabled={!isValid} type="submit">
+        {t('continue')}
+      </Button>
+    )
   }
 
   return (

--- a/core/ui/vault/deposit/hooks/useCorrectSelectedCoin.ts
+++ b/core/ui/vault/deposit/hooks/useCorrectSelectedCoin.ts
@@ -41,6 +41,23 @@ export const useCorrectSelectedCoin = () => {
           : fallbackStakeableCoin
       }
 
+      // Solana native staking funds the stake account from — and pays its fee
+      // in — native SOL. Entering the deposit flow from an SPL token's screen
+      // would otherwise carry that token in and have the delegate form bound
+      // its amount to the token's balance and decimals.
+      const selectNativeCoin = () => {
+        if (isFeeCoin(currentDepositCoin)) {
+          return currentDepositCoin
+        }
+
+        return shouldBePresent(
+          coins.find(
+            coin => coin.chain === currentDepositCoin.chain && isFeeCoin(coin)
+          ),
+          `native ${currentDepositCoin.chain} coin`
+        )
+      }
+
       const ticker = currentDepositCoin.ticker
       const potentialRUNECoin = findByTicker({ coins, ticker: 'RUNE' })
       const potentialCACAOCoin = findByTicker({ coins, ticker: 'CACAO' })
@@ -116,11 +133,11 @@ export const useCorrectSelectedCoin = () => {
         undelegate: () => currentDepositCoin,
         redelegate: () => currentDepositCoin,
         claim_rewards: () => currentDepositCoin,
-        solana_delegate: () => currentDepositCoin,
-        solana_unstake: () => currentDepositCoin,
-        solana_withdraw: () => currentDepositCoin,
-        solana_move_stake: () => currentDepositCoin,
-        solana_finish_move: () => currentDepositCoin,
+        solana_delegate: selectNativeCoin,
+        solana_unstake: selectNativeCoin,
+        solana_withdraw: selectNativeCoin,
+        solana_move_stake: selectNativeCoin,
+        solana_finish_move: selectNativeCoin,
       })
     },
     [action, coins, mergeOptions, mintOptions, redeemOptions, unmergeOptions]

--- a/core/ui/vault/deposit/hooks/useDepositBalance.ts
+++ b/core/ui/vault/deposit/hooks/useDepositBalance.ts
@@ -1,4 +1,5 @@
 import { ChainAction } from '@core/ui/vault/deposit/ChainAction'
+import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
 import { TronResourceType } from '@vultisig/core-chain/chains/tron/resources'
 import { useMemo } from 'react'
 
@@ -6,6 +7,7 @@ import { useDepositCoin } from '../providers/DepositCoinProvider'
 import { useStakeBalance } from '../staking/useStakeBalance'
 import { useDepositCoinBalance } from './useDepositCoinBalance'
 import { useRujiraStakeQuery } from './useRujiraStakeQuery'
+import { useSolanaStakeableBalance } from './useSolanaStakeableBalance'
 import { useTronFrozenBalance } from './useTronFrozenBalance'
 import { useUnbondableBalanceQuery } from './useUnbondableBalanceQuery'
 
@@ -36,9 +38,19 @@ export const useDepositBalance = ({
     resourceType: tronResourceType ?? 'BANDWIDTH',
   })
 
+  const { stakeable: solanaStakeable } = useSolanaStakeableBalance()
+
   const totalTokenAmount = useMemo(() => {
     if (selectedChainAction === 'unstake') {
       return stakeBalance
+    }
+
+    // A Solana delegate spends the entered amount PLUS the stake account's
+    // rent-exempt reserve PLUS the fee, so the form's ceiling is the stakeable
+    // balance — bounding on the raw balance would let a max stake through and
+    // the ceremony would sign a tx the network rejects at simulation.
+    if (selectedChainAction === 'solana_delegate') {
+      return fromChainAmount(solanaStakeable, selectedCoin.decimals)
     }
 
     if (selectedChainAction === 'unbond') {
@@ -56,7 +68,9 @@ export const useDepositBalance = ({
     return selectedCoinBalance
   }, [
     selectedChainAction,
+    selectedCoin.decimals,
     selectedCoinBalance,
+    solanaStakeable,
     stakeBalance,
     tronFrozenBalance,
     unbondableBalance?.humanReadableBalance,

--- a/core/ui/vault/deposit/hooks/useSolanaStakeableBalance.ts
+++ b/core/ui/vault/deposit/hooks/useSolanaStakeableBalance.ts
@@ -1,0 +1,38 @@
+import { useBalanceQuery } from '@core/ui/chain/coin/queries/useBalanceQuery'
+import { solanaStakingFloorFee } from '@core/ui/chain/solana/staking/getSolanaStakingFee'
+import { useSolanaRentReserveQuery } from '@core/ui/chain/solana/staking/queries/useSolanaRentReserveQuery'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { extractAccountCoinKey } from '@vultisig/core-chain/coin/AccountCoin'
+
+import { useDepositCoin } from '../providers/DepositCoinProvider'
+
+/**
+ * How much of the wallet's liquid SOL can actually be delegated, in lamports.
+ *
+ * A delegate creates a NEW stake account and funds it with the entered amount
+ * PLUS the rent-exempt reserve, and the wallet also pays the transaction fee —
+ * so the spendable ceiling is `balance − rentReserve − fee`, not the raw
+ * balance. Staking the raw balance encodes a transfer the account cannot cover
+ * and the network rejects it at simulation ("insufficient lamports"), after the
+ * keysign ceremony has already signed it.
+ *
+ * Single source for the delegate form's displayed max, its percentage pills and
+ * the schema bound the Continue CTA gates on, so all three agree to the lamport.
+ */
+export const useSolanaStakeableBalance = () => {
+  const [coin] = useDepositCoin()
+  const balanceQuery = useBalanceQuery(extractAccountCoinKey(coin))
+  const rentReserveQuery = useSolanaRentReserveQuery({
+    enabled: coin.chain === Chain.Solana,
+  })
+
+  const balance = balanceQuery.data ?? 0n
+  const rentReserve = rentReserveQuery.data ?? 0n
+  const reserved = rentReserve + solanaStakingFloorFee
+
+  return {
+    balance,
+    rentReserve,
+    stakeable: balance > reserved ? balance - reserved : 0n,
+  }
+}

--- a/core/ui/vault/deposit/keysignPayload/build.ts
+++ b/core/ui/vault/deposit/keysignPayload/build.ts
@@ -1,4 +1,5 @@
 import { create } from '@bufbuild/protobuf'
+import { getSolanaStakingFee } from '@core/ui/chain/solana/staking/getSolanaStakingFee'
 import { fetchRujiLiquidUnbondInputs } from '@core/ui/defi/chain/queries/services/thorchainStake/rujiStakeService'
 import { buildQBTCDirectPayload } from '@core/ui/qbtc/dapp/buildQBTCDirectPayload'
 import { QbtcDappMessage } from '@core/ui/qbtc/dapp/encodeAnyMessage'
@@ -10,6 +11,7 @@ import {
 import { toBase64 } from '@cosmjs/encoding'
 import { WalletCore } from '@trustwallet/wallet-core'
 import { PublicKey } from '@trustwallet/wallet-core/dist/src/wallet-core'
+import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
 import { toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'
 import {
   Chain,
@@ -40,7 +42,11 @@ import { solanaConfig } from '@vultisig/core-chain/chains/solana/solanaConfig'
 import { fetchSolanaRentReserve } from '@vultisig/core-chain/chains/solana/staking/rpc'
 import { buildUnsignedStakingTx } from '@vultisig/core-chain/chains/solana/staking/tx/buildUnsignedStakingTx'
 import { SolanaStakingPayload } from '@vultisig/core-chain/chains/solana/staking/tx/stakingPayload'
-import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+import {
+  AccountCoin,
+  extractAccountCoinKey,
+} from '@vultisig/core-chain/coin/AccountCoin'
+import { getCoinBalance } from '@vultisig/core-chain/coin/balance'
 import { CoinKey } from '@vultisig/core-chain/coin/Coin'
 import { getDenom } from '@vultisig/core-chain/coin/utils/getDenom'
 import { getChainSpecific } from '@vultisig/core-mpc/keysign/chainSpecific'
@@ -847,6 +853,22 @@ const applySolanaStakingSignData = async ({
   const rentReserve =
     action === 'solana_delegate' ? await fetchSolanaRentReserve() : 0n
 
+  // Floor at the config minimum so co-signers all encode the same
+  // `setComputeUnitPrice` instruction when the wire value is missing.
+  const priorityFeePrice = maxBigInt(
+    priorityFee ? BigInt(priorityFee) : 0n,
+    BigInt(solanaConfig.priorityFeePrice)
+  )
+  const priorityFeeLimit = computeLimit
+    ? Number(computeLimit)
+    : solanaConfig.priorityFeeLimit
+  // Budget against the fee this exact transaction encodes, not the form's
+  // floor-price estimate — the live priority price is only known here.
+  const feeLamports = getSolanaStakingFee({
+    priorityFeePrice,
+    priorityFeeLimit,
+  })
+
   const requireStakeAccount = (): string => {
     if (typeof stakeAccount !== 'string' || stakeAccount.length === 0) {
       throw new Error(`Solana staking '${action}' requires 'stakeAccount'`)
@@ -861,22 +883,33 @@ const applySolanaStakingSignData = async ({
     return validatorAddress
   }
 
-  const { payload, toAddress, toAmount } = match<
+  // `requiredLamports` is what this op costs the WALLET. Only a fresh delegate
+  // moves value out of it (the new stake account's funding); every other op acts
+  // on lamports that already sit on-chain in the stake account, so the wallet
+  // just pays the fee.
+  const { payload, toAddress, toAmount, requiredLamports } = match<
     SolanaStakingAction,
-    { payload: SolanaStakingPayload; toAddress: string; toAmount: string }
+    {
+      payload: SolanaStakingPayload
+      toAddress: string
+      toAmount: string
+      requiredLamports: bigint
+    }
   >(action, {
     solana_delegate: () => {
       const votePubkey = requireValidator()
       // `lamports` is the stake-account FUNDING: the delegated amount plus the
       // rent-exempt reserve, so the active stake equals the entered amount.
+      const funding = amount + rentReserve
       return {
         payload: {
           op: 'delegate',
           votePubkey,
-          lamports: amount + rentReserve,
+          lamports: funding,
         } as const,
         toAddress: votePubkey,
         toAmount: amount.toString(),
+        requiredLamports: funding + feeLamports,
       }
     },
     solana_unstake: () => {
@@ -885,6 +918,7 @@ const applySolanaStakingSignData = async ({
         payload: { op: 'unstake', stakeAccount: account } as const,
         toAddress: account,
         toAmount: '0',
+        requiredLamports: feeLamports,
       }
     },
     solana_withdraw: () => {
@@ -897,6 +931,7 @@ const applySolanaStakingSignData = async ({
         } as const,
         toAddress: account,
         toAmount: amount.toString(),
+        requiredLamports: feeLamports,
       }
     },
     // Move-stake step 1: deactivate the account (byte-identical to a plain
@@ -907,6 +942,7 @@ const applySolanaStakingSignData = async ({
         payload: { op: 'moveStakeDeactivate', stakeAccount: account } as const,
         toAddress: account,
         toAmount: '0',
+        requiredLamports: feeLamports,
       }
     },
     // Move-stake step 2: re-delegate the cooled-down account to validator B. The
@@ -924,9 +960,28 @@ const applySolanaStakingSignData = async ({
         } as const,
         toAddress: votePubkey,
         toAmount: amount.toString(),
+        requiredLamports: feeLamports,
       }
     },
   })
+
+  // Last line of defence before the ceremony. The form bounds the amount, but a
+  // prefilled or stale value can still outrun the live balance, and the priority
+  // price is only pinned here. Without this the devices sign a transaction the
+  // network rejects at simulation ("insufficient lamports"). Mirrors Android
+  // `SolanaStakingSignDataResolver`.
+  const balanceLamports = await getCoinBalance(extractAccountCoinKey(coin))
+  if (requiredLamports > balanceLamports) {
+    throw new Error(
+      `Solana staking '${action}' requires ${fromChainAmount(
+        requiredLamports,
+        coin.decimals
+      )} ${coin.ticker} but the wallet holds ${fromChainAmount(
+        balanceLamports,
+        coin.decimals
+      )} ${coin.ticker}`
+    )
+  }
 
   const rawTransaction = buildUnsignedStakingTx({
     walletCore,
@@ -934,15 +989,8 @@ const applySolanaStakingSignData = async ({
     sender: coin.address,
     hexPublicKey,
     recentBlockHash,
-    // Floor at the config minimum so co-signers all encode the same
-    // `setComputeUnitPrice` instruction when the wire value is missing.
-    priorityFeePrice: maxBigInt(
-      priorityFee ? BigInt(priorityFee) : 0n,
-      BigInt(solanaConfig.priorityFeePrice)
-    ),
-    priorityFeeLimit: computeLimit
-      ? Number(computeLimit)
-      : solanaConfig.priorityFeeLimit,
+    priorityFeePrice,
+    priorityFeeLimit,
   })
 
   return create(KeysignPayloadSchema, {

--- a/core/ui/vault/deposit/utils/getDepositFormConfig.spec.ts
+++ b/core/ui/vault/deposit/utils/getDepositFormConfig.spec.ts
@@ -11,7 +11,7 @@ import { getDepositFormConfig } from './getDepositFormConfig'
  * load in Vitest/Node ESM. Mock until the SDK fixes that internal re-export.
  */
 vi.mock('@vultisig/core-chain/coin/chainFeeCoin', () => ({
-  chainFeeCoin: {},
+  chainFeeCoin: { Solana: { ticker: 'SOL' } },
 }))
 
 vi.mock('@vultisig/core-chain/utils/isValidAddress', () => ({
@@ -150,5 +150,82 @@ describe('TON stake/unstake validation', () => {
       console.error(valid.error.format())
     }
     expect(valid.success).toBe(true)
+  })
+})
+
+/**
+ * `totalAmountAvailable` for a delegate is the STAKEABLE balance (liquid SOL
+ * minus the stake account's rent-exempt reserve and the fee) — see
+ * `useSolanaStakeableBalance`. The schema is what the footer CTA gates on, so an
+ * amount above that ceiling has to fail here or the ceremony signs a transaction
+ * the network rejects at simulation.
+ */
+describe('Solana delegate validation', () => {
+  const solCoin = {
+    chain: Chain.Solana,
+    id: 'SOL',
+    ticker: 'SOL',
+    decimals: 9,
+    address: 'sender',
+  }
+
+  const parseDelegate = ({
+    stakeable,
+    amount,
+  }: {
+    stakeable: number
+    amount: number
+  }) => {
+    const { schema } = getDepositFormConfig({
+      t,
+      coin: solCoin as any,
+      walletCore: {} as any,
+      totalAmountAvailable: stakeable,
+      selectedChainAction: 'solana_delegate',
+    })
+
+    return schema.safeParse({ amount, validatorAddress: 'vote-pubkey' })
+  }
+
+  it('rejects an amount above the stakeable balance', () => {
+    const result = parseDelegate({ stakeable: 1.571, amount: 267 })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues[0]?.message).toBe(
+      'chainFunctions.amountExceeded'
+    )
+  })
+
+  it('rejects a stake of the full balance once rent + fee are reserved', () => {
+    const result = parseDelegate({ stakeable: 9.997, amount: 10 })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues[0]?.message).toBe(
+      'chainFunctions.amountExceeded'
+    )
+  })
+
+  it('rejects an amount below the 1 SOL program minimum', () => {
+    const result = parseDelegate({ stakeable: 10, amount: 0.5 })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues[0]?.message).toBe(
+      'solana_staking_min_delegation'
+    )
+  })
+
+  it('accepts a stake of the whole stakeable balance', () => {
+    expect(parseDelegate({ stakeable: 9.997, amount: 9.997 }).success).toBe(
+      true
+    )
+  })
+
+  it('reports insufficient balance when nothing is stakeable', () => {
+    const result = parseDelegate({ stakeable: 0, amount: 1 })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues.map(issue => issue.message)).toContain(
+      'insufficient_balance'
+    )
   })
 })

--- a/core/ui/vault/deposit/utils/getFieldErrorMessage.ts
+++ b/core/ui/vault/deposit/utils/getFieldErrorMessage.ts
@@ -1,0 +1,13 @@
+import { FieldErrors } from 'react-hook-form'
+
+/**
+ * Reads a field's validation message off `formState.errors`. The deposit form is
+ * typed `Record<string, any>`, so react-hook-form widens `message` to cover
+ * nested error shapes — only a plain string is renderable. Messages come out of
+ * `getDepositFormConfig` already translated.
+ */
+export const getFieldErrorMessage = (errors: FieldErrors, name: string) => {
+  const message = errors[name]?.message
+
+  return typeof message === 'string' ? message : undefined
+}


### PR DESCRIPTION
Closes #4448

## Problem

Staking SOL signed fine but the network rejected it at simulation:

```
Transaction simulation failed. insufficient lamports 1573589522, need 267002282880
```

The transaction encoded "delegate 267 SOL" correctly — the amount was simply never checked against the ~1.57 SOL balance before signing. The form schema does `.max(balance)`, but `SolanaStakingFooterButton` gated only on `amountSet` (> 0) and a locally re-derived 1 SOL floor, so `formState` never reached the button. The over-balance error was not rendered anywhere either, and there was no guard at the sign-data layer.

There was a second gap behind it: the bound itself was wrong. A delegate spends `amount + rentReserve + fee`, so even with the CTA fixed a max-sized stake would still be signed and rejected. The form's reserve subtracted only `baseFee` (5,000 lamports), ignoring the ~100,000-lamport prioritization fee `buildUnsignedStakingTx` always attaches.

## Changes

**Ceiling.** New `useSolanaStakeableBalance` is the single source for `balance − rentReserve − fee`, feeding the displayed max, the percentage pills and the schema bound, so all three agree to the lamport. `useDepositBalance` returns it for `solana_delegate`, so both `getDepositFormConfig`'s `.max()` and the form's re-validate effect track it. New `getSolanaStakingFee` computes base + prioritization fee, ceil-rounded like the runtime.

**CTA.** `SolanaStakingFooterButton` now reads `formState`: an `errors.amount` renders that message on a disabled button, and Continue is `disabled={!isValid}`. The locally re-derived min-delegation check is gone — the schema is the one source, so the two can no longer drift.

**Visibility.** `SolanaDelegateSpecific` renders `errors.amount` under the amount input.

**Pre-sign guard.** `applySolanaStakingSignData` computes `requiredLamports` per op — delegate pays funding + fee, every other op only the fee since its lamports already sit on-chain — and throws if it exceeds the live balance. It budgets against the fee *this* transaction encodes, since the live priority price is only pinned there. Mirrors the Android `SolanaStakingSignDataResolver`, extended to all five ops.

**Coin correction.** Found while wiring the guard: `solana_delegate` is reachable from the Function picker with an SPL token selected (`chainActionsRecord[Chain.Solana]` is chain-gated), which would bind the form — and the guard — to a token's balance and decimals. The five Solana staking actions now correct to the native coin, following the existing `add_thor_lp` precedent in `useCorrectSelectedCoin`.

## Testing

- `yarn check` clean; `yarn test` 526/526
- `tsc -b` in `clients/extension` clean (ES2021 lib — shared `core/ui` changes can pass root typecheck and fail there)
- 5 new delegate cases in `getDepositFormConfig.spec.ts`, including the reported 267-SOL-on-1.57-SOL case and the full-balance case, plus a `getSolanaStakingFee` suite

## Manual check

Fast Vault on Solana, Stake screen:

- [ ] typing an amount above the stakeable balance shows the error under the input and leaves the CTA disabled
- [ ] the Max pill fills the stakeable balance and Continue stays enabled
- [ ] an amount below 1 SOL still shows the minimum-delegation hint
- [ ] "Balance available" equals balance − rent reserve − fee
- [ ] entering Stake from an SPL token screen shows SOL, not the token


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Solana staking balance calculations by reserving rent and transaction fees automatically.
  * Added accurate Solana staking fee estimation, including priority fees.
  * Added clearer validation messages for invalid delegation amounts.
  * Added final balance checks before submitting Solana staking transactions.
  * Native SOL is now selected automatically when required for staking fees.

* **Bug Fixes**
  * Prevented staking amounts from exceeding the available stakeable balance.
  * Improved handling of Solana minimum delegation and insufficient-balance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->