### PR TITLE
fix(receive): drop chain badge on QR icon, restyle Share button

### DIFF
--- a/core/ui/vault/chain/address/AddressQRCard.tsx
+++ b/core/ui/vault/chain/address/AddressQRCard.tsx
@@ -1,5 +1,5 @@
 import { ChainEntityIcon } from '@core/ui/chain/coin/icon/ChainEntityIcon'
-import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
+import { getCoinLogoSrc } from '@core/ui/chain/coin/icon/utils/getCoinLogoSrc'
 import { getChainLogoSrc } from '@core/ui/chain/metadata/getChainLogoSrc'
 import { useCore } from '@core/ui/state/core'
 import { VaultAddressCopyToast } from '@core/ui/vault/page/components/VaultAddressCopyToast'
@@ -105,15 +105,7 @@ const ButtonsRow = styled(HStack)`
 const ShareButton = styled(Button)`
   flex: 1;
   border-radius: 40px;
-  border: 2px solid ${({ theme }) => theme.colors.buttonPrimary.toCssValue()};
-  background: transparent;
-  color: ${getColor('contrast')};
   font-size: 14px;
-
-  &:hover {
-    background: ${({ theme }) =>
-      theme.colors.buttonPrimary.withAlpha(0.1).toCssValue()};
-  }
 `
 
 const CopyButton = styled(Button)`
@@ -219,11 +211,11 @@ export const AddressQRCard = ({
             level="H"
           />
           <ChainIconOverlay>
-            {coin?.logo ? (
-              <CoinIcon coin={coin} />
-            ) : (
-              <ChainEntityIcon value={getChainLogoSrc(chain)} />
-            )}
+            <ChainEntityIcon
+              value={
+                coin?.logo ? getCoinLogoSrc(coin.logo) : getChainLogoSrc(chain)
+              }
+            />
           </ChainIconOverlay>
         </QRWrapper>
         <ReceiveLabel>
@@ -238,7 +230,9 @@ export const AddressQRCard = ({
       </AddressText>
 
       <ButtonsRow>
-        <ShareButton onClick={handleShare}>{t('share')}</ShareButton>
+        <ShareButton kind="secondary" onClick={handleShare}>
+          {t('share')}
+        </ShareButton>
         <CopyButton onClick={handleCopy}>{t('copy_address')}</CopyButton>
       </ButtonsRow>
     </Container>


### PR DESCRIPTION
Closes #4457 — sub-issue of #4422 (design-verification sweep against the current Figma).

## Problem

Two deltas between the Receive (address QR) modal and Figma:

1. **Chain badge on the QR center icon.** The icon rendered via `CoinIcon`, which wraps non-fee coins in `WithChainIcon` (`shouldDisplayChainLogo`) and overlays a chain badge — so USDC on Ethereum showed an Ethereum badge. Figma shows the token logo alone.
2. **Share button.** It was a bespoke transparent button with a 2px `buttonPrimary` border. Figma shows a filled dark-navy surface, no accent border, and only a very faint hairline that reads like a shadow.

## Changes

Both in `core/ui/vault/chain/address/AddressQRCard.tsx`.

**Chain badge** — render `ChainEntityIcon` with the coin logo directly, so the badge wrapper is never reached:

```tsx
<ChainEntityIcon
  value={coin?.logo ? getCoinLogoSrc(coin.logo) : getChainLogoSrc(chain)}
/>
```

`CoinIcon` / `WithChainIcon` are untouched — other call sites still want the badge.

**Share button** — the designed treatment is already exactly what the shared `Button` encodes as `kind="secondary"`, so the hand-rolled overrides are dropped in favour of it:

| Requirement | Result |
|---|---|
| No border | `border: 2px solid buttonPrimary` removed |
| Figma fill | `buttonSecondary` → `rgb(17, 40, 75)` (`#11284B`) |
| Faint shadow-like hairline | `1px solid rgba(255, 255, 255, 0.03)` |

Net: 9 insertions, 15 deletions.

## Verification

- `yarn check` green (typecheck + lint + knip + i18n).
- `yarn build:extension` green — all four chunks, brand assertion passed.
- Button treatment verified in a real browser via the `Foundation/Button` Storybook story: the computed values in the table above are measured from the rendered DOM, not read off the source.

Not verified end-to-end: the modal itself wasn't rendered in-app — it depends on WalletCore and a real vault, so it won't mount in Storybook without mocks. The button styling was checked visually; the badge removal follows directly from `CoinIcon`'s implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the address QR card icon to use the coin logo when available, with a chain logo fallback.
  * Refined the share button’s appearance for a cleaner secondary style.
  * Preserved the existing share functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->