### PR TITLE
[Icons V3] Phase 1 — Shared icons, batch 7 + completion (Share, Pencil)

### DIFF
--- a/docs/icons-v3/PLAN.md
+++ b/docs/icons-v3/PLAN.md
@@ -81,7 +81,7 @@ final PR to `main`.)
 | Phase | Scope | Content |
 |-------|-------|---------|
 | **0 — Foundation** ✅ | tooling | Decision record, codegen (`scripts/icons/`), seed mapping table, Storybook gallery. **No icon art changes.** |
-| **1 — Shared icons** | cross-screen | Every icon used on more than one screen (nav, back, close, search, wallet, copy…). One PR, ripples across all screens by design. Excludes chevrons. |
+| **1 — Shared icons** ✅ | cross-screen | Every icon used on more than one screen. **Done: 53 migrated** across 7 batches (44 from iOS/Station V3 art, 9 from the Figma V3 library), each verified against rendered geometry. PRs #4502 + the batch-7 PR. Excludes chevrons. |
 | **2 — Main View** | screen | Portfolio / vault home — its remaining screen-unique icons. |
 | **3 — Send flow** | screen | |
 | **4 — Swap flow** | screen | |
@@ -101,6 +101,19 @@ screen split only changes *how the work is batched into PRs*.
 
 **Chevrons stay on the legacy pack on purpose** (design-confirmed) and are excluded from
 the migration entirely.
+
+### Phase 1 outcome — shared icons that stay legacy (for now)
+
+These shared icons have **no faithful V3 counterpart**, so they keep their current glyph
+until design provides one (tracked as `status: "legacy"` / `"bespoke"` in the mapping):
+
+- `ShieldCheckIcon`, `ShieldCheckFilledIcon` — V3 has `shield`/`shield-filled` but no shield-with-check.
+- `FileUpIcon` — V3 has `file-download` but no file-upload.
+- `TransactionReceiveIcon` — part of the Vultisig send/receive/swap set; decide together with design.
+- `BrowserExtensionIcon`, `CryptoIcon`, `CryptoWalletPenIcon` — Vultisig-specific/bespoke.
+
+Note: the V3 library's `pencil-2` renders a non-pencil glyph (name ≠ geometry); `PencilIcon`
+was migrated from `pen-writing` instead. Always verify V3 geometry, not just the name.
 
 ## Constraints that shape the work
 

--- a/lib/ui/icons/PenciIcon.tsx
+++ b/lib/ui/icons/PenciIcon.tsx
@@ -1,19 +1,25 @@
 import { SvgProps } from '@lib/ui/props'
-import { FC } from 'react'
 
