### PR TITLE
[Icons V3] Phase 2 — Main View (SquareBehindSquare → clone)

### DIFF
--- a/docs/icons-v3/PLAN.md
+++ b/docs/icons-v3/PLAN.md
@@ -82,7 +82,7 @@ final PR to `main`.)
 |-------|-------|---------|
 | **0 — Foundation** ✅ | tooling | Decision record, codegen (`scripts/icons/`), seed mapping table, Storybook gallery. **No icon art changes.** |
 | **1 — Shared icons** ✅ | cross-screen | Every icon used on more than one screen. **Done: 53 migrated** across 7 batches (44 from iOS/Station V3 art, 9 from the Figma V3 library), each verified against rendered geometry. PRs #4502 + the batch-7 PR. Excludes chevrons. |
-| **2 — Main View** | screen | Portfolio / vault home — its remaining screen-unique icons. |
+| **2 — Main View** ✅ | screen | Portfolio / vault home. 9 of its 17 icons already done in Phase 1 (shared) — validating the shared-first order. Migrated the 1 remaining screen-unique glyph: `SquareBehindSquare6Icon → clone`. Legacy: `EyeClosedIcon` (V3 has no eye-off — mismatches the migrated `EyeIcon` in the balance toggle; needs design). Bespoke: `CryptoIcon`, `CryptoWalletPenIcon`. |
 | **3 — Send flow** | screen | |
 | **4 — Swap flow** | screen | |
 | **5 — DeFi / Earn** | screen | |

--- a/lib/ui/icons/SquareBehindSquare6Icon.tsx
+++ b/lib/ui/icons/SquareBehindSquare6Icon.tsx
@@ -1,18 +1,27 @@
 import { SvgProps } from '@lib/ui/props'
-import { FC } from 'react'
 
-export const SquareBehindSquare6Icon: FC<SvgProps> = props => (
+export const SquareBehindSquare6Icon = (props: SvgProps) => (
   <svg
-    fill="none"
-    height="1em"
-    stroke="currentColor"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    strokeWidth="1.5"
-    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
     width="1em"
+    height="1em"
+    viewBox="0 0 24 24"
+    fill="none"
     {...props}
   >
-    <path d="M7.75 7.75V5.75C7.75 4.64543 8.64543 3.75 9.75 3.75H18.25C19.3546 3.75 20.25 4.64543 20.25 5.75V14.26C20.25 15.3646 19.3546 16.26 18.25 16.26H16.25M3.75 9.75V18.25C3.75 19.3546 4.64543 20.25 5.75 20.25H14.25C15.3546 20.25 16.25 19.3546 16.25 18.25V9.75C16.25 8.64543 15.3546 7.75 14.25 7.75H5.75C4.64543 7.75 3.75 8.64543 3.75 9.75Z" />
+    <path
+      d="M15.6004 8.40039H18.0004C19.3264 8.40039 20.4004 9.47439 20.4004 10.8004V18.0004C20.4004 19.3264 19.3264 20.4004 18.0004 20.4004H10.8004C9.47439 20.4004 8.40039 19.3264 8.40039 18.0004V15.6004"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M13.1996 3.59961H5.99961C4.67413 3.59961 3.59961 4.67413 3.59961 5.99961V13.1996C3.59961 14.5251 4.67413 15.5996 5.99961 15.5996H13.1996C14.5251 15.5996 15.5996 14.5251 15.5996 13.1996V5.99961C15.5996 4.67413 14.5251 3.59961 13.1996 3.59961Z"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
   </svg>
 )

--- a/scripts/icons/icon-mapping.json
+++ b/scripts/icons/icon-mapping.json
@@ -368,6 +368,31 @@
       "note": "Vultisig send/receive/swap set — decide together with design"
     },
     {
+      "desktop": "SquareBehindSquare6Icon",
+      "v3": "clone",
+      "status": "migrated",
+      "source": "ios"
+    },
+    {
+      "desktop": "EyeClosedIcon",
+      "v3": null,
+      "status": "legacy",
+      "source": "manual",
+      "note": "V3 has no eye-off/eye-slash; pairs with the migrated EyeIcon in the balance show/hide toggle — needs a V3 eye-off from design"
+    },
+    {
+      "desktop": "CryptoIcon",
+      "v3": null,
+      "status": "bespoke",
+      "source": "manual"
+    },
+    {
+      "desktop": "CryptoWalletPenIcon",
+      "v3": null,
+      "status": "bespoke",
+      "source": "manual"
+    },
+    {
       "desktop": "AgentIcon",
       "v3": null,
       "status": "bespoke",


### PR DESCRIPTION
Part of #4383. Closes #4505 (Phase 2 — Main View). Targets the integration branch `feature/icons-v3-adoption`.

First per-screen phase. Confirms the shared-first ordering paid off: **9 of Main View's 17 icons were already migrated in Phase 1**, so only the screen-unique tail remained.

## Migrated (1)
| icon | V3 source | note |
|------|-----------|------|
| `SquareBehindSquare6Icon` | `clone` (iOS) | two overlapping squares = clone/duplicate; geometry-verified |

## Staying legacy (documented)
- `EyeClosedIcon` — **V3 has no eye-off/eye-slash**. It pairs with the migrated `EyeIcon` in the balance show/hide toggle, so this leaves the toggle temporarily mismatched. Flagged for design to supply a V3 eye-off.
- `CryptoIcon`, `CryptoWalletPenIcon` — Vultisig-specific/bespoke.

## Verification
- `yarn typecheck` — 0 errors; ESLint clean; no dev-only files committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the overlapping-squares icon with refreshed SVG rendering for improved visual consistency.
* **Bug Fixes**
  * Corrected icon styling and dimensions to ensure more reliable display across supported interfaces.
* **Documentation**
  * Updated icon status records, including newly migrated, legacy, and bespoke icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->