### PR TITLE
test(extension): restore release QA coverage

### DIFF
--- a/clients/extension/tests/e2e/page-objects/OnboardingPage.po.ts
+++ b/clients/extension/tests/e2e/page-objects/OnboardingPage.po.ts
@@ -57,11 +57,13 @@ export class OnboardingPage extends BasePage {
    * Wait for the onboarding view to be visible
    */
   async waitForView(timeout = 10_000): Promise<void> {
-    // Wait for either vultisig text, next button, or skip button
+    // The current flow can open directly on NewVaultPage, while older
+    // onboarding variants still expose Next/Skip.
     await Promise.race([
       this.welcomeText.waitFor({ state: 'visible', timeout }),
       this.nextButton.waitFor({ state: 'visible', timeout }),
       this.skipButton.waitFor({ state: 'visible', timeout }),
+      this.newVaultGetStartedButton.waitFor({ state: 'visible', timeout }),
     ])
   }
 
@@ -74,7 +76,8 @@ export class OnboardingPage extends BasePage {
       const hasVultisig = await this.welcomeText.isVisible()
       const hasNext = await this.nextButton.isVisible()
       const hasSkip = await this.skipButton.isVisible()
-      return hasVultisig || (hasNext && hasSkip)
+      const hasNewVaultActions = await this.newVaultGetStartedButton.isVisible()
+      return hasVultisig || hasNewVaultActions || (hasNext && hasSkip)
     } catch {
       return false
     }
@@ -84,9 +87,7 @@ export class OnboardingPage extends BasePage {
    * Click "Next" to proceed from onboarding
    */
   async getStarted(): Promise<void> {
-    if (await this.nextButton.isVisible()) {
-      await this.nextButton.click()
-    } else if (await this.getStartedButton.isVisible()) {
+    if (await this.getStartedButton.isVisible()) {
       await this.getStartedButton.click()
     }
     await this.page.waitForTimeout(300)
@@ -163,10 +164,8 @@ export class OnboardingPage extends BasePage {
   async navigateToSetupVault(): Promise<void> {
     // Both NewVaultPage and SetupVaultPage label their primary button
     // "Get started", so target the NewVaultPage one by test id.
-    if (await this.newVaultGetStartedButton.isVisible()) {
-      await this.newVaultGetStartedButton.click()
-      await this.page.waitForTimeout(500)
-    }
+    await this.newVaultGetStartedButton.click()
+    await this.page.waitForTimeout(500)
   }
 
   /**

--- a/clients/extension/tests/e2e/page-objects/SeedphraseWizard.po.ts
+++ b/clients/extension/tests/e2e/page-objects/SeedphraseWizard.po.ts
@@ -26,12 +26,10 @@ export class SeedphraseWizard extends BasePage {
   }
 
   get seedphraseInput(): Locator {
-    return (
-      this.page.locator('[data-testid="seedphrase-input"]') ||
-      this.page.locator('textarea[placeholder*="seed"]') ||
-      this.page.locator('textarea[placeholder*="mnemonic"]') ||
-      this.page.getByPlaceholder(/seed|mnemonic|recovery|phrase/i)
-    )
+    return this.page
+      .locator('[data-testid="seedphrase-input"]')
+      .or(this.page.getByPlaceholder(/seed|mnemonic|recovery|phrase/i))
+      .first()
   }
 
   get wordInputs(): Locator {
@@ -39,27 +37,31 @@ export class SeedphraseWizard extends BasePage {
   }
 
   get continueButton(): Locator {
-    return (
-      this.page.locator('[data-testid="seedphrase-continue"]') ||
-      this.page.getByRole('button', { name: /continue|import|next/i })
-    )
+    return this.page
+      .locator('[data-testid="seedphrase-continue"]')
+      .or(this.page.getByRole('button', { name: /continue|import|next/i }))
+      .first()
   }
 
   get validationError(): Locator {
-    return (
-      this.page.locator('[data-testid="seedphrase-error"]') ||
-      this.page.locator('[role="alert"]') ||
-      this.page.locator('.error-message') ||
-      this.page.locator('text=/invalid.*mnemonic|invalid.*phrase|incorrect.*words/i')
-    )
+    return this.page
+      .locator('[data-testid="seedphrase-error"]')
+      .or(this.page.locator('[role="alert"]'))
+      .or(this.page.locator('.error-message'))
+      .or(
+        this.page.getByText(
+          /seed phrase must be 12 or 24|seed phrase is not correct/i
+        )
+      )
+      .first()
   }
 
   get scanProgress(): Locator {
-    return (
-      this.page.locator('[data-testid="scan-progress"]') ||
-      this.page.locator('[role="progressbar"]') ||
-      this.page.locator('text=/scanning|discovering|loading/i')
-    )
+    return this.page
+      .locator('[data-testid="scan-progress"]')
+      .or(this.page.locator('[role="progressbar"]'))
+      .or(this.page.getByText(/scanning|discovering|loading/i))
+      .first()
   }
 
   get chainList(): Locator {
@@ -71,17 +73,17 @@ export class SeedphraseWizard extends BasePage {
   }
 
   get selectAllButton(): Locator {
-    return (
-      this.page.locator('[data-testid="select-all-chains"]') ||
-      this.page.getByRole('button', { name: /select all/i })
-    )
+    return this.page
+      .locator('[data-testid="select-all-chains"]')
+      .or(this.page.getByRole('button', { name: /select all/i }))
+      .first()
   }
 
   get confirmButton(): Locator {
-    return (
-      this.page.locator('[data-testid="confirm-import"]') ||
-      this.page.getByRole('button', { name: /confirm|create|finish|import/i })
-    )
+    return this.page
+      .locator('[data-testid="confirm-import"]')
+      .or(this.page.getByRole('button', { name: /confirm|create|finish|import/i }))
+      .first()
   }
 
   get addressDisplay(): Locator {

--- a/clients/extension/tests/e2e/page-objects/SeedphraseWizard.po.ts
+++ b/clients/extension/tests/e2e/page-objects/SeedphraseWizard.po.ts
@@ -37,10 +37,7 @@ export class SeedphraseWizard extends BasePage {
   }
 
   get continueButton(): Locator {
-    return this.page
-      .locator('[data-testid="seedphrase-continue"]')
-      .or(this.page.getByRole('button', { name: /continue|import|next/i }))
-      .first()
+    return this.page.getByRole('button', { name: 'Import', exact: true })
   }
 
   get validationError(): Locator {
@@ -80,10 +77,7 @@ export class SeedphraseWizard extends BasePage {
   }
 
   get confirmButton(): Locator {
-    return this.page
-      .locator('[data-testid="confirm-import"]')
-      .or(this.page.getByRole('button', { name: /confirm|create|finish|import/i }))
-      .first()
+    return this.page.getByRole('button', { name: 'Next', exact: true })
   }
 
   get addressDisplay(): Locator {

--- a/clients/extension/tests/e2e/specs/dapp-provider.spec.ts
+++ b/clients/extension/tests/e2e/specs/dapp-provider.spec.ts
@@ -7,7 +7,7 @@
  * - personal_sign - popup shows message - approve - signature returned
  * - wallet_switchEthereumChain - chainChanged event fires
  * - reject connection returns UserRejectedRequest error
- * - window.vultisig and window.phantom.solana also injected
+ * - window.vultisig and its Solana provider are injected
  */
 
 import { test, expect } from '../fixtures/extension-loader'
@@ -222,14 +222,18 @@ test.describe('DApp Provider', () => {
     const hasRequestMethod = await page.evaluate(() => typeof window.ethereum?.request === 'function')
     expect(hasRequestMethod).toBe(true)
 
-    // Check isVultisig flag
-    const isVultisig = await page.evaluate(() => window.ethereum?.isVultisig === true)
-    // May or may not be true depending on implementation
+    await expect
+      .poll(() => page.evaluate(() => window.ethereum?.isVultiConnect === true))
+      .toBe(true)
 
     await page.close()
   })
 
   test('eth_requestAccounts - popup opens - approve - address returned', async ({ context, extensionId }) => {
+    test.skip(
+      !getVaultConfigFromEnv(),
+      'Requires the designated TEST_VAULT_PATH and TEST_VAULT_PASSWORD fixture'
+    )
     await ensureDappProviderVault({ context, extensionId })
 
     const page = await context.newPage()
@@ -246,6 +250,10 @@ test.describe('DApp Provider', () => {
   })
 
   test('personal_sign - popup shows message - approve - signature returned', async ({ context, extensionId }) => {
+    test.skip(
+      !getVaultConfigFromEnv(),
+      'Requires the designated TEST_VAULT_PATH and TEST_VAULT_PASSWORD fixture'
+    )
     const config = await ensureDappProviderVault({ context, extensionId })
 
     const page = await context.newPage()
@@ -286,149 +294,96 @@ test.describe('DApp Provider', () => {
   })
 
   test('wallet_switchEthereumChain - chainChanged event fires', async ({ context, extensionId }) => {
+    test.skip(
+      !getVaultConfigFromEnv(),
+      'Requires the designated TEST_VAULT_PATH and TEST_VAULT_PASSWORD fixture'
+    )
+    await ensureDappProviderVault({ context, extensionId })
+
     const page = await context.newPage()
 
-    await page.goto(dappUrl)
-    await page.waitForLoadState('domcontentloaded')
-    await page.waitForFunction(() => !!window.ethereum, null, { timeout: 10000 })
+    try {
+      await page.goto(dappUrl)
+      await page.waitForLoadState('domcontentloaded')
+      await page.waitForFunction(() => !!window.ethereum, null, { timeout: 10000 })
+      await connectDappWallet({ page, context, extensionId })
 
-    // Connect first
-    const connectButton = page.locator('[data-testid="connect-wallet"]')
-    await connectButton.click()
-
-    let popup = await waitForApprovalPopup(context, extensionId)
-    if (popup && !popup.isClosed()) {
-      const approval = new DAppApproval(popup, extensionId)
-      try {
-        await approval.waitForView(5000)
-        await approval.approve()
-      } catch {
-        // Already connected
-      }
-    }
-
-    await page.waitForTimeout(1000)
-
-    // Try switching chain
-    const switchButton = page.locator('[data-testid="switch-chain"]')
-    if (await switchButton.isEnabled({ timeout: 5000 }).catch(() => false)) {
-      // Select a different chain
+      const switchButton = page.locator('[data-testid="switch-chain"]')
+      await expect(switchButton).toBeEnabled()
       const chainSelect = page.locator('#chain-select')
-      await chainSelect.selectOption('0x89') // Polygon
-
+      await chainSelect.selectOption('0x89')
       await switchButton.click()
 
-      // May need approval for switch
-      popup = await waitForApprovalPopup(context, extensionId)
+      const popup = await waitForApprovalPopup({ context, extensionId })
       if (popup && !popup.isClosed()) {
         const approval = new DAppApproval(popup, extensionId)
-        try {
-          await approval.waitForView(5000)
-          await approval.approve()
-        } catch {
-          // Switch might not need approval
-        }
+        await approval.waitForView(5000)
+        await approval.approve()
       }
 
-      // Check result
-      await page.waitForTimeout(2000)
       const switchResult = page.locator('[data-testid="switch-result"]')
-      const resultText = await switchResult.textContent()
-
-      console.log('Switch result:', resultText)
-
-      // Check events log for chainChanged
+      await expect(switchResult).toContainText(/0x89/i)
       const eventsLog = page.locator('[data-testid="events-log"]')
-      const logText = await eventsLog.textContent()
-
-      if (logText?.includes('chainChanged')) {
-        expect(logText).toContain('chainChanged')
-      }
-    } else {
-      console.log('Switch button not enabled')
+      await expect(eventsLog).toContainText('chainChanged')
+    } finally {
+      await page.close()
     }
-
-    await page.close()
   })
 
   test('reject connection returns UserRejectedRequest error', async ({ context, extensionId }) => {
+    test.skip(
+      !getVaultConfigFromEnv(),
+      'Requires the designated TEST_VAULT_PATH and TEST_VAULT_PASSWORD fixture'
+    )
+    await ensureDappProviderVault({ context, extensionId })
+
     const page = await context.newPage()
 
-    await page.goto(dappUrl)
-    await page.waitForLoadState('domcontentloaded')
-    await page.waitForFunction(() => !!window.ethereum, null, { timeout: 10000 })
+    try {
+      await page.goto(dappUrl)
+      await page.waitForLoadState('domcontentloaded')
+      await page.waitForFunction(() => !!window.ethereum, null, { timeout: 10000 })
 
-    // Click connect
-    const connectButton = page.locator('[data-testid="connect-wallet"]')
-    await connectButton.click()
+      const connectButton = page.locator('[data-testid="connect-wallet"]')
+      await connectButton.click()
 
-    // Wait for popup and reject
-    const popup = await waitForApprovalPopup(context, extensionId)
-
-    if (popup && !popup.isClosed()) {
-      const approval = new DAppApproval(popup, extensionId)
-
-      try {
-        await approval.waitForView(10_000)
-        await approval.reject()
-        await approval.waitForClose()
-
-        // Check DApp received rejection error
-        await page.waitForTimeout(2000)
-        const connectResult = page.locator('[data-testid="connect-result"]')
-        const resultText = await connectResult.textContent()
-
-        console.log('Rejection result:', resultText)
-
-        // Should contain error code 4001 (UserRejectedRequest) or rejection message
-        if (resultText) {
-          const hasRejection =
-            resultText.includes('4001') ||
-            resultText.toLowerCase().includes('reject') ||
-            resultText.toLowerCase().includes('denied') ||
-            resultText.toLowerCase().includes('cancel')
-
-          expect(hasRejection).toBe(true)
-        }
-      } catch (error) {
-        console.log('Rejection test error:', error)
+      const popup = await waitForApprovalPopup({ context, extensionId })
+      if (!popup || popup.isClosed()) {
+        throw new Error('eth_requestAccounts rejection did not open an approval popup')
       }
-    }
 
-    await page.close()
+      const approval = new DAppApproval(popup, extensionId)
+      await approval.waitForView(10_000)
+      await approval.reject()
+      await approval.waitForClose()
+
+      const connectResult = page.locator('[data-testid="connect-result"]')
+      await expect(connectResult).toContainText(/4001|reject|denied|cancel/i)
+    } finally {
+      await page.close()
+    }
   })
 
-  test('window.vultisig and window.phantom.solana also injected', async ({ context }) => {
+  test('window.vultisig and its Solana provider are injected', async ({ context }) => {
     const page = await context.newPage()
 
     await page.goto(dappUrl)
     await page.waitForLoadState('domcontentloaded')
     await page.waitForTimeout(2000)
 
-    // Check for window.vultisig
-    const hasVultisig = await page.evaluate(() => !!window.vultisig)
-    console.log('window.vultisig:', hasVultisig)
-
-    // Check for window.phantom.solana
-    const hasSolana = await page.evaluate(() => !!window.phantom?.solana)
-    console.log('window.phantom.solana:', hasSolana)
-
-    // At least ethereum should be present
-    const hasEthereum = await page.evaluate(() => !!window.ethereum)
-    expect(hasEthereum).toBe(true)
-
-    // Log detected providers
     const providers = await page.evaluate(() => {
-      const detected: string[] = []
-      if (window.ethereum) detected.push('ethereum')
-      if (window.vultisig) detected.push('vultisig')
-      if (window.phantom?.solana) detected.push('phantom.solana')
-      if (window.phantom?.ethereum) detected.push('phantom.ethereum')
-      return detected
+      return {
+        ethereum: !!window.ethereum,
+        vultisig: !!window.vultisig,
+        vultisigSolana: !!window.vultisig?.solana,
+      }
     })
 
-    console.log('Detected providers:', providers)
-    expect(providers.length).toBeGreaterThan(0)
+    expect(providers).toEqual({
+      ethereum: true,
+      vultisig: true,
+      vultisigSolana: true,
+    })
 
     await page.close()
   })

--- a/clients/extension/tests/e2e/specs/dapp-provider.spec.ts
+++ b/clients/extension/tests/e2e/specs/dapp-provider.spec.ts
@@ -369,21 +369,20 @@ test.describe('DApp Provider', () => {
 
     await page.goto(dappUrl)
     await page.waitForLoadState('domcontentloaded')
-    await page.waitForTimeout(2000)
 
-    const providers = await page.evaluate(() => {
-      return {
-        ethereum: !!window.ethereum,
-        vultisig: !!window.vultisig,
-        vultisigSolana: !!window.vultisig?.solana,
-      }
-    })
-
-    expect(providers).toEqual({
-      ethereum: true,
-      vultisig: true,
-      vultisigSolana: true,
-    })
+    await expect
+      .poll(() =>
+        page.evaluate(() => ({
+          ethereum: !!window.ethereum,
+          vultisig: !!window.vultisig,
+          vultisigSolana: !!window.vultisig?.solana,
+        }))
+      )
+      .toEqual({
+        ethereum: true,
+        vultisig: true,
+        vultisigSolana: true,
+      })
 
     await page.close()
   })

--- a/clients/extension/tests/e2e/specs/seedphrase-import.spec.ts
+++ b/clients/extension/tests/e2e/specs/seedphrase-import.spec.ts
@@ -1,250 +1,121 @@
 /**
  * Seedphrase Import E2E Tests
  *
- * Tests the seedphrase import flow:
- * - enter valid 12-word mnemonic - chains discovered
- * - invalid mnemonic shows validation error
- * - select chains creates fast vault from seedphrase
- * - derived addresses match expected
+ * Uses a public BIP39 test vector with no production value. These tests prove
+ * the real extension navigation and validation states without completing a
+ * network-backed Fast Vault keygen.
  */
 
-import { test, expect } from '../fixtures/extension-loader'
+import { expect, test } from '../fixtures/extension-loader'
 import { OnboardingPage } from '../page-objects/OnboardingPage.po'
 import { SeedphraseWizard } from '../page-objects/SeedphraseWizard.po'
-import { VaultPage } from '../page-objects/VaultPage.po'
 
-// Test mnemonics - using well-known test vectors
-// DO NOT use these for real funds
 const VALID_12_WORD_MNEMONIC =
-  process.env.TEST_SEEDPHRASE ||
   'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+const INVALID_MNEMONIC =
+  'invalid words that are not a real mnemonic phrase at all testing'
 
-const INVALID_MNEMONIC = 'invalid words that are not a real mnemonic phrase at all testing'
+const openSeedphraseInput = async ({
+  onboarding,
+  seedphraseWizard,
+}: {
+  onboarding: OnboardingPage
+  seedphraseWizard: SeedphraseWizard
+}) => {
+  await onboarding.goto()
+  await onboarding.waitForView()
+  await onboarding.completeOnboarding()
 
-// Expected addresses for the test mnemonic (BIP44 derivation)
-// These are derived from 'abandon x11 about' mnemonic
-const EXPECTED_ADDRESSES: Record<string, string> = {
-  ethereum: '0x9858EfFD232B4033E47d90003D41EC34EcaEda94',
-  bitcoin: 'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu',
-  // Add more expected addresses as needed
+  await expect(onboarding.importVaultButton).toBeVisible()
+  await onboarding.importVault()
+
+  const importSeedphrase = onboarding.page.getByRole('button', {
+    name: /import seedphrase/i,
+  })
+  await expect(importSeedphrase).toBeVisible()
+  await importSeedphrase.click()
+
+  const introGetStarted = onboarding.page.getByRole('button', {
+    name: /get started/i,
+  })
+  await expect(introGetStarted).toBeVisible({ timeout: 10_000 })
+  await introGetStarted.click()
+  await seedphraseWizard.waitForView()
 }
 
 test.describe('Seedphrase Import', () => {
-  test('enter valid 12-word mnemonic - chains discovered', async ({ context, extensionId }) => {
+  test('valid 12-word mnemonic starts chain discovery', async ({
+    context,
+    extensionId,
+  }) => {
     const page = await context.newPage()
     const onboarding = new OnboardingPage(page, extensionId)
     const seedphraseWizard = new SeedphraseWizard(page, extensionId)
 
-    await onboarding.goto()
-    await page.waitForLoadState('domcontentloaded')
+    await openSeedphraseInput({ onboarding, seedphraseWizard })
+    await seedphraseWizard.enterSeedphrase(VALID_12_WORD_MNEMONIC)
 
-    // Navigate through onboarding to import option
-    try {
-      await onboarding.waitForView(10_000)
-      await onboarding.getStarted()
-      await page.waitForTimeout(500)
-    } catch {
-      // May already be past onboarding
-    }
+    await expect(seedphraseWizard.validationError).toBeHidden()
+    await expect(seedphraseWizard.continueButton).toBeEnabled()
+    await seedphraseWizard.continue()
 
-    // Look for import option
-    const importOption = page.getByText(/import.*seedphrase|import.*vault|restore.*wallet|import.*wallet/i).first()
-    if (await importOption.isVisible({ timeout: 5000 }).catch(() => false)) {
-      await importOption.click()
-      await page.waitForTimeout(500)
-    }
-
-    // Enter valid seedphrase
-    try {
-      await seedphraseWizard.waitForView(10_000)
-      await seedphraseWizard.enterSeedphrase(VALID_12_WORD_MNEMONIC)
-
-      // Should not show validation error
-      const hasError = await seedphraseWizard.hasValidationError()
-      expect(hasError).toBe(false)
-
-      // Continue should be enabled
-      const isEnabled = await seedphraseWizard.isContinueEnabled()
-      expect(isEnabled).toBe(true)
-
-      // Continue to see discovered chains
-      await seedphraseWizard.continue()
-      await seedphraseWizard.waitForScan()
-
-      // Should discover at least one chain
-      await page.waitForTimeout(2000)
-      const chains = await seedphraseWizard.getDiscoveredChains()
-      // Log discovered chains for debugging
-      console.log('Discovered chains:', chains)
-    } catch (error) {
-      console.log('Seedphrase wizard not available in current flow:', error)
-    }
+    await expect(
+      page.getByText(
+        /scanning for chains|no active chains found|we found \d+ active chains/i
+      )
+    ).toBeVisible({ timeout: 60_000 })
 
     await page.close()
   })
 
-  test('invalid mnemonic shows validation error', async ({ context, extensionId }) => {
+  test('invalid mnemonic shows validation error and blocks import', async ({
+    context,
+    extensionId,
+  }) => {
     const page = await context.newPage()
     const onboarding = new OnboardingPage(page, extensionId)
     const seedphraseWizard = new SeedphraseWizard(page, extensionId)
 
-    await onboarding.goto()
-    await page.waitForLoadState('domcontentloaded')
+    await openSeedphraseInput({ onboarding, seedphraseWizard })
+    await seedphraseWizard.enterSeedphrase(INVALID_MNEMONIC)
 
-    // Navigate to import
-    try {
-      await onboarding.waitForView(5_000)
-      await onboarding.getStarted()
-      await page.waitForTimeout(500)
-    } catch {
-      // Already past onboarding
-    }
-
-    const importOption = page.getByText(/import.*seedphrase|import.*vault|restore|import.*wallet/i).first()
-    if (await importOption.isVisible({ timeout: 5000 }).catch(() => false)) {
-      await importOption.click()
-      await page.waitForTimeout(500)
-    }
-
-    try {
-      await seedphraseWizard.waitForView(10_000)
-
-      // Enter invalid mnemonic
-      await seedphraseWizard.enterSeedphrase(INVALID_MNEMONIC)
-      await page.waitForTimeout(1000)
-
-      // Should show validation error or disable continue
-      const hasError = await seedphraseWizard.hasValidationError()
-      const isEnabled = await seedphraseWizard.isContinueEnabled()
-
-      // Either should show error OR disable continue button
-      expect(hasError || !isEnabled).toBe(true)
-
-      if (hasError) {
-        const errorText = await seedphraseWizard.getValidationError()
-        console.log('Validation error:', errorText)
-        expect(errorText).toBeTruthy()
-      }
-    } catch (error) {
-      console.log('Seedphrase wizard not available:', error)
-    }
+    await expect(seedphraseWizard.validationError).toContainText(
+      /12 or 24|not correct/i
+    )
+    await expect(seedphraseWizard.continueButton).toBeDisabled()
 
     await page.close()
   })
 
-  test('select chains creates fast vault from seedphrase', async ({ context, extensionId }) => {
-    // Skip if no test seedphrase provided
-    if (!process.env.TEST_SEEDPHRASE) {
-      test.skip()
-      return
-    }
-
-    const page = await context.newPage()
-    const onboarding = new OnboardingPage(page, extensionId)
-    const seedphraseWizard = new SeedphraseWizard(page, extensionId)
-    const vaultPage = new VaultPage(page, extensionId)
-
-    await onboarding.goto()
-    await page.waitForLoadState('domcontentloaded')
-
-    // Navigate through flow
-    try {
-      await onboarding.waitForView(5_000)
-      await onboarding.getStarted()
-    } catch {
-      // Past onboarding
-    }
-
-    const importOption = page.getByText(/import.*seedphrase|import.*vault|restore/i).first()
-    if (await importOption.isVisible({ timeout: 5000 }).catch(() => false)) {
-      await importOption.click()
-      await page.waitForTimeout(500)
-    }
-
-    try {
-      await seedphraseWizard.waitForView(10_000)
-      await seedphraseWizard.enterSeedphrase(process.env.TEST_SEEDPHRASE!)
-      await seedphraseWizard.continue()
-      await seedphraseWizard.waitForScan()
-
-      // Select specific chains (or all)
-      await seedphraseWizard.selectAllChains()
-      await seedphraseWizard.confirm()
-
-      // Wait for vault creation
-      await page.waitForTimeout(3000)
-
-      // Should be on vault page now
-      try {
-        await vaultPage.waitForView(15_000)
-        const isVaultVisible = await vaultPage.isVaultVisible()
-        expect(isVaultVisible).toBe(true)
-      } catch {
-        // May be on intermediate step
-      }
-    } catch (error) {
-      console.log('Could not complete seedphrase import:', error)
-    }
-
-    await page.close()
-  })
-
-  test('derived addresses match expected', async ({ context, extensionId }) => {
-    // Skip if no test seedphrase
-    if (!process.env.TEST_SEEDPHRASE) {
-      test.skip()
-      return
-    }
-
+  test('manual chain selection continues to imported-vault setup', async ({
+    context,
+    extensionId,
+  }) => {
     const page = await context.newPage()
     const onboarding = new OnboardingPage(page, extensionId)
     const seedphraseWizard = new SeedphraseWizard(page, extensionId)
 
-    await onboarding.goto()
-    await page.waitForLoadState('domcontentloaded')
+    await openSeedphraseInput({ onboarding, seedphraseWizard })
+    await seedphraseWizard.enterSeedphrase(VALID_12_WORD_MNEMONIC)
+    await seedphraseWizard.continue()
 
-    try {
-      await onboarding.waitForView(5_000)
-      await onboarding.getStarted()
-    } catch {
-      // Past onboarding
-    }
+    const selectManually = page.getByRole('button', {
+      name: /select chains manually/i,
+    })
+    await expect(selectManually).toBeVisible()
+    await selectManually.click()
 
-    const importOption = page.getByText(/import.*seedphrase|import.*vault|restore/i).first()
-    if (await importOption.isVisible({ timeout: 5000 }).catch(() => false)) {
-      await importOption.click()
-      await page.waitForTimeout(500)
-    }
+    await expect(page.getByText('Ethereum', { exact: true })).toBeVisible()
+    await page.getByText('Ethereum', { exact: true }).click()
 
-    try {
-      await seedphraseWizard.waitForView(10_000)
-      await seedphraseWizard.enterSeedphrase(process.env.TEST_SEEDPHRASE!)
-      await seedphraseWizard.continue()
-      await seedphraseWizard.waitForScan()
+    const nextButton = page.getByRole('button', { name: 'Next' })
+    await expect(nextButton).toBeEnabled()
+    await nextButton.click()
 
-      // Check derived addresses
-      for (const [chain, expectedAddress] of Object.entries(EXPECTED_ADDRESSES)) {
-        const derivedAddress = await seedphraseWizard.getDerivedAddress(chain)
-
-        if (derivedAddress) {
-          // Addresses might be shortened in UI, so check prefix/suffix
-          const normalizedExpected = expectedAddress.toLowerCase()
-          const normalizedDerived = derivedAddress.toLowerCase().replace(/\s/g, '')
-
-          // Check if address matches (allowing for truncation)
-          const matches =
-            normalizedDerived === normalizedExpected ||
-            normalizedExpected.startsWith(normalizedDerived.slice(0, 10)) ||
-            normalizedDerived.includes(normalizedExpected.slice(0, 6))
-
-          console.log(`${chain}: expected ${expectedAddress}, got ${derivedAddress}`)
-
-          // Don't fail the test, just log - address display varies by implementation
-        }
-      }
-    } catch (error) {
-      console.log('Could not verify addresses:', error)
-    }
+    await expect(page.locator('canvas').first()).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: /get started/i }).first()
+    ).toBeVisible()
 
     await page.close()
   })

--- a/clients/extension/tests/e2e/specs/station-migration.spec.ts
+++ b/clients/extension/tests/e2e/specs/station-migration.spec.ts
@@ -231,7 +231,7 @@ const openStationMigrationWithFixture = async ({
   }
 
   const expandedPagePromise = context.waitForEvent('page')
-  await page.getByRole('button', { name: 'Next' }).click()
+  await page.getByTestId('new-vault-get-started').click()
   const expandedPage = await expandedPagePromise
   await expandedPage.waitForLoadState('domcontentloaded')
   await expect(expandedPage.locator('body')).toContainText(
@@ -254,7 +254,7 @@ const openSetupFromPopup = async ({
   }
 
   const expandedPagePromise = context.waitForEvent('page')
-  await page.getByRole('button', { name: 'Next' }).click()
+  await page.getByTestId('new-vault-get-started').click()
   const expandedPage = await expandedPagePromise
   await expandedPage.waitForLoadState('domcontentloaded')
 

--- a/clients/extension/tests/e2e/specs/visual-regression.spec.ts
+++ b/clients/extension/tests/e2e/specs/visual-regression.spec.ts
@@ -49,25 +49,13 @@ test.describe('Visual Regression - Key Screens', () => {
     // Wait for extension to fully load
     await waitForExtensionReady(page)
 
-    // Try to skip or click next
-    const skipButton = page.getByRole('button', { name: /skip/i })
-    const nextButton = page.getByRole('button', { name: /next/i })
-    
-    if (await skipButton.isVisible().catch(() => false)) {
-      await skipButton.click()
-      await page.waitForTimeout(500)
-      await waitForExtensionReady(page)
-    } else if (await nextButton.isVisible().catch(() => false)) {
-      // Click next a few times
-      for (let i = 0; i < 4; i++) {
-        if (await nextButton.isVisible().catch(() => false)) {
-          await nextButton.click()
-          await page.waitForTimeout(200)
-        } else {
-          break
-        }
-      }
-    }
+    await onboardingPage.completeOnboarding()
+    await expect(onboardingPage.newVaultGetStartedButton).toBeVisible()
+    await onboardingPage.navigateToSetupVault()
+    await expect(page.locator('canvas').first()).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: /get started/i }).first()
+    ).toBeVisible()
 
     await page.waitForTimeout(500)
 
@@ -93,12 +81,12 @@ test.describe('Visual Regression - Key Screens', () => {
     await page.waitForTimeout(500)
     await waitForExtensionReady(page)
 
-    // Click "Next" from NewVaultPage to go to SetupVaultPage
-    const nextButton = page.getByRole('button', { name: /next/i }).first()
-    if (await nextButton.isVisible().catch(() => false)) {
-      await nextButton.click()
-      await page.waitForTimeout(1000)
-    }
+    await expect(onboardingPage.newVaultGetStartedButton).toBeVisible()
+    await onboardingPage.navigateToSetupVault()
+    await expect(page.locator('canvas').first()).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: /get started/i }).first()
+    ).toBeVisible()
 
     await expect(page).toHaveScreenshot('03-setup-vault.png', {
       maxDiffPixels: 500,


### PR DESCRIPTION
## Summary

- align onboarding, visual-regression, and Station migration coverage with the current Get started flow
- replace false-green seedphrase and dApp-provider paths with strict assertions
- make vault-dependent approval, signing, chain-switch, and rejection coverage skip explicitly when the designated fixture is unavailable

## Runtime evidence

The real extension reaches the current device-selection screen and rejects an invalid seed phrase with Import disabled. Provider injection, onboarding visuals, Station migration coverage, and seedphrase navigation pass on the published branch.

## Remaining release-QA dependency

The four vault-backed dApp checks still require a designated TEST_VAULT_PATH and TEST_VAULT_PASSWORD fixture. The canonical fixture handles are absent, and a disposable Fast Vault could not be email-verified after the initial send plus one approved resend. Those checks now report explicit skips instead of false passes; v1.0.69 should not be marked fully green until they run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated onboarding navigation for flows that open directly on vault setup, ensuring correct “Get started” progression.

* **Tests**
  * Strengthened seed phrase import E2E coverage with a fixed 12-word vector, tighter validation messaging, and more precise wizard/button locators.
  * Made the DApp-provider injection test more reliable by polling for provider availability.
  * Updated station-migration and visual regression tests to use deterministic “Get started” navigation and explicit UI assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->