### PR TITLE
fix(send): parse typed amount with exact bigint math

### DIFF
--- a/core/ui/vault/send/amount/BaseSendAmountInput.test.ts
+++ b/core/ui/vault/send/amount/BaseSendAmountInput.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseSendAmountInput } from './BaseSendAmountInput'
+
+describe('parseSendAmountInput', () => {
+  it('keeps every digit of a full-precision 18-decimal amount', () => {
+    expect(
+      parseSendAmountInput({ value: '6.123456789012345678', decimals: 18 })
+    ).toEqual({
+      normalized: '6.123456789012345678',
+      chainAmount: 6123456789012345678n,
+    })
+  })
+
+  it('does not round up amounts whose nearest float64 is larger', () => {
+    // parseFloat('6.649999999999999991') is exactly 6.65 — the old float64
+    // path signed more than the user typed (#4488)
+    const parsed = parseSendAmountInput({
+      value: '6.649999999999999991',
+      decimals: 18,
+    })
+
+    expect(parsed?.chainAmount).toBe(6649999999999999991n)
+    expect(parsed?.chainAmount).not.toBe(6650000000000000000n)
+  })
+
+  it('strips minus signs and pads a leading dot', () => {
+    expect(parseSendAmountInput({ value: '-5', decimals: 6 })).toEqual({
+      normalized: '5',
+      chainAmount: 5000000n,
+    })
+    expect(parseSendAmountInput({ value: '.5', decimals: 6 })).toEqual({
+      normalized: '0.5',
+      chainAmount: 500000n,
+    })
+  })
+
+  it('returns null for a cleared input', () => {
+    expect(parseSendAmountInput({ value: '', decimals: 18 })).toBeNull()
+    expect(parseSendAmountInput({ value: '-', decimals: 18 })).toBeNull()
+  })
+
+  it.each(['abc', '1.2.3', '1e5', '1,5'])('rejects invalid input %s', value => {
+    expect(parseSendAmountInput({ value, decimals: 18 })).toBeUndefined()
+  })
+
+  it('rejects more fraction digits than the coin supports', () => {
+    expect(
+      parseSendAmountInput({ value: '1.1234567', decimals: 6 })
+    ).toBeUndefined()
+  })
+})

