### PR TITLE
fix(defi): show zero balance when no chains are enabled

### DIFF
--- a/core/ui/defi/page/hooks/useDefiPortfolios.ts
+++ b/core/ui/defi/page/hooks/useDefiPortfolios.ts
@@ -351,9 +351,15 @@ export const useDefiPortfolioBalance = () => {
 
   const resolvedCount = resolvedChains.length + (isCircleResolved ? 1 : 0)
   const isUpdating = portfolios.isPending || isCirclePending
+  // With no enabled chains and Circle excluded there is nothing to resolve —
+  // the total is a settled zero, not an absent value waiting on queries.
+  const hasTrackedSources = portfolios.data.length > 0 || isCircleIncluded
 
   return {
-    data: resolvedCount > 0 ? chainTotal + circleTotal : undefined,
+    data:
+      resolvedCount > 0 || !hasTrackedSources
+        ? chainTotal + circleTotal
+        : undefined,
     isPending: resolvedCount === 0 && isUpdating,
     isUpdating,
     error:

--- a/core/ui/defi/page/hooks/useDefiPortfolios.ts
+++ b/core/ui/defi/page/hooks/useDefiPortfolios.ts
@@ -11,7 +11,6 @@ import { Chain } from '@vultisig/core-chain/Chain'
 import { sunToTrx } from '@vultisig/core-chain/chains/tron/resources'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { coinKeyToString } from '@vultisig/core-chain/coin/Coin'
-import { sum } from '@vultisig/lib-utils/array/sum'
 import { useMemo } from 'react'
 
 import { useDefiChains } from '../../../storage/defiChains'
@@ -21,6 +20,7 @@ import { useMayaDefiPositionsQuery } from '../../chain/queries/useMayaDefiPositi
 import { useThorchainDefiPositionsQuery } from '../../chain/queries/useThorchainDefiPositionsQuery'
 import { aggregateDefiPositions } from '../../chain/services/defiPositionAggregator'
 import { useCircleAccountUsdcFiatBalanceQuery } from '../../protocols/circle/queries/useCircleAccountUsdcFiatBalanceQuery'
+import { getDefiPortfolioBalance } from '../utils/getDefiPortfolioBalance'
 
 export type DefiChainPortfolio = {
   chain: Chain
@@ -325,43 +325,24 @@ export const useDefiChainPortfolios = () => {
 }
 
 /**
- * DeFi portfolio total, resolved progressively. `data` sums the chains (and the
- * Circle USDC balance) that have already landed, so the header shows a running
- * total instead of blocking on the slowest chain. `isUpdating` stays true while
- * any chain or the Circle balance is still pending so the UI can render an
- * "updating" affordance alongside the partial number.
+ * DeFi portfolio total, resolved progressively — see
+ * `getDefiPortfolioBalance` for the resolution rules. `isUpdating` stays true
+ * while any chain or the Circle balance is still pending so the UI can render
+ * an "updating" affordance alongside the partial number.
  */
 export const useDefiPortfolioBalance = () => {
   const portfolios = useDefiChainPortfolios()
   const isCircleIncluded = useIsCircleIncluded()
   const circleFiatBalanceQuery = useCircleAccountUsdcFiatBalanceQuery()
 
-  const resolvedChains = portfolios.data.filter(
-    portfolio => !portfolio.isLoading
-  )
-  const chainTotal = sum(resolvedChains.map(portfolio => portfolio.totalFiat))
-
-  const isCirclePending = isCircleIncluded && circleFiatBalanceQuery.isPending
-  // Count Circle only on success — a failed query is no longer pending but its
-  // data is undefined, so treating "not pending" as resolved would silently
-  // mask the failure as a zero contribution.
-  const isCircleResolved =
-    isCircleIncluded && circleFiatBalanceQuery.data !== undefined
-  const circleTotal = isCircleResolved ? (circleFiatBalanceQuery.data ?? 0) : 0
-
-  const resolvedCount = resolvedChains.length + (isCircleResolved ? 1 : 0)
-  const isUpdating = portfolios.isPending || isCirclePending
-  // With no enabled chains and Circle excluded there is nothing to resolve —
-  // the total is a settled zero, not an absent value waiting on queries.
-  const hasTrackedSources = portfolios.data.length > 0 || isCircleIncluded
-
   return {
-    data:
-      resolvedCount > 0 || !hasTrackedSources
-        ? chainTotal + circleTotal
-        : undefined,
-    isPending: resolvedCount === 0 && isUpdating,
-    isUpdating,
+    ...getDefiPortfolioBalance({
+      portfolios: portfolios.data,
+      arePortfoliosPending: portfolios.isPending,
+      isCircleIncluded,
+      circleFiatBalance: circleFiatBalanceQuery.data,
+      isCirclePending: circleFiatBalanceQuery.isPending,
+    }),
     error:
       portfolios.error ??
       (isCircleIncluded ? circleFiatBalanceQuery.error : null),

--- a/core/ui/defi/page/utils/getDefiPortfolioBalance.test.ts
+++ b/core/ui/defi/page/utils/getDefiPortfolioBalance.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+
+import { getDefiPortfolioBalance } from './getDefiPortfolioBalance'
+
+const noCircle = {
+  isCircleIncluded: false,
+  circleFiatBalance: undefined,
+  isCirclePending: false,
+}
+
+describe('getDefiPortfolioBalance', () => {
+  it('resolves to zero when no chains are enabled and Circle is excluded', () => {
+    const result = getDefiPortfolioBalance({
+      portfolios: [],
+      arePortfoliosPending: false,
+      ...noCircle,
+    })
+
+    expect(result).toEqual({ data: 0, isPending: false, isUpdating: false })
+  })
+
+  it('is pending while every enabled chain is still loading', () => {
+    const result = getDefiPortfolioBalance({
+      portfolios: [{ totalFiat: 0, isLoading: true }],
+      arePortfoliosPending: true,
+      ...noCircle,
+    })
+
+    expect(result).toEqual({
+      data: undefined,
+      isPending: true,
+      isUpdating: true,
+    })
+  })
+
+  it('reports a running total while some chains are still loading', () => {
+    const result = getDefiPortfolioBalance({
+      portfolios: [
+        { totalFiat: 100, isLoading: false },
+        { totalFiat: 50, isLoading: true },
+      ],
+      arePortfoliosPending: true,
+      ...noCircle,
+    })
+
+    expect(result).toEqual({ data: 100, isPending: false, isUpdating: true })
+  })
+
+  it('sums all chains once everything has resolved', () => {
+    const result = getDefiPortfolioBalance({
+      portfolios: [
+        { totalFiat: 100, isLoading: false },
+        { totalFiat: 50, isLoading: false },
+      ],
+      arePortfoliosPending: false,
+      ...noCircle,
+    })
+
+    expect(result).toEqual({ data: 150, isPending: false, isUpdating: false })
+  })
+
+  it('is pending while Circle is the only source and still loading', () => {
+    const result = getDefiPortfolioBalance({
+      portfolios: [],
+      arePortfoliosPending: false,
+      isCircleIncluded: true,
+      circleFiatBalance: undefined,
+      isCirclePending: true,
+    })
+
+    expect(result).toEqual({
+      data: undefined,
+      isPending: true,
+      isUpdating: true,
+    })
+  })
+
+  it('adds the Circle balance to the chain total once resolved', () => {
+    const result = getDefiPortfolioBalance({
+      portfolios: [{ totalFiat: 100, isLoading: false }],
+      arePortfoliosPending: false,
+      isCircleIncluded: true,
+      circleFiatBalance: 25,
+      isCirclePending: false,
+    })
+
+    expect(result).toEqual({ data: 125, isPending: false, isUpdating: false })
+  })
+
+  it('does not mask a failed Circle query as a resolved zero', () => {
+    const result = getDefiPortfolioBalance({
+      portfolios: [],
+      arePortfoliosPending: false,
+      isCircleIncluded: true,
+      circleFiatBalance: undefined,
+      isCirclePending: false,
+    })
+
+    expect(result).toEqual({
+      data: undefined,
+      isPending: false,
+      isUpdating: false,
+    })
+  })
+
+  it('ignores a pending Circle query when Circle is excluded', () => {
+    const result = getDefiPortfolioBalance({
+      portfolios: [],
+      arePortfoliosPending: false,
+      isCircleIncluded: false,
+      circleFiatBalance: undefined,
+      isCirclePending: true,
+    })
+
+    expect(result).toEqual({ data: 0, isPending: false, isUpdating: false })
+  })
+})

--- a/core/ui/defi/page/utils/getDefiPortfolioBalance.ts
+++ b/core/ui/defi/page/utils/getDefiPortfolioBalance.ts
@@ -1,0 +1,48 @@
+import { sum } from '@vultisig/lib-utils/array/sum'
+
+type GetDefiPortfolioBalanceInput = {
+  portfolios: { totalFiat: number; isLoading: boolean }[]
+  arePortfoliosPending: boolean
+  isCircleIncluded: boolean
+  circleFiatBalance: number | undefined
+  isCirclePending: boolean
+}
+
+/**
+ * Resolves the DeFi portfolio total progressively. `data` sums the sources
+ * (chains and the Circle USDC balance) that have already landed, so the header
+ * shows a running total instead of blocking on the slowest one. With no
+ * tracked sources at all (no enabled chains, Circle excluded) the total is a
+ * settled zero rather than an absent value — nothing is pending, so `data` is
+ * `0` and never `undefined`.
+ */
+export const getDefiPortfolioBalance = ({
+  portfolios,
+  arePortfoliosPending,
+  isCircleIncluded,
+  circleFiatBalance,
+  isCirclePending,
+}: GetDefiPortfolioBalanceInput) => {
+  const resolvedChains = portfolios.filter(portfolio => !portfolio.isLoading)
+  const chainTotal = sum(resolvedChains.map(portfolio => portfolio.totalFiat))
+
+  // Count Circle only on success — a failed query is no longer pending but its
+  // data is undefined, so treating "not pending" as resolved would silently
+  // mask the failure as a zero contribution.
+  const isCircleResolved = isCircleIncluded && circleFiatBalance !== undefined
+  const circleTotal = isCircleResolved ? circleFiatBalance : 0
+
+  const resolvedCount = resolvedChains.length + (isCircleResolved ? 1 : 0)
+  const isUpdating =
+    arePortfoliosPending || (isCircleIncluded && isCirclePending)
+  const hasTrackedSources = portfolios.length > 0 || isCircleIncluded
+
+  return {
+    data:
+      resolvedCount > 0 || !hasTrackedSources
+        ? chainTotal + circleTotal
+        : undefined,
+    isPending: resolvedCount === 0 && isUpdating,
+    isUpdating,
+  }
+}


### PR DESCRIPTION
Closes #4510

With no DeFi chains enabled and Circle excluded, `useDefiPortfolioBalance` returned `{ data: undefined, isPending: false }`, so `MatchQuery` fell through to the default `inactive` branch and the balance panel rendered blank above the empty state.

There is nothing to resolve in that case, so the total is a settled zero rather than an absent value. The hook now returns `data: 0` when there are no tracked sources, and the panel renders a formatted $0.00.

- Hide/show toggle is unchanged and still works over the zero amount.
- Enabling a chain adds a loading portfolio entry, which flips the hook back to pending, so the spinner shows until the real total lands (no flash of empty).
- Circle behavior is preserved: a failed Circle query still surfaces the error instead of masking it as zero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * DeFi portfolio balances now display as zero when no eligible chains are enabled.
  * Balance loading behavior remains accurate while tracked sources are still resolving.
  * Portfolio totals now update progressively as chain and Circle balances become available.
  * Failed or excluded balance sources no longer prevent available balances from being displayed.
  * Circle balance loading, errors, and aggregation are handled more accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->