### PR TITLE
fix(extension): restrict Keplr proxy-request handling to same-frame messages

### DIFF
--- a/clients/extension/src/inpage/providers/keplrProxyBridge.ts
+++ b/clients/extension/src/inpage/providers/keplrProxyBridge.ts
@@ -2,6 +2,50 @@ import { InjectedKeplr } from '@keplr-wallet/provider'
 
 type StartProxyKeplr = Parameters<typeof InjectedKeplr.startProxy>[0]
 
+type StartProxyEventListener = NonNullable<
+  Parameters<typeof InjectedKeplr.startProxy>[2]
+>
+
+type ProxyMessageHandler = Parameters<
+  StartProxyEventListener['addMessageListener']
+>[0]
+
+const proxyListeners = new WeakMap<
+  ProxyMessageHandler,
+  (event: MessageEvent) => void
+>()
+
+/**
+ * Same-window `message` transport for `InjectedKeplr.startProxy`.
+ *
+ * Same-window only. The library's built-in listener dispatches on `event.data`
+ * alone, so it would also serve `proxy-request` messages posted by an embedded
+ * frame, and a frame must not be able to act for another frame's origin — the
+ * constraint every other window listener in the extension already enforces.
+ * Restricting each proxy to its own frame costs nothing: clients always post to
+ * their own window, and the content script is injected into every frame, so an
+ * embedded dApp is served by the proxy in its own frame under its own origin.
+ *
+ * `startProxy` detaches its handler by reference, hence the wrapper bookkeeping.
+ */
+const sameWindowEventListener: StartProxyEventListener = {
+  addMessageListener: handler => {
+    const listener = (event: MessageEvent) => {
+      if (event.source !== window) return
+      handler(event)
+    }
+    proxyListeners.set(handler, listener)
+    window.addEventListener('message', listener)
+  },
+  removeMessageListener: handler => {
+    const listener = proxyListeners.get(handler)
+    if (!listener) return
+    proxyListeners.delete(handler)
+    window.removeEventListener('message', listener)
+  },
+  postMessage: message => window.postMessage(message, window.location.origin),
+}
+
 /**
  * Sets up the Keplr `proxy-request` postMessage bridge so cosmos-kit dApps
  * (which talk to Keplr through `@keplr-wallet/provider-extension`) can reach
@@ -20,6 +64,10 @@ type StartProxyKeplr = Parameters<typeof InjectedKeplr.startProxy>[0]
  * `proxy-request`, so we hand it a `parseMessage` that strips the suffix
  * and rewrites the type to the legacy form. The dApp's response listener
  * filters by message id, not type, so the round-trip still resolves.
+ *
+ * The transport is passed explicitly rather than left to the library's default
+ * so that each frame's proxy only answers its own frame — see
+ * {@link sameWindowEventListener}.
  */
 export const installKeplrProxyBridge = (keplr: StartProxyKeplr): void => {
   window.keplrRequestMetaIdSupport = true
@@ -33,5 +81,10 @@ export const installKeplrProxyBridge = (keplr: StartProxyKeplr): void => {
     return { ...data, type: 'proxy-request' }
   }
 
-  InjectedKeplr.startProxy(keplr, undefined, undefined, parseMessage)
+  InjectedKeplr.startProxy(
+    keplr,
+    undefined,
+    sameWindowEventListener,
+    parseMessage
+  )
 }

