### PR TITLE
chore: add jsdoc rule for agent edits

### DIFF
--- a/.claude/rules/jsdoc.md
+++ b/.claude/rules/jsdoc.md
@@ -1,0 +1,25 @@
+# JSDoc on Exports
+
+Every exported function, class, and type definition gets a `/** ... */` comment immediately before its declaration.
+
+## When editing existing files
+
+If an export you are adding or touching lacks JSDoc, add it as part of the change — do not leave it for review to catch.
+
+## Style
+
+- One or two sentences on purpose and behavior, not implementation
+- Call out non-obvious constraints, invariants, or side effects
+- Skip `@param`/`@returns` lists that only restate the types
+- Do not restate the export's name
+
+## Example
+
+```typescript
+/**
+ * Computes the navigation history the extension should open with.
+ * With no vaults in storage, persisted history is ignored so the
+ * user always lands on the splash.
+ */
+export const resolveInitialHistory = (input: ResolveInitialHistoryInput) => { ... }
+```


### PR DESCRIPTION
## Description

Adds `.claude/rules/jsdoc.md` so the JSDoc-on-exports convention surfaces during agent edits instead of only as a bullet in CLAUDE.md. Prompted by a CodeRabbit nit on #4530 where an exported function was refactored without getting a doc comment.

Tooling-only change, no app code affected.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: none
- **Confidence**: high
- **Needs human review for**: none