### PR TITLE
ci: parallelize CI jobs and quality checks to cut pipeline time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,12 @@ jobs:
           path: node_modules/.cache/eslint
           key: ${{ runner.os }}-eslint-${{ hashFiles('**/yarn.lock', 'eslint.config.mjs', 'clients/desktop/eslint.config.mjs') }}
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
       - name: Validate public files
         run: yarn validate-public
 
@@ -76,7 +82,6 @@ jobs:
         run: yarn quality:health
 
   extension:
-    needs: lint
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -105,7 +110,6 @@ jobs:
           path: clients/extension/dist
 
   extension-firefox:
-    needs: lint
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -134,7 +138,6 @@ jobs:
           path: clients/extension/dist
 
   build:
-    needs: lint
     strategy:
       fail-fast: true
       matrix:

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "quality:docs:markdown": "markdownlint-cli2 --config .config/markdownlint-cli2.jsonc",
     "quality:duplication": "jscpd --config .config/jscpd.json clients core lib scripts app.go main.go install_marker.go notification_darwin.go notification_linux.go notification_windows.go mediator relay storage tss utils",
     "quality:go": "go test ./mediator ./relay ./storage ./tss ./utils",
-    "quality:health": "yarn quality:architecture && yarn quality:duplication && yarn quality:complexity && yarn quality:secrets && yarn quality:docs && yarn quality:go && yarn quality:audit",
+    "quality:health": "concurrently --kill-others-on-fail \"yarn quality:architecture\" \"yarn quality:duplication\" \"yarn quality:complexity\" \"yarn quality:secrets\" \"yarn quality:docs\" \"yarn quality:go\" \"yarn quality:audit\"",
     "quality:secrets": "secretlint --secretlintrc .config/secretlintrc.json --secretlintignore .config/secretlintignore \"**/*.{ts,tsx,js,jsx,json,md,yml,yaml,cjs,mjs,sh,go}\"",
     "check:all": "yarn validate-public && yarn lint && yarn typecheck && yarn test && yarn workspace @clients/extension test && yarn workspace @clients/desktop test:ci && yarn workspace @core/ui i18n:check && yarn i18n:review-quality --strict && yarn knip && yarn quality:health",
     "check:client-build-flags": "yarn build:desktop && yarn build:extension:station",


### PR DESCRIPTION
## Summary
- Run `extension`, `extension-firefox`, and `build` jobs alongside `lint` instead of `needs: lint`, so the two longest jobs in the pipeline (lint, ~7-11min; Windows build, ~12-14min) no longer run back-to-back. Measured from real runs, total wall time drops from ~20-25min toward roughly the slowest single job.
- Run `quality:health`'s 7 sub-checks (architecture, duplication, complexity, secrets, docs, go test, audit) concurrently via `concurrently --kill-others-on-fail`, the same pattern already used in the `check` script, instead of chaining them with `&&`. This step was the single largest chunk of the lint job (~3.5min sequential; ~40s parallel locally).
- Add `actions/setup-go` with Go module/build caching to the lint job — `quality:go` was re-downloading the entire Go dependency graph (tss-lib, wails, cosmos SDK deps, etc.) from the network on every run.

## Trade-off
Downstream jobs (extension/build) now run even when `lint` would fail, since they're no longer gated on it — more CI minutes spent on a failing PR, in exchange for shorter wall-clock time on every run.

## Test Plan
- [x] `yarn quality:health` runs locally, all 7 sub-checks exit 0
- [x] `package.json` and `build.yml` diffs reviewed for correctness
- [ ] Confirm the actual CI run times drop as expected once this PR runs in GitHub Actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Quality Improvements**
  * Quality checks now run concurrently, reducing the time needed to complete validation.
  * Remaining checks stop automatically when one check fails, providing faster feedback.

* **Build and Release**
  * Build and browser extension workflows can proceed independently of lint results.
  * Go setup during linting now uses the project’s declared version and dependency information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->