### PR TITLE
fix(deposit): compute percentage shares and max-validation from base units

### DIFF
--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/BondSpecific/BondForm.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/BondSpecific/BondForm.tsx
@@ -27,6 +27,7 @@ import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
 import { MiddleTruncate } from '@lib/ui/truncate'
+import { toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'
 import { attempt } from '@vultisig/lib-utils/attempt'
 import { formatAmount } from '@vultisig/lib-utils/formatAmount'
 import { AnimatePresence, motion } from 'framer-motion'
@@ -40,7 +41,7 @@ import {
   ActionFormCheckBadge,
   ActionFormIconsWrapper,
 } from '../../../../components/action-form/ActionFormIconsWrapper'
-import { trimTrailingZeros } from '../../../utils/exactAmountString'
+import { getPercentageShareAmount } from '../../../utils/percentageShare'
 import { ErrorText } from '../../DepositForm.styled'
 import { FormData } from '../../types'
 
@@ -287,9 +288,11 @@ export const BondForm = ({ balance, errors, formValues }: BondFormProps) => {
                   gap={4}
                 >
                   {amountSuggestions.map(suggestion => {
-                    const suggestedAmount = trimTrailingZeros(
-                      (balance * suggestion).toFixed(coin.decimals)
-                    )
+                    const suggestedAmount = getPercentageShareAmount({
+                      balanceUnits: toChainAmount(balance, coin.decimals),
+                      percentage: suggestion * 100,
+                      decimals: coin.decimals,
+                    })
                     const isActive =
                       parsedAmount !== null &&
                       Number(parsedAmount?.toFixed(coin.decimals)) ===

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/BondSpecific/BondForm.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/BondSpecific/BondForm.tsx
@@ -47,6 +47,7 @@ import { FormData } from '../../types'
 
 type BondFormProps = {
   balance: number
+  balanceUnits: bigint | null
   errors: FieldErrors<FormData>
   formValues: FormData
 }
@@ -76,7 +77,12 @@ const measureAmountTextWidth = (text: string) => {
   return baseWidth + spacingAdjustment
 }
 
-export const BondForm = ({ balance, errors, formValues }: BondFormProps) => {
+export const BondForm = ({
+  balance,
+  balanceUnits,
+  errors,
+  formValues,
+}: BondFormProps) => {
   const { t } = useTranslation()
   const [{ register, control, setValue }] = useDepositFormHandlers()
   const [coin] = useDepositCoin()
@@ -289,7 +295,8 @@ export const BondForm = ({ balance, errors, formValues }: BondFormProps) => {
                 >
                   {amountSuggestions.map(suggestion => {
                     const suggestedAmount = getPercentageShareAmount({
-                      balanceUnits: toChainAmount(balance, coin.decimals),
+                      balanceUnits:
+                        balanceUnits ?? toChainAmount(balance, coin.decimals),
                       percentage: suggestion * 100,
                       decimals: coin.decimals,
                     })

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/StakeForm.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/StakeForm.tsx
@@ -11,6 +11,7 @@ import { Slider } from '@lib/ui/inputs/Slider'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
+import { toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'
 import { bruneBondConfig } from '@vultisig/core-chain/chains/cosmos/thor/brune-bond/config'
 import { formatAmount } from '@vultisig/lib-utils/formatAmount'
 import { useEffect, useMemo } from 'react'
@@ -18,7 +19,7 @@ import { Controller, ControllerRenderProps, FieldErrors } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
 
-import { trimTrailingZeros } from '../../../utils/exactAmountString'
+import { getPercentageShareAmount } from '../../../utils/percentageShare'
 import { FormData } from '../../types'
 
 type StakeFormProps = {
@@ -89,9 +90,11 @@ export const StakeForm = ({
   }, [parsedAmount, balance])
 
   const handleSliderChange = (percentage: number) => {
-    const amount = trimTrailingZeros(
-      ((percentage / 100) * balance).toFixed(coin.decimals)
-    )
+    const amount = getPercentageShareAmount({
+      balanceUnits: toChainAmount(balance, coin.decimals),
+      percentage,
+      decimals: coin.decimals,
+    })
     setValue('amount', amount, { shouldValidate: true, shouldDirty: true })
 
     if (isUnstake && stakeId === 'native-tcy') {

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/StakeForm.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/StakeForm.tsx
@@ -24,6 +24,7 @@ import { FormData } from '../../types'
 
 type StakeFormProps = {
   balance: number
+  balanceUnits: bigint | null
   errors: FieldErrors<FormData>
   formValues: FormData
   isUnstake?: boolean
@@ -54,6 +55,7 @@ const measureAmountTextWidth = (text: string) => {
 
 export const StakeForm = ({
   balance,
+  balanceUnits,
   errors,
   formValues,
   isUnstake = false,
@@ -91,7 +93,7 @@ export const StakeForm = ({
 
   const handleSliderChange = (percentage: number) => {
     const amount = getPercentageShareAmount({
-      balanceUnits: toChainAmount(balance, coin.decimals),
+      balanceUnits: balanceUnits ?? toChainAmount(balance, coin.decimals),
       percentage,
       decimals: coin.decimals,
     })

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/UnstakeSpecific/components/UnstakeSTCY.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/UnstakeSpecific/components/UnstakeSTCY.tsx
@@ -4,7 +4,6 @@ import { AmountTextInput } from '@lib/ui/inputs/AmountTextInput'
 import { InputContainer } from '@lib/ui/inputs/InputContainer'
 import { HStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
-import { toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { tcyAutoCompounderConfig } from '@vultisig/core-chain/chains/cosmos/thor/tcy-autocompound/config'
 import { knownCosmosTokens } from '@vultisig/core-chain/coin/knownTokens/cosmos'
@@ -27,10 +26,11 @@ export const UnstakeSTCY = () => {
   const { t } = useTranslation()
   const address = useCurrentVaultAddress(Chain.THORChain)
 
-  const { data: { humanReadableBalance = 0 } = {} } = useUnstakableStcyQuery({
-    address,
-    options: { enabled: !!address },
-  })
+  const { data: { humanReadableBalance = 0, chainBalance = 0n } = {} } =
+    useUnstakableStcyQuery({
+      address,
+      options: { enabled: !!address },
+    })
 
   const percentageValue = useWatch({ control, name: 'percentage' })
   const amountValue = useWatch({ control, name: 'amount' })
@@ -50,7 +50,7 @@ export const UnstakeSTCY = () => {
 
       const clamped = clampPercentage(percentage)
       const amount = getPercentageShareAmount({
-        balanceUnits: toChainAmount(humanReadableBalance, decimals),
+        balanceUnits: chainBalance,
         percentage: clamped,
         decimals,
       })
@@ -60,25 +60,26 @@ export const UnstakeSTCY = () => {
         shouldValidate,
       })
     },
-    [decimals, humanReadableBalance, setValue]
+    [chainBalance, decimals, setValue]
   )
 
   useEffect(() => {
     if (numericPercentage === null) return
 
     const expectedAmount = Number(
-      (
-        (clampPercentage(numericPercentage) / 100) *
-        humanReadableBalance
-      ).toFixed(decimals)
+      getPercentageShareAmount({
+        balanceUnits: chainBalance,
+        percentage: clampPercentage(numericPercentage),
+        decimals,
+      })
     )
 
     if (numericAmount !== expectedAmount) {
       syncAmountFromPercentage(numericPercentage)
     }
   }, [
+    chainBalance,
     decimals,
-    humanReadableBalance,
     numericAmount,
     numericPercentage,
     syncAmountFromPercentage,

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/UnstakeSpecific/components/UnstakeSTCY.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/UnstakeSpecific/components/UnstakeSTCY.tsx
@@ -66,21 +66,21 @@ export const UnstakeSTCY = () => {
   useEffect(() => {
     if (numericPercentage === null) return
 
-    const expectedAmount = Number(
-      getPercentageShareAmount({
-        balanceUnits: chainBalance,
-        percentage: clampPercentage(numericPercentage),
-        decimals,
-      })
-    )
+    // Compare as exact strings — Number() collapses distinct base-unit
+    // amounts for large balances, which would leave a stale amount in place
+    const expectedAmount = getPercentageShareAmount({
+      balanceUnits: chainBalance,
+      percentage: clampPercentage(numericPercentage),
+      decimals,
+    })
 
-    if (numericAmount !== expectedAmount) {
+    if (amountValue !== expectedAmount) {
       syncAmountFromPercentage(numericPercentage)
     }
   }, [
+    amountValue,
     chainBalance,
     decimals,
-    numericAmount,
     numericPercentage,
     syncAmountFromPercentage,
   ])

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/UnstakeSpecific/components/UnstakeSTCY.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/UnstakeSpecific/components/UnstakeSTCY.tsx
@@ -4,6 +4,7 @@ import { AmountTextInput } from '@lib/ui/inputs/AmountTextInput'
 import { InputContainer } from '@lib/ui/inputs/InputContainer'
 import { HStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
+import { toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { tcyAutoCompounderConfig } from '@vultisig/core-chain/chains/cosmos/thor/tcy-autocompound/config'
 import { knownCosmosTokens } from '@vultisig/core-chain/coin/knownTokens/cosmos'
@@ -14,11 +15,11 @@ import { useTranslation } from 'react-i18next'
 import { AmountSuggestion } from '../../../../../../send/amount/AmountSuggestion'
 import { useCurrentVaultAddress } from '../../../../../../state/currentVaultCoins'
 import { useDepositFormHandlers } from '../../../../../providers/DepositFormHandlersProvider'
-import { trimTrailingZeros } from '../../../../../utils/exactAmountString'
 import {
   clampPercentage,
   toNumericValue,
 } from '../../../../../utils/percentage'
+import { getPercentageShareAmount } from '../../../../../utils/percentageShare'
 import { useUnstakableStcyQuery } from '../hooks/useUnstakableSTcyQuery'
 
 export const UnstakeSTCY = () => {
@@ -48,9 +49,11 @@ export const UnstakeSTCY = () => {
       }
 
       const clamped = clampPercentage(percentage)
-      const amount = trimTrailingZeros(
-        ((clamped / 100) * humanReadableBalance).toFixed(decimals)
-      )
+      const amount = getPercentageShareAmount({
+        balanceUnits: toChainAmount(humanReadableBalance, decimals),
+        percentage: clamped,
+        decimals,
+      })
 
       setValue('amount', amount, {
         shouldDirty: true,

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/UnstakeSpecific/hooks/useUnstakableRujiQuery.ts
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/StakeSpecific/UnstakeSpecific/hooks/useUnstakableRujiQuery.ts
@@ -33,6 +33,8 @@ export const useUnstakableRujiQuery = ({
         autoCompound,
         rujiraStakingConfig.bondDecimals
       ),
+      autoCompoundUnits: autoCompound,
       bonded: fromChainAmount(bonded, rujiraStakingConfig.bondDecimals),
+      bondedUnits: bonded,
     }),
   })

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/UnbondSpecific/UnbondForm.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/UnbondSpecific/UnbondForm.tsx
@@ -17,6 +17,7 @@ import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
 import { MiddleTruncate } from '@lib/ui/truncate'
+import { toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'
 import { formatAmount } from '@vultisig/lib-utils/formatAmount'
 import { useMemo, useState } from 'react'
 import { Controller, ControllerRenderProps, FieldErrors } from 'react-hook-form'
@@ -28,7 +29,7 @@ import {
   ActionFormCheckBadge,
   ActionFormIconsWrapper,
 } from '../../../../components/action-form/ActionFormIconsWrapper'
-import { trimTrailingZeros } from '../../../utils/exactAmountString'
+import { getPercentageShareAmount } from '../../../utils/percentageShare'
 import { ErrorText } from '../../DepositForm.styled'
 import { FormData } from '../../types'
 
@@ -115,9 +116,11 @@ export const UnbondForm = ({
   }, [parsedAmount, balance])
 
   const handleSliderChange = (percentage: number) => {
-    const amount = trimTrailingZeros(
-      ((percentage / 100) * balance).toFixed(coin.decimals)
-    )
+    const amount = getPercentageShareAmount({
+      balanceUnits: toChainAmount(balance, coin.decimals),
+      percentage,
+      decimals: coin.decimals,
+    })
     setValue('amount', amount, { shouldValidate: true, shouldDirty: true })
   }
 

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/UnbondSpecific/UnbondForm.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/UnbondSpecific/UnbondForm.tsx
@@ -35,6 +35,7 @@ import { FormData } from '../../types'
 
 type UnbondFormProps = {
   balance: number
+  balanceUnits: bigint | null
   errors: FieldErrors<FormData>
   isValid: boolean
   formValues: FormData
@@ -67,6 +68,7 @@ const measureAmountTextWidth = (text: string) => {
 
 export const UnbondForm = ({
   balance,
+  balanceUnits,
   errors,
   isValid,
   formValues,
@@ -117,7 +119,7 @@ export const UnbondForm = ({
 
   const handleSliderChange = (percentage: number) => {
     const amount = getPercentageShareAmount({
-      balanceUnits: toChainAmount(balance, coin.decimals),
+      balanceUnits: balanceUnits ?? toChainAmount(balance, coin.decimals),
       percentage,
       decimals: coin.decimals,
     })

--- a/core/ui/vault/deposit/DepositForm/index.tsx
+++ b/core/ui/vault/deposit/DepositForm/index.tsx
@@ -72,7 +72,7 @@ export const DepositForm: FC<DepositFormProps> = ({ onSubmit }) => {
   // no other way to undo an invalid keystroke without re-rendering the form.
   const lastValidNumberInputs = useRef<Record<string, string>>({})
 
-  const { balance } = useDepositBalance({
+  const { balance, balanceUnits } = useDepositBalance({
     selectedChainAction,
     tronResourceType,
   })
@@ -214,6 +214,7 @@ export const DepositForm: FC<DepositFormProps> = ({ onSubmit }) => {
               <DepositDataProvider value={formValues}>
                 <BondForm
                   balance={balance}
+                  balanceUnits={balanceUnits}
                   errors={errors}
                   formValues={formValues}
                 />
@@ -222,6 +223,7 @@ export const DepositForm: FC<DepositFormProps> = ({ onSubmit }) => {
               <DepositDataProvider value={formValues}>
                 <UnbondForm
                   balance={balance}
+                  balanceUnits={balanceUnits}
                   errors={errors}
                   isValid={isValid}
                   formValues={formValues}
@@ -236,6 +238,7 @@ export const DepositForm: FC<DepositFormProps> = ({ onSubmit }) => {
               <DepositDataProvider value={formValues}>
                 <StakeForm
                   balance={balance}
+                  balanceUnits={balanceUnits}
                   errors={errors}
                   formValues={formValues}
                   isUnstake={isUnstakeAction || isRedeemAction}

--- a/core/ui/vault/deposit/DepositForm/index.tsx
+++ b/core/ui/vault/deposit/DepositForm/index.tsx
@@ -104,7 +104,7 @@ export const DepositForm: FC<DepositFormProps> = ({ onSubmit }) => {
   // a stale "valid" amount that exceeds the new balance.
   useEffect(() => {
     trigger()
-  }, [coin.id, balance, trigger])
+  }, [coin.id, balance, balanceUnits, trigger])
 
   const handleFormSubmit = (data: FieldValues) => {
     onSubmit(data)

--- a/core/ui/vault/deposit/hooks/useDepositBalance.ts
+++ b/core/ui/vault/deposit/hooks/useDepositBalance.ts
@@ -23,7 +23,8 @@ export const useDepositBalance = ({
   const [selectedCoin] = useDepositCoin()
   const chain = selectedCoin.chain
 
-  const { balance: stakeBalance } = useStakeBalance()
+  const { balance: stakeBalance, balanceUnits: stakeBalanceUnits } =
+    useStakeBalance()
   const { data: stakeAndRewards } = useRujiraStakeQuery()
   const { data: unbondableBalance } = useUnbondableBalanceQuery({
     enabled: selectedChainAction === 'unbond',
@@ -42,7 +43,7 @@ export const useDepositBalance = ({
 
   const totalTokenAmount = useMemo(() => {
     if (selectedChainAction === 'unstake') {
-      return stakeBalance
+      return { balance: stakeBalance, balanceUnits: stakeBalanceUnits }
     }
 
     // A Solana delegate spends the entered amount PLUS the stake account's
@@ -50,19 +51,26 @@ export const useDepositBalance = ({
     // balance — bounding on the raw balance would let a max stake through and
     // the ceremony would sign a tx the network rejects at simulation.
     if (selectedChainAction === 'solana_delegate') {
-      return fromChainAmount(solanaStakeable, selectedCoin.decimals)
+      return {
+        balance: fromChainAmount(solanaStakeable, selectedCoin.decimals),
+        balanceUnits: solanaStakeable,
+      }
     }
 
     if (selectedChainAction === 'unbond') {
-      return unbondableBalance?.humanReadableBalance ?? 0
+      return {
+        balance: unbondableBalance?.humanReadableBalance ?? 0,
+        balanceUnits: unbondableBalance?.totalBonded ?? null,
+      }
     }
 
+    // Rewards and TRON frozen balances only exist as floats upstream
     if (selectedChainAction === 'withdraw_ruji_rewards') {
-      return stakeAndRewards?.rewardsUSDC ?? 0
+      return { balance: stakeAndRewards?.rewardsUSDC ?? 0, balanceUnits: null }
     }
 
     if (selectedChainAction === 'unfreeze') {
-      return tronFrozenBalance
+      return { balance: tronFrozenBalance, balanceUnits: null }
     }
 
     return selectedCoinBalance
@@ -72,12 +80,16 @@ export const useDepositBalance = ({
     selectedCoinBalance,
     solanaStakeable,
     stakeBalance,
+    stakeBalanceUnits,
     tronFrozenBalance,
     unbondableBalance?.humanReadableBalance,
+    unbondableBalance?.totalBonded,
     stakeAndRewards?.rewardsUSDC,
   ])
 
   return {
-    balance: totalTokenAmount,
+    balance: totalTokenAmount.balance,
+    /** Balance in chain base units when the source is exact, else null (#4496). */
+    balanceUnits: totalTokenAmount.balanceUnits,
   }
 }

--- a/core/ui/vault/deposit/hooks/useDepositCoinBalance.ts
+++ b/core/ui/vault/deposit/hooks/useDepositCoinBalance.ts
@@ -29,16 +29,31 @@ export const useDepositCoinBalance = ({ action, chain }: Params) => {
   const { data: { balances = [] } = {} } = useMergeableTokenBalancesQuery()
 
   return useMemo(() => {
-    if (!selectedCoin) return 0
+    if (!selectedCoin) return { balance: 0, balanceUnits: 0n }
 
     if (action === 'unmerge') {
-      return balances.find(b => b.symbol === selectedCoin.ticker)?.shares ?? 0
+      // Merge shares only exist as a float in the merge API response
+      return {
+        balance:
+          balances.find(b => b.symbol === selectedCoin.ticker)?.shares ?? 0,
+        balanceUnits: null,
+      }
     }
 
     if (!vaultEntry) {
-      return fromChainAmount(yTokenRawBalance, selectedCoin.decimals)
+      return {
+        balance: fromChainAmount(yTokenRawBalance, selectedCoin.decimals),
+        balanceUnits: yTokenRawBalance,
+      }
     }
 
-    return fromChainAmount(vaultEntry.amount, vaultEntry.decimals)
+    return {
+      balance: fromChainAmount(vaultEntry.amount, vaultEntry.decimals),
+      // Units are only meaningful when they share the form coin's scale
+      balanceUnits:
+        vaultEntry.decimals === selectedCoin.decimals
+          ? BigInt(vaultEntry.amount)
+          : null,
+    }
   }, [action, balances, selectedCoin, vaultEntry, yTokenRawBalance])
 }

--- a/core/ui/vault/deposit/hooks/useDepositFormConfig.ts
+++ b/core/ui/vault/deposit/hooks/useDepositFormConfig.ts
@@ -14,7 +14,7 @@ export const useDepositFormConfig = (tronResourceType?: TronResourceType) => {
   const [coin] = useDepositCoin()
   const { t } = useTranslation()
 
-  const { balance } = useDepositBalance({
+  const { balance, balanceUnits } = useDepositBalance({
     selectedChainAction,
     tronResourceType,
   })
@@ -29,6 +29,7 @@ export const useDepositFormConfig = (tronResourceType?: TronResourceType) => {
     t,
     walletCore,
     totalAmountAvailable: balance,
+    totalAmountAvailableUnits: balanceUnits,
     trustLineCostXrp,
   })
 }

--- a/core/ui/vault/deposit/staking/useStakeBalance.ts
+++ b/core/ui/vault/deposit/staking/useStakeBalance.ts
@@ -19,6 +19,8 @@ import { StakeId } from './types'
 
 type StakeBalanceResult = {
   balance: number
+  /** Balance in chain base units — exact source for percentage shares (#4496). */
+  balanceUnits: bigint
   isLoading: boolean
   stakeId: StakeId | null
 }
@@ -87,19 +89,20 @@ export const useStakeBalance = (): StakeBalanceResult => {
   })
 
   if (!isUnstake) {
-    return { balance: 0, isLoading: false, stakeId }
+    return { balance: 0, balanceUnits: 0n, isLoading: false, stakeId }
   }
 
   if (isTonChain) {
     return {
       balance: tonBalance?.humanReadableBalance ?? 0,
+      balanceUnits: tonBalance?.chainBalance ?? 0n,
       isLoading: isLoadingTon,
       stakeId: null,
     }
   }
 
   if (!stakeId) {
-    return { balance: 0, isLoading: false, stakeId }
+    return { balance: 0, balanceUnits: 0n, isLoading: false, stakeId }
   }
 
   return match(stakeId, {
@@ -108,11 +111,13 @@ export const useStakeBalance = (): StakeBalanceResult => {
         nativeTcyBalance,
         knownCosmosTokens.THORChain.tcy.decimals
       ),
+      balanceUnits: nativeTcyBalance,
       isLoading: isLoadingNativeTcy,
       stakeId,
     }),
     stcy: () => ({
       balance: stcyData?.humanReadableBalance ?? 0,
+      balanceUnits: stcyData?.chainBalance ?? 0n,
       isLoading: isLoadingStcy,
       stakeId,
     }),
@@ -120,11 +125,15 @@ export const useStakeBalance = (): StakeBalanceResult => {
       // RUJI surfaces two positions unstaked via different routes; the card the
       // user came from sets `autocompound` (true → auto-compounding / sRUJI).
       balance: (autocompound ? rujiData?.autoCompound : rujiData?.bonded) ?? 0,
+      balanceUnits:
+        (autocompound ? rujiData?.autoCompoundUnits : rujiData?.bondedUnits) ??
+        0n,
       isLoading: isLoadingRuji,
       stakeId,
     }),
     brune: () => ({
       balance: bruneData?.humanReadableBalance ?? 0,
+      balanceUnits: bruneData?.chainBalance ?? 0n,
       isLoading: isLoadingBrune,
       stakeId,
     }),

--- a/core/ui/vault/deposit/utils/exactAmountString.ts
+++ b/core/ui/vault/deposit/utils/exactAmountString.ts
@@ -1,7 +1,7 @@
 import { fromChainAmountExact } from '@vultisig/core-chain/amount/fromChainAmountExact'
 
 /** Trims trailing fraction zeros (and a dangling dot) from a decimal string. */
-export const trimTrailingZeros = (value: string) =>
+const trimTrailingZeros = (value: string) =>
   value.includes('.') ? value.replace(/\.?0+$/, '') : value
 
 /**

--- a/core/ui/vault/deposit/utils/getDepositFormConfig.spec.ts
+++ b/core/ui/vault/deposit/utils/getDepositFormConfig.spec.ts
@@ -47,6 +47,7 @@ describe('TON stake/unstake validation', () => {
       coin: tonCoin as any,
       walletCore: {} as any,
       totalAmountAvailable: 5,
+      totalAmountAvailableUnits: null,
       selectedChainAction: 'stake',
     })
 
@@ -69,6 +70,7 @@ describe('TON stake/unstake validation', () => {
       coin: tonCoin as any,
       walletCore: {} as any,
       totalAmountAvailable: 10,
+      totalAmountAvailableUnits: null,
       selectedChainAction: 'stake',
     })
 
@@ -91,6 +93,7 @@ describe('TON stake/unstake validation', () => {
       coin: tonCoin as any,
       walletCore: {} as any,
       totalAmountAvailable: 3,
+      totalAmountAvailableUnits: null,
       selectedChainAction: 'unstake',
     })
 
@@ -112,6 +115,7 @@ describe('TON stake/unstake validation', () => {
       coin: { ...tonCoin, chain: Chain.THORChain } as any,
       walletCore: {} as any,
       totalAmountAvailable: 2,
+      totalAmountAvailableUnits: null,
       selectedChainAction: 'merge',
     })
 
@@ -133,6 +137,7 @@ describe('TON stake/unstake validation', () => {
       coin: { ...tonCoin, chain: Chain.Cosmos } as any,
       walletCore: {} as any,
       totalAmountAvailable: 10,
+      totalAmountAvailableUnits: null,
       selectedChainAction: 'ibc_transfer',
     })
 
@@ -184,6 +189,7 @@ describe('Solana delegate validation', () => {
       coin: solCoin as any,
       walletCore: {} as any,
       totalAmountAvailable: stakeable,
+      totalAmountAvailableUnits: null,
       selectedChainAction: 'solana_delegate',
     })
 
@@ -255,6 +261,7 @@ describe('Ripple open trust line affordability', () => {
       coin: rippleCoin as any,
       walletCore: {} as any,
       totalAmountAvailable: spendableXrp,
+      totalAmountAvailableUnits: null,
       selectedChainAction: 'open_trust_line',
       trustLineCostXrp,
     })

--- a/core/ui/vault/deposit/utils/getDepositFormConfig.ts
+++ b/core/ui/vault/deposit/utils/getDepositFormConfig.ts
@@ -97,6 +97,8 @@ type GetChainActionConfigParams = {
   coin: AccountCoin
   walletCore: WalletCore
   totalAmountAvailable: number
+  /** Exact balance in base units when the source is bigint-native (#4496). */
+  totalAmountAvailableUnits: bigint | null
   selectedChainAction: ChainAction
   /**
    * XRP an Open Trust Line costs (owner reserve + fee). `undefined` while it is
@@ -122,10 +124,15 @@ export const getDepositFormConfig = ({
   coin,
   walletCore,
   totalAmountAvailable,
+  totalAmountAvailableUnits,
   selectedChainAction,
   trustLineCostXrp,
 }: GetChainActionConfigParams) => {
   const chain = coin.chain
+  const amountMax =
+    totalAmountAvailableUnits !== null
+      ? { units: totalAmountAvailableUnits, decimals: coin.decimals }
+      : undefined
 
   return match<ChainAction, ChainActionConfig>(selectedChainAction, {
     withdraw_ruji_rewards: () => ({
@@ -145,7 +152,12 @@ export const getDepositFormConfig = ({
         { name: 'amount', type: 'number', label: t('amount'), required: true },
       ],
       schema: z.object({
-        amount: positiveAmountSchema(totalAmountAvailable, t),
+        amount: positiveAmountSchema(
+          totalAmountAvailable,
+          t,
+          undefined,
+          amountMax
+        ),
       }),
     }),
     redeem: () => ({
@@ -160,7 +172,12 @@ export const getDepositFormConfig = ({
         },
       ],
       schema: z.object({
-        amount: positiveAmountSchema(totalAmountAvailable, t),
+        amount: positiveAmountSchema(
+          totalAmountAvailable,
+          t,
+          undefined,
+          amountMax
+        ),
         slippage: z.preprocess(toRequiredNumber, z.number().min(0.1).max(7.5)),
       }),
     }),
@@ -174,7 +191,12 @@ export const getDepositFormConfig = ({
         },
       ],
       schema: z.object({
-        amount: positiveAmountSchema(totalAmountAvailable, t),
+        amount: positiveAmountSchema(
+          totalAmountAvailable,
+          t,
+          undefined,
+          amountMax
+        ),
       }),
     }),
     merge: () => ({
@@ -207,7 +229,12 @@ export const getDepositFormConfig = ({
               message: t('invalid_node_address'),
             }
           ),
-        amount: positiveAmountSchema(totalAmountAvailable, t),
+        amount: positiveAmountSchema(
+          totalAmountAvailable,
+          t,
+          undefined,
+          amountMax
+        ),
       }),
     }),
     switch: () => ({
@@ -220,7 +247,12 @@ export const getDepositFormConfig = ({
         },
       ],
       schema: z.object({
-        amount: positiveAmountSchema(totalAmountAvailable, t),
+        amount: positiveAmountSchema(
+          totalAmountAvailable,
+          t,
+          undefined,
+          amountMax
+        ),
         nodeAddress: z
           .string()
           .min(1, 'Required')
@@ -270,7 +302,8 @@ export const getDepositFormConfig = ({
           amount: positiveAmountSchema(
             totalAmountAvailable,
             t,
-            t('chainFunctions.amountExceeded')
+            t('chainFunctions.amountExceeded'),
+            amountMax
           ),
         })
         .superRefine((data, ctx) => {
@@ -337,7 +370,12 @@ export const getDepositFormConfig = ({
           ),
         provider: z.string().optional(),
         operatorFee: z.preprocess(toOptionalNumber, z.number().optional()),
-        amount: positiveAmountSchema(totalAmountAvailable, t),
+        amount: positiveAmountSchema(
+          totalAmountAvailable,
+          t,
+          undefined,
+          amountMax
+        ),
       }),
     }),
     bond_with_lp: () => ({
@@ -428,7 +466,12 @@ export const getDepositFormConfig = ({
               message: t('invalid_node_address'),
             }
           ),
-        amount: positiveAmountSchema(totalAmountAvailable, t),
+        amount: positiveAmountSchema(
+          totalAmountAvailable,
+          t,
+          undefined,
+          amountMax
+        ),
         provider: z.string().optional(),
       }),
     }),
@@ -587,17 +630,32 @@ export const getDepositFormConfig = ({
             THORChain: () =>
               coin.ticker === 'RUJI' || isBruneStakeCoin(coin)
                 ? z.object({
-                    amount: positiveAmountSchema(totalAmountAvailable, t),
+                    amount: positiveAmountSchema(
+                      totalAmountAvailable,
+                      t,
+                      undefined,
+                      amountMax
+                    ),
                   })
                 : coin.ticker === 'TCY'
                   ? z.object({
-                      amount: positiveAmountSchema(totalAmountAvailable, t),
+                      amount: positiveAmountSchema(
+                        totalAmountAvailable,
+                        t,
+                        undefined,
+                        amountMax
+                      ),
                       autoCompound: z.boolean().optional(),
                     })
                   : z.never(),
             Ton: () =>
               z.object({
-                amount: positiveAmountSchema(totalAmountAvailable, t),
+                amount: positiveAmountSchema(
+                  totalAmountAvailable,
+                  t,
+                  undefined,
+                  amountMax
+                ),
                 validatorAddress: z
                   .string()
                   .trim()
@@ -662,13 +720,23 @@ export const getDepositFormConfig = ({
             THORChain: () =>
               coin.ticker === 'RUJI' || isBruneStakeCoin(coin)
                 ? z.object({
-                    amount: positiveAmountSchema(totalAmountAvailable, t),
+                    amount: positiveAmountSchema(
+                      totalAmountAvailable,
+                      t,
+                      undefined,
+                      amountMax
+                    ),
                   })
                 : coin.ticker === 'TCY'
                   ? z.discriminatedUnion('autoCompound', [
                       z.object({
                         autoCompound: z.literal(true),
-                        amount: positiveAmountSchema(totalAmountAvailable, t),
+                        amount: positiveAmountSchema(
+                          totalAmountAvailable,
+                          t,
+                          undefined,
+                          amountMax
+                        ),
                         percentage: z.preprocess(
                           toOptionalNumber,
                           z
@@ -707,7 +775,12 @@ export const getDepositFormConfig = ({
                       message: t('send_invalid_receiver_address'),
                     }
                   ),
-                amount: positiveAmountSchema(totalAmountAvailable, t),
+                amount: positiveAmountSchema(
+                  totalAmountAvailable,
+                  t,
+                  undefined,
+                  amountMax
+                ),
               }) as any,
           }),
     }),
@@ -722,7 +795,12 @@ export const getDepositFormConfig = ({
       ],
       schema: z.object({
         resourceType: z.enum(['BANDWIDTH', 'ENERGY']),
-        amount: positiveAmountSchema(totalAmountAvailable, t),
+        amount: positiveAmountSchema(
+          totalAmountAvailable,
+          t,
+          undefined,
+          amountMax
+        ),
       }),
     }),
     unfreeze: () => ({
@@ -736,7 +814,12 @@ export const getDepositFormConfig = ({
       ],
       schema: z.object({
         resourceType: z.enum(['BANDWIDTH', 'ENERGY']),
-        amount: positiveAmountSchema(totalAmountAvailable, t),
+        amount: positiveAmountSchema(
+          totalAmountAvailable,
+          t,
+          undefined,
+          amountMax
+        ),
       }),
     }),
     add_cacao_pool: () => ({
@@ -749,7 +832,12 @@ export const getDepositFormConfig = ({
         },
       ],
       schema: z.object({
-        amount: positiveAmountSchema(totalAmountAvailable, t),
+        amount: positiveAmountSchema(
+          totalAmountAvailable,
+          t,
+          undefined,
+          amountMax
+        ),
       }),
     }),
     remove_cacao_pool: () => ({
@@ -781,7 +869,12 @@ export const getDepositFormConfig = ({
         },
       ],
       schema: z.object({
-        amount: positiveAmountSchema(totalAmountAvailable, t),
+        amount: positiveAmountSchema(
+          totalAmountAvailable,
+          t,
+          undefined,
+          amountMax
+        ),
         pool: z.string().min(1),
         pairedAddress: z.string().optional(),
       }),
@@ -860,7 +953,12 @@ export const getDepositFormConfig = ({
         },
       ],
       schema: z.object({
-        amount: positiveAmountSchema(totalAmountAvailable, t),
+        amount: positiveAmountSchema(
+          totalAmountAvailable,
+          t,
+          undefined,
+          amountMax
+        ),
         validatorAddress: validatorAddressSchema(t, chain),
       }),
     }),
@@ -875,7 +973,12 @@ export const getDepositFormConfig = ({
         },
       ],
       schema: z.object({
-        amount: positiveAmountSchema(totalAmountAvailable, t),
+        amount: positiveAmountSchema(
+          totalAmountAvailable,
+          t,
+          undefined,
+          amountMax
+        ),
         validatorAddress: validatorAddressSchema(t, chain),
       }),
     }),
@@ -897,7 +1000,12 @@ export const getDepositFormConfig = ({
       ],
       schema: z
         .object({
-          amount: positiveAmountSchema(totalAmountAvailable, t),
+          amount: positiveAmountSchema(
+            totalAmountAvailable,
+            t,
+            undefined,
+            amountMax
+          ),
           srcValidatorAddress: validatorAddressSchema(t, chain),
           validatorAddress: validatorAddressSchema(t, chain),
         })
@@ -962,15 +1070,17 @@ export const getDepositFormConfig = ({
         // StakeError.InsufficientDelegation (custom error 0xc). The entered
         // amount IS the active stake (funding = amount + rent), so gate the
         // amount directly on the 1 SOL floor.
-        amount: positiveAmountSchema(totalAmountAvailable, t).refine(
-          value => Number(value) >= solanaMinDelegationSol,
-          {
-            message: t('solana_staking_min_delegation', {
-              amount: solanaMinDelegationSol,
-              ticker: chainFeeCoin[Chain.Solana].ticker,
-            }),
-          }
-        ),
+        amount: positiveAmountSchema(
+          totalAmountAvailable,
+          t,
+          undefined,
+          amountMax
+        ).refine(value => Number(value) >= solanaMinDelegationSol, {
+          message: t('solana_staking_min_delegation', {
+            amount: solanaMinDelegationSol,
+            ticker: chainFeeCoin[Chain.Solana].ticker,
+          }),
+        }),
         validatorAddress: z.string().trim().min(1, t('validator_address')),
       }),
     }),

--- a/core/ui/vault/deposit/utils/getDepositFormConfig.ts
+++ b/core/ui/vault/deposit/utils/getDepositFormConfig.ts
@@ -152,12 +152,11 @@ export const getDepositFormConfig = ({
         { name: 'amount', type: 'number', label: t('amount'), required: true },
       ],
       schema: z.object({
-        amount: positiveAmountSchema(
-          totalAmountAvailable,
+        amount: positiveAmountSchema({
+          maxValue: totalAmountAvailable,
           t,
-          undefined,
-          amountMax
-        ),
+          chainAmountMax: amountMax,
+        }),
       }),
     }),
     redeem: () => ({
@@ -172,12 +171,11 @@ export const getDepositFormConfig = ({
         },
       ],
       schema: z.object({
-        amount: positiveAmountSchema(
-          totalAmountAvailable,
+        amount: positiveAmountSchema({
+          maxValue: totalAmountAvailable,
           t,
-          undefined,
-          amountMax
-        ),
+          chainAmountMax: amountMax,
+        }),
         slippage: z.preprocess(toRequiredNumber, z.number().min(0.1).max(7.5)),
       }),
     }),
@@ -191,12 +189,11 @@ export const getDepositFormConfig = ({
         },
       ],
       schema: z.object({
-        amount: positiveAmountSchema(
-          totalAmountAvailable,
+        amount: positiveAmountSchema({
+          maxValue: totalAmountAvailable,
           t,
-          undefined,
-          amountMax
-        ),
+          chainAmountMax: amountMax,
+        }),
       }),
     }),
     merge: () => ({
@@ -229,12 +226,11 @@ export const getDepositFormConfig = ({
               message: t('invalid_node_address'),
             }
           ),
-        amount: positiveAmountSchema(
-          totalAmountAvailable,
+        amount: positiveAmountSchema({
+          maxValue: totalAmountAvailable,
           t,
-          undefined,
-          amountMax
-        ),
+          chainAmountMax: amountMax,
+        }),
       }),
     }),
     switch: () => ({
@@ -247,12 +243,11 @@ export const getDepositFormConfig = ({
         },
       ],
       schema: z.object({
-        amount: positiveAmountSchema(
-          totalAmountAvailable,
+        amount: positiveAmountSchema({
+          maxValue: totalAmountAvailable,
           t,
-          undefined,
-          amountMax
-        ),
+          chainAmountMax: amountMax,
+        }),
         nodeAddress: z
           .string()
           .min(1, 'Required')
@@ -299,12 +294,12 @@ export const getDepositFormConfig = ({
             { message: 'Destination Chain is required' }
           ),
           nodeAddress: z.string().min(1, 'Destination Address is required'),
-          amount: positiveAmountSchema(
-            totalAmountAvailable,
+          amount: positiveAmountSchema({
+            maxValue: totalAmountAvailable,
             t,
-            t('chainFunctions.amountExceeded'),
-            amountMax
-          ),
+            maxMessage: t('chainFunctions.amountExceeded'),
+            chainAmountMax: amountMax,
+          }),
         })
         .superRefine((data, ctx) => {
           const { destinationChain, nodeAddress } = data
@@ -370,12 +365,11 @@ export const getDepositFormConfig = ({
           ),
         provider: z.string().optional(),
         operatorFee: z.preprocess(toOptionalNumber, z.number().optional()),
-        amount: positiveAmountSchema(
-          totalAmountAvailable,
+        amount: positiveAmountSchema({
+          maxValue: totalAmountAvailable,
           t,
-          undefined,
-          amountMax
-        ),
+          chainAmountMax: amountMax,
+        }),
       }),
     }),
     bond_with_lp: () => ({
@@ -466,12 +460,11 @@ export const getDepositFormConfig = ({
               message: t('invalid_node_address'),
             }
           ),
-        amount: positiveAmountSchema(
-          totalAmountAvailable,
+        amount: positiveAmountSchema({
+          maxValue: totalAmountAvailable,
           t,
-          undefined,
-          amountMax
-        ),
+          chainAmountMax: amountMax,
+        }),
         provider: z.string().optional(),
       }),
     }),
@@ -630,32 +623,29 @@ export const getDepositFormConfig = ({
             THORChain: () =>
               coin.ticker === 'RUJI' || isBruneStakeCoin(coin)
                 ? z.object({
-                    amount: positiveAmountSchema(
-                      totalAmountAvailable,
+                    amount: positiveAmountSchema({
+                      maxValue: totalAmountAvailable,
                       t,
-                      undefined,
-                      amountMax
-                    ),
+                      chainAmountMax: amountMax,
+                    }),
                   })
                 : coin.ticker === 'TCY'
                   ? z.object({
-                      amount: positiveAmountSchema(
-                        totalAmountAvailable,
+                      amount: positiveAmountSchema({
+                        maxValue: totalAmountAvailable,
                         t,
-                        undefined,
-                        amountMax
-                      ),
+                        chainAmountMax: amountMax,
+                      }),
                       autoCompound: z.boolean().optional(),
                     })
                   : z.never(),
             Ton: () =>
               z.object({
-                amount: positiveAmountSchema(
-                  totalAmountAvailable,
+                amount: positiveAmountSchema({
+                  maxValue: totalAmountAvailable,
                   t,
-                  undefined,
-                  amountMax
-                ),
+                  chainAmountMax: amountMax,
+                }),
                 validatorAddress: z
                   .string()
                   .trim()
@@ -720,23 +710,21 @@ export const getDepositFormConfig = ({
             THORChain: () =>
               coin.ticker === 'RUJI' || isBruneStakeCoin(coin)
                 ? z.object({
-                    amount: positiveAmountSchema(
-                      totalAmountAvailable,
+                    amount: positiveAmountSchema({
+                      maxValue: totalAmountAvailable,
                       t,
-                      undefined,
-                      amountMax
-                    ),
+                      chainAmountMax: amountMax,
+                    }),
                   })
                 : coin.ticker === 'TCY'
                   ? z.discriminatedUnion('autoCompound', [
                       z.object({
                         autoCompound: z.literal(true),
-                        amount: positiveAmountSchema(
-                          totalAmountAvailable,
+                        amount: positiveAmountSchema({
+                          maxValue: totalAmountAvailable,
                           t,
-                          undefined,
-                          amountMax
-                        ),
+                          chainAmountMax: amountMax,
+                        }),
                         percentage: z.preprocess(
                           toOptionalNumber,
                           z
@@ -775,12 +763,11 @@ export const getDepositFormConfig = ({
                       message: t('send_invalid_receiver_address'),
                     }
                   ),
-                amount: positiveAmountSchema(
-                  totalAmountAvailable,
+                amount: positiveAmountSchema({
+                  maxValue: totalAmountAvailable,
                   t,
-                  undefined,
-                  amountMax
-                ),
+                  chainAmountMax: amountMax,
+                }),
               }) as any,
           }),
     }),
@@ -795,12 +782,11 @@ export const getDepositFormConfig = ({
       ],
       schema: z.object({
         resourceType: z.enum(['BANDWIDTH', 'ENERGY']),
-        amount: positiveAmountSchema(
-          totalAmountAvailable,
+        amount: positiveAmountSchema({
+          maxValue: totalAmountAvailable,
           t,
-          undefined,
-          amountMax
-        ),
+          chainAmountMax: amountMax,
+        }),
       }),
     }),
     unfreeze: () => ({
@@ -814,12 +800,11 @@ export const getDepositFormConfig = ({
       ],
       schema: z.object({
         resourceType: z.enum(['BANDWIDTH', 'ENERGY']),
-        amount: positiveAmountSchema(
-          totalAmountAvailable,
+        amount: positiveAmountSchema({
+          maxValue: totalAmountAvailable,
           t,
-          undefined,
-          amountMax
-        ),
+          chainAmountMax: amountMax,
+        }),
       }),
     }),
     add_cacao_pool: () => ({
@@ -832,12 +817,11 @@ export const getDepositFormConfig = ({
         },
       ],
       schema: z.object({
-        amount: positiveAmountSchema(
-          totalAmountAvailable,
+        amount: positiveAmountSchema({
+          maxValue: totalAmountAvailable,
           t,
-          undefined,
-          amountMax
-        ),
+          chainAmountMax: amountMax,
+        }),
       }),
     }),
     remove_cacao_pool: () => ({
@@ -869,12 +853,11 @@ export const getDepositFormConfig = ({
         },
       ],
       schema: z.object({
-        amount: positiveAmountSchema(
-          totalAmountAvailable,
+        amount: positiveAmountSchema({
+          maxValue: totalAmountAvailable,
           t,
-          undefined,
-          amountMax
-        ),
+          chainAmountMax: amountMax,
+        }),
         pool: z.string().min(1),
         pairedAddress: z.string().optional(),
       }),
@@ -953,12 +936,11 @@ export const getDepositFormConfig = ({
         },
       ],
       schema: z.object({
-        amount: positiveAmountSchema(
-          totalAmountAvailable,
+        amount: positiveAmountSchema({
+          maxValue: totalAmountAvailable,
           t,
-          undefined,
-          amountMax
-        ),
+          chainAmountMax: amountMax,
+        }),
         validatorAddress: validatorAddressSchema(t, chain),
       }),
     }),
@@ -973,12 +955,11 @@ export const getDepositFormConfig = ({
         },
       ],
       schema: z.object({
-        amount: positiveAmountSchema(
-          totalAmountAvailable,
+        amount: positiveAmountSchema({
+          maxValue: totalAmountAvailable,
           t,
-          undefined,
-          amountMax
-        ),
+          chainAmountMax: amountMax,
+        }),
         validatorAddress: validatorAddressSchema(t, chain),
       }),
     }),
@@ -1000,12 +981,11 @@ export const getDepositFormConfig = ({
       ],
       schema: z
         .object({
-          amount: positiveAmountSchema(
-            totalAmountAvailable,
+          amount: positiveAmountSchema({
+            maxValue: totalAmountAvailable,
             t,
-            undefined,
-            amountMax
-          ),
+            chainAmountMax: amountMax,
+          }),
           srcValidatorAddress: validatorAddressSchema(t, chain),
           validatorAddress: validatorAddressSchema(t, chain),
         })
@@ -1070,12 +1050,11 @@ export const getDepositFormConfig = ({
         // StakeError.InsufficientDelegation (custom error 0xc). The entered
         // amount IS the active stake (funding = amount + rent), so gate the
         // amount directly on the 1 SOL floor.
-        amount: positiveAmountSchema(
-          totalAmountAvailable,
+        amount: positiveAmountSchema({
+          maxValue: totalAmountAvailable,
           t,
-          undefined,
-          amountMax
-        ).refine(value => Number(value) >= solanaMinDelegationSol, {
+          chainAmountMax: amountMax,
+        }).refine(value => Number(value) >= solanaMinDelegationSol, {
           message: t('solana_staking_min_delegation', {
             amount: solanaMinDelegationSol,
             ticker: chainFeeCoin[Chain.Solana].ticker,

--- a/core/ui/vault/deposit/utils/percentageShare.test.ts
+++ b/core/ui/vault/deposit/utils/percentageShare.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { getPercentageShareAmount } from './percentageShare'
+
+describe('getPercentageShareAmount', () => {
+  it('is exact for balances above 2^53 base units', () => {
+    // 2^53 + 1 — the first integer a float64 cannot represent
+    expect(
+      getPercentageShareAmount({
+        balanceUnits: 9007199254740993n,
+        percentage: 100,
+        decimals: 8,
+      })
+    ).toBe('90071992.54740993')
+  })
+
+  it('keeps every digit of an 18-decimal share', () => {
+    expect(
+      getPercentageShareAmount({
+        balanceUnits: 5123456789012345678n,
+        percentage: 100,
+        decimals: 18,
+      })
+    ).toBe('5.123456789012345678')
+  })
+
+  it('floors partial shares to whole base units', () => {
+    // 25% of (2^53 + 1) units floors to 2251799813685248 units
+    expect(
+      getPercentageShareAmount({
+        balanceUnits: 9007199254740993n,
+        percentage: 25,
+        decimals: 8,
+      })
+    ).toBe('22517998.13685248')
+  })
+
+  it('computes ordinary shares', () => {
+    expect(
+      getPercentageShareAmount({
+        balanceUnits: 100000000n,
+        percentage: 50,
+        decimals: 8,
+      })
+    ).toBe('0.5')
+  })
+})

--- a/core/ui/vault/deposit/utils/percentageShare.ts
+++ b/core/ui/vault/deposit/utils/percentageShare.ts
@@ -1,6 +1,4 @@
-import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
-
-import { trimTrailingZeros } from './exactAmountString'
+import { toExactAmountString } from './exactAmountString'
 
 type GetPercentageShareAmountInput = {
   balanceUnits: bigint
@@ -10,15 +8,17 @@ type GetPercentageShareAmountInput = {
 
 /**
  * A percentage share of a balance, as the human decimal string stored in
- * deposit form fields. Must be exact for any balance size — a float64
- * round-trip corrupts shares of balances above 2^53 base units (#4496).
+ * deposit form fields. Computed in bigint fixed-point (basis points) so the
+ * share is exact for any balance size — a float64 round-trip corrupts shares
+ * of balances above 2^53 base units (#4496).
  */
 export const getPercentageShareAmount = ({
   balanceUnits,
   percentage,
   decimals,
 }: GetPercentageShareAmountInput) => {
-  const balance = fromChainAmount(balanceUnits, decimals)
+  const shareUnits =
+    (balanceUnits * BigInt(Math.round(percentage * 100))) / 10_000n
 
-  return trimTrailingZeros(((percentage / 100) * balance).toFixed(decimals))
+  return toExactAmountString(shareUnits, decimals)
 }

--- a/core/ui/vault/deposit/utils/percentageShare.ts
+++ b/core/ui/vault/deposit/utils/percentageShare.ts
@@ -1,0 +1,24 @@
+import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
+
+import { trimTrailingZeros } from './exactAmountString'
+
+type GetPercentageShareAmountInput = {
+  balanceUnits: bigint
+  percentage: number
+  decimals: number
+}
+
+/**
+ * A percentage share of a balance, as the human decimal string stored in
+ * deposit form fields. Must be exact for any balance size — a float64
+ * round-trip corrupts shares of balances above 2^53 base units (#4496).
+ */
+export const getPercentageShareAmount = ({
+  balanceUnits,
+  percentage,
+  decimals,
+}: GetPercentageShareAmountInput) => {
+  const balance = fromChainAmount(balanceUnits, decimals)
+
+  return trimTrailingZeros(((percentage / 100) * balance).toFixed(decimals))
+}

--- a/core/ui/vault/deposit/utils/validationHelpers.test.ts
+++ b/core/ui/vault/deposit/utils/validationHelpers.test.ts
@@ -8,7 +8,9 @@ const t = ((key: string) => key) as TFunction
 
 describe('positiveAmountSchema', () => {
   it('keeps a full-precision amount exact through validation', () => {
-    const parsed = positiveAmountSchema(10, t).parse('6.123456789012345678')
+    const parsed = positiveAmountSchema({ maxValue: 10, t }).parse(
+      '6.123456789012345678'
+    )
 
     expect(toChainAmount(parsed, 18)).toBe(6123456789012345678n)
   })
@@ -16,13 +18,15 @@ describe('positiveAmountSchema', () => {
   it('does not round the amount up past what the user entered', () => {
     // Number('6.649999999999999991') is exactly 6.65 — a float64 parse
     // would submit more than the user typed (#4494)
-    const parsed = positiveAmountSchema(10, t).parse('6.649999999999999991')
+    const parsed = positiveAmountSchema({ maxValue: 10, t }).parse(
+      '6.649999999999999991'
+    )
 
     expect(toChainAmount(parsed, 18)).toBe(6649999999999999991n)
   })
 
   it('rejects zero, negative, and above-max amounts', () => {
-    const schema = positiveAmountSchema(10, t)
+    const schema = positiveAmountSchema({ maxValue: 10, t })
 
     expect(schema.safeParse('0').success).toBe(false)
     expect(schema.safeParse('-1').success).toBe(false)
@@ -33,9 +37,10 @@ describe('positiveAmountSchema', () => {
   it('compares the max in exact base units when chainAmountMax is provided', () => {
     // Balance of 2^53 + 1 base units — beyond float64, where a float compare
     // cannot tell the true balance and balance + 1 unit apart
-    const schema = positiveAmountSchema(90071992.54740992, t, undefined, {
-      units: 9007199254740993n,
-      decimals: 8,
+    const schema = positiveAmountSchema({
+      maxValue: 90071992.54740992,
+      t,
+      chainAmountMax: { units: 9007199254740993n, decimals: 8 },
     })
 
     expect(schema.safeParse('90071992.54740993').success).toBe(true)

--- a/core/ui/vault/deposit/utils/validationHelpers.test.ts
+++ b/core/ui/vault/deposit/utils/validationHelpers.test.ts
@@ -29,4 +29,16 @@ describe('positiveAmountSchema', () => {
     expect(schema.safeParse('11').success).toBe(false)
     expect(schema.safeParse('9.99').success).toBe(true)
   })
+
+  it('compares the max in exact base units when chainAmountMax is provided', () => {
+    // Balance of 2^53 + 1 base units — beyond float64, where a float compare
+    // cannot tell the true balance and balance + 1 unit apart
+    const schema = positiveAmountSchema(90071992.54740992, t, undefined, {
+      units: 9007199254740993n,
+      decimals: 8,
+    })
+
+    expect(schema.safeParse('90071992.54740993').success).toBe(true)
+    expect(schema.safeParse('90071992.54740994').success).toBe(false)
+  })
 })

--- a/core/ui/vault/deposit/utils/validationHelpers.ts
+++ b/core/ui/vault/deposit/utils/validationHelpers.ts
@@ -1,3 +1,4 @@
+import { attempt } from '@vultisig/lib-utils/attempt'
 import { decimalStringToBigInt } from '@vultisig/lib-utils/bigint/decimalStringToBigInt'
 import type { TFunction } from 'i18next'
 import { z } from 'zod'
@@ -85,12 +86,25 @@ type ChainAmountMax = {
   decimals: number
 }
 
-export const positiveAmountSchema = (
-  maxValue: number,
-  t: TFunction,
-  maxMessage?: string,
+type PositiveAmountSchemaInput = {
+  maxValue: number
+  t: TFunction
+  maxMessage?: string
   chainAmountMax?: ChainAmountMax
-) =>
+}
+
+/**
+ * Required positive amount capped at the available balance. The submitted
+ * value stays an exact decimal string; when `chainAmountMax` is provided the
+ * cap is compared in chain base units, so float64 cannot blur the boundary
+ * between the true balance and balance-plus-dust (#4496).
+ */
+export const positiveAmountSchema = ({
+  maxValue,
+  t,
+  maxMessage,
+  chainAmountMax,
+}: PositiveAmountSchemaInput) =>
   z.preprocess(
     toAmountString,
     z
@@ -105,15 +119,14 @@ export const positiveAmountSchema = (
           // compare can accept an amount a few base units above the true
           // balance when both round to the same float64 (#4496)
           if (chainAmountMax && chainAmountMax.units > 0n) {
-            try {
-              return (
-                decimalStringToBigInt(value, chainAmountMax.decimals) <=
-                chainAmountMax.units
-              )
-            } catch {
-              // more fraction digits than the coin supports — fall through to
-              // the float check, matching previous behavior for such input
+            const result = attempt(() =>
+              decimalStringToBigInt(value, chainAmountMax.decimals)
+            )
+            if (result.data !== undefined) {
+              return result.data <= chainAmountMax.units
             }
+            // more fraction digits than the coin supports — fall through to
+            // the float check, matching previous behavior for such input
           }
           return (
             Number(value) <=

--- a/core/ui/vault/deposit/utils/validationHelpers.ts
+++ b/core/ui/vault/deposit/utils/validationHelpers.ts
@@ -1,3 +1,4 @@
+import { decimalStringToBigInt } from '@vultisig/lib-utils/bigint/decimalStringToBigInt'
 import type { TFunction } from 'i18next'
 import { z } from 'zod'
 
@@ -78,10 +79,17 @@ export const optionalNonNegativeAmountSchema = (
       .optional()
   )
 
+/** Exact balance cap in chain base units, for float-free max validation. */
+type ChainAmountMax = {
+  units: bigint
+  decimals: number
+}
+
 export const positiveAmountSchema = (
   maxValue: number,
   t: TFunction,
-  maxMessage?: string
+  maxMessage?: string,
+  chainAmountMax?: ChainAmountMax
 ) =>
   z.preprocess(
     toAmountString,
@@ -92,8 +100,26 @@ export const positiveAmountSchema = (
         return Number.isFinite(parsed) && parsed > 0
       }, t('amount_must_be_positive'))
       .refine(
-        value =>
-          Number(value) <= (maxValue > 0 ? maxValue : Number.POSITIVE_INFINITY),
+        value => {
+          // Compare in base units when the exact balance is known — a float
+          // compare can accept an amount a few base units above the true
+          // balance when both round to the same float64 (#4496)
+          if (chainAmountMax && chainAmountMax.units > 0n) {
+            try {
+              return (
+                decimalStringToBigInt(value, chainAmountMax.decimals) <=
+                chainAmountMax.units
+              )
+            } catch {
+              // more fraction digits than the coin supports — fall through to
+              // the float check, matching previous behavior for such input
+            }
+          }
+          return (
+            Number(value) <=
+            (maxValue > 0 ? maxValue : Number.POSITIVE_INFINITY)
+          )
+        },
         maxMessage ?? t('chainFunctions.amountExceeded')
       )
       .superRefine((_val, ctx) => {


### PR DESCRIPTION
Fixes #4496

Follow-up to #4495: the percentage pills in the DeFi deposit forms (Stake/Unbond/Bond/UnstakeSTCY) compute their share with float math on a float balance, and `positiveAmountSchema`'s max-check compares floats — both bounded by `useDepositBalance` exposing the balance only as a `fromChainAmount` float. Shares of balances above 2^53 base units are corrupted, and an amount slightly above the true balance can pass validation.

Test-first: the first commit extracts the share computation into `getPercentageShareAmount` (taking base units, keeping today's float behavior) and adds tests asserting exactness — CI is expected to fail on it, demonstrating the bug: 100% of `9007199254740993` units (2^53 + 1) renders `…92`, and an 18-decimal share comes back with fabricated digits (`5.123456789012346135` for a `…345678` balance).

The follow-up commits make the helper pure bigint math, expose base-unit balances from the deposit balance hooks so the forms pass real units instead of a float round-trip, and add an exact base-unit max comparison to the amount validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved percentage-based amount calculations for bond, stake, unstake, and unbond actions.
  - Slider suggestions now preserve coin precision and avoid floating-point rounding errors.
  - Large balances and high-precision assets are handled more accurately.
  - Partial amounts are consistently rounded down to valid chain-supported values.
  - Deposit and staking amount validation now more reliably respects available balances, including very large balances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->