### PR TITLE
fix(deposit): carry the amount as an exact decimal string end to end

### DIFF
--- a/core/ui/defi/chain/solana/SolanaStakeDefiView.tsx
+++ b/core/ui/defi/chain/solana/SolanaStakeDefiView.tsx
@@ -39,6 +39,7 @@ import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
+import { toExactAmountString } from '../../../vault/deposit/utils/exactAmountString'
 import { SolanaDelegationCard } from './SolanaDelegationCard'
 
 const TotalStakedLogo = styled.img`
@@ -269,7 +270,7 @@ export const SolanaStakeDefiView = () => {
       stakeAccount: row.stakeAccount.pubkey,
     }
     if (action === 'solana_withdraw') {
-      form.amount = fromChainAmount(row.withdrawableLamports, solDecimals)
+      form.amount = toExactAmountString(row.withdrawableLamports, solDecimals)
     }
     if (action === 'solana_move_stake') {
       // The current validator is the one destination the move cannot have, so
@@ -282,7 +283,7 @@ export const SolanaStakeDefiView = () => {
       // above the rent-exempt reserve — rewards accrued while it was active
       // included. The destination was picked back on the Move step; without one
       // (an account deactivated elsewhere) the finish-move screen still asks.
-      form.amount = fromChainAmount(row.withdrawableLamports, solDecimals)
+      form.amount = toExactAmountString(row.withdrawableLamports, solDecimals)
       form.validatorAddress = row.moveDestination
     }
     navigate({

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/BondSpecific/BondForm.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/BondSpecific/BondForm.tsx
@@ -40,6 +40,7 @@ import {
   ActionFormCheckBadge,
   ActionFormIconsWrapper,
 } from '../../../../components/action-form/ActionFormIconsWrapper'
+import { trimTrailingZeros } from '../../../utils/exactAmountString'
 import { ErrorText } from '../../DepositForm.styled'
 import { FormData } from '../../types'
 
@@ -141,7 +142,7 @@ export const BondForm = ({ balance, errors, formValues }: BondFormProps) => {
     }
   }, [providerValue])
 
-  const handleSetAmount = (value: number) => {
+  const handleSetAmount = (value: string) => {
     setValue('amount', value, { shouldValidate: true, shouldDirty: true })
   }
 
@@ -286,13 +287,13 @@ export const BondForm = ({ balance, errors, formValues }: BondFormProps) => {
                   gap={4}
                 >
                   {amountSuggestions.map(suggestion => {
-                    const suggestedAmount = Number(
+                    const suggestedAmount = trimTrailingZeros(
                       (balance * suggestion).toFixed(coin.decimals)
                     )
                     const isActive =
                       parsedAmount !== null &&
                       Number(parsedAmount?.toFixed(coin.decimals)) ===
-                        suggestedAmount
+                        Number(suggestedAmount)
 
                     return (
                       <SuggestionOption

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/DelegateSpecific.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/DelegateSpecific.tsx
@@ -14,6 +14,7 @@ import { Controller } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
+import { toExactAmountString } from '../../../utils/exactAmountString'
 import { StakingAmountInput } from './StakingAmountInput'
 import { ValidatorPickerField } from './ValidatorPickerField'
 
@@ -79,7 +80,7 @@ export const DelegateSpecific = () => {
                   setValue('amount', '', { shouldValidate: true })
                   return
                 }
-                setValue('amount', fromChainAmount(units, coin.decimals), {
+                setValue('amount', toExactAmountString(units, coin.decimals), {
                   shouldValidate: true,
                 })
               }}

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/RedelegateSpecific.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/RedelegateSpecific.tsx
@@ -12,6 +12,7 @@ import { Controller, useWatch } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
+import { toExactAmountString } from '../../../utils/exactAmountString'
 import { StakingAmountInput } from './StakingAmountInput'
 import { ValidatorPickerField } from './ValidatorPickerField'
 
@@ -68,7 +69,7 @@ export const RedelegateSpecific = () => {
   const handleSliderChange = (percentage: number) => {
     if (stakedUnits === 0n) return
     const units = (stakedUnits * BigInt(Math.round(percentage * 100))) / 10_000n
-    setValue('amount', fromChainAmount(units, coin.decimals), {
+    setValue('amount', toExactAmountString(units, coin.decimals), {
       shouldValidate: true,
     })
   }

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/UndelegateSpecific.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/UndelegateSpecific.tsx
@@ -12,6 +12,7 @@ import { Controller, useWatch } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
+import { toExactAmountString } from '../../../utils/exactAmountString'
 import { StakingAmountInput } from './StakingAmountInput'
 
 /**
@@ -76,7 +77,7 @@ export const UndelegateSpecific = () => {
     if (stakedUnits === 0n) return
     // Floor to base units, then re-stringify with the right decimal count.
     const num = (stakedUnits * BigInt(Math.round(percentage * 100))) / 10_000n
-    setValue('amount', fromChainAmount(num, coin.decimals), {
+    setValue('amount', toExactAmountString(num, coin.decimals), {
       shouldValidate: true,
     })
   }

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/SolanaStakingSpecific/SolanaDelegateSpecific.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/SolanaStakingSpecific/SolanaDelegateSpecific.tsx
@@ -14,6 +14,7 @@ import { Controller, useFormState } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
+import { toExactAmountString } from '../../../utils/exactAmountString'
 import { StakingAmountInput } from '../CosmosStakingSpecific/StakingAmountInput'
 
 /**
@@ -79,7 +80,7 @@ export const SolanaDelegateSpecific = () => {
                   setValue('amount', '', { shouldValidate: true })
                   return
                 }
-                setValue('amount', fromChainAmount(units, coin.decimals), {
+                setValue('amount', toExactAmountString(units, coin.decimals), {
                   shouldValidate: true,
                 })
               }}

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/StakeForm.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/StakeForm.tsx
@@ -18,6 +18,7 @@ import { Controller, ControllerRenderProps, FieldErrors } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
 
+import { trimTrailingZeros } from '../../../utils/exactAmountString'
 import { FormData } from '../../types'
 
 type StakeFormProps = {
@@ -88,7 +89,9 @@ export const StakeForm = ({
   }, [parsedAmount, balance])
 
   const handleSliderChange = (percentage: number) => {
-    const amount = Number(((percentage / 100) * balance).toFixed(coin.decimals))
+    const amount = trimTrailingZeros(
+      ((percentage / 100) * balance).toFixed(coin.decimals)
+    )
     setValue('amount', amount, { shouldValidate: true, shouldDirty: true })
 
     if (isUnstake && stakeId === 'native-tcy') {

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/UnstakeSpecific/components/UnstakeSTCY.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/UnstakeSpecific/components/UnstakeSTCY.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from 'react-i18next'
 import { AmountSuggestion } from '../../../../../../send/amount/AmountSuggestion'
 import { useCurrentVaultAddress } from '../../../../../../state/currentVaultCoins'
 import { useDepositFormHandlers } from '../../../../../providers/DepositFormHandlersProvider'
+import { trimTrailingZeros } from '../../../../../utils/exactAmountString'
 import {
   clampPercentage,
   toNumericValue,
@@ -47,7 +48,7 @@ export const UnstakeSTCY = () => {
       }
 
       const clamped = clampPercentage(percentage)
-      const amount = Number(
+      const amount = trimTrailingZeros(
         ((clamped / 100) * humanReadableBalance).toFixed(decimals)
       )
 

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/UnbondSpecific/UnbondForm.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/UnbondSpecific/UnbondForm.tsx
@@ -28,6 +28,7 @@ import {
   ActionFormCheckBadge,
   ActionFormIconsWrapper,
 } from '../../../../components/action-form/ActionFormIconsWrapper'
+import { trimTrailingZeros } from '../../../utils/exactAmountString'
 import { ErrorText } from '../../DepositForm.styled'
 import { FormData } from '../../types'
 
@@ -114,7 +115,9 @@ export const UnbondForm = ({
   }, [parsedAmount, balance])
 
   const handleSliderChange = (percentage: number) => {
-    const amount = Number(((percentage / 100) * balance).toFixed(coin.decimals))
+    const amount = trimTrailingZeros(
+      ((percentage / 100) * balance).toFixed(coin.decimals)
+    )
     setValue('amount', amount, { shouldValidate: true, shouldDirty: true })
   }
 

--- a/core/ui/vault/deposit/DepositVerify/StakeOverview.tsx
+++ b/core/ui/vault/deposit/DepositVerify/StakeOverview.tsx
@@ -110,6 +110,15 @@ export const StakeOverview = ({ onBack }: OnBackProp) => {
   const amountValue =
     typeof rawAmount === 'number' ? rawAmount : Number(rawAmount ?? 0)
   const fallbackAmount = Number.isFinite(amountValue) ? amountValue : 0
+  // Exact decimal string for chain-unit conversion — the float fallbackAmount
+  // is only for display and zero-checks (#4494)
+  const exactAmount =
+    rawAmount !== undefined &&
+    rawAmount !== null &&
+    rawAmount !== '' &&
+    Number.isFinite(Number(rawAmount))
+      ? String(rawAmount)
+      : '0'
 
   // For native TCY unstaking, the payload.toAmount is '0' because the amount is
   // encoded in the memo as a percentage. We need to use the form amount instead.
@@ -118,11 +127,11 @@ export const StakeOverview = ({ onBack }: OnBackProp) => {
       const payloadAmount = payload.toAmount
       // If payload amount is 0 or empty, use the form amount (converted to chain units)
       if (!payloadAmount || payloadAmount === '0') {
-        return toChainAmount(fallbackAmount, coin.decimals).toString()
+        return toChainAmount(exactAmount, coin.decimals).toString()
       }
       return payloadAmount
     },
-    [fallbackAmount, coin.decimals]
+    [exactAmount, coin.decimals]
   )
 
   return (

--- a/core/ui/vault/deposit/keysignPayload/build.ts
+++ b/core/ui/vault/deposit/keysignPayload/build.ts
@@ -97,7 +97,8 @@ export type BuildDepositKeysignPayloadInput = {
   action: ChainAction
   depositData: FieldValues
   receiver?: string
-  amount?: number
+  /** Human amount as an exact decimal string — never a float64 (#4494). */
+  amount?: string
   memo?: string
   validatorAddress?: string
   slippage?: number
@@ -195,7 +196,8 @@ export const buildDepositKeysignPayload = async ({
   const isStake = isOneOf(action, ['stake', 'unstake', 'withdraw_ruji_rewards'])
   const isTonFunction = coin.chain === Chain.Ton
 
-  const hasAmount = amount !== undefined && Number.isFinite(amount)
+  const hasAmount =
+    amount !== undefined && amount !== '' && Number.isFinite(Number(amount))
   const amountUnits = hasAmount
     ? toChainAmount(shouldBePresent(amount), coin.decimals).toString()
     : undefined

--- a/core/ui/vault/deposit/keysignPayload/query.ts
+++ b/core/ui/vault/deposit/keysignPayload/query.ts
@@ -44,7 +44,13 @@ export const useDepositKeysignPayloadQuery = (
   const memo = useDepositMemo()
 
   const hasAmount = 'amount' in depositData
-  const amount = hasAmount ? Number(depositData['amount']) : undefined
+  // Keep the amount as its exact decimal string — Number() would corrupt
+  // amounts with more than ~15 significant digits (#4494)
+  const rawAmount = hasAmount ? depositData['amount'] : undefined
+  const amount =
+    rawAmount === undefined || rawAmount === null || rawAmount === ''
+      ? undefined
+      : String(rawAmount)
   const slippage = Number(depositData['slippage'] ?? 0)
   const validatorAddress = depositData['validatorAddress'] as string | undefined
   const autocompound = Boolean(depositData['autoCompound'])
@@ -55,8 +61,7 @@ export const useDepositKeysignPayloadQuery = (
       action,
       depositData,
       receiver,
-      amount:
-        amount !== undefined && Number.isFinite(amount) ? amount : undefined,
+      amount,
       memo,
       validatorAddress,
       slippage,

--- a/core/ui/vault/deposit/staking/resolvers/brune.test.ts
+++ b/core/ui/vault/deposit/staking/resolvers/brune.test.ts
@@ -10,38 +10,38 @@ import { selectStakeId } from './index'
 
 describe('getBruneSpecific', () => {
   it('builds a liquid.bond wasm execute funded with bRUNE for stake', () => {
-    expect(getBruneSpecific({ input: { kind: 'stake', amount: 1.5 } })).toEqual(
-      {
-        kind: 'wasm',
-        contract: bruneBondConfig.contract,
-        executeMsg: { liquid: { bond: {} } },
-        funds: [
-          {
-            denom: bruneBondConfig.depositDenom,
-            amount: toChainAmount(
-              1.5,
-              bruneBondConfig.depositDecimals
-            ).toString(),
-          },
-        ],
-      }
-    )
+    expect(
+      getBruneSpecific({ input: { kind: 'stake', amount: '1.5' } })
+    ).toEqual({
+      kind: 'wasm',
+      contract: bruneBondConfig.contract,
+      executeMsg: { liquid: { bond: {} } },
+      funds: [
+        {
+          denom: bruneBondConfig.depositDenom,
+          amount: toChainAmount(
+            1.5,
+            bruneBondConfig.depositDecimals
+          ).toString(),
+        },
+      ],
+    })
   })
 
   it('builds a liquid.unbond wasm execute funded with ybRUNE for unstake', () => {
-    expect(getBruneSpecific({ input: { kind: 'unstake', amount: 2 } })).toEqual(
-      {
-        kind: 'wasm',
-        contract: bruneBondConfig.contract,
-        executeMsg: { liquid: { unbond: {} } },
-        funds: [
-          {
-            denom: bruneBondConfig.shareDenom,
-            amount: toChainAmount(2, bruneBondConfig.shareDecimals).toString(),
-          },
-        ],
-      }
-    )
+    expect(
+      getBruneSpecific({ input: { kind: 'unstake', amount: '2' } })
+    ).toEqual({
+      kind: 'wasm',
+      contract: bruneBondConfig.contract,
+      executeMsg: { liquid: { unbond: {} } },
+      funds: [
+        {
+          denom: bruneBondConfig.shareDenom,
+          amount: toChainAmount(2, bruneBondConfig.shareDecimals).toString(),
+        },
+      ],
+    })
   })
 })
 

--- a/core/ui/vault/deposit/staking/resolvers/brune.test.ts
+++ b/core/ui/vault/deposit/staking/resolvers/brune.test.ts
@@ -28,6 +28,20 @@ describe('getBruneSpecific', () => {
     })
   })
 
+  it('keeps every digit of an amount beyond float64 precision', () => {
+    // 10 integer digits + 8 fraction digits — 18 significant digits, well past
+    // what a Number() round-trip could preserve (#4494)
+    const amount = '9007199254.74099301'
+    const expectedUnits = 900719925474099301n
+
+    const result = getBruneSpecific({ input: { kind: 'stake', amount } })
+
+    expect(result.kind).toBe('wasm')
+    if (result.kind === 'wasm') {
+      expect(result.funds[0].amount).toBe(expectedUnits.toString())
+    }
+  })
+
   it('builds a liquid.unbond wasm execute funded with ybRUNE for unstake', () => {
     expect(
       getBruneSpecific({ input: { kind: 'unstake', amount: '2' } })

--- a/core/ui/vault/deposit/staking/resolvers/ruji.test.ts
+++ b/core/ui/vault/deposit/staking/resolvers/ruji.test.ts
@@ -24,7 +24,7 @@ describe('getRujiSpecific unstake', () => {
       input: {
         kind: 'unstake',
         position: 'liquid',
-        amount: 1,
+        amount: '1',
         liquidShares,
         liquidSize,
       },
@@ -44,7 +44,7 @@ describe('getRujiSpecific unstake', () => {
       input: {
         kind: 'unstake',
         position: 'liquid',
-        amount: 0.5,
+        amount: '0.5',
         liquidShares,
         liquidSize,
       },
@@ -67,7 +67,7 @@ describe('getRujiSpecific unstake', () => {
         input: {
           kind: 'unstake',
           position: 'liquid',
-          amount: 0.00000001,
+          amount: '0.00000001',
           liquidShares,
           liquidSize,
         },
@@ -81,7 +81,7 @@ describe('getRujiSpecific unstake', () => {
       input: {
         kind: 'unstake',
         position: 'bonded',
-        amount: 0.0787,
+        amount: '0.0787',
       },
     })
 

--- a/core/ui/vault/deposit/staking/types.ts
+++ b/core/ui/vault/deposit/staking/types.ts
@@ -19,13 +19,13 @@ export type StakeSpecific =
  * `account.withdraw`), or a rewards `claim`.
  */
 export type RujiInput =
-  | { kind: 'stake'; amount: number }
+  | { kind: 'stake'; amount: string }
   | {
       // Auto-compounding (sRUJI) position — redeemed via `liquid.unbond`, so the
       // entered underlying amount is converted to receipt shares.
       kind: 'unstake'
       position: 'liquid'
-      amount: number
+      amount: string
       liquidShares: bigint
       liquidSize: bigint
     }
@@ -33,26 +33,26 @@ export type RujiInput =
       // Bonded (yielding) position — withdrawn via `account.withdraw`.
       kind: 'unstake'
       position: 'bonded'
-      amount: number
+      amount: string
     }
   | { kind: 'claim' }
 
 export type NativeTcyInput =
-  | { kind: 'stake'; amount: number }
+  | { kind: 'stake'; amount: string }
   | { kind: 'unstake'; percentage: number }
   | { kind: 'claim' }
 
 export type StcyInput =
-  | { kind: 'stake'; amount: number }
-  | { kind: 'unstake'; amount: number }
+  | { kind: 'stake'; amount: string }
+  | { kind: 'unstake'; amount: string }
 
 /**
  * Input for a bRUNE liquid-bond op — amount-based auto-compounding stake
  * (`liquid.bond`) or unstake (`liquid.unbond`), same shape as {@link StcyInput}.
  */
 export type BruneInput =
-  | { kind: 'stake'; amount: number }
-  | { kind: 'unstake'; amount: number }
+  | { kind: 'stake'; amount: string }
+  | { kind: 'unstake'; amount: string }
 
 export type RujiPayload = { coin: AccountCoin; input: RujiInput }
 export type NativeTcyPayload = { coin: AccountCoin; input: NativeTcyInput }

--- a/core/ui/vault/deposit/utils/exactAmountString.ts
+++ b/core/ui/vault/deposit/utils/exactAmountString.ts
@@ -1,0 +1,13 @@
+import { fromChainAmountExact } from '@vultisig/core-chain/amount/fromChainAmountExact'
+
+/** Trims trailing fraction zeros (and a dangling dot) from a decimal string. */
+export const trimTrailingZeros = (value: string) =>
+  value.includes('.') ? value.replace(/\.?0+$/, '') : value
+
+/**
+ * Exact base-units → trimmed human decimal string for deposit form fields.
+ * Never goes through float64, so percentage/max selections keep every digit
+ * of the share they compute (#4494).
+ */
+export const toExactAmountString = (units: bigint, decimals: number) =>
+  trimTrailingZeros(fromChainAmountExact(units, decimals))

--- a/core/ui/vault/deposit/utils/getDepositFormConfig.ts
+++ b/core/ui/vault/deposit/utils/getDepositFormConfig.ts
@@ -17,8 +17,10 @@ import { z } from 'zod'
 import { ChainAction } from '../ChainAction'
 import { isBruneStakeCoin, isStakeableChain, StakeableChain } from '../config'
 import {
-  maxOrInfinity,
+  optionalNonNegativeAmountSchema,
+  optionalPositiveAmountSchema,
   positiveAmountSchema,
+  requiredAmountSchema,
   toOptionalNumber,
   toRequiredNumber,
 } from './validationHelpers'
@@ -384,17 +386,7 @@ export const getDepositFormConfig = ({
           z.number().gt(0, t('lp_units'))
           // .max(totalAmountAvailable, t('chainFunctions.amountExceeded'))
         ),
-        amount: z.preprocess(
-          toOptionalNumber,
-          z
-            .number()
-            .gt(0, t('amount_must_be_positive'))
-            .max(
-              maxOrInfinity(totalAmountAvailable),
-              t('chainFunctions.amountExceeded')
-            )
-            .optional()
-        ),
+        amount: optionalPositiveAmountSchema(totalAmountAvailable, t),
       }),
     }),
     unbond: () => ({
@@ -486,17 +478,7 @@ export const getDepositFormConfig = ({
           // .max(totalAmountAvailable, t('chainFunctions.amountExceeded'))
         ),
         bondableAsset: z.string().min(1, t('asset')),
-        amount: z.preprocess(
-          toOptionalNumber,
-          z
-            .number()
-            .gt(0, t('amount_must_be_positive'))
-            .max(
-              maxOrInfinity(totalAmountAvailable),
-              t('chainFunctions.amountExceeded')
-            )
-            .optional()
-        ),
+        amount: optionalPositiveAmountSchema(totalAmountAvailable, t),
       }),
     }),
     leave: () => ({
@@ -544,19 +526,7 @@ export const getDepositFormConfig = ({
         },
       ],
       schema: z.object({
-        amount: z.preprocess(
-          toOptionalNumber,
-          z
-            .number()
-            .max(
-              maxOrInfinity(totalAmountAvailable),
-              t('chainFunctions.amountExceeded')
-            )
-            .refine(val => val >= 0, {
-              message: t('amount_must_be_non_negative'),
-            })
-            .optional()
-        ),
+        amount: optionalNonNegativeAmountSchema(totalAmountAvailable, t),
         customMemo: z
           .string()
           .min(1, t('chainFunctions.custom.validations.customMemo')),
@@ -857,10 +827,7 @@ export const getDepositFormConfig = ({
                 message: t('trust_line_currency_invalid'),
               }
             ),
-          amount: z.preprocess(
-            toRequiredNumber,
-            z.number().gt(0, t('amount_must_be_positive'))
-          ),
+          amount: requiredAmountSchema(t),
         })
         // The limit itself is token-denominated, but the line still costs XRP: one
         // owner-reserve increment locked up plus the fee. Below that the TrustSet
@@ -1028,10 +995,7 @@ export const getDepositFormConfig = ({
         // SOL balance and routinely exceeds it (you're withdrawing FROM the
         // stake account). Require only a positive value; capping at the liquid
         // `totalAmountAvailable` would wrongly disable Continue.
-        amount: z.preprocess(
-          toRequiredNumber,
-          z.number().gt(0, t('amount_must_be_positive'))
-        ),
+        amount: requiredAmountSchema(t),
       }),
     }),
     // Move-stake step 1 (deactivate): operates on a prefilled stake account and
@@ -1070,10 +1034,7 @@ export const getDepositFormConfig = ({
       schema: z.object({
         stakeAccount: z.string().trim().min(1),
         validatorAddress: z.string().trim().min(1, t('validator_address')),
-        amount: z.preprocess(
-          toRequiredNumber,
-          z.number().gt(0, t('amount_must_be_positive'))
-        ),
+        amount: requiredAmountSchema(t),
       }),
     }),
   })

--- a/core/ui/vault/deposit/utils/memoGenerator/index.test.ts
+++ b/core/ui/vault/deposit/utils/memoGenerator/index.test.ts
@@ -1,0 +1,42 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+import { describe, expect, it } from 'vitest'
+
+import { generateMemo } from './index'
+
+const runeCoin = {
+  chain: Chain.THORChain,
+  ticker: 'RUNE',
+  decimals: 8,
+} as AccountCoin
+
+describe('generateMemo', () => {
+  it('encodes the exact unbond amount in base units', () => {
+    // Math.round(Number('123456789.87654321') * 1e8) is 12345678987654320 —
+    // float scaling loses the last digit of full-precision amounts (#4494)
+    const memo = generateMemo({
+      selectedChainAction: 'unbond',
+      depositFormData: {
+        nodeAddress: 'thor1node',
+        amount: '123456789.87654321',
+      },
+      bondableAsset: 'THOR.RUNE',
+      chain: Chain.THORChain,
+      coin: runeCoin,
+    })
+
+    expect(memo).toBe('UNBOND:thor1node:12345678987654321')
+  })
+
+  it('encodes plain unbond amounts', () => {
+    const memo = generateMemo({
+      selectedChainAction: 'unbond',
+      depositFormData: { nodeAddress: 'thor1node', amount: '1.5' },
+      bondableAsset: 'THOR.RUNE',
+      chain: Chain.THORChain,
+      coin: runeCoin,
+    })
+
+    expect(memo).toBe('UNBOND:thor1node:150000000')
+  })
+})

--- a/core/ui/vault/deposit/utils/memoGenerator/index.ts
+++ b/core/ui/vault/deposit/utils/memoGenerator/index.ts
@@ -72,7 +72,7 @@ export const generateMemo = ({
 
           if (coin.ticker === 'RUJI') {
             const chainAmount = toChainAmount(
-              shouldBePresent(Number(amount)),
+              shouldBePresent(amount),
               coin.decimals
             ).toString()
             return `bond:${rujiraStakingConfig.bondDenom}:${chainAmount}`
@@ -109,11 +109,10 @@ export const generateMemo = ({
 
           if (coin.ticker === 'RUJI') {
             const amt = shouldBePresent(amount, 'Amount')
-            const amtNum = typeof amt === 'string' ? Number(amt) : amt
-            if (!Number.isFinite(amtNum) || amtNum <= 0) {
+            if (!Number.isFinite(Number(amt)) || Number(amt) <= 0) {
               throw new Error('Amount is required for RUJI unstake')
             }
-            const chainAmount = toChainAmount(amtNum, coin.decimals).toString()
+            const chainAmount = toChainAmount(amt, coin.decimals).toString()
             return `withdraw:${rujiraStakingConfig.bondDenom}:${chainAmount}`
           }
 
@@ -150,7 +149,7 @@ export const generateMemo = ({
     unbond: () => {
       const runeDecimals = chainFeeCoin[Chain.THORChain].decimals
       const amountInUnits = amount
-        ? Math.round(amount * Math.pow(10, runeDecimals))
+        ? toChainAmount(amount, runeDecimals).toString()
         : 0
       return provider
         ? `UNBOND:${nodeAddress}:${amountInUnits}:${provider}`
@@ -252,7 +251,7 @@ export const generateMemo = ({
 function extractFormValues(formData: FieldValues) {
   return {
     nodeAddress: formData.nodeAddress as string | null,
-    amount: formData.amount as number | null,
+    amount: formData.amount as string | null,
     lpUnits: formData.lpUnits as number | null,
     customMemo: formData.customMemo as string | undefined,
     percentage: formData.percentage as number | null,

--- a/core/ui/vault/deposit/utils/validationHelpers.test.ts
+++ b/core/ui/vault/deposit/utils/validationHelpers.test.ts
@@ -1,0 +1,32 @@
+import { toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'
+import type { TFunction } from 'i18next'
+import { describe, expect, it } from 'vitest'
+
+import { positiveAmountSchema } from './validationHelpers'
+
+const t = ((key: string) => key) as TFunction
+
+describe('positiveAmountSchema', () => {
+  it('keeps a full-precision amount exact through validation', () => {
+    const parsed = positiveAmountSchema(10, t).parse('6.123456789012345678')
+
+    expect(toChainAmount(parsed, 18)).toBe(6123456789012345678n)
+  })
+
+  it('does not round the amount up past what the user entered', () => {
+    // Number('6.649999999999999991') is exactly 6.65 — a float64 parse
+    // would submit more than the user typed (#4494)
+    const parsed = positiveAmountSchema(10, t).parse('6.649999999999999991')
+
+    expect(toChainAmount(parsed, 18)).toBe(6649999999999999991n)
+  })
+
+  it('rejects zero, negative, and above-max amounts', () => {
+    const schema = positiveAmountSchema(10, t)
+
+    expect(schema.safeParse('0').success).toBe(false)
+    expect(schema.safeParse('-1').success).toBe(false)
+    expect(schema.safeParse('11').success).toBe(false)
+    expect(schema.safeParse('9.99').success).toBe(true)
+  })
+})

--- a/core/ui/vault/deposit/utils/validationHelpers.ts
+++ b/core/ui/vault/deposit/utils/validationHelpers.ts
@@ -12,7 +12,7 @@ export const toRequiredNumber = (value: unknown) => {
   return Number.isFinite(parsed) ? parsed : NaN
 }
 
-export const maxOrInfinity = (value: number) => (value > 0 ? value : 0)
+const maxOrInfinity = (value: number) => (value > 0 ? value : 0)
 
 /**
  * Normalizes an amount field to its decimal-string representation without

--- a/core/ui/vault/deposit/utils/validationHelpers.ts
+++ b/core/ui/vault/deposit/utils/validationHelpers.ts
@@ -14,21 +14,86 @@ export const toRequiredNumber = (value: unknown) => {
 
 export const maxOrInfinity = (value: number) => (value > 0 ? value : 0)
 
+/**
+ * Normalizes an amount field to its decimal-string representation without
+ * losing precision. The string is what gets submitted — parsing it with
+ * `Number()` would corrupt amounts with more than ~15 significant digits
+ * (#4494), so floats are only used for bounds checks, never as the value.
+ */
+const toAmountString = (value: unknown): string => {
+  if (typeof value === 'string') return value.trim()
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value)
+  return ''
+}
+
+const toOptionalAmountString = (value: unknown) => {
+  const amountString = toAmountString(value)
+  return amountString === '' ? undefined : amountString
+}
+
+/** Required positive amount with no balance cap (e.g. trust-line limits). */
+export const requiredAmountSchema = (t: TFunction) =>
+  z.preprocess(
+    toAmountString,
+    z.string().refine(value => {
+      const parsed = Number(value)
+      return Number.isFinite(parsed) && parsed > 0
+    }, t('amount_must_be_positive'))
+  )
+
+/** Optional positive amount capped at maxValue when present. */
+export const optionalPositiveAmountSchema = (maxValue: number, t: TFunction) =>
+  z.preprocess(
+    toOptionalAmountString,
+    z
+      .string()
+      .refine(value => {
+        const parsed = Number(value)
+        return Number.isFinite(parsed) && parsed > 0
+      }, t('amount_must_be_positive'))
+      .refine(
+        value => Number(value) <= maxOrInfinity(maxValue),
+        t('chainFunctions.amountExceeded')
+      )
+      .optional()
+  )
+
+/** Optional non-negative amount capped at maxValue when present. */
+export const optionalNonNegativeAmountSchema = (
+  maxValue: number,
+  t: TFunction
+) =>
+  z.preprocess(
+    toOptionalAmountString,
+    z
+      .string()
+      .refine(value => {
+        const parsed = Number(value)
+        return Number.isFinite(parsed) && parsed >= 0
+      }, t('amount_must_be_non_negative'))
+      .refine(
+        value => Number(value) <= maxOrInfinity(maxValue),
+        t('chainFunctions.amountExceeded')
+      )
+      .optional()
+  )
+
 export const positiveAmountSchema = (
   maxValue: number,
   t: TFunction,
   maxMessage?: string
 ) =>
   z.preprocess(
-    toRequiredNumber,
+    toAmountString,
     z
-      // An empty/undefined amount becomes NaN via toRequiredNumber; without a
-      // custom message Zod emits its raw invalid_type error instead of the
-      // translated "amount must be positive" one.
-      .number({ error: t('amount_must_be_positive') })
-      .gt(0, t('amount_must_be_positive'))
-      .max(
-        maxValue > 0 ? maxValue : Number.POSITIVE_INFINITY,
+      .string()
+      .refine(value => {
+        const parsed = Number(value)
+        return Number.isFinite(parsed) && parsed > 0
+      }, t('amount_must_be_positive'))
+      .refine(
+        value =>
+          Number(value) <= (maxValue > 0 ? maxValue : Number.POSITIVE_INFINITY),
         maxMessage ?? t('chainFunctions.amountExceeded')
       )
       .superRefine((_val, ctx) => {


### PR DESCRIPTION
Fixes #4494

The deposit form already stores typed amounts as strings, but three chokepoints degrade them to float64 before signing: the zod `positiveAmountSchema` preprocess coerces the submitted value with `Number()`, the keysign payload query does `Number(depositData['amount'])`, and the percentage slider/pill handlers convert exact bigint shares back through `fromChainAmount`. The unbond memo even hand-rolls `Math.round(amount * 1e8)`. Amounts needing more than ~15-16 significant digits are silently perturbed — same family as #4390/#4391/#4488/#4491.

Test-first: the first commit adds tests asserting exactness at two chokepoints — CI is expected to fail on it, demonstrating the bug:
- `positiveAmountSchema` parse of `6.123456789012345678` loses the tail, and `6.649999999999999991` becomes exactly `6.65` (submits more than typed)
- unbond memo for `123456789.87654321` encodes `...320` instead of `...321`

Follow-up commits keep the amount as a decimal string through validation, the keysign query/build, memo generation, and staking resolvers, and make the percentage handlers store the exact bigint share they already compute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved precision when entering, selecting, validating, and submitting staking, bonding, unbonding, and withdrawal amounts.
  * Prevented floating-point rounding from changing high-precision decimal values or encoded transaction amounts.
  * Preserved exact decimal formatting across Solana and Cosmos staking workflows.
  * Improved amount validation for zero, negative, empty, and over-limit values.
* **Tests**
  * Added coverage for precise amount conversion, validation boundaries, and memo encoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->