### PR TITLE
fix(send): adjust a typed amount to balance − fee instead of dead-ending on "Insufficient balance"

### DIFF
--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -1851,4 +1851,6 @@ export const de = {
   price_range: 'Preisspanne',
   token_info: 'Token-Info',
   volume_24h: '24h-Volumen',
+  send_amount_adjusted_for_fee:
+    'Der Betrag wurde auf {{amount}} angepasst, um die Netzwerkgebühr zu decken.',
 }

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -1033,6 +1033,8 @@ export const en = {
     'Choose whether to back up just this vault or all vaults in your app.',
   send: 'Send',
   sends: 'Sends',
+  send_amount_adjusted_for_fee:
+    'Amount adjusted to {{amount}} to cover the network fee',
   send_amount_exceeds_balance: 'Amount exceeds balance',
   send_invalid_receiver_address: 'Wrong address for selected chain',
   send_invalid_receiver_address_with_hint: '{{error}}. {{hint}}',

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -1835,4 +1835,6 @@ export const es = {
   price_range: 'Rango de precios',
   token_info: 'Información del token',
   volume_24h: 'Volumen 24h',
+  send_amount_adjusted_for_fee:
+    'Importe ajustado a {{amount}} para cubrir la comisión de red.',
 }

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -1807,4 +1807,6 @@ export const hr = {
   price_range: 'Raspon cijena',
   token_info: 'Informacije o tokenu',
   volume_24h: '24h volumen',
+  send_amount_adjusted_for_fee:
+    'Iznos prilagođen na {{amount}} za pokrivanje mrežne naknade',
 }

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -1841,4 +1841,6 @@ export const it = {
   price_range: 'Intervallo di prezzo',
   token_info: 'Informazioni sul token',
   volume_24h: 'Volume 24h',
+  send_amount_adjusted_for_fee:
+    'Importo modificato in {{amount}} per coprire la commissione di rete',
 }

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -1797,4 +1797,6 @@ export const ko = {
   price_range: '가격 범위',
   token_info: '토큰 정보',
   volume_24h: '24시간 거래량',
+  send_amount_adjusted_for_fee:
+    '네트워크 수수료를 충당하기 위해 금액이 {{amount}}(으)로 조정되었습니다',
 }

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -1819,4 +1819,6 @@ export const nl = {
   price_range: 'Prijsbereik',
   token_info: 'Tokeninformatie',
   volume_24h: '24u volume',
+  send_amount_adjusted_for_fee:
+    'Het bedrag is aangepast naar {{amount}} om de netwerkkosten te dekken.',
 }

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -1838,4 +1838,6 @@ export const pt = {
   price_range: 'Faixa de preço',
   token_info: 'Informações do token',
   volume_24h: 'Volume 24h',
+  send_amount_adjusted_for_fee:
+    'Valor ajustado para {{amount}} para cobrir a taxa de rede.',
 }

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -1815,4 +1815,6 @@ export const ru = {
   price_range: 'Ценовой диапазон',
   token_info: 'Информация о токене',
   volume_24h: 'Объём за 24 ч',
+  send_amount_adjusted_for_fee:
+    'Сумма изменена на {{amount}}, чтобы покрыть комиссию сети',
 }

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -1687,4 +1687,5 @@ export const zh = {
   price_range: '价格区间',
   token_info: '代币信息',
   volume_24h: '24小时交易量',
+  send_amount_adjusted_for_fee: '金额已调整为 {{amount}}，以支付网络费用',
 }

--- a/core/ui/vault/send/amount/ManageAmountInputField.tsx
+++ b/core/ui/vault/send/amount/ManageAmountInputField.tsx
@@ -33,6 +33,7 @@ import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { multiplyBigInt } from '@vultisig/lib-utils/bigint/bigIntMultiplyByNumber'
 import { formatAmount } from '@vultisig/lib-utils/formatAmount'
 import { minBigInt } from '@vultisig/lib-utils/math/minBigInt'
+import { isRecordEmpty } from '@vultisig/lib-utils/record/isRecordEmpty'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -103,10 +104,15 @@ export const ManageAmountInputField = () => {
 
   // Announced while the field still holds the typed amount — the write itself
   // happens on submit — so the user learns what will be sent before committing
-  // to it rather than being surprised on Verify.
+  // to it rather than being surprised on Verify. Held back until the whole form
+  // is clean, not just the amount: the fee this number is derived from is
+  // estimated for the current receiver, so an invalid address leaves a stale
+  // one behind. Pending validation still shows it, or it would flicker on every
+  // keystroke.
   const spendableAmount = useSpendableSendAmount()
+  const isFormClean = data === undefined || isRecordEmpty(data)
   const adjustedAmount =
-    spendableAmount !== null && spendableAmount !== value
+    isFormClean && spendableAmount !== null && spendableAmount !== value
       ? formatAmount(fromChainAmount(spendableAmount, coin.decimals), coin)
       : null
 
@@ -231,7 +237,7 @@ export const ManageAmountInputField = () => {
               })}
             </HStack>
             {error && <AnimatedSendFormInputError error={error} />}
