### PR TITLE
[Icons V3] Phase 7 — Transaction History (tx-direction set scoped for batch)

### DIFF
--- a/docs/icons-v3/PLAN.md
+++ b/docs/icons-v3/PLAN.md
@@ -87,7 +87,7 @@ final PR to `main`.)
 | **4 — Swap flow** 🔄 | screen | 12 of 18 icons already done in Phase 1. Migrated `WarningIcon → circle-warning` (iOS). **Pending** (Figma-only, rate-limited): `ArrowUpDownIcon → swap`, `SwapLoadingIcon → loader` — fetch + verify in the corrections batch. |
 | **5 — DeFi / Earn** 🔄 | screen | 14 of 24 icons already done in Phase 1. Migrated `CalendarIcon → calendar-days` (iOS). Pending: `PercentIcon → percentage` (Figma). Legacy: `BrokenChainLink3Icon` (no broken-chain in V3). Special (out of scope): `CircleIcon` (gradient badge, not a glyph). |
 | **6 — Settings** 🔄 | screen | Largest screen: 46 icons, 22 already done in Phase 1. Migrated 8 from iOS: `Books, Cloud, Discord, Github, Languages, TabletSmartphone, TrashCan, Twitter(→IconX)`. **12 pending** for the Figma batch: social brands (`Facebook, Linkedin, Reddit, WhatsApp`), and `ArrowUndo, BubbleQuestion, FileQuestion, FolderUpload, GroupOne, ImageAvatarSparkle, KeyboardUp, RadioTower` (iOS candidates weren't faithful — e.g. RadioTower ≠ mobile-signal, KeyboardUp loses its up-arrow). |
-| **7 — Transaction History** | screen | |
+| **7 — Transaction History** 🔄 | screen | 4 of 10 icons already done in Phase 1. The remaining 4 are the **transaction-direction set** (`TransactionSend/Receive/Swap/Approve`, 12×12 circle badges) → `circle-arrow-up` / `circle-open-arrow-down` / `circle-sort-arrows` / `circle-check`. Scoped as one Figma-batch unit so the 4 stay visually cohesive; migrated together in the corrections pass. |
 | **8 — Vault lifecycle** | screens | Onboarding, Vault Setup, Reshare, Upgrade Vault (share most icons — grouped). |
 | **9 — Notifications** | screen | |
 | **10 — Extension surfaces** | screens | No Figma reference — migrate to desktop parity. |

--- a/scripts/icons/icon-mapping.json
+++ b/scripts/icons/icon-mapping.json
@@ -364,10 +364,10 @@
     },
     {
       "desktop": "TransactionReceiveIcon",
-      "v3": null,
-      "status": "legacy",
+      "v3": "circle-open-arrow-down",
+      "status": "pending",
       "source": "manual",
-      "note": "Vultisig send/receive/swap set — decide together with design"
+      "note": "transaction-direction set (send/receive/swap/approve) — migrate together in the Figma batch and verify the 4 look cohesive"
     },
     {
       "desktop": "SquareBehindSquare6Icon",
@@ -573,6 +573,27 @@
       "status": "pending",
       "source": "manual",
       "note": "verify geometry in corrections batch"
+    },
+    {
+      "desktop": "TransactionApproveIcon",
+      "v3": "circle-check",
+      "status": "pending",
+      "source": "manual",
+      "note": "transaction-direction set (send/receive/swap/approve) — migrate together in the Figma batch and verify the 4 look cohesive"
+    },
+    {
+      "desktop": "TransactionSwapIcon",
+      "v3": "circle-sort-arrows",
+      "status": "pending",
+      "source": "manual",
+      "note": "transaction-direction set (send/receive/swap/approve) — migrate together in the Figma batch and verify the 4 look cohesive"
+    },
+    {
+      "desktop": "TransactionSendIcon",
+      "v3": "circle-arrow-up",
+      "status": "pending",
+      "source": "manual",
+      "note": "transaction-direction set (send/receive/swap/approve) — migrate together in the Figma batch and verify the 4 look cohesive"
     },
     {
       "desktop": "CryptoIcon",


### PR DESCRIPTION
Part of #4383. Advances #4523. Targets `feature/icons-v3-adoption`.

4 of 10 icons already done in Phase 1. The remaining 4 are the transaction-direction set (Send/Receive/Swap/Approve, 12×12 circle badges) → mapped to circle-arrow-up / circle-open-arrow-down / circle-sort-arrows / circle-check, and scoped as ONE Figma-batch unit so the transaction list stays cohesive. No art change in this PR (migrating one at a time would mismatch the list). typecheck 0, no dev files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)