### PR TITLE
fix(deps): bump brace-expansion resolution to patch DoS vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "tar": ">=7.5.20",
     "js-yaml@4.1.1": "4.3.0",
     "js-yaml@^4.1.1": "4.3.0",
-    "brace-expansion@^1.1.7": "1.1.16",
+    "brace-expansion@^1.1.7": "1.1.18",
     "brace-expansion@^5.0.2": "5.0.8",
     "brace-expansion@^5.0.5": "5.0.8",
     "minimatch@^3.1.2": ">=3.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7353,13 +7353,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:1.1.16":
-  version: 1.1.16
-  resolution: "brace-expansion@npm:1.1.16"
+"brace-expansion@npm:1.1.18":
+  version: 1.1.18
+  resolution: "brace-expansion@npm:1.1.18"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/b2a915bbedbf4e45840d1fb9a4d391bbf26a79475bd134714d3cee34f1f0edb0ce982738028843be5fbaf8039429f71fa487df8c915b6065ced542c83e58fae6
+  checksum: 10c0/3432c18a9e2ebf94162d4effb62198bd0adea06a9f332b2c0188df5d5e30b1e51ea3c848b6608e47d0b857ebe1ea5b3888ed3326dd3c4f6f9645c94153cf9c14
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- `yarn quality:health` was failing at the `quality:audit` step because the `brace-expansion@^1.1.7` yarn resolution was pinned to `1.1.16`, a version vulnerable to [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) (unbounded expansion DoS). Bumped the resolution to `1.1.18` (latest patched 1.x) and ran `yarn install` to update `yarn.lock`.

## Test Plan
- [x] `yarn quality:audit` — no audit suggestions
- [x] `yarn quality:health` — exits clean

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Yarn package resolution for `brace-expansion` to version 1.1.18.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->