### PR TITLE
fix(vault): place Function before Receive in primary actions row

### DIFF
--- a/core/ui/vault/components/VaultPrimaryActions/index.tsx
+++ b/core/ui/vault/components/VaultPrimaryActions/index.tsx
@@ -58,8 +58,8 @@ export const VaultPrimaryActions = ({
       {swapCoin && <SwapPrompt fromCoin={swapCoin} />}
       <SendPrompt coin={sendCoin} />
       {buyCoin && <BuyPrompt coin={buyCoin} />}
-      {onReceive && <ReceivePrompt onClick={onReceive} />}
       {showDepositAction && depositCoin && <DepositPrompt coin={depositCoin} />}
+      {onReceive && <ReceivePrompt onClick={onReceive} />}
     </ActionsWrapper>
   )
 }


### PR DESCRIPTION
Closes #4538

## Problem

In the primary actions row, the **Function** item (the `deposit` action) rendered as the **last** item, after `Receive`:

`Swap → Send → Buy → Receive → Function`

The row is shared by the chain overview, the coin detail modal, and the vault overview, so the wrong position showed up on every one of those screens.

## Fix

Moved `DepositPrompt` above `ReceivePrompt` in `VaultPrimaryActions`:

`Swap → Send → Buy → Function → Receive`

This matches the order iOS builds in `Chain.defaultActions` ([Coin+ChainAction.swift](https://github.com/vultisig/vultisig-ios/blob/main/VultisigApp/VultisigApp/Core/Services/Actions/Coin%2BChainAction.swift)) — `swap`, `send`, `buy`, `memo` (labelled "Function"), `receive` — so desktop/extension is now at parity with native.

## Scope

JSX order only, per the issue's constraints:

- No changes to the conditions that decide whether an action is shown
- No new props, no per-screen ordering overrides
- No refactor beyond the reorder

Because each action stays conditionally rendered in place, all three consumers — `VaultChainOverview`, `CoinDetailModal`, and `VaultOverviewPrimaryActions` (which hides Function via `showDepositAction={false}`) — pick up the corrected order automatically, and the relative order holds when Swap / Buy / Function are hidden for unsupported chains. Spacing is unaffected: `ActionsWrapper` is a centered flex row with a fixed `gap`, so it has no position-dependent styling.

## Verification

- `yarn check:all` passes (lint, typecheck, knip, 1334 tests across 176 files, Go tests)
- The extension e2e send-flow spec locates the Send action by its text label rather than by index, so it is unaffected by the reorder

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reordered the vault action buttons so **Deposit** appears before **Receive**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->