### PR TITLE
feat(swap): sign and broadcast a THORChain limit order

### DIFF
--- a/core/inpage-provider/Readme.md
+++ b/core/inpage-provider/Readme.md
@@ -11,7 +11,7 @@ Install a plugin at https://store.vultisigplugin.app/
 ## Connect with various chains and providers.
 
 - Rango: https://app.rango.exchange/bridge
-- ThorSwap: https://app.thorswap.finance/swap
+- ThorSwap: https://thorswap.finance/
 
 ## Solana Swaps
 

--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -1788,15 +1788,13 @@ export const de = {
   swap_limit_expiry_3d: '3d',
   swap_limit_expiry_label: 'Ablauf',
   swap_limit_place_order: 'Bestellung aufgeben',
-  swap_limit_place_pending_signing:
-    'Die Unterstützung für Ihre Unterschrift ist unterwegs – überprüfen Sie Ihre Bestellung unten.',
   swap_limit_review_heading: 'Sie erteilen eine Limit-Order.',
   swap_limit_review_target_price: 'Kursziel',
-  swap_limit_review_title: 'Bestellung prüfen',
   swap_limit_price_market: 'Markt',
   swap_limit_warning_at_or_below_market:
     'Dieser Preis entspricht dem Marktpreis oder liegt darunter, daher kann die Order sofort ausgeführt werden.',
   swap_limit_warning_far_above_market:
     'Dieser Preis liegt weit über dem Marktpreis und es besteht die Möglichkeit, dass die Transaktion ungenutzt verfällt.',
   chain_address_copied: 'Adresse {{chain}} kopiert',
+  swap_limit_confirm: 'Die Bestelldetails sind korrekt.',
 }

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -1180,13 +1180,11 @@ export const en = {
   swap_limit_expiry_12h: '12h',
   swap_limit_expiry_24h: '24h',
   swap_limit_expiry_3d: '3d',
+  swap_limit_confirm: 'The order details are correct',
   swap_limit_expiry_label: 'Expiry',
   swap_limit_place_order: 'Place order',
-  swap_limit_place_pending_signing:
-    'Signing support is on the way — review your order below.',
   swap_limit_review_heading: "You're placing a limit order",
   swap_limit_review_target_price: 'Target price',
-  swap_limit_review_title: 'Review order',
   swap_limit_price_market: 'Market',
   swap_limit_unavailable:
     'Limit orders are temporarily unavailable on THORChain',

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -1771,15 +1771,13 @@ export const es = {
   swap_limit_expiry_3d: '3d',
   swap_limit_expiry_label: 'Expiración',
   swap_limit_place_order: 'Realizar pedido',
-  swap_limit_place_pending_signing:
-    'El soporte para la firma está en camino; revise su pedido a continuación.',
   swap_limit_review_heading: 'Estás realizando una orden limitada',
   swap_limit_review_target_price: 'Precio objetivo',
-  swap_limit_review_title: 'Revisar el pedido',
   swap_limit_price_market: 'Mercado',
   swap_limit_warning_at_or_below_market:
     'Este precio está en o por debajo del precio de mercado, por lo que la orden podría ejecutarse inmediatamente.',
   swap_limit_warning_far_above_market:
     'Este precio está muy por encima del precio de mercado y podría expirar sin que se complete la transacción.',
   chain_address_copied: 'Dirección {{chain}} copiada',
+  swap_limit_confirm: 'Los detalles del pedido son correctos.',
 }

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -1744,15 +1744,13 @@ export const hr = {
   swap_limit_expiry_3d: '3d',
   swap_limit_expiry_label: 'Istek',
   swap_limit_place_order: 'Naruči',
-  swap_limit_place_pending_signing:
-    'Podrška za potpisivanje je na putu - pregledajte svoju narudžbu u nastavku.',
   swap_limit_review_heading: 'Postavljate limitirani nalog',
   swap_limit_review_target_price: 'Ciljana cijena',
-  swap_limit_review_title: 'Pregled narudžbe',
   swap_limit_price_market: 'Tržište',
   swap_limit_warning_at_or_below_market:
     'Ova cijena je na ili ispod tržišne, tako da se narudžba može odmah ispuniti',
   swap_limit_warning_far_above_market:
     'Ova cijena je daleko iznad tržišne i mogla bi isteći ako se ne iskoristi',
   chain_address_copied: 'Adresa {{chain}} kopirana',
+  swap_limit_confirm: 'Podaci narudžbe su točni',
 }

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -1777,15 +1777,13 @@ export const it = {
   swap_limit_expiry_3d: '3d',
   swap_limit_expiry_label: 'Scadenza',
   swap_limit_place_order: "Effettua l'ordine",
-  swap_limit_place_pending_signing:
-    'Il supporto per la firma è in arrivo: controlla il tuo ordine qui sotto.',
   swap_limit_review_heading: 'Stai effettuando un ordine limite',
   swap_limit_review_target_price: 'Prezzo obiettivo',
-  swap_limit_review_title: 'Ordine di revisione',
   swap_limit_price_market: 'Mercato',
   swap_limit_warning_at_or_below_market:
     "Questo prezzo è pari o inferiore al prezzo di mercato, quindi l'ordine potrebbe essere evaso immediatamente.",
   swap_limit_warning_far_above_market:
     "Questo prezzo è di gran lunga superiore a quello di mercato e l'offerta potrebbe scadere senza che l'ordine venga evaso.",
   chain_address_copied: 'Indirizzo {{chain}} copiato',
+  swap_limit_confirm: "I dettagli dell'ordine sono corretti",
 }

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -1735,15 +1735,13 @@ export const ko = {
   swap_limit_expiry_3d: '3d',
   swap_limit_expiry_label: '만료',
   swap_limit_place_order: '주문하기',
-  swap_limit_place_pending_signing:
-    '서명 지원이 곧 제공될 예정입니다. 아래에서 주문 내역을 확인하세요.',
   swap_limit_review_heading: '지정가 주문을 하십니다.',
   swap_limit_review_target_price: '목표 가격',
-  swap_limit_review_title: '주문 검토',
   swap_limit_price_market: '시장',
   swap_limit_warning_at_or_below_market:
     '이 가격은 시장 가격과 같거나 그 이하이므로 주문이 즉시 체결될 수 있습니다.',
   swap_limit_warning_far_above_market:
     '이 가격은 시장가보다 훨씬 높으며, 거래가 성사되지 않고 만료될 가능성이 있습니다.',
   chain_address_copied: '{{chain}} 주소가 복사되었습니다.',
+  swap_limit_confirm: '주문 내역이 정확합니다.',
 }

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -1755,15 +1755,13 @@ export const nl = {
   swap_limit_expiry_3d: '3d',
   swap_limit_expiry_label: 'Vervaldatum',
   swap_limit_place_order: 'Bestelling plaatsen',
-  swap_limit_place_pending_signing:
-    'Ondersteuning voor ondertekening is onderweg — controleer uw bestelling hieronder.',
   swap_limit_review_heading: 'U plaatst een limietorder.',
   swap_limit_review_target_price: 'Doelprijs',
-  swap_limit_review_title: 'Beoordelingsbestelling',
   swap_limit_price_market: 'Markt',
   swap_limit_warning_at_or_below_market:
     'Deze prijs ligt op of onder de marktprijs, waardoor de bestelling mogelijk direct wordt uitgevoerd.',
   swap_limit_warning_far_above_market:
     'Deze prijs ligt ver boven de marktwaarde en de transactie kan onvervuld blijven.',
   chain_address_copied: '{{chain}} adres gekopieerd',
+  swap_limit_confirm: 'De bestelgegevens zijn correct.',
 }

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -1773,16 +1773,14 @@ export const pt = {
   swap_limit_expiry_3d: '3d',
   swap_limit_expiry_label: 'Termo',
   swap_limit_place_order: 'Fazer pedido',
-  swap_limit_place_pending_signing:
-    'O suporte para assinatura está a caminho — revise seu pedido abaixo.',
   swap_limit_review_heading:
     'Você está fazendo um pedido com limite de compra.',
   swap_limit_review_target_price: 'Preço alvo',
-  swap_limit_review_title: 'Revisar pedido',
   swap_limit_price_market: 'Mercado',
   swap_limit_warning_at_or_below_market:
     'Este preço está igual ou abaixo do preço de mercado, portanto a ordem pode ser executada imediatamente.',
   swap_limit_warning_far_above_market:
     'Este preço está muito acima do mercado e pode expirar sem ser atendido.',
   chain_address_copied: 'Endereço {{chain}} copiado',
+  swap_limit_confirm: 'Os detalhes do pedido estão corretos.',
 }

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -1752,15 +1752,13 @@ export const ru = {
   swap_limit_expiry_3d: '3d',
   swap_limit_expiry_label: 'Срок годности',
   swap_limit_place_order: 'Оформить заказ',
-  swap_limit_place_pending_signing:
-    'Поддержка подписи уже в пути — проверьте свой заказ ниже.',
   swap_limit_review_heading: 'Вы размещаете лимитный ордер.',
   swap_limit_review_target_price: 'Целевая цена',
-  swap_limit_review_title: 'Проверить заказ',
   swap_limit_price_market: 'Рынок',
   swap_limit_warning_at_or_below_market:
     'Эта цена соответствует рыночной или ниже, поэтому заказ может быть исполнен немедленно.',
   swap_limit_warning_far_above_market:
     'Эта цена значительно выше рыночной и может остаться нереализованной.',
   chain_address_copied: 'Адрес {{chain}} скопирован',
+  swap_limit_confirm: 'Данные заказа верны.',
 }

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -1626,14 +1626,13 @@ export const zh = {
   swap_limit_expiry_3d: '3d',
   swap_limit_expiry_label: '到期日',
   swap_limit_place_order: '下单',
-  swap_limit_place_pending_signing: '签名支持正在路上——请查看下面的订单。',
   swap_limit_review_heading: '您正在下限价单',
   swap_limit_review_target_price: '目标价格',
-  swap_limit_review_title: '审查订单',
   swap_limit_price_market: '市场',
   swap_limit_warning_at_or_below_market:
     '这个价格等于或低于市场价，所以订单可能立即成交。',
   swap_limit_warning_far_above_market:
     '这个价格远高于市场价，而且可能最终无法成交。',
   chain_address_copied: '{{chain}}地址已复制',
+  swap_limit_confirm: '订单详情正确',
 }

--- a/core/ui/vault/swap/form/LimitSwapForm.tsx
+++ b/core/ui/vault/swap/form/LimitSwapForm.tsx
@@ -214,6 +214,11 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
       ? extractErrorMsg(receiveChainAmountResult.error)
       : undefined
 
+  // Both mean "this order can't be expressed", so they share the blocker and
+  // the notice — the notice needs the specific text, since the generic
+  // memo-invalid string wouldn't tell the user what to change.
+  const orderExpressionError = memoError ?? receiveChainAmountError
+
   const blocker = getLimitOrderBlocker({
     fromChain: fromCoin.chain,
     toChain: toCoin.chain,
@@ -225,7 +230,7 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
     supportedChains,
     marketPrice: marketRate,
     destinationAddress: toCoin.address,
-    memoError: memoError ?? receiveChainAmountError,
+    memoError: orderExpressionError,
   })
 
   // Which preset (if any) the current rate corresponds to, so its pill reads as
@@ -380,8 +385,8 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
               <LimitSwapNotice
                 kind="blocker"
                 message={
-                  blocker === 'memoInvalid' && memoError
-                    ? memoError
+                  blocker === 'memoInvalid' && orderExpressionError
+                    ? orderExpressionError
                     : blockerMessage[blocker]
                 }
               />

--- a/core/ui/vault/swap/form/LimitSwapForm.tsx
+++ b/core/ui/vault/swap/form/LimitSwapForm.tsx
@@ -25,8 +25,8 @@ import { LimitOrderReviewData } from '../limit/LimitOrderReview'
 import { LimitSwapNotice } from '../limit/LimitSwapNotice'
 import {
   buildLimitSwapMemoForCoins,
+  getLimitSwapExpectedToAmount,
   getLimitSwapReceiveAmount,
-  getLimitSwapReceiveChainAmount,
 } from '../limit/memo'
 import { getLimitOrderBlocker, LimitOrderBlocker } from '../limit/placement'
 import {
@@ -185,14 +185,13 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
     farAboveMarket: t('swap_limit_warning_far_above_market'),
   }
 
-  // The same LIM in the buy coin's smallest units, for the co-signer display on
+  // The memo's LIM in THORChain's 1e8 fixed point, for the co-signer display on
   // the keysign payload — kept as a bigint so no precision is lost into signing.
-  const receiveChainAmountResult =
+  const expectedToAmountResult =
     rate !== null && amount !== null && amount > 0n
       ? attempt(() =>
-          getLimitSwapReceiveChainAmount({
+          getLimitSwapExpectedToAmount({
             fromCoin,
-            toCoin,
             amount,
             targetPrice: rate,
           })
@@ -201,23 +200,23 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
 
   // `Result`'s failure variant types `data` as `never?`, so `'data' in result`
   // does not narrow — coerce explicitly rather than trusting the check.
-  const receiveChainAmount: bigint | null =
-    receiveChainAmountResult && 'data' in receiveChainAmountResult
-      ? (receiveChainAmountResult.data ?? null)
+  const expectedToAmount: bigint | null =
+    expectedToAmountResult && 'data' in expectedToAmountResult
+      ? (expectedToAmountResult.data ?? null)
       : null
 
   // Same class of failure as the memo not building — the order can't be
   // expressed — so it blocks placement through the same reason rather than
   // leaving the CTA enabled over a `placeOrder` that would return silently.
-  const receiveChainAmountError =
-    receiveChainAmountResult && 'error' in receiveChainAmountResult
-      ? extractErrorMsg(receiveChainAmountResult.error)
+  const expectedToAmountError =
+    expectedToAmountResult && 'error' in expectedToAmountResult
+      ? extractErrorMsg(expectedToAmountResult.error)
       : undefined
 
   // Both mean "this order can't be expressed", so they share the blocker and
   // the notice — the notice needs the specific text, since the generic
   // memo-invalid string wouldn't tell the user what to change.
-  const orderExpressionError = memoError ?? receiveChainAmountError
+  const orderExpressionError = memoError ?? expectedToAmountError
 
   const blocker = getLimitOrderBlocker({
     fromChain: fromCoin.chain,
@@ -314,7 +313,7 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
     if (
       amount === null ||
       memoValue === undefined ||
-      receiveChainAmount === null
+      expectedToAmount === null
     ) {
       return
     }
@@ -325,7 +324,7 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
       sellAmount: sellAmount ?? 0,
       sellChainAmount: amount,
       receiveAmount: receiveAmount ?? 0,
-      receiveChainAmount,
+      expectedToAmount,
       memo: memoValue,
       unitPrice:
         targetAssetPrice !== null

--- a/core/ui/vault/swap/form/LimitSwapForm.tsx
+++ b/core/ui/vault/swap/form/LimitSwapForm.tsx
@@ -185,6 +185,35 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
     farAboveMarket: t('swap_limit_warning_far_above_market'),
   }
 
+  // The same LIM in the buy coin's smallest units, for the co-signer display on
+  // the keysign payload — kept as a bigint so no precision is lost into signing.
+  const receiveChainAmountResult =
+    rate !== null && amount !== null && amount > 0n
+      ? attempt(() =>
+          getLimitSwapReceiveChainAmount({
+            fromCoin,
+            toCoin,
+            amount,
+            targetPrice: rate,
+          })
+        )
+      : undefined
+
+  // `Result`'s failure variant types `data` as `never?`, so `'data' in result`
+  // does not narrow — coerce explicitly rather than trusting the check.
+  const receiveChainAmount: bigint | null =
+    receiveChainAmountResult && 'data' in receiveChainAmountResult
+      ? (receiveChainAmountResult.data ?? null)
+      : null
+
+  // Same class of failure as the memo not building — the order can't be
+  // expressed — so it blocks placement through the same reason rather than
+  // leaving the CTA enabled over a `placeOrder` that would return silently.
+  const receiveChainAmountError =
+    receiveChainAmountResult && 'error' in receiveChainAmountResult
+      ? extractErrorMsg(receiveChainAmountResult.error)
+      : undefined
+
   const blocker = getLimitOrderBlocker({
     fromChain: fromCoin.chain,
     toChain: toCoin.chain,
@@ -196,7 +225,7 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
     supportedChains,
     marketPrice: marketRate,
     destinationAddress: toCoin.address,
-    memoError,
+    memoError: memoError ?? receiveChainAmountError,
   })
 
   // Which preset (if any) the current rate corresponds to, so its pill reads as
@@ -240,23 +269,6 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
       ? withFallback(
           attempt(() =>
             getLimitSwapReceiveAmount({ fromCoin, amount, targetPrice: rate })
-          ),
-          null
-        )
-      : null
-
-  // The same LIM in the buy coin's smallest units, for the co-signer display on
-  // the keysign payload — kept as a bigint so no precision is lost into signing.
-  const receiveChainAmount =
-    rate !== null && amount !== null && amount > 0n
-      ? withFallback(
-          attempt(() =>
-            getLimitSwapReceiveChainAmount({
-              fromCoin,
-              toCoin,
-              amount,
-              targetPrice: rate,
-            })
           ),
           null
         )

--- a/core/ui/vault/swap/form/LimitSwapForm.tsx
+++ b/core/ui/vault/swap/form/LimitSwapForm.tsx
@@ -26,6 +26,7 @@ import { LimitSwapNotice } from '../limit/LimitSwapNotice'
 import {
   buildLimitSwapMemoForCoins,
   getLimitSwapReceiveAmount,
+  getLimitSwapReceiveChainAmount,
 } from '../limit/memo'
 import { getLimitOrderBlocker, LimitOrderBlocker } from '../limit/placement'
 import {
@@ -164,6 +165,7 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
 
   const memoError =
     memo && 'error' in memo ? extractErrorMsg(memo.error) : undefined
+  const memoValue = memo && 'data' in memo ? memo.data : undefined
 
   const blockerMessage: Record<LimitOrderBlocker, string> = {
     queueUnavailable: t('swap_limit_unavailable'),
@@ -243,6 +245,23 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
         )
       : null
 
+  // The same LIM in the buy coin's smallest units, for the co-signer display on
+  // the keysign payload — kept as a bigint so no precision is lost into signing.
+  const receiveChainAmount =
+    rate !== null && amount !== null && amount > 0n
+      ? withFallback(
+          attempt(() =>
+            getLimitSwapReceiveChainAmount({
+              fromCoin,
+              toCoin,
+              amount,
+              targetPrice: rate,
+            })
+          ),
+          null
+        )
+      : null
+
   const secondaryLabel = (() => {
     if (unit === 'fiat') {
       return receiveAmount !== null
@@ -271,13 +290,26 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
 
   // Hand off through the page-level flow (like the market form) so the review
   // screen replaces the whole form — header and Market/Limit tabs included —
-  // rather than nesting a second header under them.
-  const placeOrder = () =>
+  // rather than nesting a second header under them. The button is only enabled
+  // when there is no blocker, which guarantees these are present; the guard
+  // narrows the types.
+  const placeOrder = () => {
+    if (
+      amount === null ||
+      memoValue === undefined ||
+      receiveChainAmount === null
+    ) {
+      return
+    }
+
     onFinish({
       fromCoin,
       toCoin,
       sellAmount: sellAmount ?? 0,
+      sellChainAmount: amount,
       receiveAmount: receiveAmount ?? 0,
+      receiveChainAmount,
+      memo: memoValue,
       unitPrice:
         targetAssetPrice !== null
           ? `${formatNumber(targetAssetPrice)} ${fromCoin.ticker}`
@@ -288,6 +320,7 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
           : undefined,
       expiryHours,
     })
+  }
 
   return (
     <PageContent gap={12} justifyContent="space-between" scrollable>

--- a/core/ui/vault/swap/limit/LimitOrderReview.tsx
+++ b/core/ui/vault/swap/limit/LimitOrderReview.tsx
@@ -1,30 +1,38 @@
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
-import { Button } from '@lib/ui/buttons/Button'
+import { VerifyKeysignStart } from '@core/ui/mpc/keysign/start/VerifyKeysignStart'
+import { KeysignFeeAmount } from '@core/ui/mpc/keysign/tx/FeeAmount'
 import { ArrowDownIcon } from '@lib/ui/icons/ArrowDownIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
-import { PageContent } from '@lib/ui/page/PageContent'
 import { PageHeader } from '@lib/ui/page/PageHeader'
 import { OnBackProp } from '@lib/ui/props'
+import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
 import { Text } from '@lib/ui/text'
-import { Coin } from '@vultisig/core-chain/coin/Coin'
+import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
 import { LimitSwapExpiryHours } from '@vultisig/core-chain/swap/native/limitSwapMemo'
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
+import { useLimitSwapKeysignPayloadQuery } from './queries/useLimitSwapKeysignPayloadQuery'
 import { useLimitExpiryLabels } from './useLimitExpiryLabels'
 
 const formatNumber = (value: number) =>
   value.toLocaleString(undefined, { maximumFractionDigits: 8 })
 
 export type LimitOrderReviewData = {
-  fromCoin: Coin
-  toCoin: Coin
-  /** Sell amount in the sell coin's natural units. */
+  fromCoin: AccountCoin
+  toCoin: AccountCoin
+  /** Sell amount in the sell coin's natural units, for display. */
   sellAmount: number
-  /** Guaranteed-minimum output, derived from the memo's LIM. */
+  /** Source amount in the sell coin's smallest units, for signing. */
+  sellChainAmount: bigint
+  /** Guaranteed-minimum output in the buy coin's natural units, for display. */
   receiveAmount: number
+  /** The same LIM in the buy coin's smallest units, for the co-signer display. */
+  receiveChainAmount: bigint
+  /** The `=<` memo to sign. */
+  memo: string
   /** Target price of one buy unit, in sell-asset units. */
   unitPrice: string | undefined
   /** Target price of one buy unit, in fiat. */
@@ -35,17 +43,21 @@ export type LimitOrderReviewData = {
 type LimitOrderReviewProps = LimitOrderReviewData & OnBackProp
 
 /**
- * The composed order, ready to place.
+ * Verify + sign a placed limit order.
  *
- * This is the hand-off from the compose form. Signing itself — fees, the
- * security scan, and the keysign ceremony — is the follow-up that consumes
- * `buildLimitSwapKeysignPayload`, so the confirm button stays disabled here.
+ * Reuses the market swap's keysign pipeline (`VerifyKeysignStart`) — the terms
+ * checkbox, the Blockaid scan row, and the Paired / Fast Sign ceremony — feeding
+ * it a limit-order payload instead of a market one. No `swapQuote` is passed: a
+ * limit order has none, and the deposit signs like any other keysign.
  */
 export const LimitOrderReview: FC<LimitOrderReviewProps> = ({
   fromCoin,
   toCoin,
   sellAmount,
+  sellChainAmount,
   receiveAmount,
+  receiveChainAmount,
+  memo,
   unitPrice,
   targetPriceLabel,
   expiryHours,
@@ -54,14 +66,25 @@ export const LimitOrderReview: FC<LimitOrderReviewProps> = ({
   const { t } = useTranslation()
   const expiryLabel = useLimitExpiryLabels()
 
+  const keysignPayloadQuery = useLimitSwapKeysignPayloadQuery({
+    fromCoin,
+    toCoin,
+    amount: sellChainAmount,
+    memo,
+    expectedToAmount: receiveChainAmount,
+  })
+
   return (
     <>
       <PageHeader
         primaryControls={<PageHeaderBackButton onClick={onBack} />}
-        title={t('swap_limit_review_title')}
+        title={t('swap_overview')}
         hasBorder
       />
-      <PageContent gap={16} justifyContent="space-between" scrollable>
+      <VerifyKeysignStart
+        keysignPayloadQuery={keysignPayloadQuery}
+        terms={[t('swap_limit_confirm')]}
+      >
         <Card gap={16}>
           <Text size={16} weight={500} color="contrast">
             {t('swap_limit_review_heading')}
@@ -88,25 +111,27 @@ export const LimitOrderReview: FC<LimitOrderReviewProps> = ({
             label={t('swap_limit_expiry_label')}
             value={expiryLabel[expiryHours]}
           />
+          <Row
+            label={t('network_fee')}
+            value={
+              <MatchQuery
+                value={keysignPayloadQuery}
+                pending={() => t('loading')}
+                error={() => t('failed_to_load')}
+                success={keysignPayload => (
+                  <KeysignFeeAmount keysignPayload={keysignPayload} />
+                )}
+              />
+            }
+          />
         </Card>
-
-        <VStack gap={12}>
-          {/* Signing consumes buildLimitSwapKeysignPayload (core-mpc 1.13.0); the
-              fee + security-scan + keysign screen is the follow-up. */}
-          <Text size={12} color="shy" centerHorizontally>
-            {t('swap_limit_place_pending_signing')}
-          </Text>
-          <Button disabled data-testid="limit-confirm-order">
-            {t('swap_limit_place_order')}
-          </Button>
-        </VStack>
-      </PageContent>
+      </VerifyKeysignStart>
     </>
   )
 }
 
 type LegProps = {
-  coin: Coin
+  coin: AccountCoin
   amount: number
   label: string
 }
@@ -127,7 +152,7 @@ const Leg: FC<LegProps> = ({ coin, amount, label }) => (
 
 type RowProps = {
   label: string
-  value: string
+  value: React.ReactNode
 }
 
 const Row: FC<RowProps> = ({ label, value }) => (

--- a/core/ui/vault/swap/limit/LimitOrderReview.tsx
+++ b/core/ui/vault/swap/limit/LimitOrderReview.tsx
@@ -29,8 +29,8 @@ export type LimitOrderReviewData = {
   sellChainAmount: bigint
   /** Guaranteed-minimum output in the buy coin's natural units, for display. */
   receiveAmount: number
-  /** The same LIM in the buy coin's smallest units, for the co-signer display. */
-  receiveChainAmount: bigint
+  /** The memo's LIM in THORChain's 1e8 fixed point, for the co-signer display. */
+  expectedToAmount: bigint
   /** The `=<` memo to sign. */
   memo: string
   /** Target price of one buy unit, in sell-asset units. */
@@ -56,7 +56,7 @@ export const LimitOrderReview: FC<LimitOrderReviewProps> = ({
   sellAmount,
   sellChainAmount,
   receiveAmount,
-  receiveChainAmount,
+  expectedToAmount,
   memo,
   unitPrice,
   targetPriceLabel,
@@ -71,7 +71,7 @@ export const LimitOrderReview: FC<LimitOrderReviewProps> = ({
     toCoin,
     amount: sellChainAmount,
     memo,
-    expectedToAmount: receiveChainAmount,
+    expectedToAmount,
   })
 
   return (

--- a/core/ui/vault/swap/limit/keysignPayloadInput.test.ts
+++ b/core/ui/vault/swap/limit/keysignPayloadInput.test.ts
@@ -1,0 +1,107 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+import { Vault } from '@vultisig/core-mpc/vault/Vault'
+import { describe, expect, it } from 'vitest'
+
+import { getLimitSwapKeysignPayloadInput } from './keysignPayloadInput'
+
+const fromCoin: AccountCoin = {
+  chain: Chain.THORChain,
+  address: 'thor1sender',
+  ticker: 'RUNE',
+  decimals: 8,
+}
+
+const toCoin: AccountCoin = {
+  chain: Chain.Bitcoin,
+  address: 'bc1qbuyer',
+  ticker: 'BTC',
+  decimals: 8,
+}
+
+const fromPublicKey = { data: () => new Uint8Array([1]) } as never
+const toPublicKey = { data: () => new Uint8Array([2]) } as never
+const walletCore = {} as never
+
+const vault = {
+  name: 'Main Vault',
+  publicKeys: { ecdsa: 'ecdsa-key', eddsa: 'eddsa-key' },
+  hexChainCode: 'chain-code',
+  localPartyId: 'device-1',
+  signers: ['device-1', 'device-2'],
+  libType: 'DKLS',
+  isBackedUp: true,
+  order: 0,
+} as unknown as Vault
+
+const memo = '=<:BTC.BTC:bc1qbuyer:1600000000/14400/0:v0:50'
+
+const input = {
+  fromCoin,
+  toCoin,
+  amount: 100_000_000n,
+  memo,
+  expectedToAmount: 1_600_000_000n,
+  vault,
+  fromPublicKey,
+  toPublicKey,
+  walletCore,
+}
+
+describe('getLimitSwapKeysignPayloadInput', () => {
+  it('passes the composed order through unchanged', () => {
+    const result = getLimitSwapKeysignPayloadInput(input)
+
+    expect(result.fromCoin).toBe(fromCoin)
+    expect(result.toCoin).toBe(toCoin)
+    expect(result.amount).toBe(100_000_000n)
+    expect(result.memo).toBe(memo)
+  })
+
+  // The memo is the order; a mangled one signs something the user never saw.
+  it('does not rewrite the memo', () => {
+    expect(getLimitSwapKeysignPayloadInput(input).memo).toBe(memo)
+  })
+
+  // Amounts stay bigint into signing — a Number round-trip would lose precision
+  // and could emit scientific notation on a co-signer.
+  it('keeps amounts as bigints', () => {
+    const result = getLimitSwapKeysignPayloadInput(input)
+
+    expect(typeof result.amount).toBe('bigint')
+    expect(typeof result.expectedToAmount).toBe('bigint')
+    expect(result.expectedToAmount).toBe(1_600_000_000n)
+  })
+
+  it('derives the vault identity from the vault', () => {
+    const result = getLimitSwapKeysignPayloadInput(input)
+
+    expect(result.vaultId).toBe('ecdsa-key')
+    expect(result.localPartyId).toBe('device-1')
+    expect(result.libType).toBe('DKLS')
+  })
+
+  // Both keys share a type, so a swap between them type-checks but would sign
+  // against the wrong chain's key.
+  it('keeps the from and to public keys on their own sides', () => {
+    const result = getLimitSwapKeysignPayloadInput(input)
+
+    expect(result.fromPublicKey).toBe(fromPublicKey)
+    expect(result.toPublicKey).toBe(toPublicKey)
+    expect(result.fromPublicKey).not.toBe(result.toPublicKey)
+  })
+
+  it('forwards walletCore for the signing build', () => {
+    expect(getLimitSwapKeysignPayloadInput(input).walletCore).toBe(walletCore)
+  })
+
+  it('carries a same-chain pair without collapsing the sides', () => {
+    const result = getLimitSwapKeysignPayloadInput({
+      ...input,
+      toCoin: { ...toCoin, chain: Chain.THORChain, ticker: 'TCY' },
+    })
+
+    expect(result.fromCoin.ticker).toBe('RUNE')
+    expect(result.toCoin.ticker).toBe('TCY')
+  })
+})

--- a/core/ui/vault/swap/limit/keysignPayloadInput.ts
+++ b/core/ui/vault/swap/limit/keysignPayloadInput.ts
@@ -1,0 +1,55 @@
+import { WalletCore } from '@trustwallet/wallet-core'
+import { PublicKey } from '@trustwallet/wallet-core/dist/src/wallet-core'
+import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+import { BuildLimitSwapKeysignPayloadInput } from '@vultisig/core-mpc/keysign/swap/buildLimitSwapKeysignPayload'
+import { toKeysignLibType } from '@vultisig/core-mpc/types/utils/libType'
+import { getVaultId, Vault } from '@vultisig/core-mpc/vault/Vault'
+
+type GetLimitSwapKeysignPayloadInputInput = {
+  fromCoin: AccountCoin
+  toCoin: AccountCoin
+  /** Source amount in the coin's native smallest units. */
+  amount: bigint
+  /** The `=<` memo from `buildLimitSwapMemoForCoins`. */
+  memo: string
+  /** The order's LIM in the target's smallest units, for co-signer display only. */
+  expectedToAmount: bigint
+  vault: Vault
+  fromPublicKey: PublicKey
+  toPublicKey: PublicKey
+  walletCore: WalletCore
+}
+
+/**
+ * Map the composed order plus the current vault into the SDK's keysign payload
+ * input.
+ *
+ * Split out of the query hook so the mapping — which vault field feeds which
+ * payload field — is testable without React. Getting one of these wrong (the
+ * amount, the memo, or the wrong side's public key) would sign a different order
+ * than the user reviewed, and none of it is caught by types alone since several
+ * fields share a type.
+ */
+export const getLimitSwapKeysignPayloadInput = ({
+  fromCoin,
+  toCoin,
+  amount,
+  memo,
+  expectedToAmount,
+  vault,
+  fromPublicKey,
+  toPublicKey,
+  walletCore,
+}: GetLimitSwapKeysignPayloadInputInput): BuildLimitSwapKeysignPayloadInput => ({
+  fromCoin,
+  toCoin,
+  amount,
+  memo,
+  expectedToAmount,
+  vaultId: getVaultId(vault),
+  localPartyId: vault.localPartyId,
+  fromPublicKey,
+  toPublicKey,
+  libType: toKeysignLibType(vault),
+  walletCore,
+})

--- a/core/ui/vault/swap/limit/memo.test.ts
+++ b/core/ui/vault/swap/limit/memo.test.ts
@@ -158,4 +158,29 @@ describe('getLimitSwapReceiveChainAmount', () => {
       })
     ).toThrow()
   })
+
+  // 100 sats at 0.5 USDC/BTC is a LIM of 50 in THORChain's 1e8 fixed point --
+  // nonzero, so the memo builds -- but USDC's 6 decimals rescale it to 0. Passing
+  // that through as `expectedToAmount` would show a co-signer they receive
+  // nothing while the memo they sign still carries a real floor.
+  it('throws when a nonzero LIM underflows the target decimals', () => {
+    const order = {
+      fromCoin: btcCoin,
+      toCoin: usdcCoin,
+      amount: 100n,
+      targetPrice: 0.5,
+    } as const
+
+    expect(
+      buildLimitSwapMemoForCoins({
+        ...order,
+        expiryHours: 24,
+        destinationAddress: evmAddress,
+      })
+    ).toContain(':50/14400/0')
+
+    expect(() => getLimitSwapReceiveChainAmount(order)).toThrow(
+      /rounds to zero USDC/
+    )
+  })
 })

--- a/core/ui/vault/swap/limit/memo.test.ts
+++ b/core/ui/vault/swap/limit/memo.test.ts
@@ -1,10 +1,11 @@
 import { Chain } from '@vultisig/core-chain/Chain'
 import { Coin } from '@vultisig/core-chain/coin/Coin'
+import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { describe, expect, it } from 'vitest'
 
 import {
   buildLimitSwapMemoForCoins,
-  getLimitSwapReceiveChainAmount,
+  getLimitSwapExpectedToAmount,
 } from './memo'
 
 const ethCoin: Coin = { chain: Chain.Ethereum, ticker: 'ETH', decimals: 18 }
@@ -123,64 +124,52 @@ describe('buildLimitSwapMemoForCoins', () => {
   })
 })
 
-describe('getLimitSwapReceiveChainAmount', () => {
-  it('rescales the LIM to the target coin decimals', () => {
-    // 1 BTC at 16 ETH/BTC -> 16 ETH. ETH has 18 decimals, so 16e18.
-    expect(
-      getLimitSwapReceiveChainAmount({
-        fromCoin: btcCoin,
-        toCoin: ethCoin,
-        amount: 100_000_000n,
-        targetPrice: 16,
-      })
-    ).toBe(16n * 10n ** 18n)
+describe('getLimitSwapExpectedToAmount', () => {
+  // The SDK formats this field with getNativeSwapDecimals(toCoin) -- 8 for every
+  // THORChain limit-swap target -- so it must be the memo's LIM in 1e8, not the
+  // target coin's own units. Scaling to toCoin.decimals leaves the signed memo
+  // right but shows the co-signer 100x low for USDC and 1e10x high for ETH.
+  it.each([
+    ['a 6-decimal target', usdcCoin],
+    ['an 18-decimal target', ethCoin],
+  ])('equals the LIM the memo encodes for %s', (_label, toCoin) => {
+    const order = {
+      fromCoin: btcCoin,
+      amount: 100_000_000n,
+      targetPrice: 0.5,
+    } as const
+
+    const memo = buildLimitSwapMemoForCoins({
+      ...order,
+      toCoin,
+      expiryHours: 24,
+      destinationAddress: evmAddress,
+    })
+
+    const [encodedLim] = shouldBePresent(memo.split(':')[3]).split('/')
+
+    expect(getLimitSwapExpectedToAmount(order).toString()).toBe(encodedLim)
   })
 
-  it('matches the memo LIM for a 6-decimal target', () => {
-    // 1 BTC at 60000 USDC/BTC -> 60000 USDC. USDC has 6 decimals.
+  it('stays in 1e8 regardless of the source coin decimals', () => {
+    // 1 ETH at 0.04 BTC/ETH -> 0.04 BTC, which is 4000000 in 1e8.
     expect(
-      getLimitSwapReceiveChainAmount({
-        fromCoin: btcCoin,
-        toCoin: usdcCoin,
-        amount: 100_000_000n,
-        targetPrice: 60_000,
-      })
-    ).toBe(60_000n * 10n ** 6n)
-  })
-
-  it('throws on a LIM that floors to zero, like the memo', () => {
-    expect(() =>
-      getLimitSwapReceiveChainAmount({
+      getLimitSwapExpectedToAmount({
         fromCoin: ethCoin,
-        toCoin: btcCoin,
+        amount: 10n ** 18n,
+        targetPrice: 0.04,
+      })
+    ).toBe(4_000_000n)
+  })
+
+  // A zero LIM is how THORChain spells "unprotected market order".
+  it('throws when the LIM floors to zero', () => {
+    expect(() =>
+      getLimitSwapExpectedToAmount({
+        fromCoin: ethCoin,
         amount: 1n,
         targetPrice: 0.04,
       })
     ).toThrow()
-  })
-
-  // 100 sats at 0.5 USDC/BTC is a LIM of 50 in THORChain's 1e8 fixed point --
-  // nonzero, so the memo builds -- but USDC's 6 decimals rescale it to 0. Passing
-  // that through as `expectedToAmount` would show a co-signer they receive
-  // nothing while the memo they sign still carries a real floor.
-  it('throws when a nonzero LIM underflows the target decimals', () => {
-    const order = {
-      fromCoin: btcCoin,
-      toCoin: usdcCoin,
-      amount: 100n,
-      targetPrice: 0.5,
-    } as const
-
-    expect(
-      buildLimitSwapMemoForCoins({
-        ...order,
-        expiryHours: 24,
-        destinationAddress: evmAddress,
-      })
-    ).toContain(':50/14400/0')
-
-    expect(() => getLimitSwapReceiveChainAmount(order)).toThrow(
-      /rounds to zero USDC/
-    )
   })
 })

--- a/core/ui/vault/swap/limit/memo.test.ts
+++ b/core/ui/vault/swap/limit/memo.test.ts
@@ -2,7 +2,10 @@ import { Chain } from '@vultisig/core-chain/Chain'
 import { Coin } from '@vultisig/core-chain/coin/Coin'
 import { describe, expect, it } from 'vitest'
 
-import { buildLimitSwapMemoForCoins } from './memo'
+import {
+  buildLimitSwapMemoForCoins,
+  getLimitSwapReceiveChainAmount,
+} from './memo'
 
 const ethCoin: Coin = { chain: Chain.Ethereum, ticker: 'ETH', decimals: 18 }
 const btcCoin: Coin = { chain: Chain.Bitcoin, ticker: 'BTC', decimals: 8 }
@@ -115,6 +118,43 @@ describe('buildLimitSwapMemoForCoins', () => {
         targetPrice: 0.04,
         expiryHours: 24,
         destinationAddress: evmAddress,
+      })
+    ).toThrow()
+  })
+})
+
+describe('getLimitSwapReceiveChainAmount', () => {
+  it('rescales the LIM to the target coin decimals', () => {
+    // 1 BTC at 16 ETH/BTC -> 16 ETH. ETH has 18 decimals, so 16e18.
+    expect(
+      getLimitSwapReceiveChainAmount({
+        fromCoin: btcCoin,
+        toCoin: ethCoin,
+        amount: 100_000_000n,
+        targetPrice: 16,
+      })
+    ).toBe(16n * 10n ** 18n)
+  })
+
+  it('matches the memo LIM for a 6-decimal target', () => {
+    // 1 BTC at 60000 USDC/BTC -> 60000 USDC. USDC has 6 decimals.
+    expect(
+      getLimitSwapReceiveChainAmount({
+        fromCoin: btcCoin,
+        toCoin: usdcCoin,
+        amount: 100_000_000n,
+        targetPrice: 60_000,
+      })
+    ).toBe(60_000n * 10n ** 6n)
+  })
+
+  it('throws on a LIM that floors to zero, like the memo', () => {
+    expect(() =>
+      getLimitSwapReceiveChainAmount({
+        fromCoin: ethCoin,
+        toCoin: btcCoin,
+        amount: 1n,
+        targetPrice: 0.04,
       })
     ).toThrow()
   })

--- a/core/ui/vault/swap/limit/memo.ts
+++ b/core/ui/vault/swap/limit/memo.ts
@@ -102,19 +102,35 @@ type GetLimitSwapReceiveChainAmountInput = GetLimitSwapReceiveAmountInput & {
  * The SDK's LIM is in THORChain's 1e8 fixed point; rescale it to the target
  * coin's decimals with bigint math so no precision is lost passing it to signing
  * (where a `Number` round-trip could emit scientific notation on a co-signer).
+ *
+ * Throws when a nonzero LIM rescales to zero — possible for targets with fewer
+ * than 8 decimals, where a dust minimum-received rounds away entirely. Forwarding
+ * `0` there would tell a co-signer they receive nothing while the signed memo
+ * still carries a real floor, so this fails loud like the memo builder does on
+ * its own zero-LIM case.
  */
 export const getLimitSwapReceiveChainAmount = ({
   fromCoin,
   toCoin,
   amount,
   targetPrice,
-}: GetLimitSwapReceiveChainAmountInput): bigint =>
-  (getLimitSwapLimitAmount({
+}: GetLimitSwapReceiveChainAmountInput): bigint => {
+  const limit = getLimitSwapLimitAmount({
     source_amount: toThorchainFixedPoint({
       amount,
       decimals: fromCoin.decimals,
     }),
     target_price: targetPrice,
-  }) *
-    10n ** BigInt(toCoin.decimals)) /
-  thorchainFixedPointScale
+  })
+
+  const receiveChainAmount =
+    (limit * 10n ** BigInt(toCoin.decimals)) / thorchainFixedPointScale
+
+  if (receiveChainAmount === 0n) {
+    throw new Error(
+      `This order's minimum received rounds to zero ${toCoin.ticker}. Increase the amount or the target price.`
+    )
+  }
+
+  return receiveChainAmount
+}

--- a/core/ui/vault/swap/limit/memo.ts
+++ b/core/ui/vault/swap/limit/memo.ts
@@ -63,59 +63,27 @@ type GetLimitSwapReceiveAmountInput = {
 }
 
 /**
- * The order's guaranteed-minimum output, in the target's natural units, for
- * display.
+ * The order's guaranteed-minimum output as `buildLimitSwapKeysignPayload`'s
+ * `expectedToAmount` — the memo's LIM, in THORChain's 1e8 fixed point.
  *
- * Derived from the SDK's `getLimitSwapLimitAmount` — the exact truncated LIM the
- * memo encodes — rather than recomputing `amount × price` as a float. The two can
- * differ by the truncation, and showing a "you receive" figure the signed order
- * would not honor is the mismatch the issue calls out. Throws on the same
- * conditions as the memo (a LIM flooring to zero), so callers guard it the same
- * way they guard the memo.
+ * Deliberately *not* the target coin's own decimals. The SDK formats this field
+ * with `getNativeSwapDecimals(toCoin)`, which is THORChain's 8 for every
+ * limit-swap target — MayaChain, the only chain that reports otherwise, is not
+ * THORChain-routable — mirroring how the market path feeds the same field a 1e8
+ * `expected_amount_out`. Rescaling to `toCoin.decimals` would leave the signed
+ * memo correct while showing the co-signer a receive amount 100x low for a
+ * 6-decimal USDC target and 1e10x high for an 18-decimal ETH one.
+ *
+ * Throws when the LIM floors to zero, which THORChain reads as an unprotected
+ * market order — the same condition the memo builder rejects, so callers guard
+ * it the same way they guard the memo.
  */
-export const getLimitSwapReceiveAmount = ({
+export const getLimitSwapExpectedToAmount = ({
   fromCoin,
   amount,
   targetPrice,
-}: GetLimitSwapReceiveAmountInput): number =>
-  fromThorchainFixedPoint(
-    getLimitSwapLimitAmount({
-      source_amount: toThorchainFixedPoint({
-        amount,
-        decimals: fromCoin.decimals,
-      }),
-      target_price: targetPrice,
-    })
-  )
-
-const thorchainFixedPointScale = 10n ** 8n
-
-type GetLimitSwapReceiveChainAmountInput = GetLimitSwapReceiveAmountInput & {
-  toCoin: Coin
-}
-
-/**
- * The order's guaranteed-minimum output as a chain amount in the *target's*
- * smallest units — the shape `buildLimitSwapKeysignPayload`'s `expectedToAmount`
- * expects.
- *
- * The SDK's LIM is in THORChain's 1e8 fixed point; rescale it to the target
- * coin's decimals with bigint math so no precision is lost passing it to signing
- * (where a `Number` round-trip could emit scientific notation on a co-signer).
- *
- * Throws when a nonzero LIM rescales to zero — possible for targets with fewer
- * than 8 decimals, where a dust minimum-received rounds away entirely. Forwarding
- * `0` there would tell a co-signer they receive nothing while the signed memo
- * still carries a real floor, so this fails loud like the memo builder does on
- * its own zero-LIM case.
- */
-export const getLimitSwapReceiveChainAmount = ({
-  fromCoin,
-  toCoin,
-  amount,
-  targetPrice,
-}: GetLimitSwapReceiveChainAmountInput): bigint => {
-  const limit = getLimitSwapLimitAmount({
+}: GetLimitSwapReceiveAmountInput): bigint =>
+  getLimitSwapLimitAmount({
     source_amount: toThorchainFixedPoint({
       amount,
       decimals: fromCoin.decimals,
@@ -123,14 +91,13 @@ export const getLimitSwapReceiveChainAmount = ({
     target_price: targetPrice,
   })
 
-  const receiveChainAmount =
-    (limit * 10n ** BigInt(toCoin.decimals)) / thorchainFixedPointScale
-
-  if (receiveChainAmount === 0n) {
-    throw new Error(
-      `This order's minimum received rounds to zero ${toCoin.ticker}. Increase the amount or the target price.`
-    )
-  }
-
-  return receiveChainAmount
-}
+/**
+ * The same guaranteed minimum in the target's natural units, for display.
+ *
+ * Derived from the exact value handed to signing rather than recomputing
+ * `amount × price` as a float, so the reviewed figure and the signed memo cannot
+ * disagree by the LIM's truncation.
+ */
+export const getLimitSwapReceiveAmount = (
+  input: GetLimitSwapReceiveAmountInput
+): number => fromThorchainFixedPoint(getLimitSwapExpectedToAmount(input))

--- a/core/ui/vault/swap/limit/memo.ts
+++ b/core/ui/vault/swap/limit/memo.ts
@@ -87,3 +87,34 @@ export const getLimitSwapReceiveAmount = ({
       target_price: targetPrice,
     })
   )
+
+const thorchainFixedPointScale = 10n ** 8n
+
+type GetLimitSwapReceiveChainAmountInput = GetLimitSwapReceiveAmountInput & {
+  toCoin: Coin
+}
+
+/**
+ * The order's guaranteed-minimum output as a chain amount in the *target's*
+ * smallest units — the shape `buildLimitSwapKeysignPayload`'s `expectedToAmount`
+ * expects.
+ *
+ * The SDK's LIM is in THORChain's 1e8 fixed point; rescale it to the target
+ * coin's decimals with bigint math so no precision is lost passing it to signing
+ * (where a `Number` round-trip could emit scientific notation on a co-signer).
+ */
+export const getLimitSwapReceiveChainAmount = ({
+  fromCoin,
+  toCoin,
+  amount,
+  targetPrice,
+}: GetLimitSwapReceiveChainAmountInput): bigint =>
+  (getLimitSwapLimitAmount({
+    source_amount: toThorchainFixedPoint({
+      amount,
+      decimals: fromCoin.decimals,
+    }),
+    target_price: targetPrice,
+  }) *
+    10n ** BigInt(toCoin.decimals)) /
+  thorchainFixedPointScale

--- a/core/ui/vault/swap/limit/placement.test.ts
+++ b/core/ui/vault/swap/limit/placement.test.ts
@@ -126,3 +126,41 @@ describe('getLimitOrderBlocker', () => {
     ).toBe('queueUnavailable')
   })
 })
+
+// The CTA is enabled exactly when there is no blocker, and `placeOrder` then
+// guards again on the fields the hand-off needs. These assert the two agree: an
+// enabled button must never hit that guard and silently do nothing.
+describe('confirm gating contract', () => {
+  it('implies a positive amount when placeable', () => {
+    expect(getLimitOrderBlocker(placeable)).toBeUndefined()
+    expect(placeable.amount).not.toBeNull()
+    expect(placeable.amount > 0n).toBe(true)
+  })
+
+  it('implies the memo built, so the hand-off has one to sign', () => {
+    expect(getLimitOrderBlocker(placeable)).toBeUndefined()
+    expect(placeable.memoError).toBeUndefined()
+  })
+
+  it('implies a usable price and market anchor for the receive amount', () => {
+    expect(getLimitOrderBlocker(placeable)).toBeUndefined()
+    expect(placeable.price).not.toBeNull()
+    expect(placeable.marketPrice).toBeTruthy()
+  })
+
+  // Each blocker must disable the CTA — none may resolve to "placeable".
+  it.each([
+    ['queueUnavailable', { isQueueEnabled: false }],
+    ['pairNotRoutable', { toChain: Chain.Sui }],
+    ['chainUnavailable', { supportedChains: undefined }],
+    ['sameAsset', { isSameAsset: true }],
+    ['noAmount', { amount: null }],
+    ['insufficientBalance', { balance: undefined }],
+    ['noPrice', { price: null }],
+    ['noMarketPrice', { marketPrice: undefined }],
+    ['noDestination', { destinationAddress: undefined }],
+    ['memoInvalid', { memoError: 'exceeds utxo limit 80' }],
+  ] as const)('keeps the CTA disabled for %s', (_, override) => {
+    expect(getLimitOrderBlocker({ ...placeable, ...override })).toBeDefined()
+  })
+})

--- a/core/ui/vault/swap/limit/queries/useLimitSwapKeysignPayloadQuery.ts
+++ b/core/ui/vault/swap/limit/queries/useLimitSwapKeysignPayloadQuery.ts
@@ -7,8 +7,9 @@ import { noRefetchQueryOptions } from '@lib/ui/query/utils/options'
 import { useQuery } from '@tanstack/react-query'
 import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
 import { buildLimitSwapKeysignPayload } from '@vultisig/core-mpc/keysign/swap/buildLimitSwapKeysignPayload'
-import { toKeysignLibType } from '@vultisig/core-mpc/types/utils/libType'
 import { getVaultId } from '@vultisig/core-mpc/vault/Vault'
+
+import { getLimitSwapKeysignPayloadInput } from '../keysignPayloadInput'
 
 type UseLimitSwapKeysignPayloadQueryInput = {
   fromCoin: AccountCoin
@@ -56,19 +57,19 @@ export const useLimitSwapKeysignPayloadQuery = ({
       },
     ],
     queryFn: () =>
-      buildLimitSwapKeysignPayload({
-        fromCoin,
-        toCoin,
-        amount,
-        memo,
-        expectedToAmount,
-        vaultId: getVaultId(vault),
-        localPartyId: vault.localPartyId,
-        fromPublicKey,
-        toPublicKey,
-        libType: toKeysignLibType(vault),
-        walletCore,
-      }),
+      buildLimitSwapKeysignPayload(
+        getLimitSwapKeysignPayloadInput({
+          fromCoin,
+          toCoin,
+          amount,
+          memo,
+          expectedToAmount,
+          vault,
+          fromPublicKey,
+          toPublicKey,
+          walletCore,
+        })
+      ),
     ...noRefetchQueryOptions,
   })
 }

--- a/core/ui/vault/swap/limit/queries/useLimitSwapKeysignPayloadQuery.ts
+++ b/core/ui/vault/swap/limit/queries/useLimitSwapKeysignPayloadQuery.ts
@@ -1,0 +1,74 @@
+import { useAssertWalletCore } from '@core/ui/chain/providers/WalletCoreProvider'
+import {
+  useCurrentVault,
+  useCurrentVaultPublicKey,
+} from '@core/ui/vault/state/currentVault'
+import { noRefetchQueryOptions } from '@lib/ui/query/utils/options'
+import { useQuery } from '@tanstack/react-query'
+import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+import { buildLimitSwapKeysignPayload } from '@vultisig/core-mpc/keysign/swap/buildLimitSwapKeysignPayload'
+import { toKeysignLibType } from '@vultisig/core-mpc/types/utils/libType'
+import { getVaultId } from '@vultisig/core-mpc/vault/Vault'
+
+type UseLimitSwapKeysignPayloadQueryInput = {
+  fromCoin: AccountCoin
+  toCoin: AccountCoin
+  /** Source amount in the coin's native smallest units. */
+  amount: bigint
+  /** The `=<` memo from `buildLimitSwapMemoForCoins`. */
+  memo: string
+  /** The order's LIM in the target's smallest units, for co-signer display only. */
+  expectedToAmount: bigint
+}
+
+/**
+ * Build the keysign payload for a placed limit order.
+ *
+ * The SDK's `buildLimitSwapKeysignPayload` owns the branching (RUNE `MsgDeposit`
+ * / native transfer / ERC20 router deposit) and the sign-time fail-closed gates
+ * (the `EnableAdvSwapQueue` mimir and halts), so this only supplies the vault
+ * identity, keys, and `walletCore` — exactly as `useSwapKeysignPayloadQuery`
+ * does for a market swap. Its rejections (disabled queue, halted chain) surface
+ * through the query error, which the verify screen renders.
+ */
+export const useLimitSwapKeysignPayloadQuery = ({
+  fromCoin,
+  toCoin,
+  amount,
+  memo,
+  expectedToAmount,
+}: UseLimitSwapKeysignPayloadQueryInput) => {
+  const vault = useCurrentVault()
+  const walletCore = useAssertWalletCore()
+  const fromPublicKey = useCurrentVaultPublicKey(fromCoin.chain)
+  const toPublicKey = useCurrentVaultPublicKey(toCoin.chain)
+
+  return useQuery({
+    queryKey: [
+      'limitSwapKeysignPayload',
+      {
+        fromCoin,
+        toCoin,
+        amount: amount.toString(),
+        memo,
+        expectedToAmount: expectedToAmount.toString(),
+        vaultId: getVaultId(vault),
+      },
+    ],
+    queryFn: () =>
+      buildLimitSwapKeysignPayload({
+        fromCoin,
+        toCoin,
+        amount,
+        memo,
+        expectedToAmount,
+        vaultId: getVaultId(vault),
+        localPartyId: vault.localPartyId,
+        fromPublicKey,
+        toPublicKey,
+        libType: toKeysignLibType(vault),
+        walletCore,
+      }),
+    ...noRefetchQueryOptions,
+  })
+}

--- a/core/ui/vault/swap/limit/queries/useLimitSwapKeysignPayloadQuery.ts
+++ b/core/ui/vault/swap/limit/queries/useLimitSwapKeysignPayloadQuery.ts
@@ -7,7 +7,7 @@ import { noRefetchQueryOptions } from '@lib/ui/query/utils/options'
 import { useQuery } from '@tanstack/react-query'
 import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
 import { buildLimitSwapKeysignPayload } from '@vultisig/core-mpc/keysign/swap/buildLimitSwapKeysignPayload'
-import { getVaultId } from '@vultisig/core-mpc/vault/Vault'
+import { omit } from '@vultisig/lib-utils/record/omit'
 
 import { getLimitSwapKeysignPayloadInput } from '../keysignPayloadInput'
 
@@ -44,32 +44,40 @@ export const useLimitSwapKeysignPayloadQuery = ({
   const fromPublicKey = useCurrentVaultPublicKey(fromCoin.chain)
   const toPublicKey = useCurrentVaultPublicKey(toCoin.chain)
 
+  const input = getLimitSwapKeysignPayloadInput({
+    fromCoin,
+    toCoin,
+    amount,
+    memo,
+    expectedToAmount,
+    vault,
+    fromPublicKey,
+    toPublicKey,
+    walletCore,
+  })
+
   return useQuery({
+    // Keyed off the whole signing identity, not just the vault id: a reshare
+    // keeps the ECDSA key (and so the id) while changing `localPartyId` and
+    // `libType`, and refetch-on-mount is off — so a vault-id-only key could
+    // serve a payload built for the previous participant set. Mirrors the
+    // market-swap query, omitting the same unserializable WalletCore handles.
     queryKey: [
       'limitSwapKeysignPayload',
       {
-        fromCoin,
-        toCoin,
+        ...omit(
+          input,
+          'walletCore',
+          'fromPublicKey',
+          'toPublicKey',
+          'amount',
+          'expectedToAmount'
+        ),
         amount: amount.toString(),
-        memo,
         expectedToAmount: expectedToAmount.toString(),
-        vaultId: getVaultId(vault),
       },
     ],
-    queryFn: () =>
-      buildLimitSwapKeysignPayload(
-        getLimitSwapKeysignPayloadInput({
-          fromCoin,
-          toCoin,
-          amount,
-          memo,
-          expectedToAmount,
-          vault,
-          fromPublicKey,
-          toPublicKey,
-          walletCore,
-        })
-      ),
+    queryFn: () => buildLimitSwapKeysignPayload(input),
     ...noRefetchQueryOptions,
   })
 }


### PR DESCRIPTION
Closes #4452

Builds on the limit-order form (#4441, now on main): the review screen's confirm was disabled, so "Place order" led to a dead end. This wires it to the same MPC keysign pipeline the market swap uses, so a limit order can actually be signed and broadcast.

## What it does

- **`useLimitSwapKeysignPayloadQuery`** — gathers the vault id, local party id, from/to public keys, `libType`, and `walletCore` exactly as `useSwapKeysignPayloadQuery` does for a market swap, and calls `buildLimitSwapKeysignPayload` (published in `@vultisig/core-mpc@1.13.0`).
- **`LimitOrderReview` now renders `VerifyKeysignStart`** — the same component `SwapVerify` uses — so the limit flow inherits the terms checkbox, the Blockaid scan row, and the Paired / Fast Sign ceremony rather than reimplementing them. No `swapQuote` is passed: a limit order has none, and the deposit signs like any other keysign.
- **The hand-off carries what signing needs**: the `=<` memo, the native source amount, and the LIM as a chain amount in the *target's* smallest units (`expectedToAmount`).

## Worth a reviewer's attention

**Nothing about the payload is rebuilt here.** The SDK's `buildLimitSwapKeysignPayload` owns the source branching (RUNE `MsgDeposit` / native transfer to the inbound vault / ERC20 router `depositWithExpiry` + approve) and the sign-time fail-closed gates (the `EnableAdvSwapQueue` mimir re-check and halt checks). Those rejections surface through the query error, which `VerifyKeysignStart` renders as the disabled-button message instead of being swallowed.

**`expectedToAmount` is derived from the same SDK LIM** via `getLimitSwapReceiveChainAmount`, using bigint math to rescale from THORChain's 1e8 fixed point to the target coin's decimals — so the co-signer's "you receive" row shows exactly what the signed memo encodes, with no float round-trip.

## Testing

`yarn check:all` passes — 1167 tests, typecheck, lint, knip, i18n.

The payload-input assembly is split out of the query hook into a pure mapper so it can be tested without React (`core/ui` runs vitest in a node environment with no testing-library). That mapping is where a silent mistake hides: several fields share a type, so swapping the from/to public keys or dropping the memo type-checks fine but would sign a different order than the user reviewed. The gating contract is asserted too — every blocker keeps the CTA disabled, and "no blocker" implies the fields `placeOrder` guards on are present, so an enabled button can never silently do nothing.

### Verified on mainnet

A limit order composed, signed, and broadcast from this branch — and it **filled**:

**[`5CB3698C…40F9C3`](https://runescan.io/tx/5CB3698C77FC719202EB1AEE5C5060B12A86E0BC086B0BB0DCC176711640F9C3)** — Midgard reports `type: limit_swap`, `status: success`, in `1 RUNE` → out `0.43079145 USDC`.

The memo THORChain recorded:

```
=<:ETH.USDC-06EB48:0x14F6Ed6CBb27b607b0E2A48551A988F1a19c89B6:43079145/14400/0:v0:50
```

Decoding it against the implementation:

| Segment | Value | Confirms |
|---|---|---|
| target asset | `ETH.USDC-06EB48` | the last-6 contract abbreviation from `getThorchainMemoAsset` — THORChain resolved it to the full `ETH.USDC-0XA0B8…EB48` in the payout |
| destination | `0x14F6…89B6` | the user's own address on the target chain |
| LIM | `43079145` | the payout was **exactly** this, so the quantized target price and the LIM math round-trip correctly |
| interval | `14400` | 24h expiry → blocks |
| quantity | `0` | streaming quantity |
| affiliate | `v0` / `50` | affiliate config |

That exercises the **native RUNE `MsgDeposit`** branch end to end: memo construction, LIM math, expiry mapping, payload build, MPC keysign, broadcast, and THORChain accepting and filling the order.

> [!NOTE]
> The other two source branches build different transactions and are still worth exercising before merge: a **native gas asset** (transfer to the inbound vault, memo in `data`/`OP_RETURN`) and an **ERC20** (router `depositWithExpiry` + approve in one ceremony).

## Known gaps

- The review screen shows the **network fee** only; the Figma also has protocol fee and max-total-fee rows.
- Done screen + local order persistence, and open-orders tracking, are the follow-up issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new order confirmation label for limit orders and updated the review text across supported languages.
  * Limit-order review now verifies/signs the order and displays a network fee row.
* **Bug Fixes**
  * Improved confirmation gating and error messaging to prevent placing unless memo, receive amount, and signing inputs are valid (including cross-chain receive amount handling).
  * Updated the placement success details to include additional memo/amount fields.
* **Tests**
  * Expanded coverage for keysign payload construction, receive-amount calculations, and blocker-based CTA disabling.
* **Documentation**
  * Updated the in-page provider ThorSwap link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->