### PR TITLE
fix(ui): align the shared Button with the design system button set

### DIFF
--- a/lib/ui/buttons/Button/Button.spec.tsx
+++ b/lib/ui/buttons/Button/Button.spec.tsx
@@ -1,0 +1,145 @@
+import { darkTheme } from '@lib/ui/theme/darkTheme'
+import { ReactElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { ServerStyleSheet, ThemeProvider } from 'styled-components'
+import { describe, expect, test } from 'vitest'
+
+import { Button } from '.'
+
+// Values below are read straight off the "Button" component set in the
+// Vultisig design system (Web platform, dark theme). They are asserted here so
+// the shared Button cannot silently drift away from the spec again.
+const styleOf = (ui: ReactElement) => {
+  const sheet = new ServerStyleSheet()
+  try {
+    renderToStaticMarkup(
+      sheet.collectStyles(<ThemeProvider theme={darkTheme}>{ui}</ThemeProvider>)
+    )
+    return sheet.getStyleTags().replace(/\s+/g, '')
+  } finally {
+    sheet.seal()
+  }
+}
+
+const hairline = 'border:1pxsolidrgba(255,255,255,0.03)'
+const raisedInset = 'inset01px1.9px0rgba(255,255,255,0.24)'
+const flatInset = 'inset01px1px0rgba(255,255,255,0.1)'
+
+describe('design system colours', () => {
+  test.each([
+    ['buttonPrimary', '#0b4eff'],
+    ['buttonHover', '#1e6ad1'],
+    ['buttonSecondary', '#11284a'],
+    ['buttonSecondaryHover', '#1d385e'],
+    ['buttonNeutral', '#2155df'],
+    ['buttonNeutralHover', '#1e6ad1'],
+    ['buttonSuccessHover', '#0fbf93'],
+    ['buttonBackgroundDisabled', '#0b1a3a'],
+    ['buttonTextDisabled', '#718096'],
+  ] as const)('%s is %s', (token, hex) => {
+    expect(darkTheme.colors[token].toHex()).toBe(hex)
+  })
+})
+
+describe('primary', () => {
+  test('md default is a 46px pill with a hairline and the raised inset', () => {
+    const css = styleOf(<Button>Get started</Button>)
+
+    expect(css).toContain('height:46px')
+    expect(css).toContain('padding-left:24px')
+    expect(css).toContain('font-size:14px')
+    expect(css).toContain('line-height:18px')
+    expect(css).toContain('gap:8px')
+    expect(css).toContain(hairline)
+    expect(css).toContain(raisedInset)
+  })
+
+  test('sm default is a 36px pill with no hairline', () => {
+    const css = styleOf(<Button size="sm">Get started</Button>)
+
+    expect(css).toContain('height:36px')
+    expect(css).toContain('padding-left:16px')
+    expect(css).toContain('font-size:12px')
+    expect(css).toContain('line-height:16px')
+    expect(css).toContain('gap:4px')
+    expect(css).not.toContain(hairline)
+  })
+
+  test('md neutral and success sit 4px shorter', () => {
+    expect(styleOf(<Button status="neutral">x</Button>)).toContain(
+      'height:42px'
+    )
+    expect(styleOf(<Button status="success">x</Button>)).toContain(
+      'height:42px'
+    )
+  })
+
+  test('success carries no hairline while neutral does', () => {
+    expect(styleOf(<Button status="success">x</Button>)).not.toContain(hairline)
+    expect(styleOf(<Button status="neutral">x</Button>)).toContain(hairline)
+  })
+
+  test('hover drops to the flat inset', () => {
+    expect(styleOf(<Button>x</Button>)).toContain(flatInset)
+  })
+
+  test('disabled is the flat inset with no hairline', () => {
+    const css = styleOf(<Button disabled>x</Button>)
+
+    expect(css).toContain(
+      darkTheme.colors.buttonBackgroundDisabled.toCssValue()
+    )
+    expect(css).toContain(flatInset)
+    expect(css).not.toContain(hairline)
+  })
+})
+
+describe('secondary', () => {
+  test('rests as a filled pill with a hairline and the flat inset', () => {
+    const css = styleOf(<Button kind="secondary">x</Button>)
+
+    expect(css).toContain('height:46px')
+    expect(css).toContain(darkTheme.colors.buttonSecondary.toCssValue())
+    expect(css).toContain(hairline)
+    expect(css).toContain(flatInset)
+  })
+
+  test('disabled is transparent behind a 60% neutral border', () => {
+    const css = styleOf(
+      <Button kind="secondary" disabled>
+        x
+      </Button>
+    )
+
+    expect(css).toContain('background-color:transparent')
+    expect(css).toContain(
+      darkTheme.colors.buttonNeutral
+        .getVariant({ a: () => 0.6 })
+        .toCssValue()
+        .replace(/\s+/g, '')
+    )
+  })
+})
+
+describe('link', () => {
+  test('renders one 26px size for both sm and md', () => {
+    const md = styleOf(<Button kind="link">x</Button>)
+    const sm = styleOf(
+      <Button kind="link" size="sm">
+        x
+      </Button>
+    )
+
+    expect(md).toContain('height:26px')
+    expect(sm).toContain('height:26px')
+    expect(md).toContain('font-size:14px')
+    expect(sm).toContain('font-size:14px')
+    expect(md).toContain('padding-left:4px')
+  })
+
+  test('hover tints the background instead of recolouring the label', () => {
+    const css = styleOf(<Button kind="link">x</Button>)
+
+    expect(css).toContain(darkTheme.colors.buttonLinkHover.toCssValue())
+  })
+})

--- a/lib/ui/buttons/Button/Button.stories.tsx
+++ b/lib/ui/buttons/Button/Button.stories.tsx
@@ -105,6 +105,11 @@ export const Gallery: Story = {
               Get started
             </Button>
           ))}
