### PR TITLE
fix(extension): fit backup overview illustration in popup

### DIFF
--- a/core/ui/vault/backup/BackupOverviewScreen/index.tsx
+++ b/core/ui/vault/backup/BackupOverviewScreen/index.tsx
@@ -126,6 +126,7 @@ const AnimationWrapper = styled.div`
 const AnimationContainer = styled.div`
   width: 100%;
   max-width: 500px;
+  max-height: 100%;
   aspect-ratio: 500 / 350;
   position: relative;
   overflow: hidden;


### PR DESCRIPTION
Closes #4511

![screenshot-1](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/codex/4511-extension-backup-overview-cc7b7a44/screenshot-1-1786288393919.png)
![screenshot-2](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/codex/4511-extension-backup-overview-cc7b7a44/screenshot-2-1786288393919.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the backup overview screen layout by constraining the animation container’s height, helping prevent visual overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->