### PR TITLE
Fix compounded sTCY fiat valuation

### DIFF
--- a/core/ui/defi/chain/queries/services/thorchainStake/stcyStakeService.test.ts
+++ b/core/ui/defi/chain/queries/services/thorchainStake/stcyStakeService.test.ts
@@ -1,0 +1,113 @@
+import { cosmosRpcUrl } from '@vultisig/core-chain/chains/cosmos/cosmosRpcUrl'
+import { tcyAutoCompounderConfig } from '@vultisig/core-chain/chains/cosmos/thor/tcy-autocompound/config'
+import { coinKeyToString } from '@vultisig/core-chain/coin/Coin'
+import { queryUrl } from '@vultisig/lib-utils/query/queryUrl'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { thorchainTokens } from '../../tokens'
+import { fetchStcyStakePosition } from './stcyStakeService'
+
+vi.mock('@vultisig/lib-utils/query/queryUrl', () => ({
+  queryUrl: vi.fn(),
+}))
+
+const address = 'thor1holder'
+const bankApiBase = `${cosmosRpcUrl.THORChain}/cosmos/bank/v1beta1`
+const userBalanceUrl = `${bankApiBase}/balances/${address}/by_denom?denom=${encodeURIComponent(tcyAutoCompounderConfig.shareDenom)}`
+const vaultBalanceUrl = `${bankApiBase}/balances/${tcyAutoCompounderConfig.contract}/by_denom?denom=${encodeURIComponent(tcyAutoCompounderConfig.depositDenom)}`
+const supplyUrl = `${bankApiBase}/supply/by_denom?denom=${encodeURIComponent(tcyAutoCompounderConfig.shareDenom)}`
+const tcyPriceKey = coinKeyToString(thorchainTokens.tcy)
+const stcyPriceKey = coinKeyToString(thorchainTokens.stcy)
+
+const mockBalances = ({
+  shares = '116484502',
+  vaultBalance = '830427161000000',
+  shareSupply = '737370434000000',
+}: {
+  shares?: string
+  vaultBalance?: string
+  shareSupply?: string
+} = {}) => {
+  vi.mocked(queryUrl).mockImplementation(url => {
+    if (url === userBalanceUrl) {
+      return Promise.resolve({ balance: { amount: shares } })
+    }
+    if (url === vaultBalanceUrl) {
+      return Promise.resolve({ balance: { amount: vaultBalance } })
+    }
+    if (url === supplyUrl) {
+      return Promise.resolve({ amount: { amount: shareSupply } })
+    }
+
+    return Promise.reject(new Error(`Unexpected query: ${url}`))
+  })
+}
+
+const fetchPosition = () =>
+  fetchStcyStakePosition({
+    address,
+    prices: {
+      [tcyPriceKey]: 0.13977412,
+      [stcyPriceKey]: 999,
+    },
+  })
+
+describe('fetchStcyStakePosition', () => {
+  beforeEach(() => {
+    vi.mocked(queryUrl).mockReset()
+  })
+
+  it('values sTCY shares by their live underlying TCY without changing the share amount', async () => {
+    mockBalances()
+
+    const position = await fetchPosition()
+
+    expect(position?.amount).toBe(116484502n)
+    expect(position?.fiatValue).toBeCloseTo(0.183362591, 9)
+    expect(queryUrl).toHaveBeenCalledWith(vaultBalanceUrl)
+    expect(queryUrl).toHaveBeenCalledWith(supplyUrl)
+  })
+
+  it('returns zero fiat for a zero supply instead of dividing by zero or valuing shares 1:1', async () => {
+    mockBalances({ shareSupply: '0' })
+
+    const position = await fetchPosition()
+
+    expect(position?.amount).toBe(116484502n)
+    expect(position?.fiatValue).toBe(0)
+  })
+
+  it('keeps the share position visible when a redemption-rate query fails', async () => {
+    mockBalances()
+    vi.mocked(queryUrl).mockImplementation(url => {
+      if (url === userBalanceUrl) {
+        return Promise.resolve({ balance: { amount: '116484502' } })
+      }
+
+      return Promise.reject(new Error('THORChain RPC unavailable'))
+    })
+
+    const position = await fetchPosition()
+
+    expect(position?.amount).toBe(116484502n)
+    expect(position?.fiatValue).toBe(0)
+  })
+
+  it('skips redemption-rate queries for an empty share balance', async () => {
+    mockBalances({ shares: '0' })
+
+    const position = await fetchPosition()
+
+    expect(position?.amount).toBe(0n)
+    expect(position?.fiatValue).toBe(0)
+    expect(queryUrl).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns null when the user share balance cannot be read', async () => {
+    vi.mocked(queryUrl).mockRejectedValue(
+      new Error('THORChain RPC unavailable')
+    )
+
+    await expect(fetchPosition()).resolves.toBeNull()
+  })
+})

