### PR TITLE
fix(backup): stop the back button from bouncing single-vault users

### DIFF
--- a/core/ui/vault/backup/select/SelectVaultsBackupPage.tsx
+++ b/core/ui/vault/backup/select/SelectVaultsBackupPage.tsx
@@ -25,7 +25,7 @@ export const SelectVaultsBackupPage = () => {
 
   useEffect(() => {
     if (!hasMultipleVaults) {
-      navigate({ id: 'vaultBackup' })
+      navigate({ id: 'vaultBackup' }, { replace: true })
     }
   }, [hasMultipleVaults, navigate])
 


### PR DESCRIPTION
Fixes #4535

## Problem

On the "Do you want to encrypt your backup with a password?" screen (`vaultBackup`), the header back arrow did nothing for users with a **single vault** — the screen stayed exactly where it was.

The button itself was wired correctly. `SelectVaultsBackupPage` auto-redirects single-vault users forward with a **push**:

```tsx
useEffect(() => {
  if (!hasMultipleVaults) {
    navigate({ id: 'vaultBackup' })   // push, not replace
  }
}, [hasMultipleVaults, navigate])
```

So the history was `[…, vaultSettings, selectVaultsBackup, vaultBackup]`. `PageHeaderBackButton` falls back to `goBack` (`usePopNavigationHistory(1)`), which popped to `selectVaultsBackup` — whose effect immediately pushed `vaultBackup` again. The re-render is instant, so the button read as dead, and every press grew the history stack by one entry.

Introduced in 23f085aae ("Backup all vaults flow", #2590).

## Fix

One line — make the auto-redirect a replace:

```tsx
navigate({ id: 'vaultBackup' }, { replace: true })
```

`useNavigate` already supports `{ replace: true }`. The single-vault history collapses to `[…, vaultSettings, vaultBackup]`, so `goBack` lands on Vault Settings, and the intermediate select screen — which single-vault users never actually see — no longer sits in the stack waiting to bounce them forward.

As a side benefit this also makes the redirect idempotent under React StrictMode's double-invoked effects, where the push variant appended two entries.

## Why the multi-vault flow is unaffected

The effect only fires when `!hasMultipleVaults`, so with 2+ vaults nothing about the navigation changes:

- **"This vault only"** → `OptionContainer` pushes `vaultBackup`; back pops to `selectVaultsBackup`, which renders normally.
- **"All vaults"** → `VaultsBackupPage` passes an explicit `onBack` that navigates to `selectVaultsBackup`; untouched.

## Desktop + extension

Both clients render the same `core/ui` page and wire `goBack` to the same `useNavigateBack` ([clients/desktop/src/App.tsx#L62](clients/desktop/src/App.tsx#L62), [clients/extension/src/pages/index.tsx#L60](clients/extension/src/pages/index.tsx#L60)), so the fix applies identically to both by construction.

## Verification

- `yarn check:all` passes (exit 0) — typecheck, lint, knip, i18n integrity, jscpd, markdownlint, Go tests, and 1334 JS tests across 176 files.
- Navigation reasoning traced against `useNavigate` (`updateAtIndex` on the last entry for `replace`) and `usePopNavigationHistory` (`slice(0, -1)`).
- **Not manually exercised in a running app** — reproducing needs a profile with exactly one vault; worth a quick click-through by a reviewer who has one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved navigation when only one vault exists by preventing an unnecessary back-navigation step after redirecting to vault backup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->