### PR TITLE
fix(new-vault): center import modal title, rename Next to Get started

### DIFF
--- a/clients/extension/tests/e2e/page-objects/OnboardingPage.po.ts
+++ b/clients/extension/tests/e2e/page-objects/OnboardingPage.po.ts
@@ -37,8 +37,12 @@ export class OnboardingPage extends BasePage {
   }
 
   get getStartedButton(): Locator {
-    // This is actually "Next" in the UI, but some screens have "Get Started"
+    // Some onboarding screens label the primary button "Next" instead
     return this.page.getByRole('button', { name: /get.*started|next/i }).first()
+  }
+
+  get newVaultGetStartedButton(): Locator {
+    return this.page.getByTestId('new-vault-get-started')
   }
 
   get importVaultButton(): Locator {
@@ -132,34 +136,35 @@ export class OnboardingPage extends BasePage {
 
   /**
    * Check if vault type selection is visible (after onboarding)
-   * The NewVaultPage shows: "vultisig", "Scan QR", "Import", "Next" buttons
+   * The NewVaultPage shows: "vultisig", "Scan QR", "Import", "Get started" buttons
    */
   async isVaultTypeSelectionVisible(): Promise<boolean> {
     // After onboarding, user sees NewVaultPage with these options
-    const hasNext = await this.page.getByRole('button', { name: /next/i }).isVisible()
+    const hasGetStarted = await this.newVaultGetStartedButton.isVisible()
     const hasImport = await this.page.getByRole('button', { name: /import/i }).isVisible()
     const hasScanQr = await this.page.getByRole('button', { name: /scan.*qr/i }).isVisible()
 
-    return hasNext || hasImport || hasScanQr
+    return hasGetStarted || hasImport || hasScanQr
   }
 
   /**
-   * Check if we're on the SetupVaultPage (after clicking Next from NewVaultPage)
+   * Check if we're on the SetupVaultPage (after leaving NewVaultPage)
    * SetupVaultPage shows device selection animation and "Get Started" button
    */
   async isSetupVaultVisible(): Promise<boolean> {
     const hasGetStarted = await this.page.getByRole('button', { name: /get.*started/i }).isVisible()
-    return hasGetStarted
+    const hasDeviceAnimation = await this.page.locator('canvas').first().isVisible()
+    return hasGetStarted && hasDeviceAnimation
   }
 
   /**
    * Navigate through NewVaultPage to SetupVaultPage
    */
   async navigateToSetupVault(): Promise<void> {
-    // From NewVaultPage, click Next to go to SetupVaultPage
-    const nextButton = this.page.getByRole('button', { name: /next/i }).first()
-    if (await nextButton.isVisible()) {
-      await nextButton.click()
+    // Both NewVaultPage and SetupVaultPage label their primary button
+    // "Get started", so target the NewVaultPage one by test id.
+    if (await this.newVaultGetStartedButton.isVisible()) {
+      await this.newVaultGetStartedButton.click()
       await this.page.waitForTimeout(500)
     }
   }

--- a/clients/extension/tests/e2e/page-objects/OnboardingPage.po.ts
+++ b/clients/extension/tests/e2e/page-objects/OnboardingPage.po.ts
@@ -213,11 +213,10 @@ export class OnboardingPage extends BasePage {
     const options: string[] = []
 
     // From NewVaultPage
-    const nextButton = this.page.getByRole('button', { name: /next/i }).first()
     const importButton = this.page.getByRole('button', { name: /import/i }).first()
     const scanQrButton = this.page.getByRole('button', { name: /scan.*qr/i }).first()
 
-    if (await nextButton.isVisible()) options.push('create')
+    if (await this.newVaultGetStartedButton.isVisible()) options.push('create')
     if (await importButton.isVisible()) options.push('import')
     if (await scanQrButton.isVisible()) options.push('scan')
 

--- a/clients/extension/tests/e2e/specs/onboarding.spec.ts
+++ b/clients/extension/tests/e2e/specs/onboarding.spec.ts
@@ -7,7 +7,7 @@
  * 1. Loading/splash screen (shows just logo)
  * 2. OnboardingPage - Shows "vultisig" logo/text, onboarding slides, Next/Skip buttons
  *    OR
- * 2. NewVaultPage - Shows "vultisig" logo, Scan QR, Import, Next buttons (if onboarding completed)
+ * 2. NewVaultPage - Shows "vultisig" logo, Scan QR, Import, Get started buttons (if onboarding completed)
  * 3. SetupVaultPage - Shows device selection animation, Get Started button
  */
 
@@ -87,7 +87,7 @@ test.describe('Onboarding Flow', () => {
     // Now should be on NewVaultPage with these options:
     // - "Scan QR" button
     // - "Import" button  
-    // - "Next" button (to create new vault)
+    // - "Get started" button (to create new vault)
     
     const options = await onboardingPage.getVaultTypeOptions()
     

--- a/core/ui/vault/new/ImportOptionModal.tsx
+++ b/core/ui/vault/new/ImportOptionModal.tsx
@@ -14,7 +14,11 @@ export const ImportOptionModal = ({ onClose }: OnCloseProp) => {
   const navigate = useCoreNavigate()
 
   return (
-    <Modal onClose={onClose} title={t('recover_vault_or_convert_seedphrase')}>
+    <Modal
+      onClose={onClose}
+      title={t('recover_vault_or_convert_seedphrase')}
+      titleAlign="center"
+    >
       <VStack gap={14}>
         <ImportOption
           badge={<NewBadge />}

--- a/core/ui/vault/new/index.tsx
+++ b/core/ui/vault/new/index.tsx
@@ -93,8 +93,11 @@ export const NewVaultPage = () => {
             </Button>
             <ImportVaultButton />
           </UniformColumnGrid>
-          <Button onClick={() => navigate({ id: 'setupVault', state: {} })}>
-            {t('next')}
+          <Button
+            data-testid="new-vault-get-started"
+            onClick={() => navigate({ id: 'setupVault', state: {} })}
+          >
+            {t('get_started')}
           </Button>
         </VStack>
       </PageFooter>

--- a/lib/ui/modal/index.tsx
+++ b/lib/ui/modal/index.tsx
@@ -1,4 +1,3 @@
-import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { toSizeUnit } from '@lib/ui/css/toSizeUnit'
 import { BodyPortal } from '@lib/ui/dom/BodyPortal'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -6,6 +5,7 @@ import { AsProp, TitleProp } from '@lib/ui/props'
 import { ComponentProps, CSSProperties, ReactNode } from 'react'
 import styled from 'styled-components'
 
+import { sameDimensions } from '../css/sameDimensions'
 import { Backdrop } from './Backdrop'
 import { modalConfig } from './config'
 import { ModalCloseButton } from './ModalCloseButton'

--- a/lib/ui/modal/index.tsx
+++ b/lib/ui/modal/index.tsx
@@ -1,3 +1,4 @@
+import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { toSizeUnit } from '@lib/ui/css/toSizeUnit'
 import { BodyPortal } from '@lib/ui/dom/BodyPortal'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -28,6 +29,14 @@ export type ModalProps = AsProp &
   }
 
 const contentVerticalPadding = 8
+
+const closeButtonSize = 24
+
+// Balances the close button so a centered title sits on the modal's true center
+const CloseButtonBalancer = styled.div`
+  ${sameDimensions(closeButtonSize)};
+  flex-shrink: 0;
+`
 
 const Container = styled(ModalContainer)`
   > * {
@@ -66,6 +75,9 @@ export const Modal = ({
                 justifyContent="space-between"
                 gap={16}
               >
+                {titleAlign === 'center' && onClose ? (
+                  <CloseButtonBalancer />
+                ) : null}
                 <ModalTitleText align={titleAlign}>{title}</ModalTitleText>
                 {onClose && (
                   <ModalCloseButton


### PR DESCRIPTION
Closes #4465

Design reference: https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=67840-108535&t=gYnAVTwPeEbmRBp2-0

## What

Two small deviations from the Figma design on the new-vault entry flow.

### 1. Import options modal title is now centered

`ImportOptionModal` rendered **"Recover your vault or convert your seedphrase to a vault"** left-aligned; the design centers it. `Modal` already had a `titleAlign` prop, so the screen just passes `titleAlign="center"`.

The modal header is an `HStack` holding the title and the close button, so a centered title would have been optically pushed ~20px left by the button's width plus gap. `lib/ui/modal` now renders a same-size balancer opposite the close button **only** when `titleAlign === 'center'`, so the title sits on the card's true center. No existing modal uses `titleAlign="center"` in production, so nothing else changes.

### 2. New-vault primary button reads "Get started"

`t('next')` → the existing `t('get_started')` key. No new translation key, so no `yarn translate` run needed.

Because the following `SetupVaultPage` also labels its primary button "Get started", the button carries a `data-testid="new-vault-get-started"` and the extension e2e page object targets it by test id instead of by accessible name — otherwise `navigateToSetupVault()` would have become ambiguous. `isSetupVaultVisible()` now also requires the device-selection canvas for the same reason.

## Test plan

- [x] `yarn check` — typecheck, lint, i18n integrity, knip all clean
- [x] `yarn test` — 590 tests passing
- [ ] Manual: new-vault screen shows "Get started" and still navigates to setup-vault
- [ ] Manual: Import modal title is centered; other modals keep left-aligned titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the vault setup action label to “Get started” for clearer onboarding guidance.
  * Improved modal title alignment when centered titles and close buttons are displayed together.

* **Bug Fixes**
  * Improved onboarding flow detection and navigation for the new vault setup experience.
  * Updated end-to-end coverage to recognize the revised onboarding controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->