### PR TITLE
fix(ui): keep search lens visible

### DIFF
--- a/clients/extension/tests/e2e/fixtures/extension-loader.ts
+++ b/clients/extension/tests/e2e/fixtures/extension-loader.ts
@@ -52,8 +52,18 @@ export const test = base.extend<{
   testDappUrl: string
 }>({
   context: async ({}, use) => {
+    const videoDir = process.env.EXTENSION_QA_VIDEO_DIR
     const context = await chromium.launchPersistentContext('', {
       headless: false,
+      ...(videoDir
+        ? {
+            viewport: { width: 1280, height: 720 },
+            recordVideo: {
+              dir: videoDir,
+              size: { width: 1280, height: 720 },
+            },
+          }
+        : {}),
       args: [
         `--disable-extensions-except=${extensionPath}`,
         `--load-extension=${extensionPath}`,

--- a/clients/extension/tests/e2e/playwright.config.ts
+++ b/clients/extension/tests/e2e/playwright.config.ts
@@ -103,6 +103,7 @@ export default defineConfig({
         '**/address-book.spec.ts',
         '**/visual-regression.spec.ts',
         '**/station-migration.spec.ts',
+        '**/search-field.spec.ts',
       ],
       use: {
         launchOptions: {

--- a/clients/extension/tests/e2e/specs/search-field.spec.ts
+++ b/clients/extension/tests/e2e/specs/search-field.spec.ts
@@ -66,9 +66,11 @@ test('vault search keeps the lens stable through focus, typing, and blur', async
   for (let iteration = 0; iteration < 3; iteration += 1) {
     await input.focus()
     await expect(lens).toBeVisible()
+    expect(await getLensOffset()).toEqual(initialLensOffset)
     await page.waitForTimeout(350)
     await input.evaluate(element => element.blur())
     await expect(lens).toBeVisible()
+    expect(await getLensOffset()).toEqual(initialLensOffset)
     await page.waitForTimeout(350)
   }
 

--- a/clients/extension/tests/e2e/specs/search-field.spec.ts
+++ b/clients/extension/tests/e2e/specs/search-field.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test } from '../fixtures/extension-loader'
+import {
+  getVaultConfigFromEnv,
+  importVaultViaUI,
+} from '../helpers/vault-import'
+
+test('vault search keeps the lens stable through focus, typing, and blur', async ({
+  context,
+  extensionId,
+}) => {
+  const config = getVaultConfigFromEnv()
+
+  if (!config) {
+    test.skip(true, 'No vault configuration')
+    return
+  }
+
+  const page = await context.newPage()
+  const imported = await importVaultViaUI(page, { ...config, extensionId })
+  expect(imported).toBe(true)
+
+  const prompt = page.locator('[role="dialog"][aria-modal="true"]')
+  if (await prompt.isVisible({ timeout: 1000 }).catch(() => false)) {
+    await page.keyboard.press('Escape')
+    await expect(prompt).toBeHidden()
+  }
+
+  await page.locator('[data-testid="vault-chain-search-button"]').click()
+
+  const input = page.locator('input[type="text"]:visible').first()
+  const searchField = input.locator('xpath=..')
+  const lens = searchField.locator('svg').first()
+
+  await expect(input).toBeFocused()
+  await expect(lens).toBeVisible()
+
+  const getLensOffset = async () => {
+    const [fieldBox, lensBox] = await Promise.all([
+      searchField.boundingBox(),
+      lens.boundingBox(),
+    ])
+    expect(fieldBox).not.toBeNull()
+    expect(lensBox).not.toBeNull()
+
+    return {
+      left: lensBox!.x - fieldBox!.x,
+      top: lensBox!.y - fieldBox!.y,
+    }
+  }
+
+  const initialLensOffset = await getLensOffset()
+
+  await page.waitForTimeout(500)
+  await input.pressSequentially('eth', { delay: 200 })
+  await expect(input).toHaveValue('eth')
+  await expect(lens).toBeVisible()
+  expect(await getLensOffset()).toEqual(initialLensOffset)
+  await page.waitForTimeout(500)
+
+  await input.evaluate(element => element.blur())
+  await expect(input).not.toBeFocused()
+  await expect(lens).toBeVisible()
+  expect(await getLensOffset()).toEqual(initialLensOffset)
+  await page.waitForTimeout(500)
+
+  for (let iteration = 0; iteration < 3; iteration += 1) {
+    await input.focus()
+    await expect(lens).toBeVisible()
+    await page.waitForTimeout(350)
+    await input.evaluate(element => element.blur())
+    await expect(lens).toBeVisible()
+    await page.waitForTimeout(350)
+  }
+
+  const artifactDir = process.env.EXTENSION_QA_ARTIFACT_DIR
+  if (artifactDir) {
+    await page.waitForTimeout(500)
+    await page.screenshot({
+      animations: 'disabled',
+      path: `${artifactDir}/extension-search-filled-blurred.png`,
+    })
+    await input.focus()
+    await page.waitForTimeout(500)
+    await searchField.screenshot({
+      animations: 'disabled',
+      path: `${artifactDir}/extension-search-filled-focused.png`,
+    })
+  }
+
+  await page.close()
+})

--- a/core/ui/vault/chain/manage/shared/SearchInput.stories.tsx
+++ b/core/ui/vault/chain/manage/shared/SearchInput.stories.tsx
@@ -1,0 +1,62 @@
+import { SearchField } from '@lib/ui/search/SearchField'
+import { Text } from '@lib/ui/text'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { useState } from 'react'
+import styled from 'styled-components'
+
+import { CoreProvider, CoreState } from '../../../../state/core'
+import { SearchInput } from './SearchInput'
+
+const meta = {
+  title: 'Vault/Search/PersistentLens',
+  parameters: { layout: 'centered' },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj
+
+const Surface = styled.div`
+  display: grid;
+  gap: 24px;
+  width: 360px;
+`
+
+const Field = styled.div`
+  display: grid;
+  gap: 8px;
+`
+
+const coreState = {
+  getClipboardText: async () => '',
+} as CoreState
+
+const InteractiveSearchFields = () => {
+  const [searchInputValue, setSearchInputValue] = useState('')
+
+  return (
+    <CoreProvider value={coreState}>
+      <Surface>
+        <Field data-testid="search-field-surface">
+          <Text color="shy" size={13}>
+            SearchField
+          </Text>
+          <SearchField autoFocus={false} />
+        </Field>
+        <Field data-testid="search-input-surface">
+          <Text color="shy" size={13}>
+            SearchInput
+          </Text>
+          <SearchInput
+            data-testid="search-input-control"
+            value={searchInputValue}
+            onChange={setSearchInputValue}
+          />
+        </Field>
+      </Surface>
+    </CoreProvider>
+  )
+}
+
+export const Interactive: Story = {
+  render: () => <InteractiveSearchFields />,
+}

--- a/core/ui/vault/chain/manage/shared/SearchInput.tsx
+++ b/core/ui/vault/chain/manage/shared/SearchInput.tsx
@@ -36,21 +36,20 @@ export const SearchInput = ({
         <InputWrapper hasBorder={!!value}>
           <StyledTextInput
             inputOverlay={
-              !isFocused &&
-              !value && (
-                <InputOverlayWr gap={8} alignItems="center">
-                  <IconWrapper size={16}>
-                    {iconStyle === 'station' ? (
-                      <StationMagnifierIcon />
-                    ) : (
-                      <MagnifyingGlassIcon />
-                    )}
-                  </IconWrapper>
+              <InputOverlayWr gap={8} alignItems="center" aria-hidden>
+                <IconWrapper size={16}>
+                  {iconStyle === 'station' ? (
+                    <StationMagnifierIcon />
+                  ) : (
+                    <MagnifyingGlassIcon />
+                  )}
+                </IconWrapper>
+                {!isFocused && !value && (
                   <Text size={13} color="shy">
                     {t('search_field_placeholder')}
                   </Text>
-                </InputOverlayWr>
-              )
+                )}
+              </InputOverlayWr>
             }
             onValueChange={onChange}
             value={value}
@@ -99,7 +98,9 @@ const InputWrapper = styled.div<{ hasBorder?: boolean }>`
       return `1px solid ${theme.colors.foregroundExtra.toCssValue()}`
     }
 
-    return hasBorder ? `1.5px solid ${getColor('primary')({ theme })}` : 'none'
+    return hasBorder
+      ? `1.5px solid ${getColor('primary')({ theme })}`
+      : '1.5px solid transparent'
   }};
 `
 
@@ -108,6 +109,7 @@ const StyledTextInput = styled(TextInput)`
   background: ${getColor('foreground')};
   box-shadow: 0 0 8px 0 rgba(240, 244, 252, 0.03) inset;
   height: 44px;
+  padding-left: 36px;
 
   ${({ theme }) =>
     theme.iconStyle === 'station' &&
@@ -124,6 +126,7 @@ const StyledTextInput = styled(TextInput)`
 const InputOverlayWr = styled(HStack)`
   position: absolute;
   left: 12px;
+  pointer-events: none;
   top: 50%;
   transform: translateY(-50%);
 `

--- a/core/ui/vault/chain/manage/shared/SearchInput.tsx
+++ b/core/ui/vault/chain/manage/shared/SearchInput.tsx
@@ -35,6 +35,7 @@ export const SearchInput = ({
       render={({ actionSize }) => (
         <InputWrapper hasBorder={!!value}>
           <StyledTextInput
+            aria-label={t('search_field_placeholder')}
             inputOverlay={
               <InputOverlayWr gap={8} alignItems="center" aria-hidden>
                 <IconWrapper size={16}>

--- a/lib/ui/search/SearchField.tsx
+++ b/lib/ui/search/SearchField.tsx
@@ -89,7 +89,7 @@ const Wrapper = styled(HStack)`
 `
 
 const SearchIconWrapper = styled(VStack)`
-  color: ${getColor('textShy')};
+  color: ${getColor('text')};
   font-size: 20px;
   left: 8px;
   pointer-events: none;

--- a/lib/ui/search/SearchField.tsx
+++ b/lib/ui/search/SearchField.tsx
@@ -45,15 +45,13 @@ export const SearchField: React.FC<SearchFieldProps> = ({
       alignItems="center"
       gap={8}
     >
-      {(!isFocused || showPlaceholderWhenFocused) && (
-        <SearchIconWrapper>
-          {iconStyle === 'station' ? (
-            <StationMagnifierIcon />
-          ) : (
-            <SearchIcon strokeWidth={2.5} />
-          )}
-        </SearchIconWrapper>
-      )}
+      <SearchIconWrapper aria-hidden>
+        {iconStyle === 'station' ? (
+          <StationMagnifierIcon />
+        ) : (
+          <SearchIcon strokeWidth={2.5} />
+        )}
+      </SearchIconWrapper>
       <StyledInput
         autoFocus={autoFocus}
         onFocus={() => setIsFocused(true)}
@@ -94,6 +92,7 @@ const SearchIconWrapper = styled(VStack)`
   color: ${getColor('textShy')};
   font-size: 20px;
   left: 8px;
+  pointer-events: none;
   position: absolute;
   top: 50%;
   transform: translateY(-50%);


### PR DESCRIPTION
Keeps the magnifier visible in both shared search controls across focus, typing, clearing, and blur. This preserves stable text and icon spacing while preventing placeholder overlap.

Closes #4433

Real product QA: verified in the rebuilt extension with the designated Fast Vault across focus, typing, blur, and repeated refocus; the lens remained visible at a stable inset.

![screenshot-1](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/codex/4433-persistent-search-lens-24682c17/screenshot-1-1785211798925.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Stabilized the Vault search “lens”/icon position across focus, typing, and blur.
  - Ensured the search icon overlay doesn’t interfere with typing or pointer interactions.
  - Standardized overlay/layout spacing, including consistent border behavior.
- **Accessibility**
  - Marked decorative search visuals as non-interactive and hidden from assistive technologies.
- **Documentation**
  - Added a Storybook story showcasing the persistent Vault search lens behavior.
- **Tests**
  - Added an end-to-end test covering lens stability across focus/blur cycles.
  - Updated E2E configuration to include the search-field spec.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->