### PR TITLE
fix(swap): pass exact amount string to keysign payload build

### DIFF
--- a/core/ui/vault/swap/keysignPayload/query.test.ts
+++ b/core/ui/vault/swap/keysignPayload/query.test.ts
@@ -1,0 +1,38 @@
+import { toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'
+import { describe, expect, it } from 'vitest'
+
+import { getSwapKeysignAmount } from './query'
+
+describe('getSwapKeysignAmount', () => {
+  it('keeps every digit of a full-precision 18-decimal amount', () => {
+    expect(
+      getSwapKeysignAmount({ fromAmount: 6123456789012345678n, decimals: 18 })
+    ).toBe('6.123456789012345678')
+  })
+
+  it('does not round-trip the amount through float64', () => {
+    const fromAmount = 6123456789012345678n
+
+    // Number(6123456789012345678n) is 6123456789012345856 — a float64 path
+    // would corrupt the last digits (#4391)
+    expect(BigInt(Number(fromAmount))).not.toBe(fromAmount)
+    expect(getSwapKeysignAmount({ fromAmount, decimals: 18 })).toBe(
+      '6.123456789012345678'
+    )
+  })
+
+  it.each([
+    [6123456789012345678n, 18],
+    [100123456n, 6],
+    [1n, 18],
+    [123456789012345678901234567890n, 18],
+    [0n, 8],
+  ])(
+    'round-trips %s (decimals %s) exactly through toChainAmount',
+    (fromAmount, decimals) => {
+      const amount = getSwapKeysignAmount({ fromAmount, decimals })
+
+      expect(toChainAmount(amount, decimals)).toBe(fromAmount)
+    }
+  )
+})

--- a/core/ui/vault/swap/keysignPayload/query.ts
+++ b/core/ui/vault/swap/keysignPayload/query.ts
@@ -6,7 +6,6 @@ import {
 import { useCurrentVaultCoin } from '@core/ui/vault/state/currentVaultCoins'
 import { noRefetchQueryOptions } from '@lib/ui/query/utils/options'
 import { useQuery } from '@tanstack/react-query'
-import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
 import { SwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
 import {
   buildSwapKeysignPayload,
@@ -15,6 +14,7 @@ import {
 import { toKeysignLibType } from '@vultisig/core-mpc/types/utils/libType'
 import { getVaultId } from '@vultisig/core-mpc/vault/Vault'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
+import { bigIntToDecimalString } from '@vultisig/lib-utils/bigint/bigIntToDecimalString'
 import { omit } from '@vultisig/lib-utils/record/omit'
 
 import { useAdvancedSwapSettings } from '../state/advancedSettings'
@@ -39,7 +39,7 @@ export const useSwapKeysignPayloadQuery = (swapQuote: SwapQuote) => {
   const input: BuildSwapKeysignPayloadInput = {
     fromCoin,
     toCoin,
-    amount: fromChainAmount(
+    amount: bigIntToDecimalString(
       shouldBePresent(fromAmount, 'fromAmount'),
       fromCoin.decimals
     ),

--- a/core/ui/vault/swap/keysignPayload/query.ts
+++ b/core/ui/vault/swap/keysignPayload/query.ts
@@ -22,6 +22,22 @@ import { useFromAmount } from '../state/fromAmount'
 import { useSwapFromCoin } from '../state/fromCoin'
 import { useSwapToCoin } from '../state/toCoin'
 
+type GetSwapKeysignAmountInput = {
+  fromAmount: bigint
+  decimals: number
+}
+
+/**
+ * Renders the exact chain amount as a lossless decimal string for
+ * `buildSwapKeysignPayload`. Must never go through float64 — amounts with
+ * more than ~15 significant digits would be silently perturbed (#4391).
+ */
+export const getSwapKeysignAmount = ({
+  fromAmount,
+  decimals,
+}: GetSwapKeysignAmountInput): string =>
+  bigIntToDecimalString(fromAmount, decimals)
+
 export const useSwapKeysignPayloadQuery = (swapQuote: SwapQuote) => {
   const [fromCoinKey] = useSwapFromCoin()
   const [toCoinKey] = useSwapToCoin()
@@ -39,10 +55,10 @@ export const useSwapKeysignPayloadQuery = (swapQuote: SwapQuote) => {
   const input: BuildSwapKeysignPayloadInput = {
     fromCoin,
     toCoin,
-    amount: bigIntToDecimalString(
-      shouldBePresent(fromAmount, 'fromAmount'),
-      fromCoin.decimals
-    ),
+    amount: getSwapKeysignAmount({
+      fromAmount: shouldBePresent(fromAmount, 'fromAmount'),
+      decimals: fromCoin.decimals,
+    }),
     swapQuote,
     vaultId: getVaultId(vault),
     localPartyId: vault.localPartyId,


### PR DESCRIPTION
Fixes #4391

The swap keysign build converted the exact bigint `fromAmount` to a float64 via `fromChainAmount` before handing it to `buildSwapKeysignPayload`, so amounts needing more than ~15-16 significant digits were silently perturbed. A pasted full-precision 18-dp amount could even round up past the balance.

Now the bigint is rendered with `bigIntToDecimalString` and passed as a string. `buildSwapKeysignPayload` already accepts `string | number`, and `toChainAmount` parses strings losslessly through `parseUnits`, so the amount stays exact end to end, matching how Send handles it.

Verified the round trip is byte-exact: `6123456789012345678n` → `"6.123456789012345678"` → `6123456789012345678n`. Typecheck and lint pass; the 22 existing typecheck errors on main (missing SDK-main modules) are unrelated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap transaction amount handling by converting the input amount into a lossless decimal string for signing payloads.
  * Added coverage with unit tests to ensure full-precision conversions (including large and zero values) round-trip exactly without precision loss.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->