--- a/core/ui/defi/chain/queries/services/thorchainStake/stcyStakeService.ts
+++ b/core/ui/defi/chain/queries/services/thorchainStake/stcyStakeService.ts
@@ -8,6 +8,40 @@ import { thorchainTokens } from '../../tokens'
 import { ThorchainStakePosition } from '../../types'
 import { parseBigint } from '../../utils/parsers'
 
+const bankApiBase = `${cosmosRpcUrl.THORChain}/cosmos/bank/v1beta1`
+
+type BankBalanceResponse = {
+  balance?: { amount?: string }
+}
+
+type BankSupplyResponse = {
+  amount?: { amount?: string }
+}
+
+const getBalanceByDenom = (address: string, denom: string) =>
+  queryUrl<BankBalanceResponse>(
+    `${bankApiBase}/balances/${address}/by_denom?denom=${encodeURIComponent(denom)}`
+  )
+
+const getSupplyByDenom = (denom: string) =>
+  queryUrl<BankSupplyResponse>(
+    `${bankApiBase}/supply/by_denom?denom=${encodeURIComponent(denom)}`
+  )
+
+const getUnderlyingTcyAmount = ({
+  shares,
+  vaultBalance,
+  shareSupply,
+}: {
+  shares: bigint
+  vaultBalance: bigint
+  shareSupply: bigint
+}) => {
+  if (shares <= 0n || vaultBalance <= 0n || shareSupply <= 0n) return 0n
+
+  return (shares * vaultBalance) / shareSupply
+}
+
 type FetchStcyStakePositionInput = {
   address: string
   prices: Record<string, number>
@@ -18,15 +52,38 @@ export const fetchStcyStakePosition = async ({
   prices,
 }: FetchStcyStakePositionInput): Promise<ThorchainStakePosition | null> => {
   try {
-    const denom = encodeURIComponent(tcyAutoCompounderConfig.shareDenom)
-    const balance = await queryUrl<{ balance?: { amount?: string } }>(
-      `${cosmosRpcUrl.THORChain}/cosmos/bank/v1beta1/balances/${address}/by_denom?denom=${denom}`
+    const balance = await getBalanceByDenom(
+      address,
+      tcyAutoCompounderConfig.shareDenom
     )
     const amount = parseBigint(balance?.balance?.amount)
-    const price = prices[coinKeyToString(thorchainTokens.stcy)] ?? 0
+
+    let underlyingTcyAmount = 0n
+    if (amount > 0n) {
+      try {
+        const [vaultBalance, supply] = await Promise.all([
+          getBalanceByDenom(
+            tcyAutoCompounderConfig.contract,
+            tcyAutoCompounderConfig.depositDenom
+          ),
+          getSupplyByDenom(tcyAutoCompounderConfig.shareDenom),
+        ])
+
+        underlyingTcyAmount = getUnderlyingTcyAmount({
+          shares: amount,
+          vaultBalance: parseBigint(vaultBalance?.balance?.amount),
+          shareSupply: parseBigint(supply?.amount?.amount),
+        })
+      } catch {
+        // Keep the share position visible, but do not silently fall back to the
+        // known-wrong 1:1 valuation when the live redemption rate is missing.
+      }
+    }
+
+    const price = prices[coinKeyToString(thorchainTokens.tcy)] ?? 0
     const fiatValue = getCoinValue({
-      amount,
-      decimals: thorchainTokens.stcy.decimals,
+      amount: underlyingTcyAmount,
+      decimals: tcyAutoCompounderConfig.depositDecimals,
       price,
     })
 


### PR DESCRIPTION
sTCY fiat valuation now uses the live THORChain compounder vault-to-supply redemption rate while preserving the displayed share amount. Live RPC QA confirmed that 57617412014 shares resolve to 64924458857 underlying TCY base units for the verified holder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved staked position valuation using live redemption rates and vault data.
  * Displays more accurate underlying asset amounts and fiat values.

* **Bug Fixes**
  * Positions remain visible when conversion data is unavailable, with the underlying amount shown as zero instead of using an inaccurate one-to-one estimate.
  * Improved handling of empty, unreadable, or failed balance data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->