+          {SIZES.map(size => (
+            <Button key={size} kind="secondary" size={size} disabled>
+              Disabled
+            </Button>
+          ))}
         </div>
       </section>
 
@@ -129,6 +134,11 @@ export const Gallery: Story = {
           {SIZES.map(size => (
             <Button key={size} kind="link" size={size}>
               Get started
+            </Button>
+          ))}
+          {SIZES.map(size => (
+            <Button key={size} kind="link" size={size} disabled>
+              Disabled
             </Button>
           ))}
         </div>

--- a/lib/ui/buttons/Button/index.tsx
+++ b/lib/ui/buttons/Button/index.tsx
@@ -30,24 +30,35 @@ const hairlineBorder = css`
   border: 1px solid rgba(255, 255, 255, 0.03);
 `
 
-const pillMetrics = (size: ButtonSize) =>
+const pillHeight = (value: number) => css`
+  height: ${value}px;
+  min-height: ${value}px;
+  min-width: ${value}px;
+`
+
+// The design system gives the neutral and success hierarchies 12px of vertical
+// padding against the default hierarchy's 14px, so they sit 4px shorter at md.
+const mediumHeight: Record<PrimaryButtonStatus, number> = {
+  default: 46,
+  danger: 46,
+  neutral: 42,
+  success: 42,
+}
+
+const pillMetrics = (size: ButtonSize, status: PrimaryButtonStatus) =>
   match(size, {
     sm: () => css`
       font-size: 12px;
       gap: 4px;
-      height: 36px;
       line-height: 16px;
-      min-height: 36px;
-      min-width: 36px;
+      ${pillHeight(36)}
       ${horizontalPadding(16)}
     `,
     md: () => css`
       font-size: 14px;
       gap: 8px;
-      height: 46px;
       line-height: 18px;
-      min-height: 46px;
-      min-width: 46px;
+      ${pillHeight(mediumHeight[status])}
       ${horizontalPadding(24)}
     `,
   })
@@ -102,7 +113,7 @@ const StyledButton = styled(UnstyledButton)<{
             `}
       `,
       primary: () => css`
-        ${pillMetrics($size)}
+        ${pillMetrics($size, $status)}
 
         ${$disabled || $loading
           ? css`
@@ -112,8 +123,10 @@ const StyledButton = styled(UnstyledButton)<{
               cursor: default;
             `
           : css`
-              ${hairlineBorder}
               ${raisedInset}
+
+              /* Only the md pill carries a hairline, and success never does */
+              ${$size === 'md' && $status !== 'success' ? hairlineBorder : ''}
 
               ${match($status, {
                 default: () => css`
@@ -148,14 +161,14 @@ const StyledButton = styled(UnstyledButton)<{
                     background-color: ${getColor('danger')};
                   `,
                   success: () => css`
-                    background-color: ${getColor('primary')};
+                    background-color: ${getColor('buttonSuccessHover')};
                   `,
                 })}
               }
             `}
       `,
       outlined: () => css`
-        ${pillMetrics($size)}
+        ${pillMetrics($size, $status)}
 
         ${$disabled || $loading
           ? css`
@@ -175,7 +188,7 @@ const StyledButton = styled(UnstyledButton)<{
             `}
       `,
       secondary: () => css`
-        ${pillMetrics($size)}
+        ${pillMetrics($size, $status)}
         ${flatInset}
 
         ${$disabled || $loading

--- a/lib/ui/buttons/Button/index.tsx
+++ b/lib/ui/buttons/Button/index.tsx
@@ -12,14 +12,56 @@ import { ButtonProps, PrimaryButtonStatus } from '../ButtonProps'
 
 type ButtonSize = Extract<Size, 'sm' | 'md'>
 
-const ButtonShadow = styled.div`
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  border-radius: inherit;
+// A resting primary button sits proud; every other filled state (primary
+// hover/disabled, secondary) drops to the flatter inset pair.
+const raisedInset = css`
   box-shadow:
-    inset 0px -1px 0.5px 0px #0f1c3e,
-    inset 0px 1px 1px 0px rgba(255, 255, 255, 0.1);
+    inset 0 1px 1.9px 0 rgba(255, 255, 255, 0.24),
+    inset 0 -1px 1.6px 0 rgba(15, 28, 62, 0.48);
+`
+
+const flatInset = css`
+  box-shadow:
+    inset 0 1px 1px 0 rgba(255, 255, 255, 0.1),
+    inset 0 -1px 0.5px 0 rgba(15, 28, 62, 1);
+`
+
+const hairlineBorder = css`
+  border: 1px solid rgba(255, 255, 255, 0.03);
+`
+
+const pillMetrics = (size: ButtonSize) =>
+  match(size, {
+    sm: () => css`
+      font-size: 12px;
+      gap: 4px;
+      height: 36px;
+      line-height: 16px;
+      min-height: 36px;
+      min-width: 36px;
+      ${horizontalPadding(16)}
+    `,
+    md: () => css`
+      font-size: 14px;
+      gap: 8px;
+      height: 46px;
+      line-height: 18px;
+      min-height: 46px;
+      min-width: 46px;
+      ${horizontalPadding(24)}
+    `,
+  })
+
+// The link kind is one size in the design system — both `sm` and `md` render
+// the same 26px pill.
+const linkMetrics = css`
+  font-size: 14px;
+  gap: 8px;
+  height: 26px;
+  line-height: 18px;
+  min-height: 26px;
+  min-width: 26px;
+  ${horizontalPadding(4)}
 `
 
 const StyledButton = styled(UnstyledButton)<{
@@ -29,39 +71,21 @@ const StyledButton = styled(UnstyledButton)<{
   $size: ButtonSize
   $status: PrimaryButtonStatus
 }>`
-  ${({ $disabled, $kind, $loading, $size, $status }) => css`
+  ${({ $disabled, $kind, $loading, $size, $status, theme }) => css`
     align-items: center;
     border: none;
+    border-radius: 99px;
     cursor: pointer;
     display: flex;
-    gap: 8px;
+    font-weight: 500;
     justify-content: center;
+    position: relative;
     transition: all 0.2s;
     width: 100%;
-    position: relative;
 
     ${match($kind, {
       link: () => css`
-        ${match($size, {
-          sm: () => css`
-            border-radius: 26px;
-            font-size: 12px;
-            font-weight: 500;
-            height: 26px;
-            min-height: 26px;
-            min-width: 26px;
-            ${horizontalPadding(4)}
-          `,
-          md: () => css`
-            border-radius: 28px;
-            font-size: 14px;
-            font-weight: 500;
-            height: 28px;
-            min-height: 28px;
-            min-width: 28px;
-            ${horizontalPadding(4)}
-          `,
-        })}
+        ${linkMetrics}
 
         ${$disabled || $loading
           ? css`
@@ -73,39 +97,24 @@ const StyledButton = styled(UnstyledButton)<{
               color: ${getColor('text')};
 
               &:hover {
-                color: ${getColor('buttonHover')};
+                background-color: ${getColor('buttonLinkHover')};
               }
             `}
       `,
       primary: () => css`
-        ${match($size, {
-          sm: () => css`
-            border-radius: 36px;
-            font-size: 12px;
-            font-weight: 500;
-            height: 36px;
-            min-height: 36px;
-            min-width: 36px;
-            ${horizontalPadding(16)}
-          `,
-          md: () => css`
-            border-radius: 46px;
-            font-size: 14px;
-            font-weight: 500;
-            height: 46px;
-            min-height: 46px;
-            min-width: 46px;
-            ${horizontalPadding(24)}
-          `,
-        })}
+        ${pillMetrics($size)}
 
         ${$disabled || $loading
           ? css`
+              ${flatInset}
               background-color: ${getColor('buttonBackgroundDisabled')};
               color: ${getColor('buttonTextDisabled')};
               cursor: default;
             `
           : css`
+              ${hairlineBorder}
+              ${raisedInset}
+
               ${match($status, {
                 default: () => css`
                   color: ${getColor('text')};
@@ -126,6 +135,8 @@ const StyledButton = styled(UnstyledButton)<{
               })}
 
               &:hover {
+                ${flatInset}
+
                 ${match($status, {
                   default: () => css`
                     background-color: ${getColor('buttonHover')};
@@ -144,26 +155,7 @@ const StyledButton = styled(UnstyledButton)<{
             `}
       `,
       outlined: () => css`
-        ${match($size, {
-          sm: () => css`
-            border-radius: 36px;
-            font-size: 12px;
-            font-weight: 500;
-            height: 36px;
-            min-height: 36px;
-            min-width: 36px;
-            ${horizontalPadding(16)}
-          `,
-          md: () => css`
-            border-radius: 46px;
-            font-size: 14px;
-            font-weight: 500;
-            height: 46px;
-            min-height: 46px;
-            min-width: 46px;
-            ${horizontalPadding(24)}
-          `,
-        })}
+        ${pillMetrics($size)}
 
         ${$disabled || $loading
           ? css`
@@ -183,36 +175,22 @@ const StyledButton = styled(UnstyledButton)<{
             `}
       `,
       secondary: () => css`
-        ${match($size, {
-          sm: () => css`
-            border-radius: 36px;
-            font-size: 12px;
-            font-weight: 500;
-            height: 36px;
-            min-height: 36px;
-            min-width: 36px;
-            ${horizontalPadding(16)}
-          `,
-          md: () => css`
-            border-radius: 46px;
-            font-size: 14px;
-            font-weight: 500;
-            height: 46px;
-            min-height: 46px;
-            min-width: 46px;
-            ${horizontalPadding(24)}
-          `,
-        })}
+        ${pillMetrics($size)}
+        ${flatInset}
 
         ${$disabled || $loading
           ? css`
-              background-color: ${getColor('buttonBackgroundDisabled')};
+              background-color: transparent;
+              border: 1px solid
+                ${theme.colors.buttonNeutral
+                  .getVariant({ a: () => 0.6 })
+                  .toCssValue()};
               color: ${getColor('buttonTextDisabled')};
               cursor: default;
             `
           : css`
+              ${hairlineBorder}
               background-color: ${getColor('buttonSecondary')};
-              border: 1px solid rgba(255, 255, 255, 0.03);
               color: ${getColor('text')};
 
               &:hover {
@@ -249,8 +227,6 @@ export const Button: FC<
     ...rest,
   }
 
-  const showShadow = kind === 'primary' && !disabled && !loading
-
   return typeof disabled === 'string' ? (
     <Tooltip
       content={disabled}
@@ -258,7 +234,6 @@ export const Button: FC<
         <StyledButton {...options} {...htmlProps} {...styledProps}>
           {loading ? <Spinner /> : icon}
           {children}
-          {showShadow && <ButtonShadow />}
         </StyledButton>
       )}
     />
@@ -266,14 +241,13 @@ export const Button: FC<
     <StyledButton {...htmlProps} {...styledProps}>
       {loading ? <Spinner /> : icon}
       {children}
-      {showShadow && <ButtonShadow />}
     </StyledButton>
   )
 }
 
 export const buttonSize: Record<ButtonSize, number> = {
   sm: 26,
-  md: 28,
+  md: 26,
 }
 
 export const buttonHeight: Record<ButtonSize, number> = {

--- a/lib/ui/theme/ThemeColors.ts
+++ b/lib/ui/theme/ThemeColors.ts
@@ -35,6 +35,7 @@ export type ThemeColors = {
   buttonSecondaryHover: HSLA
   buttonNeutral: HSLA
   buttonNeutralHover: HSLA
+  buttonSuccessHover: HSLA
   buttonTextDisabled: HSLA
   primaryAccentTwo: HSLA
   primaryAccentFour: HSLA

--- a/lib/ui/theme/darkTheme.ts
+++ b/lib/ui/theme/darkTheme.ts
@@ -42,16 +42,18 @@ export const darkTheme: DefaultTheme = {
     mist: new HSLA(0, 0, 100, 0.06),
     mistExtra: new HSLA(0, 0, 100, 0.13),
 
-    buttonBackgroundDisabled: new HSLA(217, 57, 14),
+    // Button tokens are the exact values of the design system button set
+    buttonBackgroundDisabled: new HSLA(220.85, 68.12, 13.53), // #0b1a3a
     buttonLinkHover: new HSLA(0, 0, 100, 0.04),
     // Primary/Accent 3
-    buttonPrimary: new HSLA(224, 100, 52),
-    buttonHover: new HSLA(215, 75, 47),
-    buttonSecondary: new HSLA(216, 63, 18),
-    buttonSecondaryHover: new HSLA(215, 53, 24),
-    buttonNeutral: new HSLA(224, 75, 50),
-    buttonNeutralHover: new HSLA(215, 75, 47),
-    buttonTextDisabled: new HSLA(216, 15, 52),
+    buttonPrimary: new HSLA(223.52, 100, 52.16), // #0b4eff
+    buttonHover: new HSLA(214.53, 74.9, 46.86), // #1e6ad1
+    buttonSecondary: new HSLA(215.79, 62.64, 17.84), // #11284a
+    buttonSecondaryHover: new HSLA(215.08, 52.85, 24.12), // #1d385e
+    buttonNeutral: new HSLA(223.58, 74.8, 50.2), // #2155df
+    buttonNeutralHover: new HSLA(214.53, 74.9, 46.86), // #1e6ad1
+    buttonSuccessHover: new HSLA(165, 85.44, 40.39), // #0fbf93
+    buttonTextDisabled: new HSLA(215.68, 14.98, 51.57), // #718096
     primaryAccentTwo: new HSLA(224, 96, 40),
     primaryAccentFour: new HSLA(224, 96, 64),
 

--- a/lib/ui/theme/stationTheme.ts
+++ b/lib/ui/theme/stationTheme.ts
@@ -46,6 +46,7 @@ export const stationTheme: DefaultTheme = {
     buttonSecondaryHover: new HSLA(240, 5, 25),
     buttonNeutral: new HSLA(224, 82, 60), // #4572ed
     buttonNeutralHover: new HSLA(224, 89, 66), // #5b84f5
+    buttonSuccessHover: new HSLA(167, 78, 45), // #1cba97
     buttonTextDisabled: new HSLA(240, 3, 54),
     primaryAccentTwo: new HSLA(224, 82, 60),
     primaryAccentFour: new HSLA(224, 89, 66),


### PR DESCRIPTION
First of three PRs for #4548. This one only touches the shared `Button` and its colour tokens — no screen changes yet.

## Where the spec came from

Read directly off the `Button` component set in the Vultisig design system (dark theme). The set is keyed on five axes: `Variant`, `Size`, `State`, `Platform`, `Hierarchy`.

`Platform` matters: the set has **App** and **Web** variants with different geometry. The desktop app and extension already matched **Web** exactly (46/36 heights, 24/16 side padding, 14/12 labels), so Web is what this PR implements. App would have meant 42px small buttons and side padding that grows from 32 to 40 on hover.

## What was actually wrong

| | before | design system |
|---|---|---|
| primary inner shadow | `1px/0.1 + 0.5px/1.0` | `1.9px/0.24 + 1.6px/0.48` |
| primary hairline border | none | `1px rgba(255,255,255,0.03)` |
| secondary inner shadow | none | `1px/0.1 + 0.5px/1.0` |
| secondary disabled | filled grey pill | transparent pill, 60% neutral border |
| link height at md | 28px | 26px |
| link label at sm | 12px | 14px |
| link hover | recoloured the label | tints the background |
| icon gap at sm | 8px | 4px |
| line-height | unset | 18px / 16px |

The shadow the code was putting on primary buttons turns out to be the *secondary* shadow — the two were swapped.

## Things that look like mistakes in the spec but aren't

Two places where the design system reads as inconsistent, and this PR follows it literally anyway because the evidence says it is deliberate:

1. **The md primary carries a hairline border, the sm primary does not**, and success never does. Consistent across default/hover/disabled.
2. **The neutral and success hierarchies sit at 42px against the default hierarchy's 46px.** This is driven by vertical padding — 12px vs 14px — and holds across all three states, so it is a design decision rather than a layout artifact.

## Colour tokens

Every `button*` token now carries the exact design system value. `HSLA` accepts decimals, so each one round-trips to the precise hex:

```
buttonPrimary             #0b4eff
buttonHover               #1e6ad1
buttonSecondary           #11284a
buttonSecondaryHover      #1d385e
buttonNeutral             #2155df
buttonSuccessHover        #0fbf93   (new)
buttonBackgroundDisabled  #0b1a3a
buttonTextDisabled        #718096
```

Each was already within three units per channel, so nothing shifts visibly — but the tokens are now the spec rather than an approximation of it.

`buttonSuccessHover` is new because the success button had no hover state at all: it was reusing its resting colour.

App-wide tokens (`text`, `background`, `primary`) are left alone. They differ by one or two units and changing them belongs in a theme pass, not here.

Heads up that `buttonBackgroundDisabled` is also read by `IconButton`, `MultiCharacterInput` and `AgentChatInput`. The shift there is five units per channel.

## Verification

`Button.spec.tsx` renders the button through styled-components and asserts the generated CSS against the design system, so this cannot drift silently again. 19 tests.

I sanity-checked that the tests are not vacuous by deliberately breaking the neutral height and confirming the matching test failed.

## Not touched

`kind="outlined"` is used in six places but does not exist in the design system at all. Left as-is — that is a design decision, not a code one.

Refs #4548

🤖 Generated with [Claude Code](https://claude.com/claude-code)