--- a/core/ui/vault/send/amount/BaseSendAmountInput.tsx
+++ b/core/ui/vault/send/amount/BaseSendAmountInput.tsx
@@ -1,0 +1,117 @@
+import { TextInput, TextInputProps } from '@lib/ui/inputs/TextInput'
+import { InputProps } from '@lib/ui/props'
+import { bigIntToDecimalString } from '@vultisig/lib-utils/bigint/bigIntToDecimalString'
+import { decimalStringToBigInt } from '@vultisig/lib-utils/bigint/decimalStringToBigInt'
+import { useEffect, useRef, useState } from 'react'
+
+type BaseSendAmountInputProps = InputProps<bigint | null> &
+  Pick<TextInputProps, 'validation' | 'placeholder' | 'disabled'> & {
+    decimals: number
+  }
+
+type ParseSendAmountInputInput = {
+  value: string
+  decimals: number
+}
+
+/**
+ * Normalizes a raw amount input string and parses it with exact bigint math.
+ * Returns `null` for a cleared input, `undefined` for a rejected one
+ * (invalid characters or more fraction digits than the coin supports).
+ * Must never go through float64 — amounts with more than ~15 significant
+ * digits would be silently perturbed before signing (#4488).
+ */
+export const parseSendAmountInput = ({
+  value,
+  decimals,
+}: ParseSendAmountInputInput) => {
+  let normalized = value.replace(/-/g, '')
+
+  if (normalized.startsWith('.')) {
+    normalized = `0${normalized}`
+  }
+
+  if (normalized === '') {
+    return null
+  }
+
+  if (!/^\d*\.?\d*$/.test(normalized)) {
+    return undefined
+  }
+
+  try {
+    return {
+      normalized,
+      chainAmount: decimalStringToBigInt(normalized, decimals),
+    }
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Base-currency send amount input that keeps the typed string exact:
+ * the stored chain amount always matches the visible digits.
+ */
+export const BaseSendAmountInput = ({
+  value,
+  onChange,
+  decimals,
+  ...inputProps
+}: BaseSendAmountInputProps) => {
+  const previousValueRef = useRef<bigint | null>(null)
+
+  const fullDecimalString =
+    value !== null ? bigIntToDecimalString(value, decimals) : ''
+  const trimmedDecimalString = fullDecimalString.includes('.')
+    ? fullDecimalString.replace(/\.?0+$/, '')
+    : fullDecimalString
+  const [inputValue, setInputValue] = useState<string>(trimmedDecimalString)
+
+  useEffect(() => {
+    // Only update input if the value changed externally (not from user typing)
+    if (value !== previousValueRef.current) {
+      const parsed = parseSendAmountInput({ value: inputValue, decimals })
+      const currentInputAsBigInt = parsed === null ? null : parsed?.chainAmount
+      if (currentInputAsBigInt !== value) {
+        setInputValue(trimmedDecimalString)
+      }
+      previousValueRef.current = value
+    }
+  }, [value, trimmedDecimalString, inputValue, decimals])
+
+  const handleInputValueChange = (rawValue: string) => {
+    const parsed = parseSendAmountInput({ value: rawValue, decimals })
+
+    if (parsed === null) {
+      setInputValue('')
+      previousValueRef.current = null
+      onChange(null)
+      return
+    }
+
+    if (parsed === undefined) {
+      return
+    }
+
+    setInputValue(parsed.normalized)
+    previousValueRef.current = parsed.chainAmount
+    onChange(parsed.chainAmount)
+  }
+
+  return (
+    <TextInput
+      {...inputProps}
+      type="text"
+      inputMode="decimal"
+      onWheel={event => event.currentTarget.blur()}
+      value={inputValue}
+      onValueChange={handleInputValueChange}
+      onPaste={event => {
+        event.preventDefault()
+        handleInputValueChange(event.clipboardData.getData('text'))
+      }}
+      data-testid="send-amount-input"
+    />
+  )
+}

--- a/core/ui/vault/send/amount/ManageAmountInputField.tsx
+++ b/core/ui/vault/send/amount/ManageAmountInputField.tsx
@@ -3,6 +3,7 @@ import { useBalanceQuery } from '@core/ui/chain/coin/queries/useBalanceQuery'
 import { AmountInReverseCurrencyDisplay } from '@core/ui/vault/send/amount/AmountInReverseCurrencyDisplay'
 import { AmountSuggestion } from '@core/ui/vault/send/amount/AmountSuggestion'
 import { CurrencySwitch } from '@core/ui/vault/send/amount/AmountSwitch'
+import { BaseSendAmountInput } from '@core/ui/vault/send/amount/BaseSendAmountInput'
 import { FiatSendAmountInput } from '@core/ui/vault/send/amount/FiatSendAmountInput'
 import { AnimatedSendFormInputError } from '@core/ui/vault/send/components/AnimatedSendFormInputError'
 import { HorizontalLine } from '@core/ui/vault/send/components/HorizontalLine'
@@ -15,10 +16,7 @@ import { useCurrentSendCoin } from '@core/ui/vault/send/state/sendCoin'
 import { ActionInsideInteractiveElement } from '@lib/ui/base/ActionInsideInteractiveElement'
 import { Match } from '@lib/ui/base/Match'
 import { borderRadius } from '@lib/ui/css/borderRadius'
-import {
-  AmountTextInput,
-  AmountTextInputProps,
-} from '@lib/ui/inputs/AmountTextInput'
+import { AmountTextInputProps } from '@lib/ui/inputs/AmountTextInput'
 import { InputLabel } from '@lib/ui/inputs/InputLabel'
 import { HStack, VStack, vStack } from '@lib/ui/layout/Stack'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
@@ -27,7 +25,6 @@ import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
 import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
 import { getMaxValue } from '@vultisig/core-chain/amount/getMaxValue'
-import { toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'
 import { extractAccountCoinKey } from '@vultisig/core-chain/coin/AccountCoin'
 import { isFeeCoin } from '@vultisig/core-chain/coin/utils/isFeeCoin'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
@@ -146,21 +143,13 @@ export const ManageAmountInputField = () => {
                           />
                         )}
                         base={() => (
-                          <AmountTextInput
-                            {...sharedInputProps}
-                            value={
-                              value === null
-                                ? value
-                                : fromChainAmount(value, coin.decimals)
-                            }
-                            onValueChange={newValue =>
-                              setValue(
-                                newValue === null
-                                  ? newValue
-                                  : toChainAmount(newValue, coin.decimals)
-                              )
-                            }
-                            data-testid="send-amount-input"
+                          <BaseSendAmountInput
+                            validation={sharedInputProps.validation}
+                            placeholder={sharedInputProps.placeholder}
+                            disabled={sharedInputProps.disabled}
+                            value={value}
+                            onChange={setValue}
+                            decimals={coin.decimals}
                           />
                         )}
                       />


### PR DESCRIPTION
Fixes #4488

The send amount input parsed the typed/pasted string with `parseFloat` (`AmountTextInput` hands the consumer a `number`), and the float was converted to the stored bigint via `toChainAmount`. Any amount with more than ~15-16 significant digits was corrupted before it was even stored, so the wrong value got signed. Confirmed on-chain: pasting `6.123456789012345678` VULT transferred `6123456789012345000` base units. The error can also round up — `6.649999999999999991` became exactly `6.65`, more than the user authorized.

New `BaseSendAmountInput` replaces the float-based input in base-currency mode. It follows the same pattern as the swap form's `ManageFromAmount`: local string state, `decimalStringToBigInt` for parsing, `bigIntToDecimalString` for rendering external updates. The stored chain amount now always matches the visible digits exactly. The fiat input mode is unchanged (inherently float via price division), and the Max/percentage suggestions were already exact.

Unit tests cover the full-precision 18-dp case, the round-up case, input sanitization, and rejection of excess fraction digits.

Sibling of #4390/#4391 (swap-side) from the cross-platform max send/swap audit; the audit had marked the Windows send flow correct, but that only covered the suggestion buttons, not typed input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a send-amount input that preserves precise decimal values without rounding.
  * Improved input handling for pasted, partial, and normalized values, including leading decimals and cleared fields.
  * Prevented accidental amount changes caused by mouse-wheel interaction.

* **Bug Fixes**
  * Invalid formats and values exceeding supported decimal precision are now rejected consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->