### PR TITLE
fix(tss): reject malformed ciphertext instead of panicking

### DIFF
--- a/tss/tss.go
+++ b/tss/tss.go
@@ -393,12 +393,17 @@ func decrypt(cipherText, hexKey string) (string, error) {
 	}
 
 	if len(cipherByte) < aes.BlockSize {
-		fmt.Printf("ciphertext too short")
-		return "", err
+		return "", errors.New("decrypt: ciphertext shorter than one AES block")
 	}
 
 	iv := cipherByte[:aes.BlockSize]
 	cipherByte = cipherByte[aes.BlockSize:]
+
+	// CryptBlocks panics on a partial trailing block, and this runs in the
+	// message-download goroutine where a panic would take down the process.
+	if len(cipherByte)%aes.BlockSize != 0 {
+		return "", errors.New("decrypt: ciphertext is not a multiple of the block size")
+	}
 
 	cbc := cipher.NewCBCDecrypter(block, iv)
 	plaintext := make([]byte, len(cipherByte))

--- a/tss/tss_test.go
+++ b/tss/tss_test.go
@@ -1,0 +1,90 @@
+package tss
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+const testHexKey = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+
+// encryptForTest mirrors the CBC/PKCS#7 wire format decrypt expects, so the
+// round-trip case stays honest about what a well-formed message looks like.
+func encryptForTest(t *testing.T, plaintext string) string {
+	t.Helper()
+
+	key, err := hex.DecodeString(testHexKey)
+	if err != nil {
+		t.Fatalf("decode key: %v", err)
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatalf("new cipher: %v", err)
+	}
+
+	padding := aes.BlockSize - len(plaintext)%aes.BlockSize
+	padded := append([]byte(plaintext), strings.Repeat(string(rune(padding)), padding)...)
+
+	out := make([]byte, aes.BlockSize+len(padded))
+	iv := out[:aes.BlockSize]
+	if _, err := rand.Read(iv); err != nil {
+		t.Fatalf("read iv: %v", err)
+	}
+	cipher.NewCBCEncrypter(block, iv).CryptBlocks(out[aes.BlockSize:], padded)
+
+	return string(out)
+}
+
+// A ciphertext whose body is not block-aligned used to reach CryptBlocks and
+// panic, killing the downloadMessages goroutine and with it the whole process.
+func TestDecryptRejectsNonBlockAlignedCiphertext(t *testing.T) {
+	malformed := string(make([]byte, aes.BlockSize+5))
+
+	out, err := decrypt(malformed, testHexKey)
+
+	if err == nil {
+		t.Fatalf("expected an error for non-block-aligned ciphertext, got out=%q", out)
+	}
+	if out != "" {
+		t.Errorf("expected empty plaintext on error, got %q", out)
+	}
+}
+
+// The short-ciphertext guard used to return a nil error, so callers treated a
+// rejected message as an empty but valid plaintext.
+func TestDecryptRejectsShortCiphertext(t *testing.T) {
+	for _, size := range []int{0, 1, aes.BlockSize - 1} {
+		out, err := decrypt(string(make([]byte, size)), testHexKey)
+
+		if err == nil {
+			t.Errorf("size %d: expected an error, got out=%q with nil error", size, out)
+		}
+		if out != "" {
+			t.Errorf("size %d: expected empty plaintext on error, got %q", size, out)
+		}
+	}
+}
+
+func TestDecryptRoundTripsWellFormedCiphertext(t *testing.T) {
+	const plaintext = "tss message body"
+
+	out, err := decrypt(encryptForTest(t, plaintext), testHexKey)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != plaintext {
+		t.Errorf("expected %q, got %q", plaintext, out)
+	}
+}
+
+func TestDecryptRejectsInvalidKey(t *testing.T) {
+	out, err := decrypt(string(make([]byte, aes.BlockSize*2)), "not-hex")
+
+	if err == nil {
+		t.Fatalf("expected an error for a non-hex key, got out=%q", out)
+	}
+}


### PR DESCRIPTION
Fixes #4613

## Fix

Validate the ciphertext length up front in `decrypt()` and return real errors from both guards, instead of relying on `err` happening to be non-nil. Uses `errors.New` to match `unpad` in the same file.

## Tests

`tss/tss_test.go` covers the non-aligned case, the short case (0, 1, `BlockSize-1`), a well-formed round-trip, and an invalid key.

These are real regression guards, not vacuous passes — against the unfixed `decrypt` the suite panics at `tss.go:405` rather than failing an assertion:

```
panic: crypto/cipher: input not full blocks
crypto/internal/fips140/aes.(*CBCDecrypter).CryptBlocks
github.com/vultisig/vultisig-win/tss.decrypt(...)
FAIL	github.com/vultisig/vultisig-win/tss
```

## Verification

- `go test ./tss/ ./mediator/` passes
- `go vet ./tss/`, `gofmt -l tss/`, and `go build ./...` clean

## Follow-ups

Both deliberately out of scope here, and noted in #4613: a `recover()` in the per-message loop as defense-in-depth, and moving the transport off unauthenticated CBC to AES-GCM — the latter needs the wire format to change in lockstep with iOS and Android.

🤖 Generated with [Claude Code](https://claude.com/claude-code)