### PR TITLE
fix(defi): respect the position selection on the Solana staked tab

### DIFF
--- a/core/ui/defi/chain/tabs/StakedPositions.tsx
+++ b/core/ui/defi/chain/tabs/StakedPositions.tsx
@@ -87,6 +87,9 @@ export const StakedPositions = () => {
   }
 
   if (chain === Chain.Solana) {
+    if (selectedPositions.length === 0) {
+      return <DefiPositionEmptyState returnTab="staked" />
+    }
     return <SolanaStakeDefiView />
   }
 


### PR DESCRIPTION
## Description

On `DeFi → Solana → Staked`, disabling the `SOL` position in `Manage Positions` had no effect — the `Total Staked SOL` summary card, the `Delegate to New Validator` button and every stake-account row kept rendering, and the `No positions selected` empty state was never reached.

`StakedPositions` returns `SolanaStakeDefiView` before any selection gate runs, and that view never reads `useDefiPositions` itself — the file has no reference to the selection state at all. Meanwhile `solana-stake-sol` is a real toggleable tile in `staticDefiPositions`, so the user could switch it off and nothing happened.

This applies the same gate the TON branch already uses two blocks above. Gated on the selection being empty rather than on the `solana-stake-sol` id, to match the TON and Terra-family branches in the same file — Solana has exactly one static position, so the two are equivalent today and the length check stays correct if more are added.

Same class of bug as #4479 / #4480 (the `RUJI (Merged)` card), but wider: it covered the whole tab rather than one extra card. With this, every chain on the Staked tab gates consistently — THORChain/MayaChain inside `ThorchainStakedPositions`, TON at the top, Terra/TerraClassic/QBTC in the cosmos branch, and now Solana.

Scope note: this is about the opt-out state only. A selected position with zero staked SOL still shows the summary card at `0` with the delegate CTA — that was already correct and is unchanged.

Fixes #4482

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

`yarn check` passes (typecheck + lint clean). No test added — `StakedPositions` has no existing test harness and the change is a single render-gate condition mirroring the TON branch.

## Screenshots (if applicable):

Reproduced on a vault with two Solana stake accounts: `SOL` unticked in `Select positions`, yet the Staked tab still rendered `Total Staked SOL 2.00060395 SOL`, the delegate button and both validator rows. After the fix the tab shows only the `No positions selected` empty state.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #4482
- **Confidence**: high
- **Needs human review for**: none — single render-gate condition, no Solana staking logic touched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Solana staking now displays an empty state when no positions are selected, instead of showing an empty staking view.
  * Improved consistency with empty-state behavior across supported chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->