### PR TITLE
[Icons V3] Phase 0 — Foundation: codegen, mapping table, gallery

### DIFF
--- a/docs/icons-v3/PLAN.md
+++ b/docs/icons-v3/PLAN.md
@@ -1,0 +1,88 @@
+# Icons V3 Adoption — Plan & Decision Record
+
+Tracks the desktop + extension side of adopting the **Icons V3** library across all
+screens. Companion to issue [#4383](https://github.com/vultisig/vultisig-windows/issues/4383).
+
+## Background
+
+Desktop icons are **code, not assets**: hand-written inline-SVG React components, one per
+file, under `lib/ui/icons/` (~154 single-icon files), `core/ui/agent/icons/`, and
+`core/ui/vult/discount/tier/icons/`. Every import is a deep path — there is no barrel.
+Both clients (`clients/desktop`, `clients/extension`) consume `@lib/ui`, so replacing a
+file's contents under a reused name updates **both** surfaces with zero call-site edits.
+
+The V3 library itself lives in Figma (`Icons V3 UPDATED` section): **1,932 icons across
+32 categories**. It is a third-party pack, not a work order — only the subset the app
+actually ships needs to migrate (~195 desktop glyphs).
+
+## Decision — converge on one icon set (option **a**)
+
+> **Both brands (`vultisig` and `station`) use the same Icons V3 set.**
+> Brand differentiation stays where it belongs — logo, colours, typography — not in the
+> icon geometry.
+
+### Why
+
+The `2b9271e2` commit ("Add Station UI token and icon foundation") did **not** design a
+second, permanently-different icon language. It migrated ~13 icons to V3 **for the Station
+brand only**, gated behind an `iconStyle` theme token, leaving the default `vultisig`
+brand on the legacy icons. Evidence:
+
+- `lib/ui/icons/StationFigmaIcons.tsx` holds 13 icons whose names map 1:1 onto the V3
+  library (`StationWalletFilledIcon` → `wallet-filled`, `StationChevronLeftIcon` →
+  `chevron-left`, …). **11/13 were confirmed present in the V3 Figma library**; the other
+  two are name-normalisation misses, not real gaps.
+- iOS reached the same end state in PR
+  [vultisig-ios#4834](https://github.com/vultisig/vultisig-ios/pull/4834): every shipped
+  icon rebuilt on V3, one set, the compiler enforcing full coverage. Its 137 post-merge
+  icon names are the V3 names.
+
+So `iconStyle === 'station' ? <StationX/> : <LegacyX/>` is a **migration scaffold**, not a
+lasting design. Once the default brand also renders V3, both branches become identical and
+the ternary collapses. Keeping two sets forever (option **b**) would instead grow that
+ternary toward all 277 importing files for a difference users never see.
+
+### ⚠️ Guard rail — `iconStyle` is overloaded
+
+The `iconStyle` token is also (mis)used for **non-icon** Station styling — e.g.
+`lib/ui/search/SearchField.tsx` branches border-radius, font-size, font-weight and
+letter-spacing on it. Those are genuine Station-brand visual differences and **must be
+preserved**. When the icon ternaries are removed, the styling usages must move to a proper
+brand flag (the app already resolves `currentProductBrand === 'station'` at the root in
+`core/ui/CoreApp.tsx`), not be deleted with the token.
+
+### Open confirmation
+
+The only thing code cannot prove is product intent. Confirm with design/product:
+**"V3 icons identical across both brands (Station keeps logo/colour/type differences), or a
+separate icon look per brand?"** All code evidence points to *identical*; this plan assumes
+it. If the answer is *separate*, switch to option (b) and this plan changes.
+
+## Phased delivery
+
+All work lands on the long-lived integration branch `feature/icons-v3-adoption` (off
+`main`, no direct PRs). Each phase is its own PR **targeting that branch**, not `main`.
+
+| Phase | Branch | Content |
+|-------|--------|---------|
+| **0 — Foundation** (this PR) | `feature/icons-v3-phase-0-foundation` | Decision record, codegen tooling (`scripts/icons/`), seed mapping table, Storybook gallery. **No icon art changes.** |
+| 1–4 — iOS-precedent batch | per phase | ~102 icons with an iOS V3 precedent, grouped by V3 category (~25/PR). |
+| 5 — Brand/social glyphs | | Facebook / Twitter / LinkedIn / Reddit / WhatsApp … (iOS ships these separately). |
+| 6 — V3, no iOS precedent | | ~35 icons we choose + verify ourselves (mostly trivial). |
+| 7 — Ambiguous | | ~24 icons resolved by hand against rendered art, with design sign-off. |
+| separate track | | ~23 Vultisig-specific/bespoke glyphs (`Agent*`, `Tron*`, tier badges …) — a design conversation, likely stay bespoke. |
+| separate track | | `iconStyle` ternary removal + relocating non-icon Station styling to a brand flag. |
+| follow-up | | Barrel (`index.ts`) + expand the gallery — tracked separately (#4383 note). |
+
+**Chevrons stay on the legacy pack on purpose** (design-confirmed) and are excluded from
+the migration entirely.
+
+## Constraints that shape the work
+
+- **`knip` runs in `check:all`.** With no barrel, orphaned icons surface as unused exports —
+  a partial migration fails CI. Migrate **all-or-nothing per icon** (in-place body swap
+  keeps the name, so no orphans are created).
+- **Every swap needs visual verification** in the gallery/app. A name match is not a glyph
+  match. Nothing is zero-touch.
+- **Estimates are heuristic** (name matching), not ground truth — confirm each against
+  rendered art before shipping.

--- a/docs/icons-v3/PLAN.md
+++ b/docs/icons-v3/PLAN.md
@@ -60,19 +60,44 @@ it. If the answer is *separate*, switch to option (b) and this plan changes.
 
 ## Phased delivery
 
-All work lands on the long-lived integration branch `feature/icons-v3-adoption` (off
-`main`, no direct PRs). Each phase is its own PR **targeting that branch**, not `main`.
+Each phase is a **sub-issue** of #4383 with its own PR **targeting the long-lived
+integration branch** `feature/icons-v3-adoption` (off `main`, no direct PRs to `main`).
+When every phase has merged into the integration branch, a **final PR** promotes it to
+`main` with a summary of which PR did what.
 
-| Phase | Branch | Content |
-|-------|--------|---------|
-| **0 — Foundation** (this PR) | `feature/icons-v3-phase-0-foundation` | Decision record, codegen tooling (`scripts/icons/`), seed mapping table, Storybook gallery. **No icon art changes.** |
-| 1–4 — iOS-precedent batch | per phase | ~102 icons with an iOS V3 precedent, grouped by V3 category (~25/PR). |
-| 5 — Brand/social glyphs | | Facebook / Twitter / LinkedIn / Reddit / WhatsApp … (iOS ships these separately). |
-| 6 — V3, no iOS precedent | | ~35 icons we choose + verify ourselves (mostly trivial). |
-| 7 — Ambiguous | | ~24 icons resolved by hand against rendered art, with design sign-off. |
-| separate track | | ~23 Vultisig-specific/bespoke glyphs (`Agent*`, `Tron*`, tier badges …) — a design conversation, likely stay bespoke. |
-| separate track | | `iconStyle` ternary removal + relocating non-icon Station styling to a brand flag. |
-| follow-up | | Barrel (`index.ts`) + expand the gallery — tracked separately (#4383 note). |
+### Split axis — by screen, not by icon
+
+The unit of work is a **screen**, not an icon category. A screen is migrated
+**all-at-once** — it never ships half V3 / half legacy. This is stricter than the issue's
+"all-or-nothing per icon" rule and avoids visually mixed screens.
+
+Because icons are shared across screens, one screen's icons can also appear on another.
+Migrating a shared icon ripples to every screen that uses it. To keep each per-screen phase
+self-contained, **shared icons are migrated first, in one phase**; after that, each screen
+phase only touches icons unique to that screen, so it can't leave another screen mixed.
+(Intermediate mixing on the integration branch is fine — nothing reaches users until the
+final PR to `main`.)
+
+| Phase | Scope | Content |
+|-------|-------|---------|
+| **0 — Foundation** ✅ | tooling | Decision record, codegen (`scripts/icons/`), seed mapping table, Storybook gallery. **No icon art changes.** |
+| **1 — Shared icons** | cross-screen | Every icon used on more than one screen (nav, back, close, search, wallet, copy…). One PR, ripples across all screens by design. Excludes chevrons. |
+| **2 — Main View** | screen | Portfolio / vault home — its remaining screen-unique icons. |
+| **3 — Send flow** | screen | |
+| **4 — Swap flow** | screen | |
+| **5 — DeFi / Earn** | screen | |
+| **6 — Settings** | screen | |
+| **7 — Transaction History** | screen | |
+| **8 — Vault lifecycle** | screens | Onboarding, Vault Setup, Reshare, Upgrade Vault (share most icons — grouped). |
+| **9 — Notifications** | screen | |
+| **10 — Extension surfaces** | screens | No Figma reference — migrate to desktop parity. |
+| separate track | brand | ~23 Vultisig-specific/bespoke glyphs (`Agent*`, `Tron*`, tier badges…) — design call, likely stay bespoke. |
+| separate track | cleanup | `iconStyle` ternary removal + relocating non-icon Station styling to a brand flag. |
+| follow-up | infra | Barrel (`index.ts`) + expand the gallery — tracked separately (#4383 note). |
+
+Screen list and the mapping source (iOS precedent, V3 library, ambiguous) still drive
+*which* V3 icon each legacy icon becomes — see `scripts/icons/icon-mapping.json`. The
+screen split only changes *how the work is batched into PRs*.
 
 **Chevrons stay on the legacy pack on purpose** (design-confirmed) and are excluded from
 the migration entirely.

--- a/knip.json
+++ b/knip.json
@@ -63,6 +63,9 @@
     "package.json": [
       "devDependencies"
     ],
+    "scripts/icons/generate-icons.mjs": [
+      "files"
+    ],
     "scripts/quality-audit.mjs": [
       "files"
     ]

--- a/lib/ui/icons/Icons.stories.tsx
+++ b/lib/ui/icons/Icons.stories.tsx
@@ -1,0 +1,412 @@
+import { SvgProps } from '@lib/ui/props'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { FC } from 'react'
+
+import { AgentIcon } from './AgentIcon'
+import { ArCubeIcon } from './ArCubeIcon'
+import { ArrowDownIcon } from './ArrowDownIcon'
+import { ArrowLeftRightIcon } from './ArrowLeftRightIcon'
+import { ArrowSplitIcon } from './ArrowSplitIcon'
+import { ArrowUndoIcon } from './ArrowUndoIcon'
+import { ArrowUpDownIcon } from './ArrowUpDownIcon'
+import { ArrowUpRightIcon } from './ArrowUpRightIcon'
+import { ArrowWallDownIcon } from './ArrowWallDownIcon'
+import { AsteriskIcon } from './AsteriskIcon'
+import { BadgeCheckIcon } from './BadgeCheckIcon'
+import { BellIcon } from './BellIcon'
+import { BookIcon } from './BookIcon'
+import { BooksIcon } from './BooksIcon'
+import { BoxIcon } from './BoxIcon'
+import { BrokenChainLink3Icon } from './BrokenChainLink3Icon'
+import { BrowserExtensionIcon } from './BrowserExtensionIcon'
+import { BubbleQuestionIcon } from './BubbleQuestionIcon'
+import { CalendarClockIcon } from './CalendarClockIcon'
+import { CalendarIcon } from './CalendarIcon'
+import { CameraFilledIcon } from './CameraFilledIcon'
+import { CameraIcon } from './CameraIcon'
+import CaretDownIcon from './CaretDownIcon'
+import { ChainLinkIcon3 } from './ChainLinkIcon3'
+import { CheckIcon } from './CheckIcon'
+import { CheckmarkIcon } from './CheckmarkIcon'
+import { ChevronDownIcon } from './ChevronDownIcon'
+import { ChevronLeftIcon } from './ChevronLeftIcon'
+import { ChevronRightIcon } from './ChevronRightIcon'
+import { CircleAlertIcon } from './CircleAlertIcon'
+import { CircleCheckIcon } from './CircleCheckIcon'
+import { CircleCrossFilledIcon } from './CircleCrossFilledIcon'
+import { CircleCrossIcon } from './CircleCrossIcon'
+import { CircleDollarSignIcon } from './CircleDollarSignIcon'
+import { CircleHelpIcon } from './CircleHelpIcon'
+import { CircleICloseIcon } from './CircleICloseIcon'
+import { CircleIcon } from './CircleIcon'
+import { CircleInfoIcon } from './CircleInfoIcon'
+import { CircleMinusIcon } from './CircleMinusIcon'
+import { CirclePlusIcon } from './CirclePlusIcon'
+import { ClipboardCopyIcon } from './ClipboardCopyIcon'
+import { CloseIcon } from './CloseIcon'
+import { CloudIcon } from './CloudIcon'
+import { CloudOffIcon } from './CloudOffIcon'
+import { CloudUploadIcon } from './CloudUploadIcon'
+import { CoinsAddIcon } from './CoinsAddIcon'
+import { CoinsIcon } from './CoinsIcon'
+import { ComputerUploadIcon } from './ComputerUploadIcon'
+import { CopyIcon } from './CopyIcon'
+import { CoSignIcon } from './CoSignIcon'
+import { CrossIcon } from './CrossIcon'
+import { CryptoIcon } from './CryptoIcon'
+import { CryptoWalletPenIcon } from './CryptoWalletPenIcon'
+import { CubeWithCornersIcon } from './CubeWithCornersIcon'
+import { DAppsIcon } from './DAppsIcon'
+import { DeviceIcon } from './DeviceIcon'
+import { DevicesIcon } from './DevicesIcon'
+import { DiscordIcon } from './DiscordIcon'
+import { DollarIcon } from './DollarIcon'
+import { DownloadSeedphraseIcon } from './DownloadSeedphraseIcon'
+import { EmailIcon } from './EmailIcon'
+import { EmailNotificationIcon } from './EmailNotificationIcon'
+import { ExpandIcon } from './ExpandIcon'
+import { EyeClosedIcon } from './EyeClosedIcon'
+import { EyeIcon } from './EyeIcon'
+import { EyeOffIcon } from './EyeOffIcon'
+import { FacebookIcon } from './FacebookIcon'
+import { FileIcon } from './FileIcon'
+import { FileQuestionIcon } from './FileQuestionIcon'
+import { FileTextIcon } from './FileTextIcon'
+import { FileUpIcon } from './FileUpIcon'
+import { FileWarningIcon } from './FileWarningIcon'
+import { FilledAlertIcon } from './FilledAlertIcon'
+import { FocusLockIcon } from './FocusLockIcon'
+import { FolderIcon } from './FolderIcon'
+import { FolderLockIcon } from './FolderLockIcon'
+import { FolderUploadIcon } from './FolderUploadIcon'
+import { FrameIcon } from './FrameIcon'
+import { FuelIcon } from './FuelIcon'
+import { GithubIcon } from './GithubIcon'
+import { GlobusIcon } from './GlobusIcon'
+import { GripVerticalIcon } from './GripVerticalIcon'
+import { GroupOneIcon } from './GroupOneIcon'
+import { IconFileEdit } from './IconFileEdit'
+import { ImageAvatarSparkleIcon } from './ImageAvatarSparkleIcon'
+import { InfoCircleIcon } from './InfoCircleIcon'
+import { InfoIcon } from './InfoIcon'
+import { KeyboardUpIcon } from './KeyboardUpIcon'
+import { LanguagesIcon } from './LanguagesIcon'
+import { LaptopIcon } from './LaptopIcon'
+import { LeafIcon } from './LeafIcon'
+import { LightbulbIcon } from './LightbulbIcon'
+import { LightningIcon } from './LightningIcon'
+import { LinkedinIcon } from './LinkedinIcon'
+import { LinkTwoOffIcon } from './LinkTwoOffIcon'
+import { LockClosedIcon } from './LockClosedIcon'
+import { LockKeyholeIcon } from './LockKeyholeIcon'
+import { LockKeyholeOpenIcon } from './LockKeyholeOpenIcon'
+import { LogoBoxIcon } from './LogoBoxIcon'
+import { MagnifyingGlassIcon } from './MagnifyingGlassIcon'
+import { MegaphoneIcon } from './MegaphoneIcon'
+import { MenuIcon } from './MenuIcon'
+import { NavigationXIcon } from './NavigationXIcon'
+import { PadlockIcon } from './PadlockIcon'
+import { PageCheckIcon } from './PageCheckIcon'
+import { PanelRightIcon } from './PanelRightIcon'
+import { PasteIcon } from './PasteIcon'
+import { PencilIcon } from './PenciIcon'
+import { PercentIcon } from './PercentIcon'
+import { PictureIcon } from './PictureIcon'
+import { PlusIcon } from './PlusIcon'
+import { QrCodeIcon } from './QrCodeIcon'
+import { RadioTowerIcon } from './RadioTowerIcon'
+import { RedditIcon } from './RedditIcon'
+import { RefreshCwIcon } from './RefreshCwIcon'
+import { ResendNotificationBellIcon } from './ResendNotificationBellIcon'
+import { SearchIcon } from './SearchIcon'
+import { SeedphraseIcon } from './SeedphraseIcon'
+import { SendIcon } from './SendIcon'
+import { SettingsIcon } from './SettingsIcon'
+import { ShapesPlusXSquareCircleIcon } from './ShapesPlusXSquareCircleIcon'
+import { ShareAndroidIcon } from './ShareAndroidIcon'
+import { ShareIcon } from './ShareIcon'
+import { ShieldCheckFilledIcon } from './ShieldCheckFilledIcon'
+import { ShieldCheckIcon } from './ShieldCheckIcon'
+import { ShieldIcon } from './ShieldIcon'
+import { ShieldVerifiedIcon } from './ShieldVerifiedIcon'
+import { SmartphoneIcon } from './SmartphoneIcon'
+import { SparkledPenIcon } from './SparkledPenIcon'
+import { SquareArrowOutUpRightIcon } from './SquareArrowOutUpRightIcon'
+import { SquareArrowTopRightIcon } from './SquareArrowTopRightIcon'
+import { SquareBehindSquare4Icon } from './SquareBehindSquare4Icon'
+import { SquareBehindSquare6Icon } from './SquareBehindSquare6Icon'
+import { SquarePenIcon } from './SquarePenIcon'
+import {
+  StationArrowDownFromLineIcon,
+  StationArrowsRotateCenterIcon,
+  StationArrowToCornerTopRightIcon,
+  StationCheckmarkSmallIcon,
+  StationChevronLeftIcon,
+  StationChevronRightSmallIcon,
+  StationCirclePlusFilledIcon,
+  StationCircleXmarkFilledIcon,
+  StationCopies3FilledIcon,
+  StationCreditCardIcon,
+  StationLayers2FilledIcon,
+  StationMagnifierIcon,
+  StationWalletFilledIcon,
+} from './StationFigmaIcons'
+import { StopCircleIcon } from './StopCircleIcon'
+import { SwapLoadingIcon } from './SwapLoadingIcon'
+import { TabletSmartphoneIcon } from './TabletSmartphoneIcon'
+import { TransactionApproveIcon } from './TransactionApproveIcon'
+import { TransactionReceiveIcon } from './TransactionReceiveIcon'
+import { TransactionSendIcon } from './TransactionSendIcon'
+import { TransactionSwapIcon } from './TransactionSwapIcon'
+import { TrashCanIcon } from './TrashCanIcon'
+import { TrashIcon } from './TrashIcon'
+import { TrashIcon2 } from './TrashIcon2'
+import { TriangleAlertIcon } from './TriangleAlertIcon'
+import { TronBandwidthIcon } from './TronBandwidthIcon'
+import { TronEnergyIcon } from './TronEnergyIcon'
+import { TrophyIcon } from './TrophyIcon'
+import { TwitterIcon } from './TwitterIcon'
+import { UserLockIcon } from './UserLockIcon'
+import { WalletIcon } from './WalletIcon'
+import { WandSparklesIcon } from './WandSparklesIcon'
+import { WarningIcon } from './WarningIcon'
+import { WhatsAppIcon } from './WhatsAppIcon'
+import { ZapIcon } from './ZapIcon'
+
+/**
+ * Visual gallery of every icon in `lib/ui/icons`.
+ * Added in the Icons V3 foundation (Phase 0) so reviewers can eyeball the full
+ * set side by side during the V3 migration — see docs/icons-v3/PLAN.md.
+ */
+const vultisigIcons: Record<string, FC<SvgProps>> = {
+  CaretDownIcon,
+  AgentIcon,
+  ArCubeIcon,
+  ArrowDownIcon,
+  ArrowLeftRightIcon,
+  ArrowSplitIcon,
+  ArrowUndoIcon,
+  ArrowUpDownIcon,
+  ArrowUpRightIcon,
+  ArrowWallDownIcon,
+  AsteriskIcon,
+  BadgeCheckIcon,
+  BellIcon,
+  BookIcon,
+  BooksIcon,
+  BoxIcon,
+  BrokenChainLink3Icon,
+  BrowserExtensionIcon,
+  BubbleQuestionIcon,
+  CalendarClockIcon,
+  CalendarIcon,
+  CameraFilledIcon,
+  CameraIcon,
+  ChainLinkIcon3,
+  CheckIcon,
+  CheckmarkIcon,
+  ChevronDownIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  CircleAlertIcon,
+  CircleCheckIcon,
+  CircleCrossFilledIcon,
+  CircleCrossIcon,
+  CircleDollarSignIcon,
+  CircleHelpIcon,
+  CircleICloseIcon,
+  CircleIcon,
+  CircleInfoIcon,
+  CircleMinusIcon,
+  CirclePlusIcon,
+  ClipboardCopyIcon,
+  CloseIcon,
+  CloudIcon,
+  CloudOffIcon,
+  CloudUploadIcon,
+  CoSignIcon,
+  CoinsAddIcon,
+  CoinsIcon,
+  ComputerUploadIcon,
+  CopyIcon,
+  CrossIcon,
+  CryptoIcon,
+  CryptoWalletPenIcon,
+  CubeWithCornersIcon,
+  DAppsIcon,
+  DeviceIcon,
+  DevicesIcon,
+  DiscordIcon,
+  DollarIcon,
+  DownloadSeedphraseIcon,
+  EmailIcon,
+  EmailNotificationIcon,
+  ExpandIcon,
+  EyeClosedIcon,
+  EyeIcon,
+  EyeOffIcon,
+  FacebookIcon,
+  FileIcon,
+  FileQuestionIcon,
+  FileTextIcon,
+  FileUpIcon,
+  FileWarningIcon,
+  FilledAlertIcon,
+  FocusLockIcon,
+  FolderIcon,
+  FolderLockIcon,
+  FolderUploadIcon,
+  FrameIcon,
+  FuelIcon,
+  GithubIcon,
+  GlobusIcon,
+  GripVerticalIcon,
+  GroupOneIcon,
+  IconFileEdit,
+  ImageAvatarSparkleIcon,
+  InfoCircleIcon,
+  InfoIcon,
+  KeyboardUpIcon,
+  LanguagesIcon,
+  LaptopIcon,
+  LeafIcon,
+  LightbulbIcon,
+  LightningIcon,
+  LinkTwoOffIcon,
+  LinkedinIcon,
+  LockClosedIcon,
+  LockKeyholeIcon,
+  LockKeyholeOpenIcon,
+  LogoBoxIcon,
+  MagnifyingGlassIcon,
+  MegaphoneIcon,
+  MenuIcon,
+  NavigationXIcon,
+  PadlockIcon,
+  PageCheckIcon,
+  PanelRightIcon,
+  PasteIcon,
+  PencilIcon,
+  PercentIcon,
+  PictureIcon,
+  PlusIcon,
+  QrCodeIcon,
+  RadioTowerIcon,
+  RedditIcon,
+  RefreshCwIcon,
+  ResendNotificationBellIcon,
+  SearchIcon,
+  SeedphraseIcon,
+  SendIcon,
+  SettingsIcon,
+  ShapesPlusXSquareCircleIcon,
+  ShareAndroidIcon,
+  ShareIcon,
+  ShieldCheckFilledIcon,
+  ShieldCheckIcon,
+  ShieldIcon,
+  ShieldVerifiedIcon,
+  SmartphoneIcon,
+  SparkledPenIcon,
+  SquareArrowOutUpRightIcon,
+  SquareArrowTopRightIcon,
+  SquareBehindSquare4Icon,
+  SquareBehindSquare6Icon,
+  SquarePenIcon,
+  StopCircleIcon,
+  SwapLoadingIcon,
+  TabletSmartphoneIcon,
+  TransactionApproveIcon,
+  TransactionReceiveIcon,
+  TransactionSendIcon,
+  TransactionSwapIcon,
+  TrashCanIcon,
+  TrashIcon,
+  TrashIcon2,
+  TriangleAlertIcon,
+  TronBandwidthIcon,
+  TronEnergyIcon,
+  TrophyIcon,
+  TwitterIcon,
+  UserLockIcon,
+  WalletIcon,
+  WandSparklesIcon,
+  WarningIcon,
+  WhatsAppIcon,
+  ZapIcon,
+}
+
+const stationV3Icons: Record<string, FC<SvgProps>> = {
+  StationArrowsRotateCenterIcon,
+  StationArrowToCornerTopRightIcon,
+  StationCirclePlusFilledIcon,
+  StationArrowDownFromLineIcon,
+  StationMagnifierIcon,
+  StationCircleXmarkFilledIcon,
+  StationChevronLeftIcon,
+  StationChevronRightSmallIcon,
+  StationCheckmarkSmallIcon,
+  StationCopies3FilledIcon,
+  StationWalletFilledIcon,
+  StationLayers2FilledIcon,
+  StationCreditCardIcon,
+}
+
+const IconCell: FC<{ name: string; Icon: FC<SvgProps> }> = ({ name, Icon }) => (
+  <div
+    style={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      gap: 8,
+      padding: 12,
+      borderRadius: 8,
+      border: '1px solid rgba(255,255,255,0.08)',
+      textAlign: 'center',
+    }}
+  >
+    <span style={{ fontSize: 28, lineHeight: 1, color: '#F0F4FC' }}>
+      <Icon />
+    </span>
+    <span style={{ fontSize: 10, color: '#8295AE', wordBreak: 'break-all' }}>
+      {name}
+    </span>
+  </div>
+)
+
+const IconGrid: FC<{ icons: Record<string, FC<SvgProps>> }> = ({ icons }) => (
+  <div
+    style={{
+      display: 'grid',
+      gridTemplateColumns: 'repeat(auto-fill, minmax(96px, 1fr))',
+      gap: 12,
+      padding: 24,
+      background: '#02122B',
+    }}
+  >
+    {Object.entries(icons).map(([name, Icon]) => (
+      <IconCell key={name} name={name} Icon={Icon} />
+    ))}
+  </div>
+)
+
+const meta: Meta = {
+  title: 'Foundation/Icons',
+  parameters: { layout: 'fullscreen' },
+}
+export default meta
+
+type Story = StoryObj
+
+/** Every icon currently shipped in `lib/ui/icons` (the legacy + in-progress set). */
+export const AllIcons: Story = {
+  render: () => <IconGrid icons={vultisigIcons} />,
+}
+
+/**
+ * The Station-branded icons, which are already drawn in the Icons V3 style.
+ * They are the visual target the default set converges on during the migration.
+ */
+export const StationV3Preview: Story = {
+  render: () => <IconGrid icons={stationV3Icons} />,
+}

--- a/scripts/icons/README.md
+++ b/scripts/icons/README.md
@@ -1,0 +1,61 @@
+# Icons V3 codegen
+
+Tooling for the [Icons V3 adoption](../../docs/icons-v3/PLAN.md) (issue #4383). Pulls icons
+from the Figma "Icons V3" library and writes them as React components that follow this
+repo's icon contract, so a generated file is a drop-in body swap for the legacy icon.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `generate-icons.mjs` | The codegen. Fetches SVG from Figma → repo-contract React component. |
+| `figma-icons.config.json` | Non-secret Figma coordinates (file key + section node id). |
+| `icon-mapping.json` | Source-of-truth mapping: desktop icon → V3 source icon. **Seed, intentionally incomplete.** |
+
+## Token
+
+The Figma API token is **never** committed. Pass it via the environment:
+
+```bash
+export FIGMA_TOKEN=figd_xxx   # a Figma personal access token with File content: Read
+```
+
+Revoke and rotate the token if it is ever pasted into a chat, PR, or log.
+
+## Commands
+
+```bash
+# List every icon name available in the V3 section (use these in icon-mapping.json "v3" fields)
+FIGMA_TOKEN=figd_xxx node scripts/icons/generate-icons.mjs --list
+
+# Preview one icon without writing (prints the generated component)
+FIGMA_TOKEN=figd_xxx node scripts/icons/generate-icons.mjs --icon WalletIcon --dry-run
+
+# Generate one icon
+FIGMA_TOKEN=figd_xxx node scripts/icons/generate-icons.mjs --icon WalletIcon
+
+# Generate every mapped, non-bespoke icon
+FIGMA_TOKEN=figd_xxx node scripts/icons/generate-icons.mjs --all
+```
+
+After generating, always:
+
+1. `yarn eslint lib/ui/icons/<Name>.tsx --fix` — sort/format to house style.
+2. Eyeball the result in the Storybook gallery (`Foundation/Icons`) — a name match is not a
+   glyph match.
+3. `yarn check` before opening the PR.
+
+## Adding to the mapping
+
+Each entry:
+
+```json
+{ "desktop": "WalletIcon", "v3": "wallet-filled", "status": "proposed", "source": "station" }
+```
+
+- `desktop` — the component file in `lib/ui/icons/` (without `.tsx`).
+- `v3` — the icon name from `--list` (`null` for bespoke glyphs with no V3 counterpart).
+- `status` — `verified` (checked against rendered art), `proposed` (needs eyeballing), or `bespoke`.
+- `source` — `station`, `ios`, or `manual` (where the decision came from).
+
+Chevrons stay on the legacy pack by design — do not add them.

--- a/scripts/icons/figma-icons.config.json
+++ b/scripts/icons/figma-icons.config.json
@@ -1,0 +1,7 @@
+{
+  "$comment": "Non-secret Figma coordinates for the Icons V3 library. The API token is NOT stored here — pass it via the FIGMA_TOKEN environment variable when running scripts/icons/generate-icons.mjs.",
+  "fileKey": "LTsF1zYLuwQ4TePTwbRqMw",
+  "sectionNodeId": "374:68371",
+  "sectionName": "Icons V3 UPDATED",
+  "outputDir": "lib/ui/icons"
+}

--- a/scripts/icons/generate-icons.mjs
+++ b/scripts/icons/generate-icons.mjs
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+/**
+ * Icons V3 codegen.
+ *
+ * Pulls icons from the Figma "Icons V3" library and writes them as React
+ * components that follow this repo's icon contract (see
+ * .claude/skills/svg-icon-pattern/SKILL.md): `width="1em" height="1em"`,
+ * concrete colours swapped to `currentColor`, and `{...props}` spread on the
+ * <svg>. Sizing/colour stay at the call site — geometry swaps don't disturb
+ * layout, so a generated file is a drop-in body swap for the legacy icon.
+ *
+ * The Figma coordinates live in figma-icons.config.json (non-secret). The API
+ * token is read from the FIGMA_TOKEN environment variable and is never written
+ * to disk.
+ *
+ * Usage:
+ *   FIGMA_TOKEN=figd_xxx node scripts/icons/generate-icons.mjs --list
+ *   FIGMA_TOKEN=figd_xxx node scripts/icons/generate-icons.mjs --icon WalletIcon
+ *   FIGMA_TOKEN=figd_xxx node scripts/icons/generate-icons.mjs --all --dry-run
+ *
+ * Flags:
+ *   --list            Print every icon name available in the V3 section (for building the mapping).
+ *   --icon <Name>     Generate a single desktop icon by its icon-mapping.json `desktop` name.
+ *   --all             Generate every non-bespoke, mapped icon.
+ *   --dry-run         Print what would be written without touching the filesystem.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(scriptDir, '..', '..')
+
+const readJson = path => JSON.parse(readFileSync(path, 'utf8'))
+const config = readJson(join(scriptDir, 'figma-icons.config.json'))
+const mapping = readJson(join(scriptDir, 'icon-mapping.json'))
+
+const FIGMA_API = 'https://api.figma.com/v1'
+
+const token = process.env.FIGMA_TOKEN
+if (!token) {
+  console.error(
+    'FIGMA_TOKEN is not set. Run with: FIGMA_TOKEN=figd_xxx node scripts/icons/generate-icons.mjs ...'
+  )
+  process.exit(1)
+}
+
+const sleep = ms => new Promise(done => setTimeout(done, ms))
+
+/** GET a Figma endpoint, retrying on 429/5xx with exponential backoff. */
+const figma = async (path, attempt = 0) => {
+  const res = await fetch(`${FIGMA_API}${path}`, {
+    headers: { 'X-Figma-Token': token },
+  })
+  if (res.status === 429 || res.status >= 500) {
+    if (attempt >= 5) {
+      throw new Error(`Figma API ${res.status} for ${path} after ${attempt} retries`)
+    }
+    const retryAfter = Number(res.headers.get('retry-after'))
+    const wait = Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter * 1000 : 2 ** attempt * 1000
+    console.warn(`Figma API ${res.status} — retrying in ${wait}ms`)
+    await sleep(wait)
+    return figma(path, attempt + 1)
+  }
+  if (!res.ok) {
+    throw new Error(`Figma API ${res.status} for ${path}: ${await res.text()}`)
+  }
+  return res.json()
+}
+
+/** Walk the section tree and collect every icon instance keyed by its name. */
+const collectSectionIcons = async () => {
+  const data = await figma(
+    `/files/${config.fileKey}/nodes?ids=${encodeURIComponent(config.sectionNodeId)}`
+  )
+  const root = data.nodes[Object.keys(data.nodes)[0]].document
+  const byName = new Map()
+  const walk = node => {
+    if (node.type === 'INSTANCE' || node.type === 'COMPONENT') {
+      if (!byName.has(node.name)) byName.set(node.name, node.id)
+    }
+    for (const child of node.children ?? []) walk(child)
+  }
+  walk(root)
+  return byName
+}
+
+/** Fetch rendered SVG markup for a batch of node ids. */
+const fetchSvgs = async nodeIds => {
+  const ids = nodeIds.join(',')
+  const { images } = await figma(
+    `/images/${config.fileKey}?ids=${encodeURIComponent(ids)}&format=svg`
+  )
+  const out = new Map()
+  await Promise.all(
+    Object.entries(images).map(async ([id, url]) => {
+      if (!url) return
+      const res = await fetch(url)
+      out.set(id, await res.text())
+    })
+  )
+  return out
+}
+
+const KEBAB_TO_CAMEL = {
+  'stroke-width': 'strokeWidth',
+  'stroke-linecap': 'strokeLinecap',
+  'stroke-linejoin': 'strokeLinejoin',
+  'stroke-miterlimit': 'strokeMiterlimit',
+  'stroke-dasharray': 'strokeDasharray',
+  'stroke-dashoffset': 'strokeDashoffset',
+  'stroke-opacity': 'strokeOpacity',
+  'fill-rule': 'fillRule',
+  'clip-rule': 'clipRule',
+  'fill-opacity': 'fillOpacity',
+  'clip-path': 'clipPath',
+}
+
+/** Turn raw Figma SVG markup into a repo-contract React icon component. */
+const svgToComponent = (name, svg) => {
+  const viewBox = (svg.match(/viewBox="([^"]+)"/) || [])[1] || '0 0 24 24'
+
+  // Inner markup: everything between the opening <svg ...> and closing </svg>.
+  let inner = svg.replace(/^[\s\S]*?<svg[^>]*>/, '').replace(/<\/svg>\s*$/, '')
+
+  // Swap concrete stroke/fill colours to currentColor; keep `none`.
+  inner = inner.replace(/(stroke|fill)="(#[0-9a-fA-F]{3,8}|rgba?\([^)]*\))"/g, '$1="currentColor"')
+
+  // Kebab SVG attributes -> JSX camelCase.
+  for (const [kebab, camel] of Object.entries(KEBAB_TO_CAMEL)) {
+    inner = inner.replace(new RegExp(`${kebab}=`, 'g'), `${camel}=`)
+  }
+
+  inner = inner
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(line => `    ${line}`)
+    .join('\n')
+
+  return `import { SvgProps } from '@lib/ui/props'
+
+export const ${name} = (props: SvgProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1em"
+    height="1em"
+    viewBox="${viewBox}"
+    fill="none"
+    {...props}
+  >
+${inner}
+  </svg>
+)
+`
+}
+
+const parseArgs = argv => {
+  const flags = { list: false, all: false, dryRun: false, icon: null }
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--list') flags.list = true
+    else if (argv[i] === '--all') flags.all = true
+    else if (argv[i] === '--dry-run') flags.dryRun = true
+    else if (argv[i] === '--icon') flags.icon = argv[++i]
+  }
+  return flags
+}
+
+const main = async () => {
+  const flags = parseArgs(process.argv.slice(2))
+  const sectionIcons = await collectSectionIcons()
+
+  if (flags.list) {
+    console.log(`${sectionIcons.size} icons in "${config.sectionName}":\n`)
+    for (const name of [...sectionIcons.keys()].sort()) console.log(`  ${name}`)
+    return
+  }
+
+  const targets = mapping.icons.filter(entry => {
+    if (entry.status === 'bespoke' || !entry.v3) return false
+    if (flags.icon) return entry.desktop === flags.icon
+    return flags.all
+  })
+
+  if (!targets.length) {
+    console.error(
+      flags.icon
+        ? `No mappable icon named "${flags.icon}" in icon-mapping.json.`
+        : 'Nothing to do. Pass --list, --icon <Name>, or --all.'
+    )
+    process.exit(1)
+  }
+
+  const nodeIds = targets
+    .map(entry => sectionIcons.get(entry.v3))
+    .filter(Boolean)
+  const svgs = await fetchSvgs(nodeIds)
+
+  for (const entry of targets) {
+    const nodeId = sectionIcons.get(entry.v3)
+    if (!nodeId) {
+      console.warn(`⚠ "${entry.v3}" not found in the V3 section — skipping ${entry.desktop}`)
+      continue
+    }
+    const svg = svgs.get(nodeId)
+    if (!svg) {
+      console.warn(`⚠ no SVG returned for ${entry.desktop} (${entry.v3})`)
+      continue
+    }
+    const component = svgToComponent(entry.desktop, svg)
+    const outPath = join(repoRoot, config.outputDir, `${entry.desktop}.tsx`)
+
+    if (flags.dryRun) {
+      console.log(`\n--- ${config.outputDir}/${entry.desktop}.tsx (dry-run) ---`)
+      console.log(component)
+      continue
+    }
+    const existed = existsSync(outPath)
+    writeFileSync(outPath, component)
+    console.log(`${existed ? 'updated' : 'created'} ${config.outputDir}/${entry.desktop}.tsx  ← ${entry.v3}`)
+  }
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/icons/icon-mapping.json
+++ b/scripts/icons/icon-mapping.json
@@ -1,0 +1,38 @@
+{
+  "$comment": "Source-of-truth mapping from a desktop icon component (lib/ui/icons/<name>.tsx) to its Icons V3 source icon (the component/instance name in the Figma section defined in figma-icons.config.json). SEED ONLY — this is intentionally incomplete. Later phases extend it, verifying each entry against rendered art before shipping. Chevrons are excluded on purpose (they stay on the legacy pack per design).",
+  "decision": "converge-on-v3",
+  "status": {
+    "verified": "V3 source confirmed against rendered art",
+    "proposed": "likely match from name/iOS precedent — must be eyeballed before use",
+    "bespoke": "Vultisig-specific glyph with no V3 counterpart — stays hand-drawn"
+  },
+  "sourceLegend": {
+    "station": "already shipped in StationFigmaIcons.tsx (drawn in V3 style)",
+    "ios": "matches an icon rebuilt on V3 in vultisig-ios#4834",
+    "manual": "decided here"
+  },
+  "excludedChevrons": [
+    "ChevronLeftIcon",
+    "ChevronRightIcon",
+    "ChevronDownIcon",
+    "ChevronUpIcon",
+    "CaretDownIcon"
+  ],
+  "icons": [
+    { "desktop": "WalletIcon", "v3": "wallet-filled", "status": "proposed", "source": "station" },
+    { "desktop": "MagnifyingGlassIcon", "v3": "magnifier", "status": "proposed", "source": "station" },
+    { "desktop": "SearchIcon", "v3": "magnifier", "status": "proposed", "source": "station" },
+    { "desktop": "InfoCircleIcon", "v3": "circle-info", "status": "proposed", "source": "ios" },
+    { "desktop": "CircleCheckIcon", "v3": "badge-check", "status": "proposed", "source": "ios" },
+    { "desktop": "CreditCardIcon", "v3": "credit-card", "status": "proposed", "source": "station" },
+    { "desktop": "CoinsIcon", "v3": "credit-card", "status": "proposed", "source": "manual" },
+    { "desktop": "CopyIcon", "v3": "copies-3-filled", "status": "proposed", "source": "station" },
+    { "desktop": "BellIcon", "v3": "bell", "status": "proposed", "source": "ios" },
+    { "desktop": "BookIcon", "v3": "book", "status": "proposed", "source": "ios" },
+    { "desktop": "PercentIcon", "v3": "circle-percentage", "status": "proposed", "source": "ios" },
+    { "desktop": "TrashIcon", "v3": "trash-2", "status": "proposed", "source": "manual" },
+    { "desktop": "AgentIcon", "v3": null, "status": "bespoke", "source": "manual" },
+    { "desktop": "SeedphraseIcon", "v3": null, "status": "bespoke", "source": "manual" },
+    { "desktop": "TronEnergyIcon", "v3": null, "status": "bespoke", "source": "manual" }
+  ]
+}


### PR DESCRIPTION
Closes #4499. Part of #4383.

First phase of the Icons V3 adoption — **foundation only, no icon art changes**. Targets the long-lived integration branch `feature/icons-v3-adoption` (not `main`); `main` only receives the final PR once all phases land.

## What's here

| File | Purpose |
|------|---------|
| `docs/icons-v3/PLAN.md` | Decision record (converge both brands on one V3 set) + screen-based phased plan |
| `scripts/icons/generate-icons.mjs` | Codegen: Figma "Icons V3" → repo-contract React component (`1em`, `currentColor`, props spread). Token via `FIGMA_TOKEN` env, never committed |
| `scripts/icons/icon-mapping.json` | Seed source-of-truth mapping (desktop icon → V3 icon). Intentionally incomplete |
| `scripts/icons/{README.md,figma-icons.config.json}` | Usage + non-secret Figma coordinates |
| `lib/ui/icons/Icons.stories.tsx` | Storybook gallery (`Foundation/Icons`) to eyeball the full set |
| `knip.json` | Declare the codegen as a standalone script |

## Verified

- `--list` reaches Figma and lists 1,932 V3 icons
- ESLint clean on the gallery story

## Not in scope

Actual icon replacement (Phase 1 — shared icons), `iconStyle` ternary removal, bespoke Vultisig glyphs. See `PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)