### PR TITLE
fix(defi): hide the merged RUJI card when RUJI is not selected

### DIFF
--- a/core/ui/defi/chain/tabs/StakedPositions.tsx
+++ b/core/ui/defi/chain/tabs/StakedPositions.tsx
@@ -113,9 +113,17 @@ export const StakedPositions = () => {
     )
   }
 
+  // The merged RUJI balance belongs to the RUJI position, so it follows the
+  // same selection id as the auto-compounding and bonded RUJI cards.
+  const isRujiSelected = selectedPositions.includes(
+    rujiAutoCompoundStakePositionId
+  )
+
   return (
     <VStack gap={12}>
-      {chain === Chain.THORChain ? <RujiMergedPositionCard /> : null}
+      {chain === Chain.THORChain && isRujiSelected ? (
+        <RujiMergedPositionCard />
+      ) : null}
       <ThorchainStakedPositions />
     </VStack>
   )


### PR DESCRIPTION
## Description

On `DeFi → THORChain → Staked`, the `RUJI (Merged)` card stayed visible after the user disabled every position for the chain — it rendered directly above the `No positions selected` empty state, which is contradictory. The `Bonded` and `LPs` tabs already behaved correctly.

The card was rendered as a sibling of `ThorchainStakedPositions`, i.e. outside the component that applies the selected-positions gate, and it never read `useDefiPositions(chain)` itself — it only checked that the vault holds RUJI and that the merged balance is non-zero. Since the merged position has no tile of its own in `Manage Positions`, there was no way for the user to hide it.

This gates the card on `thor-stake-ruji` (`rujiAutoCompoundStakePositionId`) — the selection id the auto-compounding and bonded RUJI cards already share via `selectionIdForStakePosition` — so all three RUJI surfaces follow a single toggle. No new position id and no storage migration.

Fixes #4479

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

`yarn check` passes (typecheck + lint clean). No test added — `StakedPositions` has no existing test harness and the change is a single render-gate condition.

## Screenshots (if applicable):

Before — all THORChain positions disabled, `RUJI (Merged)` still rendered above the empty state:

| Staked (before) | Bonded (correct) |
|---|---|
| `RUJI (Merged)` card + `No positions selected` | `No positions selected` only |

After — `Staked` matches `Bonded`/`LPs`: only the empty state.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #4479
- **Confidence**: high
- **Needs human review for**: none — single render-gate condition, no chain/MPC logic touched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * RUJI merged-position details now appear only when the corresponding auto-compounding position is selected.
  * Prevented unselected RUJI positions from being displayed on THORChain staking screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->