### PR TITLE
fix(vaults): make the folder active-vault subtitle translatable

### DIFF
--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -1764,4 +1764,5 @@ export const de = {
   nothing_to_add_hint_secondary:
     'Erstellen Sie einen neuen Tresor, um ihn hier hinzuzufügen.',
   no_results_found: 'Keine Ergebnisse gefunden',
+  folder_active_vault: '„{{name}}“ Aktiv',
 }

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -483,6 +483,7 @@ export const en = {
   fast_sign: 'Fast Sign',
   fill_the_form: 'Fill the form',
   find_custom_token: 'Find custom token',
+  folder_active_vault: '‘{{name}}’ Active',
   folder_name: 'Folder name',
   folder_name_already_exists: 'That folder name already exists. Try a new one.',
   folder_name_required: 'Folder name is required',

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -1748,4 +1748,5 @@ export const es = {
   edit_folder: 'Editar carpeta',
   nothing_to_add_hint_secondary: 'Crea una nueva bóveda para agregarlo aquí.',
   no_results_found: 'No se encontraron resultados',
+  folder_active_vault: '«{{name}}» Activo',
 }

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -1721,4 +1721,5 @@ export const hr = {
   nothing_to_add_hint_secondary:
     'Izradite novi trezor da biste ga dodali ovdje.',
   no_results_found: 'Nisu pronađeni rezultati',
+  folder_active_vault: '„{{name}}“ Aktivno',
 }

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -1754,4 +1754,5 @@ export const it = {
   edit_folder: 'Modifica cartella',
   nothing_to_add_hint_secondary: 'Crea un nuovo vault per aggiungerlo qui.',
   no_results_found: 'Nessun risultato trovato',
+  folder_active_vault: '«{{name}}» Attivo',
 }

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -1712,4 +1712,5 @@ export const ko = {
   edit_folder: '폴더 편집',
   nothing_to_add_hint_secondary: '여기에 추가하려면 새 볼트를 생성하세요.',
   no_results_found: '검색 결과가 없습니다.',
+  folder_active_vault: '‘{{name}}’ 활성',
 }

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -1732,4 +1732,5 @@ export const nl = {
   nothing_to_add_hint_secondary:
     'Maak een nieuwe kluis aan om deze hier toe te voegen.',
   no_results_found: 'Geen resultaten gevonden',
+  folder_active_vault: '‘{{name}}’ Actief',
 }

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -1750,4 +1750,5 @@ export const pt = {
   edit_folder: 'Pasta de edição',
   nothing_to_add_hint_secondary: 'Crie um novo cofre para adicioná-lo aqui.',
   no_results_found: 'Nenhum resultado encontrado',
+  folder_active_vault: '“{{name}}” Ativo',
 }

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -1729,4 +1729,5 @@ export const ru = {
   nothing_to_add_hint_secondary:
     'Создайте новое хранилище, чтобы добавить его сюда.',
   no_results_found: 'Результаты не найдены',
+  folder_active_vault: '«{{name}}» Активен',
 }

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -1608,4 +1608,5 @@ export const zh = {
   edit_folder: '编辑文件夹',
   nothing_to_add_hint_secondary: '创建一个新的保险库，将其添加到这里。',
   no_results_found: '未找到结果',
+  folder_active_vault: '“{{name}}”已激活',
 }

--- a/core/ui/vaultsOrganisation/index.tsx
+++ b/core/ui/vaultsOrganisation/index.tsx
@@ -17,6 +17,7 @@ import {
 } from '@core/ui/vaultsOrganisation/components'
 import { useVaultsTotalBalances } from '@core/ui/vaultsOrganisation/hooks/useVaultsTotalBalances'
 import { IconButton } from '@lib/ui/buttons/IconButton'
+import { CheckIcon } from '@lib/ui/icons/CheckIcon'
 import { ChevronRightIcon } from '@lib/ui/icons/ChevronRightIcon'
 import { FolderIcon } from '@lib/ui/icons/FolderIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
@@ -29,9 +30,11 @@ import { PageContent } from '@lib/ui/page/PageContent'
 import { PageHeader } from '@lib/ui/page/PageHeader'
 import { OnFinishProp } from '@lib/ui/props'
 import { Text } from '@lib/ui/text'
+import { getColor } from '@lib/ui/theme/getters'
 import { getVaultId } from '@vultisig/core-mpc/vault/Vault'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
 
 import { useCore } from '../state/core'
 
@@ -227,9 +230,16 @@ export const VaultsPage = ({ onFinish }: Partial<OnFinishProp>) => {
         {displayedFolders.length > 0 && (
           <VStack gap={12}>
             {displayedFolders.map(folder => {
-              const subtitle = folder.activeVaultName
-                ? `✓ '${folder.activeVaultName}' ${t('active')}`
-                : t('vault_count', { count: folder.vaultCount })
+              const subtitle = folder.activeVaultName ? (
+                <ActiveVaultSubtitle>
+                  <IconWrapper size={14}>
+                    <CheckIcon />
+                  </IconWrapper>
+                  {t('folder_active_vault', { name: folder.activeVaultName })}
+                </ActiveVaultSubtitle>
+              ) : (
+                t('vault_count', { count: folder.vaultCount })
+              )
 
               return (
                 <VaultListRow
@@ -241,16 +251,7 @@ export const VaultsPage = ({ onFinish }: Partial<OnFinishProp>) => {
                     </LeadingIconBadge>
                   }
                   title={folder.name}
-                  subtitle={
-                    <Text
-                      size={13}
-                      weight={500}
-                      color={folder.activeVaultName ? 'info' : 'shy'}
-                      cropped
-                    >
-                      {subtitle}
-                    </Text>
-                  }
+                  subtitle={subtitle}
                   trailing={
                     <IconWrapper size={18} color="textShy">
                       <ChevronRightIcon />
@@ -318,3 +319,10 @@ export const VaultsPage = ({ onFinish }: Partial<OnFinishProp>) => {
     </VStack>
   )
 }
+
+const ActiveVaultSubtitle = styled.span`
+  align-items: center;
+  color: ${getColor('info')};
+  display: inline-flex;
+  gap: 4px;
+`


### PR DESCRIPTION
Closes #4451.

## Problem

The folder row on the Vaults list built its active-vault subtitle by gluing literal characters onto a single translated word:

```tsx
const subtitle = folder.activeVaultName
  ? `✓ '${folder.activeVaultName}' ${t('active')}`
  : t('vault_count', { count: folder.vaultCount })
```

Three defects in one expression:

- **The checkmark was a text character**, outside the icon system — its size and colour were whatever the font produced.
- **The quotation marks were hardcoded ASCII apostrophes**, which is wrong typography in most shipped locales.
- **Word order was locked in code.** A translator received only the trailing adjective and could not move it, change the quotes, or close the space before it. In Korean the row rendered as an ASCII-quoted name followed by `활성` with a Latin space.

None of this is visible in the English build, which is why it survived the folder-area review.

## Change

- New interpolated key `folder_active_vault` carries the complete phrase, quotation marks included, so each locale owns its own punctuation and word order.
- The checkmark is now a `CheckIcon` in an `IconWrapper`.
- The shared `active` key is untouched — it is a standalone adjective used by three unrelated screens.

Locale values use the quotation marks each language actually uses: guillemets for `es` / `it` / `ru`, low-high for `de` / `hr`, curly for `nl` / `pt` / `ko`, and full-width for `zh` with no space before the state word. Native review welcome.

## Also fixed

`VaultListRow` already wraps `subtitle` in a `Text`, which is a `p`. The old caller passed another `Text` into it, nesting a paragraph inside a paragraph. The replacement is an inline `span`, valid inside that paragraph — which is also why this uses a `span` rather than an `HStack`.

## Note — the nine locale values were authored by hand

`yarn translate` cannot produce them. The pipeline sends `mimeType: 'text/html'` and never decodes the response, so every apostrophe comes back as `&#39;`:

```
de  folder_active_vault: '&#39; {{name}} &#39; Aktiv',
ko  folder_active_vault: '&#39; {{name}} &#39; 활성',
```

The HTML mode is deliberate — placeholder sentinels are protected with `<span class="notranslate">`, which only works in HTML mode — so the fix is the missing decode step on the way back, not dropping the mode.

This is **pre-existing and already shipped**: 47 strings on `main` carry the same corruption, e.g. `it` renders `L&#39;approvazione scade` and `ko` renders `&#39;{{title}}&#39; 앱을 설치하세요`. Being tracked separately; it is not introduced by this PR.

## Verification

- `yarn check` green: typecheck 0, lint 0, i18n integrity passed, i18n quality review 0 strict blockers, knip 0.
- The one `knip` failure seen locally came from local SDK tarball overrides in `package.json`; with those set aside `knip` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)