### PR TITLE
fix(deposit): stop validating untouched fields when the balance lands

### DIFF
--- a/core/ui/vault/deposit/DepositForm/index.tsx
+++ b/core/ui/vault/deposit/DepositForm/index.tsx
@@ -48,6 +48,7 @@ import {
   shouldShowBalance,
   shouldShowTicker,
 } from '../utils/chainActionConfig'
+import { revalidateAmountOnBalanceChange } from '../utils/revalidateAmountOnBalanceChange'
 import { stepFromDecimals } from '../utils/stepFromDecimals'
 import { FormData } from './types'
 
@@ -98,13 +99,13 @@ export const DepositForm: FC<DepositFormProps> = ({ onSubmit }) => {
     },
   })
 
-  // Re-validate when the selected coin or its balance changes — the resolver
-  // schema rebuilds with the new max, but react-hook-form only re-runs
-  // validation on field changes, so switching coins would otherwise leave
-  // a stale "valid" amount that exceeds the new balance.
+  // The resolver schema rebuilds with the new max when the coin or its balance
+  // changes, but react-hook-form only re-runs validation on field changes — so
+  // switching coins would otherwise leave a stale "valid" amount that exceeds
+  // the new balance.
   useEffect(() => {
-    trigger()
-  }, [coin.id, balance, balanceUnits, trigger])
+    revalidateAmountOnBalanceChange({ getValues, trigger })
+  }, [coin.id, balance, balanceUnits, trigger, getValues])
 
   const handleFormSubmit = (data: FieldValues) => {
     onSubmit(data)

--- a/core/ui/vault/deposit/utils/revalidateAmountOnBalanceChange.test.ts
+++ b/core/ui/vault/deposit/utils/revalidateAmountOnBalanceChange.test.ts
@@ -1,0 +1,133 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { WalletCore } from '@trustwallet/wallet-core'
+import { toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+import type { TFunction } from 'i18next'
+import { createFormControl, Resolver } from 'react-hook-form'
+import { describe, expect, it, vi } from 'vitest'
+
+import { FormData } from '../DepositForm/types'
+import { getDepositFormConfig } from './getDepositFormConfig'
+import { revalidateAmountOnBalanceChange } from './revalidateAmountOnBalanceChange'
+
+// The bond schema runs the node address through WalletCore; these cases are
+// about which fields get validated, not about address parsing itself.
+vi.mock('@vultisig/core-chain/utils/isValidAddress', () => ({
+  isValidAddress: ({ address }: { address: string }) =>
+    address.startsWith('thor'),
+}))
+
+const t = ((key: string) => key) as TFunction
+
+const coin: AccountCoin = {
+  chain: Chain.THORChain,
+  ticker: 'RUNE',
+  decimals: 8,
+  address: 'thor1sender',
+}
+
+type SetupBondFormInput = {
+  balance: number
+  values: FormData
+}
+
+// Mirrors DepositForm: the resolver is rebuilt from the latest balance on
+// every render, so a balance that arrives late tightens the amount's max.
+const setupBondForm = ({ balance, values }: SetupBondFormInput) => {
+  let currentBalance = balance
+
+  // Matches DepositForm's own `zodResolver(schema as any)` — the config
+  // returns one of many per-action schemas, so it is typed as ZodTypeAny.
+  const buildResolver = (): Resolver<FormData> =>
+    zodResolver(
+      getDepositFormConfig({
+        t,
+        coin,
+        walletCore: {} as WalletCore,
+        totalAmountAvailable: currentBalance,
+        totalAmountAvailableUnits: toChainAmount(currentBalance, coin.decimals),
+        selectedChainAction: 'bond',
+      }).schema as any
+    )
+
+  const form = createFormControl<FormData>({
+    resolver: (formValues, context, options) =>
+      buildResolver()(formValues, context, options),
+    mode: 'onChange',
+    defaultValues: values,
+  })
+
+  return {
+    ...form,
+    setBalance: (value: number) => {
+      currentBalance = value
+    },
+  }
+}
+
+describe('revalidateAmountOnBalanceChange', () => {
+  it('leaves an untouched form free of errors', async () => {
+    const { getValues, trigger, getFieldState } = setupBondForm({
+      balance: 10,
+      values: { nodeAddress: '', amount: '' },
+    })
+
+    await revalidateAmountOnBalanceChange({ getValues, trigger })
+
+    expect(getFieldState('nodeAddress').error).toBeUndefined()
+    expect(getFieldState('amount').error).toBeUndefined()
+  })
+
+  it('re-checks an entered amount against the new balance', async () => {
+    const { getValues, trigger, getFieldState, setBalance } = setupBondForm({
+      balance: 10,
+      values: { nodeAddress: '', amount: '8' },
+    })
+
+    await revalidateAmountOnBalanceChange({ getValues, trigger })
+    expect(getFieldState('amount').error).toBeUndefined()
+
+    setBalance(4)
+    await revalidateAmountOnBalanceChange({ getValues, trigger })
+
+    expect(getFieldState('amount').error?.message).toBe(
+      'chainFunctions.amountExceeded'
+    )
+  })
+
+  it('re-disables the submit button by keeping isValid in sync', async () => {
+    const { getValues, trigger, subscribe, setBalance } = setupBondForm({
+      balance: 10,
+      values: { nodeAddress: 'thor1node', amount: '8' },
+    })
+
+    let isValid = true
+    subscribe({
+      formState: { isValid: true },
+      callback: state => {
+        if (state.isValid !== undefined) {
+          isValid = state.isValid
+        }
+      },
+    })
+
+    setBalance(4)
+    await revalidateAmountOnBalanceChange({ getValues, trigger })
+
+    expect(isValid).toBe(false)
+  })
+
+  it('shows what validating the whole form did on mount instead (#4546)', async () => {
+    const { trigger, getFieldState } = setupBondForm({
+      balance: 10,
+      values: { nodeAddress: '', amount: '' },
+    })
+
+    await trigger()
+
+    expect(getFieldState('nodeAddress').error?.message).toBe(
+      'required_node_address'
+    )
+  })
+})

--- a/core/ui/vault/deposit/utils/revalidateAmountOnBalanceChange.ts
+++ b/core/ui/vault/deposit/utils/revalidateAmountOnBalanceChange.ts
@@ -1,0 +1,28 @@
+import { UseFormGetValues, UseFormTrigger } from 'react-hook-form'
+
+import { FormData } from '../DepositForm/types'
+
+type RevalidateAmountOnBalanceChangeInput = {
+  getValues: UseFormGetValues<FormData>
+  trigger: UseFormTrigger<FormData>
+}
+
+/**
+ * Re-runs amount validation after the selected coin or its balance changed, so
+ * an amount that was valid against the previous max stops passing. Only the
+ * amount is validated, and only once it holds a value — validating the whole
+ * form here would mark every untouched required field as errored on mount
+ * (#4546). Resolves once validation settled, or immediately when it was
+ * skipped.
+ */
+export const revalidateAmountOnBalanceChange = ({
+  getValues,
+  trigger,
+}: RevalidateAmountOnBalanceChangeInput) => {
+  const amount = getValues('amount')
+  if (amount === undefined || amount === null || amount === '') {
+    return Promise.resolve()
+  }
+
+  return trigger('amount')
+}


### PR DESCRIPTION
## Description

Opening the Bond view showed "Node Address is required" before the user had typed anything.

The mount effect in `DepositForm` called `trigger()` with no argument. That validates every field and makes its error visible regardless of touched state, so the empty required `nodeAddress` errored the moment the view opened — and again when the balance query hydrated. The comment said the intent was only to re-check the amount against the rebuilt max.

Only `amount` depends on the balance, so it now re-validates just that field, and only once it holds a value. An empty amount is skipped so an untouched form stays clean.

Worth noting: `trigger()` was the only source of these errors. With `mode: 'onChange'` plus a resolver, react-hook-form validates the whole schema on each change but writes back only the changed field's error, so untouched fields never error on their own. That's why no touched-gate is needed on the error rendering.

`trigger('amount')` still recomputes global `isValid`, so the Continue button stays correct.

Fixes #4546

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

Deposit actions (bond / unbond / stake / …) on both extension and desktop. No keysign, broadcast, or fee code touched.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional context

The rule lives in `revalidateAmountOnBalanceChange` so it can be tested without a DOM. The test drives the real bond schema through a react-hook-form control and covers four things: an untouched form stays error-free, an entered amount is re-checked against a smaller balance, `isValid` follows so the submit button re-disables, and the old whole-form validation is pinned as the thing that caused the report.

Reverting the helper to a bare `trigger()` fails the first test with exactly the reported `nodeAddress` error, so the guard bites.

`yarn check` is clean and the 41 deposit tests pass. Not yet verified by hand in the running extension.

### Related, not fixed here

Create Referral has the same bug. [`Fields/Fees.tsx:48`](https://github.com/vultisig/vultisig-windows/blob/main/core/ui/vault/settings/referral/components/CreateReferral/CreateReferralForm/Fields/Fees.tsx#L48) calls bare `trigger()` once the fee query lands, `referralName` defaults to `''` and is required, and its error renders ungated on the same screen — so "referral code is required" appears under an empty untouched field. Left out to keep this PR on one issue; happy to follow up.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #4546
- **Confidence**: high
- **Needs human review for**: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deposit amount validation now refreshes automatically when the available balance or selected coin changes.
  * Empty amount fields remain free of unnecessary validation errors.
  * Deposit submission is correctly disabled when the entered amount exceeds the updated balance.
  * Unrelated form validation errors no longer appear during balance or coin changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->