### PR TITLE
fix(tron): show freeze/unfreeze as a staking op on the verify screens

### DIFF
--- a/core/ui/chain/tx/getTronStakingDisplay.test.ts
+++ b/core/ui/chain/tx/getTronStakingDisplay.test.ts
@@ -1,0 +1,38 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { describe, expect, it } from 'vitest'
+
+import { getTronStakingDisplay } from './getTronStakingDisplay'
+
+describe('getTronStakingDisplay', () => {
+  it.each([
+    ['FREEZE:BANDWIDTH', 'freeze', 'BANDWIDTH'],
+    ['FREEZE:ENERGY', 'freeze', 'ENERGY'],
+    ['UNFREEZE:BANDWIDTH', 'unfreeze', 'BANDWIDTH'],
+    ['UNFREEZE:ENERGY', 'unfreeze', 'ENERGY'],
+  ])('recognizes %s', (memo, operation, resource) => {
+    expect(getTronStakingDisplay({ chain: Chain.Tron, memo })).toEqual({
+      operation,
+      resource,
+    })
+  })
+
+  it.each([
+    undefined,
+    '',
+    'FREEZE',
+    'FREEZE:',
+    'FREEZE:CPU',
+    'FREEZE:BANDWIDTH:ENERGY',
+    'freeze:bandwidth',
+    'THIS IS A FREEZE:BANDWIDTH',
+    'STAKE:BANDWIDTH',
+  ])('ignores the memo %s', memo => {
+    expect(getTronStakingDisplay({ chain: Chain.Tron, memo })).toBeUndefined()
+  })
+
+  it('ignores a staking memo on another chain', () => {
+    expect(
+      getTronStakingDisplay({ chain: Chain.Ethereum, memo: 'FREEZE:ENERGY' })
+    ).toBeUndefined()
+  })
+})

--- a/core/ui/chain/tx/getTronStakingDisplay.ts
+++ b/core/ui/chain/tx/getTronStakingDisplay.ts
@@ -8,6 +8,12 @@ type TronStakingDisplay = {
   resource: TronResourceType
 }
 
