### PR TITLE
feat(swap, send): label native assets in the coin selector

### DIFF
--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -1799,4 +1799,5 @@ export const de = {
   swap_limit_warning_far_above_market:
     'Dieser Preis liegt weit über dem Marktpreis und es besteht die Möglichkeit, dass die Transaktion ungenutzt verfällt.',
   chain_address_copied: 'Adresse {{chain}} kopiert',
+  native: 'Nativ',
 }

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -652,6 +652,7 @@ export const en = {
   more_coming_soon: 'More coming soon',
   name: 'Name',
   name_your_vault: 'Name your vault',
+  native: 'Native',
   network: 'Network',
   network_fee: 'Network Fee',
   network_rate: 'Network rate',

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -1782,4 +1782,5 @@ export const es = {
   swap_limit_warning_far_above_market:
     'Este precio está muy por encima del precio de mercado y podría expirar sin que se complete la transacción.',
   chain_address_copied: 'Dirección {{chain}} copiada',
+  native: 'Nativo',
 }

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -1755,4 +1755,5 @@ export const hr = {
   swap_limit_warning_far_above_market:
     'Ova cijena je daleko iznad tržišne i mogla bi isteći ako se ne iskoristi',
   chain_address_copied: 'Adresa {{chain}} kopirana',
+  native: 'Izvorni',
 }

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -1788,4 +1788,5 @@ export const it = {
   swap_limit_warning_far_above_market:
     "Questo prezzo è di gran lunga superiore a quello di mercato e l'offerta potrebbe scadere senza che l'ordine venga evaso.",
   chain_address_copied: 'Indirizzo {{chain}} copiato',
+  native: 'Nativo',
 }

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -1746,4 +1746,5 @@ export const ko = {
   swap_limit_warning_far_above_market:
     '이 가격은 시장가보다 훨씬 높으며, 거래가 성사되지 않고 만료될 가능성이 있습니다.',
   chain_address_copied: '{{chain}} 주소가 복사되었습니다.',
+  native: '네이티브',
 }

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -1766,4 +1766,5 @@ export const nl = {
   swap_limit_warning_far_above_market:
     'Deze prijs ligt ver boven de marktwaarde en de transactie kan onvervuld blijven.',
   chain_address_copied: '{{chain}} adres gekopieerd',
+  native: 'Native',
 }

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -1785,4 +1785,5 @@ export const pt = {
   swap_limit_warning_far_above_market:
     'Este preço está muito acima do mercado e pode expirar sem ser atendido.',
   chain_address_copied: 'Endereço {{chain}} copiado',
+  native: 'Nativo',
 }

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -1763,4 +1763,5 @@ export const ru = {
   swap_limit_warning_far_above_market:
     'Эта цена значительно выше рыночной и может остаться нереализованной.',
   chain_address_copied: 'Адрес {{chain}} скопирован',
+  native: 'Нативный',
 }

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -1636,4 +1636,5 @@ export const zh = {
   swap_limit_warning_far_above_market:
     '这个价格远高于市场价，而且可能最终无法成交。',
   chain_address_copied: '{{chain}}地址已复制',
+  native: '原生',
 }

--- a/core/ui/vault/send/components/SendCoinInputField/index.tsx
+++ b/core/ui/vault/send/components/SendCoinInputField/index.tsx
@@ -6,6 +6,7 @@ import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { ValueProp } from '@lib/ui/props'
 import { Text } from '@lib/ui/text'
 import { Coin } from '@vultisig/core-chain/coin/Coin'
+import { isFeeCoin } from '@vultisig/core-chain/coin/utils/isFeeCoin'
 import { useTranslation } from 'react-i18next'
 
 import { getChainLogoSrc } from '../../../../chain/metadata/getChainLogoSrc'
@@ -65,10 +66,17 @@ export const SendCoinInputField = ({
           data-testid="coin-selector-trigger"
         >
           <CoinIcon coin={value} style={{ fontSize: 32 }} />
-          <HStack gap={4}>
-            <Text weight="500" size={16} color="contrast">
-              {value.ticker}
-            </Text>
+          <HStack gap={4} alignItems="center">
+            <VStack gap={2}>
+              <Text weight="500" size={16} color="contrast">
+                {value.ticker}
+              </Text>
+              {isFeeCoin(value) ? (
+                <Text weight="500" size={12} color="shy">
+                  {t('native')}
+                </Text>
+              ) : null}
+            </VStack>
             <ChevronRightIcon />
           </HStack>
         </CoinWrapper>

--- a/core/ui/vault/swap/components/SwapCoinInputField/index.tsx
+++ b/core/ui/vault/swap/components/SwapCoinInputField/index.tsx
@@ -5,10 +5,11 @@ import { ManageFromAmount } from '@core/ui/vault/swap/form/amount/ManageFromAmou
 import { ToAmount } from '@core/ui/vault/swap/form/amount/ToAmount'
 import { ChevronDownIcon } from '@lib/ui/icons/ChevronDownIcon'
 import { ChevronRightIcon } from '@lib/ui/icons/ChevronRightIcon'
-import { HStack } from '@lib/ui/layout/Stack'
+import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { ValueProp } from '@lib/ui/props'
 import { Text } from '@lib/ui/text'
 import { Coin } from '@vultisig/core-chain/coin/Coin'
+import { isFeeCoin } from '@vultisig/core-chain/coin/utils/isFeeCoin'
 import { match } from '@vultisig/lib-utils/match'
 import { useTranslation } from 'react-i18next'
 
@@ -77,10 +78,17 @@ export const SwapCoinInputField = ({
           data-testid={`swap-${side}-coin-selector`}
         >
           <CoinIcon coin={value} style={{ fontSize: 32 }} />
-          <HStack gap={4}>
-            <Text weight="500" size={16} color="contrast">
-              {value.ticker}
-            </Text>
+          <HStack gap={4} alignItems="center">
+            <VStack gap={2}>
+              <Text weight="500" size={16} color="contrast">
+                {value.ticker}
+              </Text>
+              {isFeeCoin(value) ? (
+                <Text weight="500" size={12} color="shy">
+                  {t('native')}
+                </Text>
+              ) : null}
+            </VStack>
             <ChevronRightIcon />
           </HStack>
         </CoinWrapper>


### PR DESCRIPTION
## Description

The swap and send asset pickers rendered only the ticker, so a chain's native asset looked identical to a contract token on the same chain. iOS and Android render **Native** as a sub-label under the ticker for native assets, and nothing for tokens. This brings desktop and the extension to parity.

Two things worth calling out:

**Swap: one site covers both tabs.** `ManageFromCoin` / `ManageToCoin` (market) and `LimitManageFromCoin` / `LimitManageToCoin` (limit) all render `SwapCoinInput`, which renders `SwapCoinInputField` — the rounded coin pill. Adding the sub-label there covers from **and** to on **both** the market and limit tabs from a single change.

**Native detection reuses the existing predicate.** `isFeeCoin` (`coin => !coin.id`) from `@vultisig/core-chain` is already the app's source of truth for this distinction — it is what `shouldDisplayChainLogo` uses to decide which pills get a chain badge, which is why RUNE has no badge and USDC does. No new native-detection path was introduced.

Layout-wise the ticker moved into a `VStack` with the sub-label beneath it, and the chevron is now vertically centered against the two-line block.

`SwapCoinInputField` and `SendCoinInputField` are the **only** two coin-pill components in the codebase (verified by searching every `CoinWrapper` usage), so this covers the pattern completely. They are near-identical but live in separate feature folders and already duplicated their `CoinWrapper` styled-component before this change; extracting a shared pill would be a worthwhile follow-up but is deliberately out of scope here.

Fixes #4467

### Note on translations

`yarn translate` returned the wrong sense for this context-free single word in six locales — de `Einheimisch` (indigenous person), hr `Domorodac` (aborigine), ko `토종의` (native-bred, of plants/animals), ru `Родной` (dear/mother tongue), zh `本国的` (of one's own country), nl `Oorspronkelijk` (original). Those six were corrected by hand to the crypto sense (`Nativ`, `Izvorni`, `네이티브`, `Нативный`, `原生`, `Native`). es/it/pt came back as `Nativo`, which is correct and was left as generated. Since the English source is unchanged, a future `yarn translate` run will not overwrite these.

## Which feature is affected?
- [x] Sending — UI-only label change in the asset picker; no transaction is constructed or broadcast differently, so there is no tx link to attach.
- [x] Swap — same, UI-only.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

No test was added: this is a presentational branch on an existing predicate, and there is no existing render-test harness or story for either pill component to extend. The full suite (590 tests) passes unchanged.

## Screenshots (if applicable):

Swap tab, verified in a local extension build — `BTC` and `ETH` both render the `Native` sub-label under the ticker. The token case (no sub-label) and the pixel comparison against the iOS/Android reference still want a reviewer's eye.

## Additional context

`yarn check:all` passes green on this branch — typecheck, lint, 103/103 test files, 590/590 tests, knip, i18n integrity, i18n quality, jscpd, markdownlint, Go tests, audit.

Verified in a real extension build that the change actually reaches the bundle rather than trusting exit code 0: all seven distinct locale values for the new key are present in `clients/extension/dist`.

Note for anyone testing the limit tab: it sits behind the `limitSwap` feature flag, which defaults to `false`. Build with `VITE_FF_limitSwap=true yarn build:extension` to see it. This PR deliberately does not touch that flag.

Out of scope, deliberately: the asset list inside the picker modal (`CoinOption`, which already shows a chain pill) and the collapsed limit summary row (`LimitAssetSummary`, a single-line recap).

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #4467
- **Confidence**: high on the logic, the shared-component analysis, and the validation; medium on pixel fidelity against the native reference
- **Needs human review for**: visual comparison against the iOS/Android reference, and a sanity read of the six hand-corrected locale strings by anyone who reads those languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
