### PR TITLE
chore: declare cross-platform parity in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,26 @@ Fixes #<issue-number>
 - [ ] Swap - Please attach a tx link for the swap here
 - [ ] New Chain / Chain related feature  -  Please attach tx link here
 
+## Parity
+
+<!-- REQUIRED if you ticked Sending, Swap, or New Chain above, or touched keysign,
+     broadcast, or fee computation. Delete this section otherwise.
+
+     One verdict per surface:
+       linked: <repo>#<n>  sibling issue already exists — link it above
+       filed:  <repo>#<n>  sibling filed as part of this PR
+       n/a:    <reason>    genuinely platform-specific (storage migration, service worker, ...)
+       first:  <surface>   first implementation anywhere — name the surface so the other
+                           platforms' tickets can be raised from it
+
+     A fix that lands on one platform and nowhere else is how the same bug ships three times.
+     A superseded fix that stays uncited is how the wrong shape gets copied into the next app.
+-->
+
+- iOS:
+- Android:
+- SDK:
+
 ## Checklist
 
 - [ ] I have performed a self-review of my code


### PR DESCRIPTION
## What

Adds a `## Parity` section to the PR template, directly under the existing "Which feature is affected?" checkboxes. It asks for one verdict per sibling surface when a change touches a shared behavioural surface — send, swap, keysign, broadcast, or fee computation.

```
- <other platforms>:
```

Each line resolves to one of:

| Verdict | Meaning |
| --- | --- |
| `linked: <repo>#<n>` | Sibling issue already exists — link it |
| `filed: <repo>#<n>` | Sibling filed as part of this PR |
| `n/a: <reason>` | Genuinely platform-specific |
| `first: <surface>` | First implementation anywhere — name the surface so the other platforms' tickets can be raised from it |

## Why

A fix that lands on one platform and nowhere else is how the same bug ships three times. We have live examples across the current sprint:

- **RUJI staking positions.** iOS fixed the bonded-vs-auto-compound split in vultisig-ios#4865. Windows had already corrected itself. Android still reads a single collapsed position and shows `0` to every bonded-only staker — and its source comment cites `vultisig-windows#4337`, the *superseded* Windows fix, as its model. Filed as vultisig-android#5419.
- **Swap slippage.** iOS and Android send a spot-anchored `tolerance_bps` that is unusable; Windows sends `liquidity_tolerance_bps` (vultisig-ios#4838).
- **Max / percentage decimals.** Shipped on iOS (#4835), still open on Android (#5318) and Windows (#4390).
- **Sui coin selection.** Ported to Android (#5252) days after iOS (#4734).

The second failure mode is the one the RUJI case actually demonstrates, and it is why `first:` requires naming the surface rather than being a free bypass: the risk is not only a forgotten port, it is a corrected-elsewhere fix that stays uncited, so the next platform copies a shape that is already known to be wrong.

## Scope

Convention only — **no CI gate**. This is tier 1 of a deliberate two-step: see whether the block gets filled in before deciding whether to enforce it. Additive to the template; no existing lines changed.

## receipts

- `.github/PULL_REQUEST_TEMPLATE.md` — one additive section, 20 lines, inserted before `## Checklist`
- Sibling PRs opened simultaneously on the other three repos (linked below) so the convention lands as one change, not four stray doc edits
- Trigger deliberately reuses the template's existing Sending / Swap / New Chain checkboxes rather than introducing new taxonomy
- No behavioural code touched — **no runtime changes**, nothing to test

## Sibling PRs

Same convention, landing together:

- vultisig/vultisig-ios#4933
- vultisig/vultisig-android#5422
- vultisig/vultisig-windows#4468 ← this PR
- vultisig/vultisig-sdk#1589