--- a/clients/extension/tests/unit/keplr-proxy-bridge.test.ts
+++ b/clients/extension/tests/unit/keplr-proxy-bridge.test.ts
@@ -1,0 +1,164 @@
+// @vitest-environment happy-dom
+
+/**
+ * Frame isolation for the Keplr `proxy-request` bridge.
+ *
+ * The bridge installs a `window` message listener, and `window` receives
+ * messages from embedded frames as readily as from the page itself. A frame must
+ * not be able to act for another frame's origin, so these tests pin the
+ * same-window constraint in both directions: own-frame requests still served,
+ * other-frame requests ignored.
+ */
+import { installKeplrProxyBridge } from '@clients/extension/src/inpage/providers/keplrProxyBridge'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getKey = vi.fn()
+const signAmino = vi.fn()
+
+type BridgeKeplr = Parameters<typeof installKeplrProxyBridge>[0]
+
+const keplr = { getKey, signAmino } as unknown as BridgeKeplr
+
+/**
+ * happy-dom's `postMessage` does not populate `source`, which is the very field
+ * under test. Re-dispatch the way a real browser does: `source` is the posting
+ * window, and delivery is asynchronous.
+ */
+const installBrowserFaithfulPostMessage = () => {
+  vi.spyOn(window, 'postMessage').mockImplementation((message: unknown) => {
+    setTimeout(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: message,
+          origin: window.location.origin,
+          source: window,
+        })
+      )
+    }, 0)
+  })
+}
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 0))
+
+const proxyRequest = (
+  type: string,
+  method: string,
+  args: unknown[],
+  id = 'request-id'
+) => ({
+  type,
+  id,
+  method,
+  args,
+})
+
+describe('Keplr proxy bridge frame isolation', () => {
+  beforeAll(() => {
+    installBrowserFaithfulPostMessage()
+    installKeplrProxyBridge(keplr)
+  })
+
+  beforeEach(() => {
+    getKey.mockReset()
+    getKey.mockResolvedValue({ bech32Address: 'cosmos1abc' })
+    signAmino.mockReset()
+    signAmino.mockResolvedValue({})
+  })
+
+  describe('messages from the page itself', () => {
+    it('serves the legacy proxy-request type', async () => {
+      window.postMessage(
+        proxyRequest('proxy-request', 'getKey', ['cosmoshub-4']),
+        window.location.origin
+      )
+      await flush()
+
+      expect(getKey).toHaveBeenCalledWith('cosmoshub-4')
+    })
+
+    // A distinct chainId, so a call still in flight from the previous test
+    // cannot satisfy this assertion.
+    it('serves the metaId-namespaced type cosmos-kit builds emit', async () => {
+      window.postMessage(
+        proxyRequest('proxy-request-abc123', 'getKey', ['osmosis-1']),
+        window.location.origin
+      )
+      await flush()
+
+      expect(getKey).toHaveBeenCalledWith('osmosis-1')
+    })
+
+    // Supplying our own transport means we also own the reply leg the library
+    // would otherwise have provided, so assert the round-trip still resolves.
+    it('posts the result back under the id the client correlates on', async () => {
+      // Replies are correlated by id, exactly as the client does — earlier
+      // tests in this file do not await their own reply timers, so their
+      // responses can still be in flight here.
+      const id = 'round-trip-request'
+      const responses: Record<string, unknown>[] = []
+      window.addEventListener('message', (event: MessageEvent) => {
+        if (
+          event.data?.id === id &&
+          event.data?.type === 'proxy-request-response'
+        ) {
+          responses.push(event.data)
+        }
+      })
+
+      window.postMessage(
+        proxyRequest('proxy-request', 'getKey', ['cosmoshub-4'], id),
+        window.location.origin
+      )
+      await flush()
+      await flush()
+
+      expect(responses).toEqual([
+        {
+          type: 'proxy-request-response',
+          id,
+          result: { return: { bech32Address: 'cosmos1abc' } },
+        },
+      ])
+    })
+  })
+
+  describe('messages from an embedded frame', () => {
+    const postAsFrame = async (data: unknown) => {
+      const frame = document.createElement('iframe')
+      document.body.appendChild(frame)
+      const frameWindow = frame.contentWindow
+      expect(frameWindow).toBeTruthy()
+      expect(frameWindow).not.toBe(window)
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data,
+          origin: 'https://embedded.example',
+          source: frameWindow,
+        })
+      )
+      await flush()
+      frame.remove()
+    }
+
+    it('ignores an account read request', async () => {
+      await postAsFrame(
+        proxyRequest('proxy-request', 'getKey', ['cosmoshub-4'])
+      )
+
+      expect(getKey).not.toHaveBeenCalled()
+    })
+
+    it('ignores a sign request regardless of the type suffix used', async () => {
+      await postAsFrame(
+        proxyRequest('proxy-request-abc123', 'signAmino', [
+          'cosmoshub-4',
+          'cosmos1abc',
+          {},
+        ])
+      )
+
+      expect(signAmino).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
Closes #4587

## Problem

`installKeplrProxyBridge` called `InjectedKeplr.startProxy(keplr, undefined, undefined, parseMessage)`, leaving the `eventListener` argument unset. The library then installs its own default transport — a bare `window.addEventListener('message', fn)` whose handler dispatches on `event.data` alone and never consults `event.source` (confirmed in `@keplr-wallet/provider@0.13.38`, both the TypeScript source and the shipped `build/inject.js`).

A `window` message listener receives messages from embedded frames as readily as from the page itself, so the proxy answered `proxy-request` messages that did not originate in its own frame. A frame must not be able to act for another frame's origin. Every other window message listener in the extension already enforces this, which made the Keplr proxy the one remaining inconsistency:

| Listener | Guard |
|---|---|
| `clients/extension/src/inpage/providers/xrpl/index.ts:75` | `event.source !== window` |
| `core/inpage-provider/background/events/inpage.ts:15` | source and origin |
| `lib/extension/bridge/inpage.ts:28` | `source !== window` |
| `lib/extension/bridge/content.ts:19` | `source !== window` |

## Change

Pass an explicit same-window transport to `startProxy`, dropping any message whose `source` is not this window. `postMessage` is kept byte-identical to the library default (`window.postMessage(message, window.location.origin)`) so the reply leg is unchanged. `startProxy` detaches its handler by reference, so the wrapper is tracked in a `WeakMap` for `removeMessageListener` to unregister correctly.

`parseMessage` is deliberately untouched. It is not load-bearing here: the library accepts the bare legacy `proxy-request` type unconditionally, and because we pass `metaId: undefined` the computed `proxyRequestType` already *is* that bare string.

## Why this does not reduce functionality

A client only ever posts to its own window — `requestMethod` goes through the same default transport (`inject.ts:558-563`), which is always `window.postMessage(message, window.location.origin)`. Combined with `all_frames: true`, a dApp that is itself framed gets its own proxy in its own frame and is served there under its own origin, which is the correct attribution rather than a regression.

Cross-realm messaging is unaffected: a content script in the isolated world posting to the MAIN world of the same frame satisfies `source === window` — `bridge/content.ts` and `bridge/inpage.ts` already rely on exactly that in production.

## Tests

New `clients/extension/tests/unit/keplr-proxy-bridge.test.ts` (happy-dom), five cases:

- own-frame request served for the legacy `proxy-request` type
- own-frame request served for the `proxy-request-<metaId>` form
- `proxy-request-response` round-trip resolves under the id the client correlates on (this covers the reply leg, which the explicit transport now owns)
- other-frame `getKey` ignored
- other-frame `signAmino` ignored, regardless of type suffix

The other-frame cases use a real `iframe.contentWindow` as the message source rather than a stub. happy-dom does not populate `source` on `postMessage`, so the test installs a browser-faithful shim — the same approach `xrpl-adapter.test.ts` already uses.

Verified the test actually catches the regression: reverting only the `eventListener` argument makes exactly the two other-frame cases fail.

## Verification

- `yarn workspace @clients/extension test` — 45 files, 542 tests pass
- `yarn eslint` clean on both files
- `yarn knip` clean (only pre-existing config hints)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet proxy communication to keep requests and responses isolated to the active browser frame.
  * Preserved support for existing and namespaced page requests.
  * Prevented embedded frames from accessing account data or initiating signing requests.

* **Tests**
  * Added coverage for frame isolation, request handling, and correlated responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->