### PR TITLE
fix(deps): pin nanoid to 3.3.17 to clear npm audit advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "linkify-it@^5.0.0": "5.0.2",
     "path-to-regexp": "8.4.2",
     "postcss": "8.5.18",
+    "nanoid": "3.3.17",
     "picomatch@^2.0.4": "2.3.2",
     "picomatch@^2.2.1": "2.3.2",
     "picomatch@^2.3.1": "2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13267,12 +13267,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.12":
-  version: 3.3.12
-  resolution: "nanoid@npm:3.3.12"
+"nanoid@npm:3.3.17":
+  version: 3.3.17
+  resolution: "nanoid@npm:3.3.17"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/ba142b7b39e11e80c16dd74b0365d407880c87c1cf7e1480956981ae940ee36060fa5b6f092cd1e315184dd19244c657bd017d03327bd3c62247d691c5e8edfb
+  checksum: 10c0/06f7949c7cce5c92c6aea66022f29a1eae7f56e05acbfddf1e049e819b4bf234c44a765cc44da7163482b111677948514012e27acdfa56f95309295768bdae32
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- `yarn quality:health` was failing at the `quality:audit` step: `postcss@8.5.18` pulls in `nanoid@3.3.12`, which is flagged by two new high-severity advisories (GHSA-28wg-ghj8-5hjv, GHSA-2v37-7h3g-55p8 — non-secure generators can loop indefinitely with a negative/zero size)
- Pin `nanoid` to `3.3.17` via the root `resolutions` field (following the existing pattern used for `postcss`, `fast-uri`, etc.) — the latest 3.x release that fixes both advisories while staying within `postcss`'s `^3.3.12` semver range

## Test plan
- [x] `yarn install` resolves cleanly to `nanoid@3.3.17`
- [x] `node scripts/quality-audit.mjs` → "No audit suggestions"
- [x] `yarn quality:health` passes end to end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s package resolution configuration to use a specific version of a supporting dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->