-export const PencilIcon: FC<SvgProps> = props => (
+export const PencilIcon = (props: SvgProps) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width="1em"
     height="1em"
-    viewBox="0 0 20 20"
+    viewBox="0 0 24 24"
     fill="none"
     {...props}
   >
     <path
-      d="M11.0417 5.20873L13.4049 2.84558C14.0557 2.1947 15.111 2.1947 15.7619 2.84558L17.1549 4.23855C17.8057 4.88943 17.8057 5.9447 17.1549 6.59558L14.7917 8.95873M11.0417 5.20873L2.77985 13.4706C2.46728 13.7831 2.29169 14.2071 2.29169 14.6491V17.7087H5.35133C5.79336 17.7087 6.21728 17.5331 6.52985 17.2206L14.7917 8.95873M11.0417 5.20873L14.7917 8.95873"
+      d="M20.4004 20.4004H14.4004"
       stroke="currentColor"
-      strokeWidth="1.5"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M3.59961 20.3993L4.79961 14.3993L14.8964 4.30251C15.8336 3.36531 17.3528 3.36531 18.29 4.30251L19.6964 5.70891C20.6336 6.64611 20.6336 8.16531 19.6964 9.10251L9.59961 19.1993L3.59961 20.3993Z"
+      stroke="currentColor"
+      strokeWidth="2"
       strokeLinecap="round"
       strokeLinejoin="round"
     />

--- a/lib/ui/icons/ShareIcon.tsx
+++ b/lib/ui/icons/ShareIcon.tsx
@@ -1,18 +1,34 @@
 import { SvgProps } from '@lib/ui/props'
-import { FC } from 'react'
 
-export const ShareIcon: FC<SvgProps> = props => (
+export const ShareIcon = (props: SvgProps) => (
   <svg
-    fill="none"
-    height="1em"
-    stroke="currentColor"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    strokeWidth="1.5"
-    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
     width="1em"
+    height="1em"
+    viewBox="0 0 24 24"
+    fill="none"
     {...props}
   >
-    <path d="M4 12V20C4 20.5304 4.21071 21.0391 4.58579 21.4142C4.96086 21.7893 5.46957 22 6 22H18C18.5304 22 19.0391 21.7893 19.4142 21.4142C19.7893 21.0391 20 20.5304 20 20V12M16 6L12 2M12 2L8 6M12 2V15" />
+    <path
+      d="M8.69922 6.89961L11.9992 3.59961L15.2992 6.89961"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M12 15.5996V3.59961"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M7.2001 10.8848C5.7409 11.2064 4.5985 12.4172 4.4065 13.9532L4.1065 16.3532C3.8377 18.5024 5.5129 20.3996 7.6789 20.3996H16.3225C18.4873 20.3996 20.1637 18.5012 19.8949 16.3532L19.5949 13.9532C19.4029 12.416 18.2593 11.2064 16.8013 10.8848"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
   </svg>
 )

--- a/scripts/icons/icon-mapping.json
+++ b/scripts/icons/icon-mapping.json
@@ -5,7 +5,8 @@
     "migrated": "already swapped to V3 art in lib/ui/icons",
     "verified": "V3 source confirmed against rendered art",
     "proposed": "likely match from name/iOS precedent — must be eyeballed before use",
-    "bespoke": "Vultisig-specific glyph with no V3 counterpart — stays hand-drawn"
+    "bespoke": "Vultisig-specific glyph with no V3 counterpart — stays hand-drawn",
+    "legacy": "shared icon with no faithful V3 counterpart yet — stays on the legacy glyph pending design"
   },
   "sourceLegend": {
     "station": "already shipped in StationFigmaIcons.tsx (drawn in V3 style)",
@@ -325,6 +326,46 @@
       "v3": "file-content",
       "status": "migrated",
       "source": "manual"
+    },
+    {
+      "desktop": "ShareIcon",
+      "v3": "upload",
+      "status": "migrated",
+      "source": "manual"
+    },
+    {
+      "desktop": "PenciIcon",
+      "v3": "pen-writing",
+      "status": "migrated",
+      "source": "manual"
+    },
+    {
+      "desktop": "ShieldCheckIcon",
+      "v3": null,
+      "status": "legacy",
+      "source": "manual",
+      "note": "V3 has shield/shield-filled but no shield-check"
+    },
+    {
+      "desktop": "ShieldCheckFilledIcon",
+      "v3": null,
+      "status": "legacy",
+      "source": "manual",
+      "note": "no shield-check in V3"
+    },
+    {
+      "desktop": "FileUpIcon",
+      "v3": null,
+      "status": "legacy",
+      "source": "manual",
+      "note": "V3 has file-download but no file-upload"
+    },
+    {
+      "desktop": "TransactionReceiveIcon",
+      "v3": null,
+      "status": "legacy",
+      "source": "manual",
+      "note": "Vultisig send/receive/swap set — decide together with design"
     },
     {
       "desktop": "AgentIcon",


### PR DESCRIPTION
Part of #4383. **Completes #4501 (Phase 1 — shared icons).** Targets the integration branch `feature/icons-v3-adoption`. Follows PR #4502 (batches 1–6, 51 icons), now merged.

## Batch 7 — the last cleanly-migratable shared icons (2)

Geometry-verified from the Figma V3 library:

| icon | V3 source | note |
|------|-----------|------|
| `ShareIcon` | `upload` | up-arrow-out-of-tray = share/upload |
| `PencilIcon` | `pen-writing` | the library's `pencil-2` renders a **non-pencil** glyph (name ≠ geometry), so `pen-writing` is used |

## Phase 1 complete — 53 shared icons on V3

Across 7 batches: 44 from the sibling iOS repo's shipped V3 art (vultisig-ios#4834) + 9 from the Figma V3 library, each verified against rendered geometry.

## Shared icons that stay legacy (documented, not migrated)

No faithful V3 counterpart yet — kept on their current glyph pending design (`status: "legacy"`/`"bespoke"` in the mapping, and in `docs/icons-v3/PLAN.md`):

- `ShieldCheckIcon`, `ShieldCheckFilledIcon` — V3 has no shield-with-check
- `FileUpIcon` — V3 has file-download but no file-upload
- `TransactionReceiveIcon` — part of the Vultisig send/receive/swap set (design decision)
- `BrowserExtensionIcon`, `CryptoIcon`, `CryptoWalletPenIcon` — Vultisig-specific/bespoke

## Verification

- `yarn typecheck` — 0 errors
- ESLint clean; no dev-only files committed
- `PenciIcon.tsx` keeps its load-bearing `export const PencilIcon` (the filename typo is preserved on purpose)

## Next

With shared icons done, the per-screen phases (Phase 2 — Main View, …) can start without leaving other screens half-migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
