### PR TITLE
fix(extension): with no vault, always open on the splash

### DIFF
--- a/clients/extension/src/navigation/NavigationProvider.tsx
+++ b/clients/extension/src/navigation/NavigationProvider.tsx
@@ -1,4 +1,4 @@
-import { initialCoreView } from '@core/ui/navigation/CoreView'
+import { vaultsStorage } from '@core/extension/storage/vaults'
 import { Center } from '@lib/ui/layout/Center'
 import { Spinner } from '@lib/ui/loaders/Spinner'
 import { NavigationProvider as CoreNavigationProvider } from '@lib/ui/navigation/state'
@@ -12,28 +12,29 @@ import { useEffect } from 'react'
 import { getInitialView, removeInitialView } from '../storage/initialView'
 import { getPersistedHistory } from '../storage/persistedView'
 import { PersistNavigationState } from './PersistNavigationState'
+import { resolveInitialHistory } from './resolveInitialHistory'
 
-const resolveInitialHistory = async (): Promise<View[]> => {
-  const initialView = await getInitialView()
+const getInitialHistory = async (): Promise<View[]> => {
+  const [initialView, persistedHistory, vaults] = await Promise.all([
+    getInitialView(),
+    getPersistedHistory(),
+    vaultsStorage.getVaults(),
+  ])
+
   if (initialView !== null) {
     await removeInitialView()
-    if (initialView.id === initialCoreView.id) {
-      return [initialView]
-    }
-    return [initialCoreView, initialView]
   }
 
-  const persistedHistory = await getPersistedHistory()
-  if (persistedHistory !== null && persistedHistory.length > 0) {
-    return persistedHistory
-  }
-
-  return [initialCoreView]
+  return resolveInitialHistory({
+    initialView,
+    persistedHistory,
+    hasVaults: vaults.length > 0,
+  })
 }
 
 export const NavigationProvider = ({ children }: ChildrenProp) => {
   const { mutate, ...mutationState } = useMutation({
-    mutationFn: resolveInitialHistory,
+    mutationFn: getInitialHistory,
   })
 
   useEffect(() => {

--- a/clients/extension/src/navigation/NavigationProvider.tsx
+++ b/clients/extension/src/navigation/NavigationProvider.tsx
@@ -32,6 +32,10 @@ const getInitialHistory = async (): Promise<View[]> => {
   })
 }
 
+/**
+ * Provides navigation state to the extension app, resolving the initial
+ * history from stored state and the vault list before rendering children.
+ */
 export const NavigationProvider = ({ children }: ChildrenProp) => {
   const { mutate, ...mutationState } = useMutation({
     mutationFn: getInitialHistory,

--- a/clients/extension/src/navigation/resolveInitialHistory.ts
+++ b/clients/extension/src/navigation/resolveInitialHistory.ts
@@ -1,0 +1,47 @@
+import { initialCoreView } from '@core/ui/navigation/CoreView'
+
+import { AppView, AppViewId } from './AppView'
+
+const onboardingViews: ReadonlySet<AppViewId> = new Set<AppViewId>([
+  'onboarding',
+  'newVault',
+  'setupVault',
+  'setupVaultOverview',
+  'importVault',
+  'importSeedphrase',
+  'joinKeygen',
+])
+
+type ResolveInitialHistoryInput = {
+  initialView: AppView | null
+  persistedHistory: AppView[] | null
+  hasVaults: boolean
+}
+
+/**
+ * Computes the navigation history the extension should open with.
+ *
+ * With no vaults in storage, a stored initial view is only honored when it is
+ * part of onboarding (e.g. reopening setup in an expanded tab), and persisted
+ * history is ignored entirely — otherwise a stale history like
+ * `[vault, setupVault]` would skip the no-vault splash and land the user on
+ * vault setup directly.
+ */
+export const resolveInitialHistory = ({
+  initialView,
+  persistedHistory,
+  hasVaults,
+}: ResolveInitialHistoryInput): AppView[] => {
+  if (initialView && (hasVaults || onboardingViews.has(initialView.id))) {
+    if (initialView.id === initialCoreView.id) {
+      return [initialView]
+    }
+    return [initialCoreView, initialView]
+  }
+
+  if (hasVaults && persistedHistory && persistedHistory.length > 0) {
+    return persistedHistory
+  }
+
+  return [initialCoreView]
+}

--- a/clients/extension/tests/unit/resolveInitialHistory.test.ts
+++ b/clients/extension/tests/unit/resolveInitialHistory.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+
+import { AppView } from '@clients/extension/src/navigation/AppView'
+import { resolveInitialHistory } from '@clients/extension/src/navigation/resolveInitialHistory'
+
+const vaultView: AppView = { id: 'vault' }
+const setupVaultView: AppView = { id: 'setupVault', state: {} }
+const settingsView: AppView = { id: 'settings' }
+
+describe('resolveInitialHistory', () => {
+  describe('with no vaults', () => {
+    it('ignores persisted history and opens on the initial core view', () => {
+      // Regression for #4514: abandoning setup mid-flow persisted
+      // [vault, setupVault], which skipped the splash on the next open
+      expect(
+        resolveInitialHistory({
+          initialView: null,
+          persistedHistory: [vaultView, setupVaultView],
+          hasVaults: false,
+        })
+      ).toEqual([vaultView])
+    })
+
+    it('ignores a stored non-onboarding initial view', () => {
+      expect(
+        resolveInitialHistory({
+          initialView: settingsView,
+          persistedHistory: null,
+          hasVaults: false,
+        })
+      ).toEqual([vaultView])
+    })
+
+    it('honors an onboarding initial view so expanded-tab setup still works', () => {
+      expect(
+        resolveInitialHistory({
+          initialView: setupVaultView,
+          persistedHistory: null,
+          hasVaults: false,
+        })
+      ).toEqual([vaultView, setupVaultView])
+    })
+
+    it('honors an import-vault initial view', () => {
+      const importVaultView: AppView = { id: 'importVault' }
+
+      expect(
+        resolveInitialHistory({
+          initialView: importVaultView,
+          persistedHistory: null,
+          hasVaults: false,
+        })
+      ).toEqual([vaultView, importVaultView])
+    })
+
+    it('opens on the initial core view when nothing is stored', () => {
+      expect(
+        resolveInitialHistory({
+          initialView: null,
+          persistedHistory: null,
+          hasVaults: false,
+        })
+      ).toEqual([vaultView])
+    })
+  })
+
+  describe('with vaults', () => {
+    it('prefers the stored initial view over persisted history', () => {
+      expect(
+        resolveInitialHistory({
+          initialView: settingsView,
+          persistedHistory: [vaultView, setupVaultView],
+          hasVaults: true,
+        })
+      ).toEqual([vaultView, settingsView])
+    })
+
+    it('does not duplicate the initial core view', () => {
+      expect(
+        resolveInitialHistory({
+          initialView: vaultView,
+          persistedHistory: null,
+          hasVaults: true,
+        })
+      ).toEqual([vaultView])
+    })
+
+    it('restores persisted history', () => {
+      expect(
+        resolveInitialHistory({
+          initialView: null,
+          persistedHistory: [vaultView, setupVaultView],
+          hasVaults: true,
+        })
+      ).toEqual([vaultView, setupVaultView])
+    })
+
+    it('falls back to the initial core view for empty persisted history', () => {
+      expect(
+        resolveInitialHistory({
+          initialView: null,
+          persistedHistory: [],
+          hasVaults: true,
+        })
+      ).toEqual([vaultView])
+    })
+  })
+})


### PR DESCRIPTION
## Description

With zero vaults, opening the extension could land straight on the vault-setup device-count screen instead of the splash. Persisted navigation history (e.g. `[vault, setupVault]` left behind after abandoning setup) was restored before the no-vault redirect in the `vault` view could run.

The history resolution is now a pure function (`resolveInitialHistory`) that takes the vault count into account: with no vaults it ignores persisted history and any stored initial view that isn't part of onboarding. Onboarding views (`setupVault`, `importVault`, etc.) are still honored as initial view so the expanded-tab setup flow keeps working. With at least one vault, behavior is unchanged.

Fixes #4514

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

Extension navigation only.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #4514
- **Confidence**: high
- **Needs human review for**: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup navigation by reliably loading the initial view, saved history, and available vaults.
  * Preserved onboarding and import screens when no vaults are available.
  * Added safer fallback behavior when saved navigation history is unavailable or empty.
  * Prevented duplicate views during initial navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->