### PR TITLE
[Icons V3] Phase 4 — Swap flow (Warning → circle-warning; 2 pending)

### DIFF
--- a/docs/icons-v3/PLAN.md
+++ b/docs/icons-v3/PLAN.md
@@ -84,7 +84,7 @@ final PR to `main`.)
 | **1 — Shared icons** ✅ | cross-screen | Every icon used on more than one screen. **Done: 53 migrated** across 7 batches (44 from iOS/Station V3 art, 9 from the Figma V3 library), each verified against rendered geometry. PRs #4502 + the batch-7 PR. Excludes chevrons. |
 | **2 — Main View** ✅ | screen | Portfolio / vault home. 9 of its 17 icons already done in Phase 1 (shared) — validating the shared-first order. Migrated the 1 remaining screen-unique glyph: `SquareBehindSquare6Icon → clone`. Legacy: `EyeClosedIcon` (V3 has no eye-off — mismatches the migrated `EyeIcon` in the balance toggle; needs design). Bespoke: `CryptoIcon`, `CryptoWalletPenIcon`. |
 | **3 — Send flow** 🔄 | screen | 8 of 13 icons already done in Phase 1. Migrated `SquareBehindSquare4Icon → clone` (iOS). `DollarIcon → currency-dollar` is **pending** — a verified V3 target, but generation is blocked by a persistent Figma rate-limit; fetch when access returns. |
-| **4 — Swap flow** | screen | |
+| **4 — Swap flow** 🔄 | screen | 12 of 18 icons already done in Phase 1. Migrated `WarningIcon → circle-warning` (iOS). **Pending** (Figma-only, rate-limited): `ArrowUpDownIcon → swap`, `SwapLoadingIcon → loader` — fetch + verify in the corrections batch. |
 | **5 — DeFi / Earn** | screen | |
 | **6 — Settings** | screen | |
 | **7 — Transaction History** | screen | |

--- a/lib/ui/icons/WarningIcon.tsx
+++ b/lib/ui/icons/WarningIcon.tsx
@@ -1,43 +1,17 @@
-import { SvgProps } from '../props'
+import { SvgProps } from '@lib/ui/props'
 
-export const WarningIcon = (props: SvgProps) => {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="1em"
-      height="1em"
-      viewBox="0 0 20 20"
-      fill="none"
-      {...props}
-    >
-      <g clipPath="url(#clip0_63766_53488)">
-        <path
-          d="M9.99984 18.3337C14.6022 18.3337 18.3332 14.6027 18.3332 10.0003C18.3332 5.39795 14.6022 1.66699 9.99984 1.66699C5.39746 1.66699 1.6665 5.39795 1.6665 10.0003C1.6665 14.6027 5.39746 18.3337 9.99984 18.3337Z"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-        <path
-          d="M10 6.66699V10.0003"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-        <path
-          d="M10 13.333H10.0083"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-      </g>
-      <defs>
-        <clipPath id="clip0_63766_53488">
-          <rect width="20" height="20" fill="white" />
-        </clipPath>
-      </defs>
-    </svg>
-  )
-}
+export const WarningIcon = (props: SvgProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1em"
+    height="1em"
+    viewBox="0 0 24 24"
+    fill="none"
+    {...props}
+  >
+    <path
+      d="M12.0004 21.6004C17.2936 21.6004 21.6004 17.2936 21.6004 12.0004C21.6004 6.70719 17.2936 2.40039 12.0004 2.40039C6.70719 2.40039 2.40039 6.70719 2.40039 12.0004C2.40039 17.2936 6.70719 21.6004 12.0004 21.6004ZM10.8004 7.20039C10.8004 6.53799 11.3368 6.00039 12.0004 6.00039C12.664 6.00039 13.2004 6.53799 13.2004 7.20039V12.6004C13.2004 13.2628 12.664 13.8004 12.0004 13.8004C11.3368 13.8004 10.8004 13.2628 10.8004 12.6004V7.20039ZM12.0004 15.0004C12.8272 15.0004 13.5004 15.6736 13.5004 16.5004C13.5004 17.3272 12.8272 18.0004 12.0004 18.0004C11.1736 18.0004 10.5004 17.3272 10.5004 16.5004C10.5004 15.6736 11.1736 15.0004 12.0004 15.0004Z"
+      fill="currentColor"
+    />
+  </svg>
+)

--- a/scripts/icons/icon-mapping.json
+++ b/scripts/icons/icon-mapping.json
@@ -395,6 +395,26 @@
       "note": "V3 currency-dollar; fetch + verify when Figma access returns"
     },
     {
+      "desktop": "WarningIcon",
+      "v3": "circle-warning",
+      "status": "migrated",
+      "source": "ios"
+    },
+    {
+      "desktop": "ArrowUpDownIcon",
+      "v3": "swap",
+      "status": "pending",
+      "source": "manual",
+      "note": "candidate swap — verify geometry (two vertical arrows) when Figma access returns"
+    },
+    {
+      "desktop": "SwapLoadingIcon",
+      "v3": "loader",
+      "status": "pending",
+      "source": "manual",
+      "note": "spinner arc; verify vs V3 loader when Figma access returns"
+    },
+    {
       "desktop": "CryptoIcon",
       "v3": null,
       "status": "bespoke",


### PR DESCRIPTION
Part of #4383. Advances #4517. Targets `feature/icons-v3-adoption`.

12 of Swap's 18 icons already done in Phase 1. Migrated `WarningIcon → circle-warning` (iOS). Pending (Figma-only, rate-limited): `ArrowUpDownIcon → swap`, `SwapLoadingIcon → loader` — batched for the corrections pass. typecheck 0, no dev files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)