### PR TITLE
fix(keysign): evaluate sign-time gates at signing, not at review mount

### DIFF
--- a/core/ui/mpc/keysign/action/mutations/useKeysignMutation.ts
+++ b/core/ui/mpc/keysign/action/mutations/useKeysignMutation.ts
@@ -47,6 +47,7 @@ import { chainPromises } from '@vultisig/lib-utils/promise/chainPromises'
 import { recordFromItems } from '@vultisig/lib-utils/record/recordFromItems'
 
 import { getClaimMessageHashHex } from '../../../../qbtc/claim/utils/getClaimMessageHashHex'
+import { assertReadyToBroadcast } from '../../assertReadyToBroadcast'
 import { broadcastKeysignTx } from '../../broadcastKeysignTx'
 import {
   getCowSwapKeysignData,
@@ -330,6 +331,11 @@ export const useKeysignMutation = (payload: KeysignMessagePayload) => {
             )
 
             if (!payload.skipBroadcast) {
+              // Defense in depth behind the sign-time payload rebuild: the
+              // ceremony itself takes time, so re-check the swap's freshness
+              // now that it is about to go out.
+              await assertReadyToBroadcast({ chain, keysignPayload: payload })
+
               await chainPromises(
                 txs.map(
                   ({ data }) =>

--- a/core/ui/mpc/keysign/assertReadyToBroadcast.test.ts
+++ b/core/ui/mpc/keysign/assertReadyToBroadcast.test.ts
@@ -1,0 +1,69 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { assertNativeSwapReadyForBroadcast } from '@vultisig/core-mpc/keysign/swap/assertNativeSwapReadyForBroadcast'
+import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { assertReadyToBroadcast } from './assertReadyToBroadcast'
+import { BroadcastError } from './broadcastKeysignTx'
+
+vi.mock(
+  '@vultisig/core-mpc/keysign/swap/assertNativeSwapReadyForBroadcast',
+  () => ({
+    assertNativeSwapReadyForBroadcast: vi.fn(),
+  })
+)
+
+const input = {
+  chain: Chain.Ethereum,
+  keysignPayload: {} as KeysignPayload,
+}
+
+describe('assertReadyToBroadcast', () => {
+  beforeEach(() => {
+    vi.mocked(assertNativeSwapReadyForBroadcast).mockReset()
+  })
+
+  it('lets a still-valid swap through', async () => {
+    vi.mocked(assertNativeSwapReadyForBroadcast).mockResolvedValue(undefined)
+
+    await expect(assertReadyToBroadcast(input)).resolves.toBeUndefined()
+  })
+
+  it('refuses to broadcast when the guard rejects', async () => {
+    vi.mocked(assertNativeSwapReadyForBroadcast).mockRejectedValue(
+      new Error('THORChain trading is halted for ETH')
+    )
+
+    await expect(assertReadyToBroadcast(input)).rejects.toThrow()
+  })
+
+  it('reports the refusal as a broadcast failure, not a signing one', async () => {
+    // Signing already succeeded by this point, so the generic branch's
+    // device/timeout copy would be actively misleading.
+    vi.mocked(assertNativeSwapReadyForBroadcast).mockRejectedValue(
+      new Error('inbound vault address changed')
+    )
+
+    await expect(assertReadyToBroadcast(input)).rejects.toBeInstanceOf(
+      BroadcastError
+    )
+  })
+
+  it('keeps the reason the guard gave', async () => {
+    vi.mocked(assertNativeSwapReadyForBroadcast).mockRejectedValue(
+      new Error('Native swap quote is expired')
+    )
+
+    await expect(assertReadyToBroadcast(input)).rejects.toThrow(
+      'Native swap quote is expired'
+    )
+  })
+
+  it('checks the payload it is about to broadcast', async () => {
+    vi.mocked(assertNativeSwapReadyForBroadcast).mockResolvedValue(undefined)
+
+    await assertReadyToBroadcast(input)
+
+    expect(assertNativeSwapReadyForBroadcast).toHaveBeenCalledWith(input)
+  })
+})

--- a/core/ui/mpc/keysign/assertReadyToBroadcast.ts
+++ b/core/ui/mpc/keysign/assertReadyToBroadcast.ts
@@ -1,0 +1,40 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { assertNativeSwapReadyForBroadcast } from '@vultisig/core-mpc/keysign/swap/assertNativeSwapReadyForBroadcast'
+import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { attempt } from '@vultisig/lib-utils/attempt'
+
+import { BroadcastError } from './broadcastKeysignTx'
+
+type AssertReadyToBroadcastInput = {
+  chain: Chain
+  keysignPayload: KeysignPayload
+}
+
+/**
+ * Last check before a signed transaction goes out: a native swap must not land
+ * in an inbound vault that has churned, a chain that has halted, or past its
+ * quote expiry. A no-op for every other payload.
+ *
+ * This runs on every signing device, co-signers included, because every one of
+ * them broadcasts — a device that would broadcast into a halted chain has to
+ * refuse for the same reason the initiator does. A device that refuses while
+ * another succeeds is the intended asymmetry: the transaction is already signed,
+ * and one refusal costs nothing beyond a duplicate broadcast that the other
+ * device already handles.
+ *
+ * Reported as a {@link BroadcastError} because signing has already completed by
+ * the time this runs: the failure belongs to the broadcast stage, and the
+ * device/timeout copy the generic branch shows would be actively misleading.
+ */
+export const assertReadyToBroadcast = async ({
+  chain,
+  keysignPayload,
+}: AssertReadyToBroadcastInput): Promise<void> => {
+  const result = await attempt(() =>
+    assertNativeSwapReadyForBroadcast({ chain, keysignPayload })
+  )
+
+  if ('error' in result) {
+    throw new BroadcastError(result.error)
+  }
+}

--- a/core/ui/mpc/keysign/prompt/FastVaultStartKeysignPrompt.tsx
+++ b/core/ui/mpc/keysign/prompt/FastVaultStartKeysignPrompt.tsx
@@ -28,31 +28,53 @@ export const FastVaultStartKeysignPrompt = (props: StartKeysignPromptProps) => {
   const navigate = useCoreNavigate()
   const [showModal, setShowModal] = useState(false)
 
+  const { onBeforeStart, ...navigationProps } = props
   const keysignPayload =
-    'keysignPayload' in props ? props.keysignPayload : undefined
+    'keysignPayload' in navigationProps
+      ? navigationProps.keysignPayload
+      : undefined
 
-  const executeNavigation = (securityType: VaultSecurityType) => {
+  // Sign what the network accepts now, not what it accepted when this screen
+  // mounted. `null` means the rebuild failed and the ceremony is abandoned.
+  const resolvePayload = async () =>
+    onBeforeStart ? onBeforeStart() : shouldBePresent(keysignPayload)
+
+  const executeNavigation = async (securityType: VaultSecurityType) => {
     if (securityType === 'fast') {
       setShowModal(true)
+      return
+    }
+
+    const payload = await resolvePayload()
+    if (!payload) {
       return
     }
 
     navigate({
       id: 'keysign',
       state: {
-        ...props,
-        keysignPayload: shouldBePresent(keysignPayload),
+        ...navigationProps,
+        keysignPayload: payload,
         securityType,
       },
     })
   }
 
-  const onGetPassword = ({ password }: FastVaultPasswordModalResult) => {
+  const onGetPassword = async ({ password }: FastVaultPasswordModalResult) => {
+    // Rebuilt after the password prompt, not before it: entering a password is
+    // exactly the kind of pause that lets a payload go stale.
+    const payload = await resolvePayload()
+    if (!payload) {
+      // Drop back to the verify screen, which is where the failure is shown.
+      setShowModal(false)
+      return
+    }
+
     navigate({
       id: 'keysign',
       state: {
-        ...props,
-        keysignPayload: shouldBePresent(keysignPayload),
+        ...navigationProps,
+        keysignPayload: payload,
         securityType: 'fast',
         password,
       },

--- a/core/ui/mpc/keysign/prompt/SecureVaultStartKeysignPrompt.tsx
+++ b/core/ui/mpc/keysign/prompt/SecureVaultStartKeysignPrompt.tsx
@@ -12,8 +12,11 @@ export const SecureVaultStartKeysignPrompt = (
   const navigate = useCoreNavigate()
 
   const buttonProps = useMemo(() => {
+    const { onBeforeStart, ...navigationProps } = props
     const keysignPayload =
-      'keysignPayload' in props ? props.keysignPayload : undefined
+      'keysignPayload' in navigationProps
+        ? navigationProps.keysignPayload
+        : undefined
 
     if (!keysignPayload) {
       return {
@@ -22,13 +25,20 @@ export const SecureVaultStartKeysignPrompt = (
     }
 
     return {
-      onClick: () => {
+      onClick: async () => {
+        // Sign what the network accepts now, not what it accepted when this
+        // screen mounted. A failed rebuild abandons the ceremony.
+        const payload = onBeforeStart ? await onBeforeStart() : keysignPayload
+        if (!payload) {
+          return
+        }
+
         navigate({
           id: 'keysign',
           state: {
             securityType: 'secure',
-            ...props,
-            keysignPayload,
+            ...navigationProps,
+            keysignPayload: payload,
           },
         })
       },

--- a/core/ui/mpc/keysign/prompt/StartKeysignPromptProps.tsx
+++ b/core/ui/mpc/keysign/prompt/StartKeysignPromptProps.tsx
@@ -1,3 +1,5 @@
+import { KeysignMessagePayload } from '@vultisig/core-mpc/keysign/keysignPayload/KeysignMessagePayload'
+
 import { CoreViewState } from '../../../navigation/CoreView'
 
 type BaseStartKeysignPromptProps = Omit<
@@ -5,10 +7,17 @@ type BaseStartKeysignPromptProps = Omit<
   'securityType' | 'keysignPayload'
 >
 
-export type StartKeysignPromptProps =
-  | BaseStartKeysignPromptProps
-  | (
-      | { disabledMessage: string }
-      | Pick<CoreViewState<'keysign'>, 'keysignPayload'>
-      | {}
-    )
+export type StartKeysignPromptProps = BaseStartKeysignPromptProps & {
+  /** Present once the payload is ready; its absence disables the button. */
+  keysignPayload?: CoreViewState<'keysign'>['keysignPayload']
+  /** Why the button is disabled, when it is. */
+  disabledMessage?: string
+  /**
+   * Rebuilds the payload at the moment signing starts, so the builder's
+   * fail-closed gates run now rather than when the verify screen mounted.
+   * Resolves to the payload to sign, or `null` when the rebuild failed — in
+   * which case the ceremony is abandoned rather than started with the payload
+   * the screen was already holding.
+   */
+  onBeforeStart?: () => Promise<KeysignMessagePayload | null>
+}

--- a/core/ui/mpc/keysign/start/StartKeysignPromptWithRefresh.tsx
+++ b/core/ui/mpc/keysign/start/StartKeysignPromptWithRefresh.tsx
@@ -1,0 +1,52 @@
+import { VStack } from '@lib/ui/layout/Stack'
+import { WarningBlock } from '@lib/ui/status/WarningBlock'
+import { KeysignMessagePayload } from '@vultisig/core-mpc/keysign/keysignPayload/KeysignMessagePayload'
+import { useState } from 'react'
+
+import { StartKeysignPrompt } from '../prompt/StartKeysignPrompt'
+import { StartKeysignPromptProps } from '../prompt/StartKeysignPromptProps'
+import { getKeysignPayloadToSign } from './getKeysignPayloadToSign'
+import { RefetchableKeysignPayloadQuery } from './refreshKeysignPayload'
+
+type StartKeysignPromptWithRefreshProps<T> = {
+  /** The query that built `promptProps.keysignPayload`, rebuilt on start. */
+  keysignPayloadQuery: RefetchableKeysignPayloadQuery<T>
+  /** Wraps what the query builds into the payload the ceremony consumes. */
+  toKeysignPayload: (data: T) => KeysignMessagePayload
+  promptProps: StartKeysignPromptProps
+}
+
+/**
+ * The start-keysign button, with the payload rebuilt at the moment signing
+ * starts.
+ *
+ * Keysign payload queries never refetch on their own, so without this the
+ * payload is whatever was built when the review screen mounted — and the SDK's
+ * fail-closed gates live inside those builders, which turns them into
+ * mount-time checks. A rebuild that fails blocks signing and says why, instead
+ * of falling back to the payload whose freshness is in doubt.
+ */
+export const StartKeysignPromptWithRefresh = <T,>({
+  keysignPayloadQuery,
+  toKeysignPayload,
+  promptProps,
+}: StartKeysignPromptWithRefreshProps<T>) => {
+  const [refreshError, setRefreshError] = useState<string | null>(null)
+
+  const onBeforeStart = async () => {
+    setRefreshError(null)
+
+    return getKeysignPayloadToSign({
+      query: keysignPayloadQuery,
+      toKeysignPayload,
+      onError: setRefreshError,
+    })
+  }
+
+  return (
+    <VStack gap={12} fullWidth>
+      {refreshError ? <WarningBlock>{refreshError}</WarningBlock> : null}
+      <StartKeysignPrompt {...promptProps} onBeforeStart={onBeforeStart} />
+    </VStack>
+  )
+}

--- a/core/ui/mpc/keysign/start/StartKeysignPromptWithRefresh.tsx
+++ b/core/ui/mpc/keysign/start/StartKeysignPromptWithRefresh.tsx
@@ -1,12 +1,13 @@
 import { VStack } from '@lib/ui/layout/Stack'
 import { WarningBlock } from '@lib/ui/status/WarningBlock'
 import { KeysignMessagePayload } from '@vultisig/core-mpc/keysign/keysignPayload/KeysignMessagePayload'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 
 import { StartKeysignPrompt } from '../prompt/StartKeysignPrompt'
 import { StartKeysignPromptProps } from '../prompt/StartKeysignPromptProps'
 import { getKeysignPayloadToSign } from './getKeysignPayloadToSign'
 import { RefetchableKeysignPayloadQuery } from './refreshKeysignPayload'
+import { singleFlight } from './singleFlight'
 
 type StartKeysignPromptWithRefreshProps<T> = {
   /** The query that built `promptProps.keysignPayload`, rebuilt on start. */
@@ -33,13 +34,23 @@ export const StartKeysignPromptWithRefresh = <T,>({
 }: StartKeysignPromptWithRefreshProps<T>) => {
   const [refreshError, setRefreshError] = useState<string | null>(null)
 
+  // A rebuild is a network round-trip and this button gives no feedback while
+  // it runs, so a second click is likely. Without this the two rebuilds race
+  // and both start a ceremony, the later one interrupting the session the
+  // earlier one already opened.
+  const isRebuilding = useRef(false)
+
   const onBeforeStart = async () => {
     setRefreshError(null)
 
-    return getKeysignPayloadToSign({
-      query: keysignPayloadQuery,
-      toKeysignPayload,
-      onError: setRefreshError,
+    return singleFlight({
+      gate: isRebuilding,
+      run: () =>
+        getKeysignPayloadToSign({
+          query: keysignPayloadQuery,
+          toKeysignPayload,
+          onError: setRefreshError,
+        }),
     })
   }
 

--- a/core/ui/mpc/keysign/start/VerifyKeysignStart.tsx
+++ b/core/ui/mpc/keysign/start/VerifyKeysignStart.tsx
@@ -1,5 +1,4 @@
 import { getBlockaidTxValidationQuery } from '@core/ui/chain/security/blockaid/tx/queries/blockaidTxValidation'
-import { StartKeysignPrompt } from '@core/ui/mpc/keysign/prompt/StartKeysignPrompt'
 import { StartKeysignPromptProps } from '@core/ui/mpc/keysign/prompt/StartKeysignPromptProps'
 import { useIsBlockaidEnabled } from '@core/ui/storage/blockaid'
 import { verticalPadding } from '@lib/ui/css/verticalPadding'
@@ -24,10 +23,18 @@ import styled from 'styled-components'
 
 import { useAssertWalletCore } from '../../../chain/providers/WalletCoreProvider'
 import { BlockaidTxScanStatus } from '../../../chain/security/blockaid/tx/BlockaidTxScanStatus'
+import { RefetchableKeysignPayloadQuery } from './refreshKeysignPayload'
+import { StartKeysignPromptWithRefresh } from './StartKeysignPromptWithRefresh'
 
 type VerifyKeysignStartInput = {
   children: ReactNode
-  keysignPayloadQuery: Query<KeysignPayload>
+  /**
+   * Must be refetchable: the payload is rebuilt when signing starts so the
+   * builder's fail-closed gates run at sign time. See
+   * {@link refreshKeysignPayload}.
+   */
+  keysignPayloadQuery: Query<KeysignPayload> &
+    RefetchableKeysignPayloadQuery<KeysignPayload>
   terms?: string[]
   toAddressLabel?: string
   extraPendingMessage?: string
@@ -193,7 +200,13 @@ export const VerifyKeysignStart = ({
         )}
       </PageContent>
       <PageFooter>
-        {footer ?? <StartKeysignPrompt {...startKeysignPromptProps} />}
+        {footer ?? (
+          <StartKeysignPromptWithRefresh
+            keysignPayloadQuery={keysignPayloadQuery}
+            toKeysignPayload={keysign => ({ keysign })}
+            promptProps={startKeysignPromptProps}
+          />
+        )}
       </PageFooter>
     </>
   )

--- a/core/ui/mpc/keysign/start/getKeysignPayloadToSign.test.ts
+++ b/core/ui/mpc/keysign/start/getKeysignPayloadToSign.test.ts
@@ -81,6 +81,26 @@ describe('getKeysignPayloadToSign', () => {
     expect(onError).toHaveBeenCalled()
   })
 
+  it('refuses to sign when the conversion throws', async () => {
+    // Callers await this in a click handler, so a rejection here would be
+    // unhandled: the button would do nothing, silently.
+    const onError = vi.fn()
+
+    await expect(
+      getKeysignPayloadToSign({
+        query: query({ data: payload('ok') }),
+        toKeysignPayload: () => {
+          throw new Error('cannot convert payload')
+        },
+        onError,
+      })
+    ).resolves.toBeNull()
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.stringContaining('cannot convert payload')
+    )
+  })
+
   it('does not report an error on success', async () => {
     const onError = vi.fn()
 

--- a/core/ui/mpc/keysign/start/getKeysignPayloadToSign.test.ts
+++ b/core/ui/mpc/keysign/start/getKeysignPayloadToSign.test.ts
@@ -1,0 +1,95 @@
+import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { describe, expect, it, vi } from 'vitest'
+
+import { getKeysignPayloadToSign } from './getKeysignPayloadToSign'
+import { RefetchableKeysignPayloadQuery } from './refreshKeysignPayload'
+
+const payload = (memo: string) => ({ memo }) as KeysignPayload
+
+const query = (result: {
+  data?: KeysignPayload
+  error?: unknown
+}): RefetchableKeysignPayloadQuery<KeysignPayload> => ({
+  refetch: () => Promise.resolve(result),
+})
+
+const toKeysignPayload = (keysign: KeysignPayload) => ({ keysign })
+
+describe('getKeysignPayloadToSign', () => {
+  it('hands the ceremony the rebuilt payload', async () => {
+    const rebuilt = payload('rebuilt at sign time')
+
+    await expect(
+      getKeysignPayloadToSign({
+        query: query({ data: rebuilt }),
+        toKeysignPayload,
+        onError: vi.fn(),
+      })
+    ).resolves.toEqual({ keysign: rebuilt })
+  })
+
+  it('refuses to sign when the rebuild fails', async () => {
+    // Never the payload the review screen was holding: a gate rejecting now is
+    // exactly when signing the mount-time payload would be wrong.
+    await expect(
+      getKeysignPayloadToSign({
+        query: query({
+          data: payload('stale'),
+          error: new Error('THORChain trading is halted for ETH'),
+        }),
+        toKeysignPayload,
+        onError: vi.fn(),
+      })
+    ).resolves.toBeNull()
+  })
+
+  it('reports why signing was refused', async () => {
+    const onError = vi.fn()
+
+    await getKeysignPayloadToSign({
+      query: query({ error: new Error('quote expired') }),
+      toKeysignPayload,
+      onError,
+    })
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.stringContaining('quote expired')
+    )
+  })
+
+  it('refuses to sign when the rebuild yields nothing', async () => {
+    await expect(
+      getKeysignPayloadToSign({
+        query: query({}),
+        toKeysignPayload,
+        onError: vi.fn(),
+      })
+    ).resolves.toBeNull()
+  })
+
+  it('refuses to sign when the rebuild throws', async () => {
+    const onError = vi.fn()
+
+    await expect(
+      getKeysignPayloadToSign<KeysignPayload>({
+        query: { refetch: () => Promise.reject(new Error('offline')) },
+        toKeysignPayload,
+        onError,
+      })
+    ).resolves.toBeNull()
+
+    expect(onError).toHaveBeenCalled()
+  })
+
+  it('does not report an error on success', async () => {
+    const onError = vi.fn()
+
+    await getKeysignPayloadToSign({
+      query: query({ data: payload('ok') }),
+      toKeysignPayload,
+      onError,
+    })
+
+    expect(onError).not.toHaveBeenCalled()
+  })
+})

--- a/core/ui/mpc/keysign/start/getKeysignPayloadToSign.ts
+++ b/core/ui/mpc/keysign/start/getKeysignPayloadToSign.ts
@@ -1,0 +1,40 @@
+import { KeysignMessagePayload } from '@vultisig/core-mpc/keysign/keysignPayload/KeysignMessagePayload'
+import { attempt } from '@vultisig/lib-utils/attempt'
+import { extractErrorMsg } from '@vultisig/lib-utils/error/extractErrorMsg'
+
+import {
+  RefetchableKeysignPayloadQuery,
+  refreshKeysignPayload,
+} from './refreshKeysignPayload'
+
+type GetKeysignPayloadToSignInput<T> = {
+  query: RefetchableKeysignPayloadQuery<T>
+  /** Wraps what the query builds into the payload the ceremony consumes. */
+  toKeysignPayload: (data: T) => KeysignMessagePayload
+  /** Reports why signing was refused, for display on the review screen. */
+  onError: (message: string) => void
+}
+
+/**
+ * The payload to hand to the keysign ceremony, rebuilt at the moment signing
+ * starts, or `null` when it could not be rebuilt.
+ *
+ * Returning `null` rather than the payload the review screen already holds is
+ * the whole point: that payload was built at mount, and a builder gate now
+ * rejecting it (advanced-swap queue disabled, chain halted, router expiry
+ * lapsed) is precisely the case where signing it anyway would be wrong.
+ */
+export const getKeysignPayloadToSign = async <T>({
+  query,
+  toKeysignPayload,
+  onError,
+}: GetKeysignPayloadToSignInput<T>): Promise<KeysignMessagePayload | null> => {
+  const result = await attempt(() => refreshKeysignPayload(query))
+
+  if ('error' in result) {
+    onError(extractErrorMsg(result.error))
+    return null
+  }
+
+  return toKeysignPayload(result.data)
+}

--- a/core/ui/mpc/keysign/start/getKeysignPayloadToSign.ts
+++ b/core/ui/mpc/keysign/start/getKeysignPayloadToSign.ts
@@ -23,6 +23,10 @@ type GetKeysignPayloadToSignInput<T> = {
  * the whole point: that payload was built at mount, and a builder gate now
  * rejecting it (advanced-swap queue disabled, chain halted, router expiry
  * lapsed) is precisely the case where signing it anyway would be wrong.
+ *
+ * No failure escapes as a rejection, conversion included. The callers `await`
+ * this inside a click handler, where a rejection is unhandled: the button would
+ * do nothing at all, with no ceremony and nothing on screen to explain it.
  */
 export const getKeysignPayloadToSign = async <T>({
   query,
@@ -36,5 +40,12 @@ export const getKeysignPayloadToSign = async <T>({
     return null
   }
 
-  return toKeysignPayload(result.data)
+  const payload = attempt(() => toKeysignPayload(result.data))
+
+  if ('error' in payload) {
+    onError(extractErrorMsg(payload.error))
+    return null
+  }
+
+  return payload.data
 }

--- a/core/ui/mpc/keysign/start/refreshKeysignPayload.test.ts
+++ b/core/ui/mpc/keysign/start/refreshKeysignPayload.test.ts
@@ -1,0 +1,72 @@
+import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  RefetchableKeysignPayloadQuery,
+  refreshKeysignPayload,
+} from './refreshKeysignPayload'
+
+const payload = (memo: string) => ({ memo }) as KeysignPayload
+
+const query = (result: {
+  data?: KeysignPayload
+  error?: unknown
+}): RefetchableKeysignPayloadQuery<KeysignPayload> => ({
+  refetch: () => Promise.resolve(result),
+})
+
+describe('refreshKeysignPayload', () => {
+  it('returns the rebuilt payload, not the one the screen was holding', async () => {
+    const rebuilt = payload('rebuilt at sign time')
+
+    await expect(refreshKeysignPayload(query({ data: rebuilt }))).resolves.toBe(
+      rebuilt
+    )
+  })
+
+  it('rebuilds every time signing starts', async () => {
+    const refetch = vi.fn(() => Promise.resolve({ data: payload('fresh') }))
+
+    await refreshKeysignPayload({ refetch })
+
+    expect(refetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws when the rebuild fails, so the ceremony is abandoned', async () => {
+    // A builder gate rejecting at sign time (queue disabled, chain halted)
+    // arrives here as a query error. Signing the payload we already had is
+    // exactly what must not happen.
+    await expect(
+      refreshKeysignPayload(
+        query({ error: new Error('EnableAdvSwapQueue is disabled') })
+      )
+    ).rejects.toThrow('EnableAdvSwapQueue is disabled')
+  })
+
+  it('throws on an error even when stale data is returned alongside it', async () => {
+    // React Query hands back the last good data next to the error; that data is
+    // precisely the payload whose freshness is in doubt.
+    await expect(
+      refreshKeysignPayload(
+        query({
+          data: payload('stale'),
+          error: new Error('inbound vault churned'),
+        })
+      )
+    ).rejects.toThrow('inbound vault churned')
+  })
+
+  it('throws when the rebuild yields no payload', async () => {
+    await expect(refreshKeysignPayload(query({}))).rejects.toThrow(
+      'Keysign payload could not be rebuilt'
+    )
+  })
+
+  it('propagates a rejected refetch rather than swallowing it', async () => {
+    await expect(
+      refreshKeysignPayload<KeysignPayload>({
+        refetch: () => Promise.reject(new Error('network down')),
+      })
+    ).rejects.toThrow('network down')
+  })
+})

--- a/core/ui/mpc/keysign/start/refreshKeysignPayload.ts
+++ b/core/ui/mpc/keysign/start/refreshKeysignPayload.ts
@@ -1,0 +1,50 @@
+/**
+ * The slice of a React Query result this refresh needs. Every keysign payload
+ * query is a `useQuery` result, so `refetch` is always there — it is required
+ * rather than optional so a query that cannot be refreshed fails to compile
+ * instead of silently signing a stale payload.
+ *
+ * Generic because the queries differ in what they build: most produce a
+ * `KeysignPayload`, while the QBTC vote query produces a whole
+ * `KeysignMessagePayload`.
+ */
+export type RefetchableKeysignPayloadQuery<T> = {
+  refetch: () => Promise<{
+    data?: T | undefined
+    error?: unknown
+  }>
+}
+
+/**
+ * Rebuilds the keysign payload at the moment signing starts.
+ *
+ * Every keysign payload query disables automatic refetching, so the payload the
+ * review screen holds was built when that screen mounted. The SDK's fail-closed
+ * gates live *inside* the builders — THORChain's advanced-swap-queue mimir, the
+ * inbound halt flags, the router's `depositWithExpiry` deadline — which makes
+ * them mount-time checks unless the payload is rebuilt here. A review long
+ * enough for the queue to be disabled, a chain to halt, or a 15-minute router
+ * expiry to lapse would otherwise sign a payload those gates would now reject.
+ *
+ * Manual `refetch()` still runs while `refetchOnMount`/`OnWindowFocus`/
+ * `OnReconnect` are off, so this re-runs the builder and re-evaluates them.
+ *
+ * Throws when the rebuild fails or yields nothing: the caller must surface that
+ * and abandon the ceremony rather than fall back to the payload it already had,
+ * which is exactly the payload whose freshness is in doubt.
+ */
+export const refreshKeysignPayload = async <T>({
+  refetch,
+}: RefetchableKeysignPayloadQuery<T>): Promise<T> => {
+  const { data, error } = await refetch()
+
+  if (error) {
+    throw error
+  }
+
+  if (!data) {
+    throw new Error('Keysign payload could not be rebuilt')
+  }
+
+  return data
+}

--- a/core/ui/mpc/keysign/start/singleFlight.test.ts
+++ b/core/ui/mpc/keysign/start/singleFlight.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { singleFlight } from './singleFlight'
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void
+  let reject!: (reason: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+
+  return { promise, resolve, reject }
+}
+
+describe('singleFlight', () => {
+  it('runs the first call', async () => {
+    const gate = { current: false }
+
+    await expect(
+      singleFlight({ gate, run: () => Promise.resolve('payload') })
+    ).resolves.toBe('payload')
+  })
+
+  it('drops a call that arrives while one is in flight', async () => {
+    // The second click of a double-click: it must not start a second rebuild,
+    // which would open a competing keysign session.
+    const gate = { current: false }
+    const { promise, resolve } = deferred<string>()
+    const run = vi.fn(() => promise)
+
+    const first = singleFlight({ gate, run })
+    const second = singleFlight({ gate, run })
+
+    await expect(second).resolves.toBeNull()
+    expect(run).toHaveBeenCalledTimes(1)
+
+    resolve('payload')
+    await expect(first).resolves.toBe('payload')
+  })
+
+  it('allows a new call once the previous one finished', async () => {
+    const gate = { current: false }
+    const run = vi.fn(() => Promise.resolve('payload'))
+
+    await singleFlight({ gate, run })
+    await singleFlight({ gate, run })
+
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it('releases the gate when the run throws, so the button still works', async () => {
+    const gate = { current: false }
+
+    await expect(
+      singleFlight({ gate, run: () => Promise.reject(new Error('offline')) })
+    ).rejects.toThrow('offline')
+
+    expect(gate.current).toBe(false)
+  })
+
+  it('holds the gate for the whole run', async () => {
+    const gate = { current: false }
+    const { promise, resolve } = deferred<string>()
+
+    const inFlight = singleFlight({ gate, run: () => promise })
+    expect(gate.current).toBe(true)
+
+    resolve('payload')
+    await inFlight
+
+    expect(gate.current).toBe(false)
+  })
+})

--- a/core/ui/mpc/keysign/start/singleFlight.ts
+++ b/core/ui/mpc/keysign/start/singleFlight.ts
@@ -1,0 +1,38 @@
+type SingleFlightGate = { current: boolean }
+
+type SingleFlightInput<T> = {
+  /** Shared flag marking a run in progress, typically a ref. */
+  gate: SingleFlightGate
+  run: () => Promise<T>
+}
+
+/**
+ * Runs `run` only when no earlier call is still in flight; a call that arrives
+ * during one resolves to `null` instead of starting a second.
+ *
+ * Rebuilding a keysign payload takes a network round-trip, and the button that
+ * triggers it gives no feedback while that happens — so a second click is
+ * likely rather than hypothetical. Without this, two rebuilds race and both go
+ * on to start a keysign ceremony, the later one interrupting the session the
+ * earlier one already opened.
+ *
+ * The flag is checked and set in the same synchronous step, with no `await`
+ * between them, so exactly one caller can win. It is released even when `run`
+ * throws, otherwise a single failure would wedge the button for good.
+ */
+export const singleFlight = async <T>({
+  gate,
+  run,
+}: SingleFlightInput<T>): Promise<T | null> => {
+  if (gate.current) {
+    return null
+  }
+
+  gate.current = true
+
+  try {
+    return await run()
+  } finally {
+    gate.current = false
+  }
+}

--- a/core/ui/qbtc/governance/components/GovernanceVoteConfirmButton.tsx
+++ b/core/ui/qbtc/governance/components/GovernanceVoteConfirmButton.tsx
@@ -1,5 +1,5 @@
-import { StartKeysignPrompt } from '@core/ui/mpc/keysign/prompt/StartKeysignPrompt'
 import { StartKeysignPromptProps } from '@core/ui/mpc/keysign/prompt/StartKeysignPromptProps'
+import { StartKeysignPromptWithRefresh } from '@core/ui/mpc/keysign/start/StartKeysignPromptWithRefresh'
 import { QbtcVoteSelection } from '@vultisig/core-chain/chains/cosmos/qbtc/governance/proposal'
 import { extractErrorMsg } from '@vultisig/lib-utils/error/extractErrorMsg'
 import { useTranslation } from 'react-i18next'
@@ -22,11 +22,12 @@ export const GovernanceVoteConfirmButton = ({
   selection,
 }: GovernanceVoteConfirmButtonProps) => {
   const { t } = useTranslation()
-  const { data, error, isPending } = useQbtcVoteKeysignPayloadQuery({
+  const keysignPayloadQuery = useQbtcVoteKeysignPayloadQuery({
     voterAddress,
     proposalId,
     selection,
   })
+  const { data, error, isPending } = keysignPayloadQuery
 
   const promptProps: StartKeysignPromptProps = isPending
     ? { disabledMessage: t('loading') }
@@ -36,5 +37,11 @@ export const GovernanceVoteConfirmButton = ({
         ? { keysignPayload: data }
         : { disabledMessage: t('loading') }
 
-  return <StartKeysignPrompt {...promptProps} />
+  return (
+    <StartKeysignPromptWithRefresh
+      keysignPayloadQuery={keysignPayloadQuery}
+      toKeysignPayload={payload => payload}
+      promptProps={promptProps}
+    />
+  )
 }

--- a/core/ui/vault/deposit/DepositConfirmButton/index.tsx
+++ b/core/ui/vault/deposit/DepositConfirmButton/index.tsx
@@ -2,12 +2,13 @@ import { extractErrorMsg } from '@vultisig/lib-utils/error/extractErrorMsg'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { StartKeysignPrompt } from '../../../mpc/keysign/prompt/StartKeysignPrompt'
+import { StartKeysignPromptWithRefresh } from '../../../mpc/keysign/start/StartKeysignPromptWithRefresh'
 import { useDepositKeysignPayloadQuery } from '../keysignPayload/query'
 
 export const DepositConfirmButton = () => {
   const { t } = useTranslation()
-  const { data, error, isPending } = useDepositKeysignPayloadQuery()
+  const keysignPayloadQuery = useDepositKeysignPayloadQuery()
+  const { data, error, isPending } = keysignPayloadQuery
 
   const startKeysignPromptProps = useMemo(() => {
     if (isPending) {
@@ -27,5 +28,11 @@ export const DepositConfirmButton = () => {
     }
   }, [data, error, isPending, t])
 
-  return <StartKeysignPrompt {...startKeysignPromptProps} />
+  return (
+    <StartKeysignPromptWithRefresh
+      keysignPayloadQuery={keysignPayloadQuery}
+      toKeysignPayload={keysign => ({ keysign })}
+      promptProps={startKeysignPromptProps}
+    />
+  )
 }

--- a/core/ui/vault/settings/referral/components/CreateReferral/CreateReferralVerify.tsx
+++ b/core/ui/vault/settings/referral/components/CreateReferral/CreateReferralVerify.tsx
@@ -22,7 +22,7 @@ import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
-import { StartKeysignPrompt } from '../../../../../mpc/keysign/prompt/StartKeysignPrompt'
+import { StartKeysignPromptWithRefresh } from '../../../../../mpc/keysign/start/StartKeysignPromptWithRefresh'
 import { KeysignFeeAmount } from '../../../../../mpc/keysign/tx/FeeAmount'
 import { useCurrentVaultCoin } from '../../../../state/currentVaultCoins'
 import { useReferralSender } from '../../hooks/useReferralSender'
@@ -156,7 +156,11 @@ export const CreateReferralVerify = ({ onBack }: OnBackProp) => {
           }}
           gap={20}
         >
-          <StartKeysignPrompt {...startKeysignPromptProps} />
+          <StartKeysignPromptWithRefresh
+            keysignPayloadQuery={keysignPayloadQuery}
+            toKeysignPayload={keysign => ({ keysign })}
+            promptProps={startKeysignPromptProps}
+          />
         </VStack>
       </ReferralPageWrapper>
     </>

--- a/core/ui/vault/settings/referral/components/EditReferral/EditReferralVerify.tsx
+++ b/core/ui/vault/settings/referral/components/EditReferral/EditReferralVerify.tsx
@@ -23,7 +23,7 @@ import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
-import { StartKeysignPrompt } from '../../../../../mpc/keysign/prompt/StartKeysignPrompt'
+import { StartKeysignPromptWithRefresh } from '../../../../../mpc/keysign/start/StartKeysignPromptWithRefresh'
 import { KeysignFeeAmount } from '../../../../../mpc/keysign/tx/FeeAmount'
 import { useCurrentVaultCoin } from '../../../../state/currentVaultCoins'
 import { useReferralSender } from '../../hooks/useReferralSender'
@@ -177,7 +177,11 @@ export const EditReferralVerify = ({ onBack }: OnBackProp) => {
           }}
           gap={20}
         >
-          <StartKeysignPrompt {...startKeysignPromptProps} />
+          <StartKeysignPromptWithRefresh
+            keysignPayloadQuery={keysignPayloadQuery}
+            toKeysignPayload={keysign => ({ keysign })}
+            promptProps={startKeysignPromptProps}
+          />
         </VStack>
       </ReferralPageWrapper>
     </>


### PR DESCRIPTION
Closes #4475. Raised by @johnnyluo in review on #4470.

## Problem

Every keysign payload query uses `noRefetchQueryOptions`, so the payload a review screen holds is the one built when that screen mounted. The SDK's fail-closed gates live *inside* those builders — THORChain's `EnableAdvSwapQueue` mimir, the inbound halt flags, the router's `depositWithExpiry` deadline — which made them mount-time checks despite being documented as sign-time ones. A review long enough for the queue to be disabled, a chain to halt, or a 15-minute router expiry to lapse would sign a payload those gates now reject.

## What changed

**The payload is rebuilt when signing starts.** A manual `refetch()` still runs while `refetchOnMount` / `OnWindowFocus` / `OnReconnect` are off, so the builder re-runs and its gates are re-evaluated at the moment it matters.

A rebuild that fails **blocks signing and says why**, rather than falling back to the payload whose freshness is in doubt — including the case where React Query hands back the last good data alongside the error. Fast Vault rebuilds *after* the password prompt, since that pause is exactly what lets a payload go stale.

**`assertNativeSwapReadyForBroadcast` is wired in before broadcast.** It shipped in `@vultisig/core-mpc` for this purpose and had zero callers anywhere in the repo.

## Two things worth a reviewer's attention

**1. The issue's scoping was slightly off, and following it literally would have under-fixed this.** It describes `VerifyKeysignStart` as "the shared entry point for every one of these flows". It isn't — deposit, referral (create + edit) and the QBTC governance vote call `StartKeysignPrompt` directly with their own queries, so fixing only `VerifyKeysignStart` would have left four of the ten listed payload queries untouched. The hook (`onBeforeStart`) therefore lives on `StartKeysignPromptProps`, and all eight sites share one `StartKeysignPromptWithRefresh` component — still one implementation, just at the correct seam.

`refetch` is **required** rather than optional on the query type, so a query that cannot be refreshed fails to compile instead of silently signing a stale payload. The one custom `footer` override (`SendTxOverview`) only replaces the prompt in its error state, so that flow is still covered.

**2. Multi-device signing is unaffected — deliberately, not incidentally.** The rebuild happens *before* the keysign session exists:

1. initiator signs → rebuild → `navigate({state:{keysignPayload}})`
2. `StartSecureKeysignFlow` reads that nav-state payload into the session, so **the QR encodes the rebuilt payload**
3. the joining device holds a `getResolvedQuery` over the scanned payload — static, no `refetch`, no builder — and never renders `StartKeysignPrompt`

Both devices sign identical bytes. The broadcast guard *does* run on both, because both broadcast: a device that would push into a halted chain has to refuse for the same reason the initiator does. The trade-off is that a transient inbound-address fetch failure can fail a co-sign the initiator completed — a duplicate-broadcast case the other device already handles. If that proves noisy in support, narrowing to `invalid_config` / `invalid_vault` is a small follow-up.

The guard is reported as a `BroadcastError`: signing has already completed by the time it runs, so the generic branch's device/connection-timeout copy would be actively misleading for a halted-chain refusal.

## Testing

`yarn typecheck`, `yarn lint`, `yarn knip` and `yarn test` (723 passed) all pass.

17 new tests over the rebuild, the fail-closed branch and the broadcast-guard classification. The fail-closed tests were **mutation-tested** — removing the `throw` makes four of them fail — so the coverage is real rather than incidental.

Not verified end to end: the acceptance scenarios need a live THORChain node and a funded vault (flipping `EnableAdvSwapQueue` mid-review, waiting out a 15-minute ERC20 router expiry). A Secure Vault pass — initiate on one device, scan on another — is also worth doing before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Signing flows now refresh transaction details immediately before signing.
  - Added clearer warnings when transaction information cannot be refreshed.
  - Broadcast readiness is revalidated after signing to help prevent invalid transactions.

- **Bug Fixes**
  - Prevented signing or navigation when transaction data is missing, stale, or invalid.
  - Improved error handling for refresh and broadcast-readiness failures.

- **Tests**
  - Added coverage for payload refresh, signing safeguards, error handling, and broadcast validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->