### PR TITLE
[Icons V3] Phase 3 — Send flow (SquareBehindSquare4 → clone; Dollar pending)

### DIFF
--- a/docs/icons-v3/PLAN.md
+++ b/docs/icons-v3/PLAN.md
@@ -83,7 +83,7 @@ final PR to `main`.)
 | **0 — Foundation** ✅ | tooling | Decision record, codegen (`scripts/icons/`), seed mapping table, Storybook gallery. **No icon art changes.** |
 | **1 — Shared icons** ✅ | cross-screen | Every icon used on more than one screen. **Done: 53 migrated** across 7 batches (44 from iOS/Station V3 art, 9 from the Figma V3 library), each verified against rendered geometry. PRs #4502 + the batch-7 PR. Excludes chevrons. |
 | **2 — Main View** ✅ | screen | Portfolio / vault home. 9 of its 17 icons already done in Phase 1 (shared) — validating the shared-first order. Migrated the 1 remaining screen-unique glyph: `SquareBehindSquare6Icon → clone`. Legacy: `EyeClosedIcon` (V3 has no eye-off — mismatches the migrated `EyeIcon` in the balance toggle; needs design). Bespoke: `CryptoIcon`, `CryptoWalletPenIcon`. |
-| **3 — Send flow** | screen | |
+| **3 — Send flow** 🔄 | screen | 8 of 13 icons already done in Phase 1. Migrated `SquareBehindSquare4Icon → clone` (iOS). `DollarIcon → currency-dollar` is **pending** — a verified V3 target, but generation is blocked by a persistent Figma rate-limit; fetch when access returns. |
 | **4 — Swap flow** | screen | |
 | **5 — DeFi / Earn** | screen | |
 | **6 — Settings** | screen | |

--- a/lib/ui/icons/SquareBehindSquare4Icon.tsx
+++ b/lib/ui/icons/SquareBehindSquare4Icon.tsx
@@ -1,18 +1,27 @@
 import { SvgProps } from '@lib/ui/props'
-import { FC } from 'react'
 
-export const SquareBehindSquare4Icon: FC<SvgProps> = props => (
+export const SquareBehindSquare4Icon = (props: SvgProps) => (
   <svg
-    fill="none"
-    height="1em"
-    stroke="currentColor"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    strokeWidth="1.5"
-    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
     width="1em"
+    height="1em"
+    viewBox="0 0 24 24"
+    fill="none"
     {...props}
   >
-    <path d="M15.25 15.25V20C15.25 20.6904 14.6904 21.25 14 21.25H4C3.30964 21.25 2.75 20.6904 2.75 20V10C2.75 9.30964 3.30964 8.75 4 8.75H8.75M10 15.25H20C20.6904 15.25 21.25 14.6904 21.25 14V4C21.25 3.30964 20.6904 2.75 20 2.75H10C9.30964 2.75 8.75 3.30964 8.75 4V14C8.75 14.6904 9.30964 15.25 10 15.25Z" />
+    <path
+      d="M15.6004 8.40039H18.0004C19.3264 8.40039 20.4004 9.47439 20.4004 10.8004V18.0004C20.4004 19.3264 19.3264 20.4004 18.0004 20.4004H10.8004C9.47439 20.4004 8.40039 19.3264 8.40039 18.0004V15.6004"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M13.1996 3.59961H5.99961C4.67413 3.59961 3.59961 4.67413 3.59961 5.99961V13.1996C3.59961 14.5251 4.67413 15.5996 5.99961 15.5996H13.1996C14.5251 15.5996 15.5996 14.5251 15.5996 13.1996V5.99961C15.5996 4.67413 14.5251 3.59961 13.1996 3.59961Z"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
   </svg>
 )

--- a/scripts/icons/icon-mapping.json
+++ b/scripts/icons/icon-mapping.json
@@ -6,7 +6,8 @@
     "verified": "V3 source confirmed against rendered art",
     "proposed": "likely match from name/iOS precedent — must be eyeballed before use",
     "bespoke": "Vultisig-specific glyph with no V3 counterpart — stays hand-drawn",
-    "legacy": "shared icon with no faithful V3 counterpart yet — stays on the legacy glyph pending design"
+    "legacy": "shared icon with no faithful V3 counterpart yet — stays on the legacy glyph pending design",
+    "pending": "verified-name V3 target, generation deferred (Figma rate-limited) — fetch when access returns"
   },
   "sourceLegend": {
     "station": "already shipped in StationFigmaIcons.tsx (drawn in V3 style)",
@@ -379,6 +380,19 @@
       "status": "legacy",
       "source": "manual",
       "note": "V3 has no eye-off/eye-slash; pairs with the migrated EyeIcon in the balance show/hide toggle — needs a V3 eye-off from design"
+    },
+    {
+      "desktop": "SquareBehindSquare4Icon",
+      "v3": "clone",
+      "status": "migrated",
+      "source": "ios"
+    },
+    {
+      "desktop": "DollarIcon",
+      "v3": "currency-dollar",
+      "status": "pending",
+      "source": "manual",
+      "note": "V3 currency-dollar; fetch + verify when Figma access returns"
     },
     {
       "desktop": "CryptoIcon",


### PR DESCRIPTION
Part of #4383. Advances #4515 (Phase 3 — Send flow). Targets `feature/icons-v3-adoption`.

8 of Send flow's 13 icons were already migrated in Phase 1 (shared).

## Migrated (1)
| icon | V3 source | note |
|------|-----------|------|
| `SquareBehindSquare4Icon` | `clone` (iOS) | two overlapping squares; geometry matches iOS clone |

## Pending (1)
- `DollarIcon → currency-dollar` — verified V3 target, but generation is blocked by a **persistent Figma rate-limit**. Marked `status: "pending"` in the mapping; will be fetched (and geometry-verified) when Figma access returns, before the final PR to main.

## Verification
- `yarn typecheck` — 0 errors; ESLint clean; no dev-only files committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