-            {!error && adjustedAmount !== null ? (
+            {adjustedAmount !== null ? (
               <Text size={12} color="shy">
                 {t('send_amount_adjusted_for_fee', { amount: adjustedAmount })}
               </Text>

--- a/core/ui/vault/send/amount/ManageAmountInputField.tsx
+++ b/core/ui/vault/send/amount/ManageAmountInputField.tsx
@@ -5,6 +5,7 @@ import { AmountSuggestion } from '@core/ui/vault/send/amount/AmountSuggestion'
 import { CurrencySwitch } from '@core/ui/vault/send/amount/AmountSwitch'
 import { BaseSendAmountInput } from '@core/ui/vault/send/amount/BaseSendAmountInput'
 import { FiatSendAmountInput } from '@core/ui/vault/send/amount/FiatSendAmountInput'
+import { useSpendableSendAmount } from '@core/ui/vault/send/amount/useSpendableSendAmount'
 import { AnimatedSendFormInputError } from '@core/ui/vault/send/components/AnimatedSendFormInputError'
 import { HorizontalLine } from '@core/ui/vault/send/components/HorizontalLine'
 import { SendInputContainer } from '@core/ui/vault/send/components/SendInputContainer'
@@ -30,6 +31,7 @@ import { extractAccountCoinKey } from '@vultisig/core-chain/coin/AccountCoin'
 import { isFeeCoin } from '@vultisig/core-chain/coin/utils/isFeeCoin'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { multiplyBigInt } from '@vultisig/lib-utils/bigint/bigIntMultiplyByNumber'
+import { formatAmount } from '@vultisig/lib-utils/formatAmount'
 import { minBigInt } from '@vultisig/lib-utils/math/minBigInt'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -98,6 +100,15 @@ export const ManageAmountInputField = () => {
   const error = !!amountError && value ? amountError : undefined
   const isWaitingForFee =
     pendingSuggestion != null && isNative && feeEstimateQuery.isPending
+
+  // Announced while the field still holds the typed amount — the write itself
+  // happens on submit — so the user learns what will be sent before committing
+  // to it rather than being surprised on Verify.
+  const spendableAmount = useSpendableSendAmount()
+  const adjustedAmount =
+    spendableAmount !== null && spendableAmount !== value
+      ? formatAmount(fromChainAmount(spendableAmount, coin.decimals), coin)
+      : null
 
   const sharedInputProps: Pick<
     AmountTextInputProps,
@@ -220,6 +231,11 @@ export const ManageAmountInputField = () => {
               })}
             </HStack>
             {error && <AnimatedSendFormInputError error={error} />}
+            {!error && adjustedAmount !== null ? (
+              <Text size={12} color="shy">
+                {t('send_amount_adjusted_for_fee', { amount: adjustedAmount })}
+              </Text>
+            ) : null}
             <MatchQuery
               value={balanceQuery}
               success={amount => (

--- a/core/ui/vault/send/amount/adjustAmountForFee.test.ts
+++ b/core/ui/vault/send/amount/adjustAmountForFee.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { adjustAmountForFee } from './adjustAmountForFee'
+
+describe('adjustAmountForFee', () => {
+  it('adjusts down to balance - fee when only the fee overshoots', () => {
+    expect(adjustAmountForFee({ amount: 95n, balance: 100n, fee: 6n })).toBe(
+      94n
+    )
+  })
+
+  it('adjusts a full-balance amount', () => {
+    expect(adjustAmountForFee({ amount: 100n, balance: 100n, fee: 6n })).toBe(
+      94n
+    )
+  })
+
+  it('leaves an amount the balance already covers with its fee', () => {
+    expect(adjustAmountForFee({ amount: 50n, balance: 100n, fee: 6n })).toBe(
+      50n
+    )
+  })
+
+  it('leaves an amount that overshoots the balance on its own', () => {
+    expect(adjustAmountForFee({ amount: 101n, balance: 100n, fee: 6n })).toBe(
+      101n
+    )
+  })
+
+  it('leaves the amount alone when the fee swallows the whole balance', () => {
+    expect(adjustAmountForFee({ amount: 50n, balance: 100n, fee: 100n })).toBe(
+      50n
+    )
+  })
+})

--- a/core/ui/vault/send/amount/adjustAmountForFee.ts
+++ b/core/ui/vault/send/amount/adjustAmountForFee.ts
@@ -1,0 +1,31 @@
+import { getMaxValue } from '@vultisig/core-chain/amount/getMaxValue'
+
+type AdjustAmountForFeeInput = {
+  amount: bigint
+  balance: bigint
+  fee: bigint
+}
+
+/**
+ * Reduces an amount to `balance - fee` when the balance covers the amount on its
+ * own but not together with the network fee. Only ever reduces, so a send never
+ * grows past what was asked for.
+ *
+ * An amount that overshoots the balance by itself is returned untouched — that
+ * is a real over-entry for the caller to reject, not a fee edge — and so is one
+ * whose fee swallows the whole balance, since there is nothing left to adjust
+ * to.
+ */
+export const adjustAmountForFee = ({
+  amount,
+  balance,
+  fee,
+}: AdjustAmountForFeeInput): bigint => {
+  if (amount > balance || amount + fee <= balance) {
+    return amount
+  }
+
+  const spendable = getMaxValue(balance, fee)
+
+  return spendable > 0n ? spendable : amount
+}

--- a/core/ui/vault/send/amount/useSpendableSendAmount.ts
+++ b/core/ui/vault/send/amount/useSpendableSendAmount.ts
@@ -1,0 +1,30 @@
+import { extractAccountCoinKey } from '@vultisig/core-chain/coin/AccountCoin'
+import { isFeeCoin } from '@vultisig/core-chain/coin/utils/isFeeCoin'
+
+import { useBalanceQuery } from '../../../chain/coin/queries/useBalanceQuery'
+import { useSendFeeEstimateQuery } from '../queries/useSendFeeEstimateQuery'
+import { useSendAmount } from '../state/amount'
+import { useCurrentSendCoin } from '../state/sendCoin'
+import { adjustAmountForFee } from './adjustAmountForFee'
+
+/**
+ * The amount the send will actually move: the entered amount, reduced to what
+ * the balance still covers once the network fee is reserved out of it. Tokens
+ * pay their fee from the native balance, so their entered amount is spendable
+ * in full and is returned as typed.
+ */
+export const useSpendableSendAmount = () => {
+  const coin = useCurrentSendCoin()
+  const [amount] = useSendAmount()
+  const balanceQuery = useBalanceQuery(extractAccountCoinKey(coin))
+  const feeEstimateQuery = useSendFeeEstimateQuery()
+
+  const balance = balanceQuery.data
+  const fee = feeEstimateQuery.data
+
+  if (amount === null || balance == null || fee == null || !isFeeCoin(coin)) {
+    return amount
+  }
+
+  return adjustAmountForFee({ amount, balance, fee })
+}

--- a/core/ui/vault/send/form/SendForm.tsx
+++ b/core/ui/vault/send/form/SendForm.tsx
@@ -2,9 +2,11 @@ import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { ActionForm } from '@core/ui/vault/components/action-form/ActionForm'
 import { ManageAddresses } from '@core/ui/vault/send/addresses/ManageAddresses'
 import { ManageAmount } from '@core/ui/vault/send/amount/ManageAmount'
+import { useSpendableSendAmount } from '@core/ui/vault/send/amount/useSpendableSendAmount'
 import { ManageSendCoin } from '@core/ui/vault/send/coin/ManageSendCoin'
 import { useSendValidationQuery } from '@core/ui/vault/send/queries/useSendValidationQuery'
 import { RefreshSend } from '@core/ui/vault/send/RefreshSend'
+import { useSendAmount } from '@core/ui/vault/send/state/amount'
 import { Button } from '@lib/ui/buttons/Button'
 import { getFormProps } from '@lib/ui/form/utils/getFormProps'
 import { VStack } from '@lib/ui/layout/Stack'
@@ -17,6 +19,20 @@ import { useTranslation } from 'react-i18next'
 export const SendForm = ({ onFinish }: OnFinishProp) => {
   const { t } = useTranslation()
   const { data, error, isPending } = useSendValidationQuery()
+  const [amount, setAmount] = useSendAmount()
+  const spendableAmount = useSpendableSendAmount()
+
+  // Commit a fee-driven adjustment only here, never while the field is being
+  // typed into: rewriting the amount on every keystroke would fight the user
+  // for the field. Verify reads the same state, so it shows — and signs — the
+  // adjusted amount rather than the one that no longer fits.
+  const handleSubmit = () => {
+    if (spendableAmount !== null && spendableAmount !== amount) {
+      setAmount(spendableAmount)
+    }
+
+    onFinish()
+  }
 
   const isDisabled = (() => {
     if (data && !isRecordEmpty(data)) {
@@ -45,7 +61,7 @@ export const SendForm = ({ onFinish }: OnFinishProp) => {
         gap={40}
         data-testid="send-form"
         {...getFormProps({
-          onSubmit: onFinish,
+          onSubmit: handleSubmit,
           isDisabled,
         })}
       >

--- a/core/ui/vault/send/queries/useSendValidationQuery.ts
+++ b/core/ui/vault/send/queries/useSendValidationQuery.ts
@@ -8,8 +8,8 @@ import { useTranslation } from 'react-i18next'
 
 import { useBalanceQuery } from '../../../chain/coin/queries/useBalanceQuery'
 import { useAssertWalletCore } from '../../../chain/providers/WalletCoreProvider'
+import { useSpendableSendAmount } from '../amount/useSpendableSendAmount'
 import { validateSendForm } from '../form/validateSendForm'
-import { useSendAmount } from '../state/amount'
 import { useSendDestinationTagInput } from '../state/destinationTag'
 import { useSendReceiver } from '../state/receiver'
 import { useCurrentSendCoin } from '../state/sendCoin'
@@ -19,7 +19,11 @@ export const useSendValidationQuery = () => {
   const { t } = useTranslation()
 
   const coin = useCurrentSendCoin()
-  const [amount] = useSendAmount()
+  // The spendable amount, not the entered one: an entered amount that only
+  // overshoots once the fee is added is adjusted down to what the balance
+  // covers, and the send is committed at that amount — so the form must judge
+  // the amount it will actually sign.
+  const amount = useSpendableSendAmount()
   const [destinationTag] = useSendDestinationTagInput()
   const [address] = useSendReceiver()
   const walletCore = useAssertWalletCore()


### PR DESCRIPTION
## Description

A hand-typed native amount that fits the balance but not `amount + fee` had nowhere to go: validation returned `insufficient_balance`, which disabled Continue, and the user had to guess a smaller number — the fee is only known once the form has an amount, so there was nothing to guess against.

The form now judges the **spendable** amount rather than the entered one:

- When the fee alone is what pushes the amount over (`amount ≤ balance < amount + fee`), it clamps to `balance − fee` — the same value the Max suggestion already uses — and the send commits at that amount.
- An amount that overshoots the balance **by itself** still errors: that is a real over-entry, not a fee edge. So does one whose fee swallows the whole balance, since a zero clamp has nothing to send and would otherwise report itself as a missing amount.
- Tokens are left alone. They pay gas from the native balance, so their own balance stays spendable in full and a shortfall there is never fee-caused.
- The write lands on **submit**, not on every keystroke — rewriting the field mid-entry would fight the user for it. Until then a line under the field names the amount that will be sent (`send_amount_adjusted_for_fee`), and Verify reads the same state, so what is signed is what was shown.
- Routing the clamped amount through validation also re-runs the checks that follow it: a Cardano clamp landing under the minimum-send floor is still rejected, and the UTXO change check sees the amount actually being spent.

Falls out for free: a 100% tap whose fee rises before submit now re-clamps instead of failing as insufficient.

New:
- `core/ui/vault/send/amount/adjustAmountForFee.ts` — the pure clamp decision, unit-tested.
- `core/ui/vault/send/amount/useSpendableSendAmount.ts` — the amount the send will actually move.

Fixes #4545

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [x] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Parity

- iOS: linked: vultisig/vultisig-ios#5020 — open, unimplemented there
- Android: linked: vultisig/vultisig-android#5493 — closed
- SDK: n/a — `@vultisig/core-chain/amount/getMaxValue` already provides the clamp primitive and is what this uses. The SDK's own send path has no equivalent dead-end (`VaultBase.send()` does not validate `amount + fee` for a non-`max` amount), and shrinking a programmatic caller's amount behind its back would be the wrong behaviour there.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

`yarn check:all` passes end to end on this branch — lint, typecheck, `yarn test` (828), `@clients/extension test` (537), `@clients/desktop test:ci` (26), knip, `i18n:check`, `i18n:review-quality --strict`, `validate-public`, markdownlint and the Go suites.

> Correction to the original description: it claimed pre-existing `typecheck` / `validate-public` failures on `main` (`Robinhood`, `usde.svg`, `usdg.svg`, `robinhood.svg`). That was a stale local build state on my side, not a repo problem — both are clean after dropping the cached `*.tsbuildinfo`.

## Additional context

Translations for the new key were generated with `yarn translate` and then hand-corrected in `ru` (ungrammatical clause), `ko` (stray space before the particle) and `zh` (word-order drift).

Two adjacent problems left alone rather than folded in:
- The Verify screen's fee settings (`ManageFee`) can raise the fee *after* the amount is locked, which can still overshoot. That already affects the existing Max button.
- `validateUtxoRequirements` returns hardcoded English, bypassing i18n — so a clamp that lands under a UTXO floor surfaces an untranslated string.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #4545
- **Confidence**: high
- **Needs human review for**: the clamp boundary on UTXO/Cardano (floors run after the clamp, so a low balance is rejected rather than adjusted) and whether the inline notice is the wording you want

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Send amounts are automatically adjusted to account for network fees when needed.
  * An informational message shows the adjusted amount before sending.
  * Send validation and submission now use the fee-adjusted amount.

* **Localization**
  * Added translations for the fee adjustment message across supported languages.

* **Tests**
  * Added coverage for fee adjustments, full-balance sends, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