+/** Amount heading each staking operation replaces "You're sending" / "Sent" with. */
+export const tronStakingTitleKey = {
+  freeze: 'tron_freeze_verify_title',
+  unfreeze: 'tron_unfreeze_verify_title',
+} as const satisfies Record<TronStakingOperation, string>
+
 const operationByMemoPrefix: Record<string, TronStakingOperation> = {
   FREEZE: 'freeze',
   UNFREEZE: 'unfreeze',

--- a/core/ui/chain/tx/getTronStakingDisplay.ts
+++ b/core/ui/chain/tx/getTronStakingDisplay.ts
@@ -1,0 +1,55 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { TronResourceType } from '@vultisig/core-chain/chains/tron/resources'
+
+type TronStakingOperation = 'freeze' | 'unfreeze'
+
+type TronStakingDisplay = {
+  operation: TronStakingOperation
+  resource: TronResourceType
+}
+
+const operationByMemoPrefix: Record<string, TronStakingOperation> = {
+  FREEZE: 'freeze',
+  UNFREEZE: 'unfreeze',
+}
+
+const resourceByMemoSuffix: Record<string, TronResourceType> = {
+  BANDWIDTH: 'BANDWIDTH',
+  ENERGY: 'ENERGY',
+}
+
+const stakingMemo = /^([A-Z]+):([A-Z]+)$/
+
+type GetTronStakingDisplayInput = {
+  chain: Chain
+  memo: string | undefined
+}
+
+/**
+ * TRON Stake 2.0 rides through the regular transfer payload and carries its
+ * operation only as an internal `FREEZE:<resource>` / `UNFREEZE:<resource>`
+ * memo, which the signer turns into a FreezeBalanceV2 / UnfreezeBalanceV2
+ * contract — the memo itself never reaches the chain. Recognizing it lets the
+ * verify screens name the operation and surface the frozen resource the same
+ * way the initiating device does, instead of leaking the raw marker as a memo.
+ *
+ * The match mirrors the signer's dispatch (memo prefix plus a valid resource)
+ * so the screen can never describe something other than what gets signed.
+ */
+export const getTronStakingDisplay = ({
+  chain,
+  memo,
+}: GetTronStakingDisplayInput): TronStakingDisplay | undefined => {
+  if (chain !== Chain.Tron || !memo) return undefined
+
+  const match = stakingMemo.exec(memo)
+  if (!match) return undefined
+
+  const [, prefix, suffix] = match
+  const operation = operationByMemoPrefix[prefix]
+  const resource = resourceByMemoSuffix[suffix]
+
+  if (!operation || !resource) return undefined
+
+  return { operation, resource }
+}

--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -1806,4 +1806,6 @@ export const de = {
   trust_line_insufficient_xrp:
     'Nicht genügend {{ticker}}. Zum Öffnen dieser Vertrauenslinie werden {{amount}} {{ticker}} für die Kontoreserve und die Gebühr benötigt.',
   swap_limit_payout_to: 'Auszahlung an',
+  tron_freeze_verify_title: 'Freeze TRON',
+  tron_unfreeze_verify_title: 'TRON freigeben',
 }

--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -1806,6 +1806,6 @@ export const de = {
   trust_line_insufficient_xrp:
     'Nicht genügend {{ticker}}. Zum Öffnen dieser Vertrauenslinie werden {{amount}} {{ticker}} für die Kontoreserve und die Gebühr benötigt.',
   swap_limit_payout_to: 'Auszahlung an',
-  tron_freeze_verify_title: 'Freeze TRON',
+  tron_freeze_verify_title: 'TRON einfrieren',
   tron_unfreeze_verify_title: 'TRON freigeben',
 }

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -1254,10 +1254,12 @@ export const en = {
   tron_energy: 'Energy',
   tron_freeze_button: 'Freeze',
   tron_freeze_title: 'TRON Freeze',
+  tron_freeze_verify_title: 'Freeze TRON',
   tron_frozen_label: 'Frozen',
   tron_pending_withdrawals: 'Pending Withdrawals',
   tron_ready_to_claim: 'Ready to claim',
   tron_unfreeze_button: 'Unfreeze',
+  tron_unfreeze_verify_title: 'Unfreeze TRON',
   tron_bandwidth_and_energy: 'Bandwidth & Energy',
   tron_bandwidth_description:
     'Bandwidth Points are required for every transaction on TRON, including both standard token sends and smart contract interactions. Every TRON user receives 600 free Bandwidth Points per day, which can cover approximately two basic sends. Additionally, you can earn extra Bandwidth Points by staking TRX, increasing your daily balance to support more transactions. If you have enough Bandwidth Points, you can send tokens, stake TRX, or interact with smart contracts without paying TRX in gas fees.',

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -1790,4 +1790,6 @@ export const es = {
   trust_line_insufficient_xrp:
     'No hay suficientes {{ticker}}. Para abrir esta línea de confianza se necesitan {{amount}} {{ticker}} para la reserva de la cuenta y la comisión.',
   swap_limit_payout_to: 'Pago a',
+  tron_freeze_verify_title: 'Congelar TRON',
+  tron_unfreeze_verify_title: 'Descongelar TRON',
 }

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -1762,4 +1762,6 @@ export const hr = {
   trust_line_insufficient_xrp:
     'Nema dovoljno {{ticker}}. Za otvaranje ove linije povjerenja potrebno je {{amount}} {{ticker}} za rezervu računa i naknadu.',
   swap_limit_payout_to: 'Isplata na',
+  tron_freeze_verify_title: 'Zamrzni TRON',
+  tron_unfreeze_verify_title: 'Odmrzni TRON',
 }

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -1796,4 +1796,6 @@ export const it = {
   trust_line_insufficient_xrp:
     '{{ticker}} non è sufficiente. Per aprire questa linea di fiducia sono necessari {{amount}} {{ticker}} per la riserva del conto e la commissione.',
   swap_limit_payout_to: 'Pagamento a',
+  tron_freeze_verify_title: 'Congela TRON',
+  tron_unfreeze_verify_title: 'Sblocca TRON',
 }

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -1753,4 +1753,6 @@ export const ko = {
   trust_line_insufficient_xrp:
     '{{ticker}} 부족합니다. 이 신뢰 라인을 개설하려면 계좌 준비금 및 수수료로 {{amount}} {{ticker}} 필요합니다.',
   swap_limit_payout_to: '지급 대상',
+  tron_freeze_verify_title: 'TRON 동결합니다',
+  tron_unfreeze_verify_title: 'TRON 동결 해제하세요',
 }

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -1774,4 +1774,6 @@ export const nl = {
   trust_line_insufficient_xrp:
     'Er zijn onvoldoende {{ticker}}. Voor het openen van deze trustlijn zijn {{amount}} {{ticker}} nodig voor de accountreservering en de bijbehorende kosten.',
   swap_limit_payout_to: 'Uitbetaling aan',
+  tron_freeze_verify_title: 'Freeze TRON',
+  tron_unfreeze_verify_title: 'Deblokkeer TRON',
 }

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -1774,6 +1774,6 @@ export const nl = {
   trust_line_insufficient_xrp:
     'Er zijn onvoldoende {{ticker}}. Voor het openen van deze trustlijn zijn {{amount}} {{ticker}} nodig voor de accountreservering en de bijbehorende kosten.',
   swap_limit_payout_to: 'Uitbetaling aan',
-  tron_freeze_verify_title: 'Freeze TRON',
+  tron_freeze_verify_title: 'Bevries TRON',
   tron_unfreeze_verify_title: 'Deblokkeer TRON',
 }

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -1793,4 +1793,6 @@ export const pt = {
   trust_line_insufficient_xrp:
     'Não há {{ticker}} suficientes. Para abrir esta linha de confiança, são necessários {{amount}} {{ticker}} para a reserva e taxa da conta.',
   swap_limit_payout_to: 'Pagamento para',
+  tron_freeze_verify_title: 'Congelar TRON',
+  tron_unfreeze_verify_title: 'Descongelar TRON',
 }

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -1770,4 +1770,6 @@ export const ru = {
   trust_line_insufficient_xrp:
     'Недостаточно {{ticker}}. Для открытия этой доверительной линии требуется {{amount}} {{ticker}} для резервирования счета и комиссии.',
   swap_limit_payout_to: 'Выплата на',
+  tron_freeze_verify_title: 'Freeze TRON',
+  tron_unfreeze_verify_title: 'Разморозить TRON',
 }

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -1770,6 +1770,6 @@ export const ru = {
   trust_line_insufficient_xrp:
     'Недостаточно {{ticker}}. Для открытия этой доверительной линии требуется {{amount}} {{ticker}} для резервирования счета и комиссии.',
   swap_limit_payout_to: 'Выплата на',
-  tron_freeze_verify_title: 'Freeze TRON',
+  tron_freeze_verify_title: 'Заморозить TRON',
   tron_unfreeze_verify_title: 'Разморозить TRON',
 }

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -1643,4 +1643,6 @@ export const zh = {
   trust_line_insufficient_xrp:
     '{{ticker}}不足。开通此信任线需要{{amount}} {{ticker}}作为账户储备金和手续费。',
   swap_limit_payout_to: '支付至',
+  tron_freeze_verify_title: '冻结TRON',
+  tron_unfreeze_verify_title: '解冻TRON',
 }

--- a/core/ui/mpc/keysign/join/tx/JoinKeysignTxOverview.tsx
+++ b/core/ui/mpc/keysign/join/tx/JoinKeysignTxOverview.tsx
@@ -2,6 +2,7 @@ import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { useGetCoin } from '@core/ui/chain/coin/useGetCoin'
 import { BlockaidTxScan } from '@core/ui/chain/security/blockaid/tx/BlockaidTxScan'
 import { getRippleKeysignDisplay } from '@core/ui/chain/tx/getRippleKeysignDisplay'
+import { getTronStakingDisplay } from '@core/ui/chain/tx/getTronStakingDisplay'
 import { TxOverviewMemo } from '@core/ui/chain/tx/TxOverviewMemo'
 import { extractTokenAndAmount } from '@core/ui/chain/tx/utils/extractTokenAndAmount'
 import { formatTokenAmount } from '@core/ui/chain/tx/utils/formatTokenAmount'
@@ -26,6 +27,7 @@ import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/key
 import { isOneOf } from '@vultisig/lib-utils/array/isOneOf'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { capitalizeFirstLetter } from '@vultisig/lib-utils/capitalizeFirstLetter'
+import { match } from '@vultisig/lib-utils/match'
 import { assertField } from '@vultisig/lib-utils/record/assertField'
 import { useTranslation } from 'react-i18next'
 
@@ -125,6 +127,18 @@ export const JoinKeysignTxOverview = ({ value }: ValueProp<KeysignPayload>) => {
         })()
       : null
 
+  // A TRON freeze/unfreeze is signed as a staking contract, not a transfer, and
+  // carries its operation as an internal memo marker. Name the operation and
+  // show only the resource being staked, matching what the initiator displays.
+  const tronStaking = getTronStakingDisplay({ chain: coin.chain, memo })
+  const amountLabel = tronStaking
+    ? match(tronStaking.operation, {
+        freeze: () => t('tron_freeze_verify_title'),
+        unfreeze: () => t('tron_unfreeze_verify_title'),
+      })
+    : undefined
+  const memoValue = tronStaking ? tronStaking.resource : displayMemo
+
   const keysignPayloadQuery = getResolvedQuery(value)
 
   // Sui dApp signing carries a pre-built PTB with no transfer amount/recipient,
@@ -165,6 +179,7 @@ export const JoinKeysignTxOverview = ({ value }: ValueProp<KeysignPayload>) => {
         receiverVaultName={receiverVaultName ?? undefined}
         receiverAddressBookName={receiverAddressBookName ?? undefined}
         chain={coin.chain}
+        amountLabel={amountLabel}
         keysignPayloadQuery={keysignPayloadQuery}
         getPayloadAmount={
           wasmDisplay ? () => wasmDisplay.fundAmount : undefined
@@ -205,9 +220,9 @@ export const JoinKeysignTxOverview = ({ value }: ValueProp<KeysignPayload>) => {
             }
           />
         )}
-        {displayMemo && (
+        {memoValue && (
           <ListItem
-            title={<TxOverviewMemo value={displayMemo} chain={coin.chain} />}
+            title={<TxOverviewMemo value={memoValue} chain={coin.chain} />}
           />
         )}
         {destinationTag !== undefined && (

--- a/core/ui/mpc/keysign/join/tx/JoinKeysignTxOverview.tsx
+++ b/core/ui/mpc/keysign/join/tx/JoinKeysignTxOverview.tsx
@@ -2,7 +2,10 @@ import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { useGetCoin } from '@core/ui/chain/coin/useGetCoin'
 import { BlockaidTxScan } from '@core/ui/chain/security/blockaid/tx/BlockaidTxScan'
 import { getRippleKeysignDisplay } from '@core/ui/chain/tx/getRippleKeysignDisplay'
-import { getTronStakingDisplay } from '@core/ui/chain/tx/getTronStakingDisplay'
+import {
+  getTronStakingDisplay,
+  tronStakingTitleKey,
+} from '@core/ui/chain/tx/getTronStakingDisplay'
 import { TxOverviewMemo } from '@core/ui/chain/tx/TxOverviewMemo'
 import { extractTokenAndAmount } from '@core/ui/chain/tx/utils/extractTokenAndAmount'
 import { formatTokenAmount } from '@core/ui/chain/tx/utils/formatTokenAmount'
@@ -27,7 +30,6 @@ import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/key
 import { isOneOf } from '@vultisig/lib-utils/array/isOneOf'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { capitalizeFirstLetter } from '@vultisig/lib-utils/capitalizeFirstLetter'
-import { match } from '@vultisig/lib-utils/match'
 import { assertField } from '@vultisig/lib-utils/record/assertField'
 import { useTranslation } from 'react-i18next'
 
@@ -132,10 +134,7 @@ export const JoinKeysignTxOverview = ({ value }: ValueProp<KeysignPayload>) => {
   // show only the resource being staked, matching what the initiator displays.
   const tronStaking = getTronStakingDisplay({ chain: coin.chain, memo })
   const amountLabel = tronStaking
-    ? match(tronStaking.operation, {
-        freeze: () => t('tron_freeze_verify_title'),
-        unfreeze: () => t('tron_unfreeze_verify_title'),
-      })
+    ? t(tronStakingTitleKey[tronStaking.operation])
     : undefined
   const memoValue = tronStaking ? tronStaking.resource : displayMemo
 

--- a/core/ui/mpc/keysign/tx/KeysignTxOverview.tsx
+++ b/core/ui/mpc/keysign/tx/KeysignTxOverview.tsx
@@ -2,7 +2,10 @@ import { ChainEntityIcon } from '@core/ui/chain/coin/icon/ChainEntityIcon'
 import { getChainLogoSrc } from '@core/ui/chain/metadata/getChainLogoSrc'
 import { useTxHash } from '@core/ui/chain/state/txHash'
 import { getRippleKeysignDisplay } from '@core/ui/chain/tx/getRippleKeysignDisplay'
-import { getTronStakingDisplay } from '@core/ui/chain/tx/getTronStakingDisplay'
+import {
+  getTronStakingDisplay,
+  tronStakingTitleKey,
+} from '@core/ui/chain/tx/getTronStakingDisplay'
 import { TxOverviewMemo } from '@core/ui/chain/tx/TxOverviewMemo'
 import { useKeysignMessagePayload } from '@core/ui/mpc/keysign/state/keysignMessagePayload'
 import { TxOverviewAmount } from '@core/ui/mpc/keysign/tx/TxOverviewAmount'
@@ -68,8 +71,9 @@ export const KeysignTxOverview = ({
       : null
 
   // A TRON freeze/unfreeze carries its operation as an internal memo marker
-  // that the signer turns into a staking contract, so surface the staked
-  // resource instead of the raw marker — the memo never reaches the chain.
+  // that the signer turns into a staking contract, so name the operation and
+  // surface the staked resource instead of reporting a send with a raw marker
+  // for a memo the chain never sees.
   const tronStaking = getTronStakingDisplay({ chain, memo })
   const memoValue = tronStaking ? tronStaking.resource : memo
 
@@ -124,6 +128,11 @@ export const KeysignTxOverview = ({
           value={displayCoin}
           actionLabel={
             txAction?.action !== 'send' ? txAction?.labelKey : undefined
+          }
+          resolvedLabel={
+            tronStaking
+              ? t(tronStakingTitleKey[tronStaking.operation])
+              : undefined
           }
         />
       )}

--- a/core/ui/mpc/keysign/tx/KeysignTxOverview.tsx
+++ b/core/ui/mpc/keysign/tx/KeysignTxOverview.tsx
@@ -2,6 +2,7 @@ import { ChainEntityIcon } from '@core/ui/chain/coin/icon/ChainEntityIcon'
 import { getChainLogoSrc } from '@core/ui/chain/metadata/getChainLogoSrc'
 import { useTxHash } from '@core/ui/chain/state/txHash'
 import { getRippleKeysignDisplay } from '@core/ui/chain/tx/getRippleKeysignDisplay'
+import { getTronStakingDisplay } from '@core/ui/chain/tx/getTronStakingDisplay'
 import { TxOverviewMemo } from '@core/ui/chain/tx/TxOverviewMemo'
 import { useKeysignMessagePayload } from '@core/ui/mpc/keysign/state/keysignMessagePayload'
 import { TxOverviewAmount } from '@core/ui/mpc/keysign/tx/TxOverviewAmount'
@@ -65,6 +66,12 @@ export const KeysignTxOverview = ({
     : toAmount
       ? fromChainAmount(BigInt(toAmount), displayCoin.decimals)
       : null
+
+  // A TRON freeze/unfreeze carries its operation as an internal memo marker
+  // that the signer turns into a staking contract, so surface the staked
+  // resource instead of the raw marker — the memo never reaches the chain.
+  const tronStaking = getTronStakingDisplay({ chain, memo })
+  const memoValue = tronStaking ? tronStaking.resource : memo
 
   const txAction = getSignDataTxAction(keysignPayload, formattedToAmount ?? 0)
 
@@ -188,7 +195,7 @@ export const KeysignTxOverview = ({
               </HStack>
             </VStack>
           )}
-          {memo && <TxOverviewMemo value={memo} chain={chain} />}
+          {memoValue && <TxOverviewMemo value={memoValue} chain={chain} />}
           {destinationTag !== undefined && (
             <HStack justifyContent="space-between">
               <Text color="shy" weight="500">

--- a/core/ui/mpc/keysign/tx/TxSuccess.tsx
+++ b/core/ui/mpc/keysign/tx/TxSuccess.tsx
@@ -1,6 +1,10 @@
 import { useAssertWalletCore } from '@core/ui/chain/providers/WalletCoreProvider'
 import { hasBlockaidEvmChangesForSummary } from '@core/ui/chain/security/blockaid/tx/blockaidEvmSimulationNormalize'
 import { useBlockaidPayloadSimulationQuery } from '@core/ui/chain/security/blockaid/tx/queries/blockaidPayloadSimulation'
+import {
+  getTronStakingDisplay,
+  tronStakingTitleKey,
+} from '@core/ui/chain/tx/getTronStakingDisplay'
 import { extractApprovalCounterparty } from '@core/ui/chain/tx/utils/extractApprovalCounterparty'
 import { extractTokenAndAmount } from '@core/ui/chain/tx/utils/extractTokenAndAmount'
 import { formatLabeledEvmAddress } from '@core/ui/chain/tx/utils/formatLabeledEvmAddress'
@@ -103,11 +107,17 @@ export const TxSuccess = ({
     staleTime: Infinity,
   })
 
+  // A TRON freeze/unfreeze is signed as a staking contract, so name the
+  // operation rather than reporting the staked amount as sent.
+  const tronStaking = getTronStakingDisplay({ chain: coin.chain, memo })
+
   const rawFunctionName =
     functionQuery.data?.functionSignature?.split('(')[0] ?? undefined
-  const resolvedLabel = rawFunctionName
-    ? capitalizeFirstLetter(rawFunctionName)
-    : undefined
+  const resolvedLabel = tronStaking
+    ? t(tronStakingTitleKey[tronStaking.operation])
+    : rawFunctionName
+      ? capitalizeFirstLetter(rawFunctionName)
+      : undefined
 
   const resolvedToken = useMemo(() => {
     if (!functionQuery.data) return null

--- a/core/ui/mpc/keysign/verify/VerifyTransactionOverview.tsx
+++ b/core/ui/mpc/keysign/verify/VerifyTransactionOverview.tsx
@@ -48,6 +48,12 @@ type VerifyTransactionOverviewProps = {
    */
   receiverAddressLabel?: string
   chain: Chain
+  /**
+   * Heading above the amount. Defaults to "You're sending"; operations that are
+   * not a plain transfer (e.g. a TRON freeze) name themselves instead, so both
+   * devices in a keysign session frame the transaction the same way.
+   */
+  amountLabel?: ReactNode
   keysignPayloadQuery: Query<KeysignPayload>
   /**
    * Overrides how the signed amount is read from the payload. Wasm contract
@@ -69,6 +75,7 @@ export const VerifyTransactionOverview = ({
   receiverAddressBookName,
   receiverAddressLabel,
   chain,
+  amountLabel,
   keysignPayloadQuery,
   getPayloadAmount,
   renderFeeExtra,
@@ -102,7 +109,7 @@ export const VerifyTransactionOverview = ({
   return (
     <List border="gradient" radius={16}>
       <TransactionOverviewAmount
-        label={t('you_are_sending')}
+        label={amountLabel ?? t('you_are_sending')}
         coin={coin}
         fallbackAmount={formattedAmount}
         keysignPayloadQuery={keysignPayloadQuery}

--- a/core/ui/vault/deposit/DepositVerify/index.tsx
+++ b/core/ui/vault/deposit/DepositVerify/index.tsx
@@ -1,3 +1,4 @@
+import { getTronStakingDisplay } from '@core/ui/chain/tx/getTronStakingDisplay'
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { DepositConfirmButton } from '@core/ui/vault/deposit/DepositConfirmButton'
 import { getFormattedFormData } from '@core/ui/vault/deposit/DepositVerify/utils'
@@ -35,6 +36,14 @@ export const DepositVerify = ({ onBack }: OnBackProp) => {
     selectedChainAction,
     coin
   )
+
+  // A TRON freeze/unfreeze memo is an internal marker for the staking contract
+  // and never reaches the chain, so show the staked resource the way the other
+  // signing device does instead of the raw `FREEZE:<resource>` marker.
+  const tronStaking = getTronStakingDisplay({ chain: coin.chain, memo })
+  const displayMemo = tronStaking
+    ? tronStaking.resource
+    : formattedDepositFormData['memo']
 
   const sender = useSender()
   const { t } = useTranslation()
@@ -118,11 +127,8 @@ export const DepositVerify = ({ onBack }: OnBackProp) => {
               title={t('trust_line_issuer')}
             />
           )}
-          {Boolean(formattedDepositFormData['memo']) && (
-            <ListItem
-              description={String(formattedDepositFormData['memo'])}
-              title={t('memo')}
-            />
+          {Boolean(displayMemo) && (
+            <ListItem description={String(displayMemo)} title={t('memo')} />
           )}
           <ListItem description={<DepositFee />} title={t('est_network_fee')} />
         </List>


### PR DESCRIPTION
Closes #4363

## Problem

TRON Stake 2.0 rides through the regular transfer payload and carries its operation only as an internal `FREEZE:<resource>` / `UNFREEZE:<resource>` memo, which the signer turns into a `FreezeBalanceV2` / `UnfreezeBalanceV2` contract — the memo itself never reaches the chain.

We rendered that marker as a plain memo and headed the amount with "You're sending", so a device joining a freeze started on another platform described a stake as a transfer (`FREEZE:BANDWIDTH` in the Memo row), while the initiating device showed `Freeze TRON` and just the staked resource.

## Change

`getTronStakingDisplay` recognizes the marker — mirroring the signer's dispatch (memo prefix plus a valid resource), so the screen can never describe something other than what gets signed — and the verify surfaces use it to:

- head the amount with `Freeze TRON` / `Unfreeze TRON` instead of `You're sending`
- show the staked resource (`BANDWIDTH` / `ENERGY`) in place of the raw marker

Applied to the join verify, the keysign overview and our own deposit verify, so both directions match (whether we start the freeze or join one).

| | Before (joined device) | After |
|---|---|---|
| Amount heading | `You're sending` | `Freeze TRON` |
| Memo | `FREEZE:BANDWIDTH` | `BANDWIDTH` |

## Not covered here

The **est. network fee** difference reported in the issue (`1 TRX` vs `0.8 TRX`) is not a rendering bug on our side — we display the fee the signed payload actually carries (`tronSpecific.gasEstimation`, which the initiator sets to 800 000 sun for a native TRX transaction). The initiator's own row is computed separately and adds a 1 TRX memo fee for the staking marker, even though that marker is not part of the signed freeze transaction. That one needs a fix on the initiating platform, so I left our fee logic alone rather than inventing a number that matches neither the payload nor the chain.

## Testing

- 14 unit tests for the memo matcher (valid pairs, malformed/lowercase/prefixed memos, other chains)
- `yarn check` and `yarn test` clean
- Translations propagated with `yarn translate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear TRON staking details for freeze and unfreeze transactions.
  * Displays the staked resource instead of technical memo markers across transaction reviews and deposit verification.
  * Added localized verification labels for TRON staking actions in supported languages.

* **Bug Fixes**
  * Prevents malformed, unsupported, or non-TRON memos from being incorrectly identified as staking actions.

* **Tests**
  * Added coverage for valid, invalid, unsupported, and cross-chain TRON staking memos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->