### PR TITLE
fix(address-book): chain selection overlay covers whole screen, not just content

### DIFF
--- a/core/ui/chain/chainSelection/ChainSelectionScreen.styles.ts
+++ b/core/ui/chain/chainSelection/ChainSelectionScreen.styles.ts
@@ -6,7 +6,7 @@ export const FullScreenContainer = styled.div`
   height: 100%;
   display: flex;
   flex-direction: column;
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   right: 0;


### PR DESCRIPTION
## Description

In the Address Book "Add Address" flow, tapping the "Chain" field opened the "Select chains" screen as an overlay that only covered the content area, not the "Add Address" header above it — leaving two headers and two back chevrons stacked.

Root cause: `AddressBookChainSelectionScreen`'s `FullScreenContainer` used `position: absolute`, which sizes against its nearest positioned ancestor (`AddressBookForm`'s inner `VStack`, which sits below the "Add Address" `PageHeader`), not the whole screen.

Fix: changed `position: absolute` to `position: fixed` in `ChainSelectionScreen.styles.ts` so the overlay anchors to the viewport and covers the entire screen, including the "Add Address" header. This container is only used by `AddressBookChainSelectionScreen`, so no other screens are affected.

Fixes #4580

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

Verified manually in the desktop app (`yarn dev:desktop`): opening chain selection from Add Address now shows a single "Select chains" header with one back chevron, fully covering the "Add Address" screen. Back navigation returns to "Add Address" with form values intact.

## Additional context

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #4580
- **Confidence**: high
- **Needs human review for**: none — single-line CSS fix, verified in running app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved full-screen layout behavior by using fixed positioning for the chain selection screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->