### PR TITLE
fix(storage): roll back transaction on failed chain-keyshare write

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -763,7 +763,8 @@ func (s *Store) SaveVaultsKeyShares(vaultKeyShares map[string]VaultAllKeyShares)
 		// Update chain_key_shares in vaults table ONLY if provided (imported vaults only)
 		// Regular vaults will have nil/empty ChainKeyShares - we skip the update for them
 		if len(allKeyShares.ChainKeyShares) > 0 {
-			chainKeySharesJSON, err := json.Marshal(allKeyShares.ChainKeyShares)
+			var chainKeySharesJSON []byte
+			chainKeySharesJSON, err = json.Marshal(allKeyShares.ChainKeyShares)
 			if err != nil {
 				return fmt.Errorf("could not marshal chain key shares: %w", err)
 			}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 	"time"
@@ -77,6 +78,45 @@ func TestSaveVaultUpdatePreservesChildRows(t *testing.T) {
 	}
 	if len(records) != 1 || records[0].ID != record.ID {
 		t.Fatalf("expected transaction record %q to survive vault update, got %#v", record.ID, records)
+	}
+}
+
+func TestSaveVaultsKeySharesRollsBackFailedChainKeyShareWrite(t *testing.T) {
+	store := newTestStore(t)
+
+	vault := testVault()
+	if err := store.SaveVault(vault); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pin the pool to a single connection so a leaked transaction starves
+	// every later write instead of silently grabbing a fresh connection.
+	store.db.SetMaxOpenConns(1)
+
+	// Fail only the chain-keyshare UPDATE, so the preceding DELETE and INSERT
+	// still succeed and the transaction is open when the error surfaces.
+	if _, err := store.db.Exec(`CREATE TRIGGER fail_vault_update BEFORE UPDATE ON vaults
+		BEGIN SELECT RAISE(ABORT, 'forced update failure'); END;`); err != nil {
+		t.Fatal(err)
+	}
+
+	err := store.SaveVaultsKeyShares(map[string]VaultAllKeyShares{
+		vault.PublicKeyECDSA: {
+			KeyShares:      vault.KeyShares,
+			ChainKeyShares: map[string]string{"Bitcoin": "chain-share"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected chain key share update to fail")
+	}
+
+	// The deferred rollback must have released the transaction. If err was
+	// shadowed the rollback never ran, and this write blocks on the pinned
+	// connection until the context deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := store.db.ExecContext(ctx, "SELECT 1"); err != nil {
+		t.Fatalf("transaction was not released, subsequent write failed: %v", err)
 	}
 }
 


### PR DESCRIPTION
Fixes #4605

## Problem

`SaveVaultsKeyShares` declared `chainKeySharesJSON, err := json.Marshal(...)` with `:=` inside the `if` block, which declares a **new** `err` scoped to that block. The deferred rollback tests the **outer** `err`, which stayed `nil`.

So on a failed chain-keyshare write the function returned an error with the transaction neither committed nor rolled back — leaking the `*sql.Tx`, pinning its connection for the process lifetime and wedging subsequent writes. It fires on the key-import-vault passcode set/change/disable path.

Data survives (no commit means the `DELETE FROM keyshares` is not applied), so this is an availability bug, not data loss.

## One correction to the issue's analysis

The shadow covers the **whole** `if` block, so the `tx.Exec` below it also assigned to the inner `err`. That matters, because the `json.Marshal` failure the issue leads with is effectively unreachable — `ChainKeyShares` is a `map[string]string`, which always marshals cleanly. The `tx.Exec` failure is the only trigger reachable in practice, and the same shadow swallowed it.

## Fix

```go
var chainKeySharesJSON []byte
chainKeySharesJSON, err = json.Marshal(allKeyShares.ChainKeyShares)
```

Both writes now assign to the outer `err`, so the deferred rollback runs.

## Test

The regression test is verified to actually catch the bug rather than pass either way:

- **Before the fix** → `FAIL: transaction was not released, subsequent write failed: context deadline exceeded`
- **After the fix** → `PASS` (0.01s)

Getting there needed one correction worth recording. My first attempt forced the failure by dropping the `vaults` table, and it **passed against the buggy code** — the drop cascaded and failed the earlier `DELETE`, which assigns to the outer `err`, so the correct rollback ran and the shadowed line was never reached.

The committed version instead installs a `BEFORE UPDATE` trigger, so the `DELETE` and `INSERT` succeed and only the chain-keyshare `UPDATE` fails. Pinning the pool to a single connection (`SetMaxOpenConns(1)`) makes the leak observable: under the bug `db.Stats()` reports `InUse:1, Idle:0` after the call and the next write wedges.

## Verification

- `go test ./storage/...` passes
- `go vet` and `gofmt` clean on both changed files
- The `shadow` analyzer no longer reports the fixed lines

## Follow-up

The issue's second acceptance criterion — linting to catch this class — is tracked in #4606. It needs Go static analysis added to CI, which is a pipeline change rather than part of this fix. Worth noting there: plain `go vet` would **not** have caught this, as shadow detection is not among its default analyzers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when updating chain key shares by ensuring failed database updates are rolled back correctly.
  * Prevented stalled transactions, allowing subsequent vault data updates to complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->