### PR TITLE
test(storage): assert rollback state, not only connection release

### DIFF
--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -100,9 +100,13 @@ func TestSaveVaultsKeySharesRollsBackFailedChainKeyShareWrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Distinct payload, so a committed transaction would be visible in the
+	// keyshares table and a rolled-back one would not.
 	err := store.SaveVaultsKeyShares(map[string]VaultAllKeyShares{
 		vault.PublicKeyECDSA: {
-			KeyShares:      vault.KeyShares,
+			KeyShares: []KeyShare{
+				{PublicKey: "replacement-public-key", KeyShare: "replacement-share"},
+			},
 			ChainKeyShares: map[string]string{"Bitcoin": "chain-share"},
 		},
 	})
@@ -117,6 +121,30 @@ func TestSaveVaultsKeySharesRollsBackFailedChainKeyShareWrite(t *testing.T) {
 	defer cancel()
 	if _, err := store.db.ExecContext(ctx, "SELECT 1"); err != nil {
 		t.Fatalf("transaction was not released, subsequent write failed: %v", err)
+	}
+
+	// Releasing the connection is not enough: the DELETE and INSERT that ran
+	// before the failure must also have been undone.
+	keyShares, err := store.getKeyShares(vault.PublicKeyECDSA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(keyShares) != len(vault.KeyShares) {
+		t.Fatalf("expected the original %d keyshares to survive rollback, got %d: %#v",
+			len(vault.KeyShares), len(keyShares), keyShares)
+	}
+	for _, keyShare := range keyShares {
+		if keyShare.PublicKey == "replacement-public-key" {
+			t.Fatalf("uncommitted keyshare survived the failed transaction: %#v", keyShare)
+		}
+	}
+
+	saved, err := store.GetVault(vault.PublicKeyECDSA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(saved.ChainKeyShares) != 0 {
+		t.Fatalf("expected no chain key shares after rollback, got %#v", saved.ChainKeyShares)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #4607, which merged before I could push this. Addresses the CodeRabbit review nitpick left on that PR.

## Problem

The regression test added in #4607 passed the vault's **existing** `KeyShares` back into `SaveVaultsKeyShares`. So the rows afterwards were identical whether the transaction rolled back or committed — the test only ever proved the *connection was released*, never that the `DELETE` and `INSERT` were undone.

Those are different guarantees, and rollback is the one the fix is actually about.

## Change

Writes a distinct keyshare payload, then asserts:

- the original keyshares survive the failed write
- the replacement row is absent
- `chain_key_shares` stays empty

## Verification

- **The new assertions have teeth.** Against a genuinely committed write they fire on both the replacement row and the count (1 vs 2) — confirmed with a scratch test, not assumed.
- **The test still fails against the unfixed code.** Reverting the `:=` shadow makes it fail as before.
- `go test ./storage/...` passes against current `main`; `gofmt` clean.

Test-only change — no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction rollback handling so failed writes restore the original key shares.
  * Ensured chain key shares remain absent after a rolled-back transaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->