### PR TITLE
fix(deeplink): parse send amount string without float64 round-trip

### DIFF
--- a/core/ui/deeplink/components/ProcessSend.tsx
+++ b/core/ui/deeplink/components/ProcessSend.tsx
@@ -7,7 +7,6 @@ import { VaultListItem } from '@core/ui/vaultsOrganisation/components/VaultListI
 import { VStack } from '@lib/ui/layout/Stack'
 import { PageContent } from '@lib/ui/page/PageContent'
 import { ValueProp } from '@lib/ui/props'
-import { toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'
 import { extractCoinKey } from '@vultisig/core-chain/coin/Coin'
 import { getVaultId } from '@vultisig/core-mpc/vault/Vault'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
@@ -15,6 +14,7 @@ import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { SendDeeplinkData } from '../core'
+import { getDeeplinkSendAmount } from '../getDeeplinkSendAmount'
 
 export const ProcessSend = ({ value }: ValueProp<SendDeeplinkData>) => {
   const { t } = useTranslation()
@@ -85,7 +85,10 @@ export const ProcessSend = ({ value }: ValueProp<SendDeeplinkData>) => {
                           coin: extractCoinKey(coin),
                           address: value.toAddress,
                           amount: value.amount
-                            ? toChainAmount(Number(value.amount), coin.decimals)
+                            ? getDeeplinkSendAmount({
+                                amount: value.amount,
+                                decimals: coin.decimals,
+                              })
                             : undefined,
                           memo: value.memo,
                         },

--- a/core/ui/deeplink/getDeeplinkSendAmount.test.ts
+++ b/core/ui/deeplink/getDeeplinkSendAmount.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { getDeeplinkSendAmount } from './getDeeplinkSendAmount'
+
+describe('getDeeplinkSendAmount', () => {
+  it('keeps every digit of a full-precision 18-decimal amount', () => {
+    expect(
+      getDeeplinkSendAmount({ amount: '6.123456789012345678', decimals: 18 })
+    ).toBe(6123456789012345678n)
+  })
+
+  it('does not round up amounts whose nearest float64 is larger', () => {
+    // Number('6.649999999999999991') is exactly 6.65 — a float64 path would
+    // pre-fill more than the deeplink specified (#4491)
+    expect(
+      getDeeplinkSendAmount({ amount: '6.649999999999999991', decimals: 18 })
+    ).toBe(6649999999999999991n)
+  })
+
+  it('converts plain amounts', () => {
+    expect(getDeeplinkSendAmount({ amount: '1.5', decimals: 8 })).toBe(
+      150000000n
+    )
+    expect(getDeeplinkSendAmount({ amount: '100', decimals: 6 })).toBe(
+      100000000n
+    )
+  })
+})

--- a/core/ui/deeplink/getDeeplinkSendAmount.ts
+++ b/core/ui/deeplink/getDeeplinkSendAmount.ts
@@ -1,0 +1,16 @@
+import { toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'
+
+type GetDeeplinkSendAmountInput = {
+  amount: string
+  decimals: number
+}
+
+/**
+ * Converts a deeplink amount string to chain base units.
+ * The string must be parsed exactly — a float64 round-trip would corrupt
+ * amounts with more than ~15 significant digits (#4491).
+ */
+export const getDeeplinkSendAmount = ({
+  amount,
+  decimals,
+}: GetDeeplinkSendAmountInput) => toChainAmount(Number(amount), decimals)

--- a/core/ui/deeplink/getDeeplinkSendAmount.ts
+++ b/core/ui/deeplink/getDeeplinkSendAmount.ts
@@ -13,4 +13,4 @@ type GetDeeplinkSendAmountInput = {
 export const getDeeplinkSendAmount = ({
   amount,
   decimals,
-}: GetDeeplinkSendAmountInput) => toChainAmount(Number(amount), decimals)
+}: GetDeeplinkSendAmountInput) => toChainAmount(amount, decimals)


### PR DESCRIPTION
Fixes #4491

The send deeplink amount arrives as a string but was converted with `toChainAmount(Number(value.amount), decimals)` — the `Number()` call snaps it to the nearest float64, corrupting any amount with more than ~15-16 significant digits before the send form opens. Same defect family as #4390/#4391/#4488.

Test-first: the first commit extracts the conversion into `getDeeplinkSendAmount` (behavior unchanged) and adds tests asserting exact parsing — CI is expected to fail on it, demonstrating the bug: `6.123456789012345678` becomes `6123456789012345000` and `6.649999999999999991` becomes exactly `6.65`. The follow-up commit drops the `Number()` call so the string goes straight to `toChainAmount`, which parses it losslessly, turning the tests green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deeplink-initiated send amounts to preserve exact decimal precision, including assets with 18 decimal places.
  - Prevented rounding errors when converting decimal amounts into blockchain base units.
  - Standard decimal amounts continue to convert correctly for sending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->