### PR TITLE
fix(dapp): return 4001 UserRejectedRequest when the user rejects

### DIFF
--- a/core/inpage-provider/popup/error.ts
+++ b/core/inpage-provider/popup/error.ts
@@ -1,3 +1,16 @@
 export enum PopupError {
   RejectedByUser = 'rejectedByUser',
 }
+
+/**
+ * Result a popup view finishes with when the user declines the request.
+ *
+ * The sentinel has to stay a plain string: popup responses cross
+ * `chrome.runtime` messaging, which serializes them, so an `Error` instance
+ * arrives as a bare object that no consumer recognises as a rejection —
+ * dApps then see EIP-1193 `-32603 Internal error` instead of
+ * `4001 UserRejectedRequest`.
+ */
+export const userRejectedPopupResult = {
+  error: PopupError.RejectedByUser,
+} as const

--- a/core/inpage-provider/popup/resolvers/background/index.test.ts
+++ b/core/inpage-provider/popup/resolvers/background/index.test.ts
@@ -12,6 +12,8 @@ vi.mock('./inNewWindow', () => ({
   inNewWindow: (...args: unknown[]) => mockInNewWindow(...args),
 }))
 
+import { PopupError, userRejectedPopupResult } from '../../error'
+import { getPopupMessageSourceId } from '../../resolver'
 import { callPopupFromBackground } from '.'
 
 describe('callPopupFromBackground', () => {
@@ -97,5 +99,56 @@ describe('callPopupFromBackground', () => {
     ])
 
     expect(mockInNewWindow).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects with the RejectedByUser sentinel when the popup view declines', async () => {
+    const listeners = new Set<(message: unknown) => void>()
+    vi.stubGlobal('chrome', {
+      runtime: {
+        getURL: (path: string) => `chrome-extension://id/${path}`,
+        onMessage: {
+          addListener: (listener: (message: unknown) => void) =>
+            listeners.add(listener),
+          removeListener: (listener: (message: unknown) => void) =>
+            listeners.delete(listener),
+        },
+      },
+    })
+    type ExecuteWindow = {
+      execute: (input: {
+        abortSignal: AbortSignal
+        close: () => void
+      }) => Promise<unknown>
+    }
+    mockInNewWindow.mockImplementation(({ execute }: ExecuteWindow) =>
+      execute({
+        abortSignal: new AbortController().signal,
+        close: () => undefined,
+      })
+    )
+
+    const call = callPopupFromBackground({
+      call: { grantVaultAccess: { chain: Chain.Ethereum } },
+      options: {},
+      context: { requestOrigin: 'https://reject.example.com' },
+    })
+
+    await vi.waitFor(() => {
+      expect(listeners.size).toBe(1)
+    })
+
+    // chrome.runtime messaging serializes the response, so anything the view
+    // sends has to survive the trip — an `Error` instance would not.
+    const response = JSON.parse(
+      JSON.stringify({
+        sourceId: getPopupMessageSourceId('popup'),
+        callId: 'call-1',
+        result: userRejectedPopupResult,
+        shouldClosePopup: true,
+      })
+    )
+    listeners.forEach(listener => listener(response))
+
+    await expect(call).rejects.toBe(PopupError.RejectedByUser)
   })
 })

--- a/core/inpage-provider/popup/view/resolvers/grantVaultAccess/index.tsx
+++ b/core/inpage-provider/popup/view/resolvers/grantVaultAccess/index.tsx
@@ -1,5 +1,6 @@
 import { getAppSessionFieldsForApprovedChains } from '@core/extension/storage/appSessionChainAuthorization'
 import { useSetExclusiveVaultAppSessionMutation } from '@core/extension/storage/hooks/appSessions'
+import { userRejectedPopupResult } from '@core/inpage-provider/popup/error'
 import { PopupResolver } from '@core/inpage-provider/popup/view/resolver'
 import { BlockaidNoScanStatus } from '@core/ui/chain/security/blockaid/scan/BlockaidNoScanStatus'
 import { BlockaidScanning } from '@core/ui/chain/security/blockaid/scan/BlockaidScanning'
@@ -201,7 +202,7 @@ export const GrantVaultAccess: PopupResolver<'grantVaultAccess'> = ({
 
   const handleReject = () => {
     onFinish({
-      result: { error: new Error('User rejected the request') },
+      result: userRejectedPopupResult,
       shouldClosePopup: true,
     })
   }

--- a/core/inpage-provider/popup/view/resolvers/suggestKeplrChain/index.tsx
+++ b/core/inpage-provider/popup/view/resolvers/suggestKeplrChain/index.tsx
@@ -1,3 +1,4 @@
+import { userRejectedPopupResult } from '@core/inpage-provider/popup/error'
 import { PopupResolver } from '@core/inpage-provider/popup/view/resolver'
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { Button } from '@lib/ui/buttons/Button'
@@ -25,7 +26,7 @@ export const SuggestKeplrChain: PopupResolver<'suggestKeplrChain'> = ({
 
   const handleReject = () => {
     onFinish({
-      result: { error: new Error('User rejected the request') },
+      result: userRejectedPopupResult,
       shouldClosePopup: true,
     })
   }

--- a/core/inpage-provider/popup/view/resolvers/watchAsset/index.tsx
+++ b/core/inpage-provider/popup/view/resolvers/watchAsset/index.tsx
@@ -1,3 +1,4 @@
+import { userRejectedPopupResult } from '@core/inpage-provider/popup/error'
 import { PopupResolver } from '@core/inpage-provider/popup/view/resolver'
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
@@ -41,7 +42,7 @@ export const WatchAsset: PopupResolver<'watchAsset'> = ({
 
   const handleReject = () => {
     onFinish({
-      result: { error: new Error('User rejected the request') },
+      result: userRejectedPopupResult,
       shouldClosePopup: true,
     })
   }


### PR DESCRIPTION
Fixes #4564

When you click Reject on a dApp connect prompt, the dApp got `-32603 Internal error` instead of `4001 UserRejectedRequest`. Closing the same popup with X gave 4001, so the two reject paths did not agree.

The popup rejected with `new Error('User rejected the request')`. That crosses chrome.runtime messaging, which serializes it, so consumers got a bare object. `requestAccount.ts` compares against the `PopupError.RejectedByUser` string, never matched, and fell through to InternalError.

Now the popup views finish with a shared `userRejectedPopupResult` built on that string. It survives the trip and every consumer already understands it.

Same fix applied to `wallet_watchAsset` and `suggestKeplrChain`, which had the same bug.

What changes for dApps:
- connect reject (EVM, Solana, Cosmos, UTXO): -32603 -> 4001
- wallet_watchAsset reject: -32603 -> 4001
- keplr suggestChain reject: now throws the intended "Request rejected by user"

Test: added a case in `popup/resolvers/background/index.test.ts` that sends the rejection through the real message listener with a serialization round trip.

`yarn check` and the full unit suite pass (774 tests). The e2e spec `dapp-provider.spec.ts:333` needs a built extension and the vault fixture, so I did not run it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized handling of user-rejected popup requests.
  - Popup-based actions now consistently report when a request is declined.
  - Improved rejection behavior across vault access, chain suggestions, and asset-watching prompts.

- **Tests**
  - Added coverage confirming rejected popup responses are correctly propagated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->