### PR TITLE
refactor(ui): stop overriding the shared Button's own design language

### DIFF
--- a/clients/desktop/src/versioning/CheckUpdatePage.tsx
+++ b/clients/desktop/src/versioning/CheckUpdatePage.tsx
@@ -7,7 +7,6 @@ import { PageHeader } from '@lib/ui/page/PageHeader'
 import { PageSlice } from '@lib/ui/page/PageSlice'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
 import { Text } from '@lib/ui/text'
-import { getColor } from '@lib/ui/theme/getters'
 import { desktopDownloadUrl } from '@vultisig/core-config'
 import { extractErrorMsg } from '@vultisig/lib-utils/error/extractErrorMsg'
 import { useTranslation } from 'react-i18next'
@@ -143,10 +142,5 @@ const CenteredText = styled(Text)`
 `
 
 const DownloadButton = styled(Button)`
-  padding: 14px 32px;
-  border-radius: 99px;
-  background-color: ${getColor('buttonPrimary')};
-  font-weight: 600;
-  font-size: 14px;
   max-width: 148px;
 `

--- a/core/ui/mpc/fast/FastVaultPasswordModal.tsx
+++ b/core/ui/mpc/fast/FastVaultPasswordModal.tsx
@@ -182,7 +182,7 @@ export const FastVaultPasswordModal: React.FC<FastVaultPasswordModalProps> = ({
             />
           )}
 
-          <ConfirmButton
+          <Button
             data-testid="fast-vault-submit"
             disabled={mutationIsPending || !isValid}
             loading={mutationIsPending}
@@ -190,7 +190,7 @@ export const FastVaultPasswordModal: React.FC<FastVaultPasswordModalProps> = ({
             kind="primary"
           >
             {t('confirm')}
-          </ConfirmButton>
+          </Button>
         </VStack>
       </ModalWrapper>
     </Backdrop>
@@ -222,12 +222,4 @@ const ModalWrapper = styled(VStack)`
   border-radius: 24px;
   border: 1px solid #11284a;
   background: #02122b;
-`
-
-const ConfirmButton = styled(Button)`
-  width: 100%;
-  height: 48px;
-  border-radius: 24px;
-  font-size: 14px;
-  font-weight: 600;
 `

--- a/core/ui/mpc/keygen/create/steps/ReferralHeaderButton.tsx
+++ b/core/ui/mpc/keygen/create/steps/ReferralHeaderButton.tsx
@@ -17,19 +17,15 @@ export const ReferralHeaderButton = ({
   const { t } = useTranslation()
 
   return (
-    <StyledButton size="sm" kind="secondary" onClick={onClick}>
+    <Button size="sm" kind="secondary" onClick={onClick}>
       <HStack alignItems="center" gap={4}>
         {hasReferral && <CheckIcon />}
 
         {hasReferral ? t('fastVaultSetup.referralAdded') : t('add_referral')}
       </HStack>
-    </StyledButton>
+    </Button>
   )
 }
-
-const StyledButton = styled(Button)`
-  cursor: pointer;
-`
 
 const CheckIcon = styled(CircleCheckIcon)`
   font-size: 14px;

--- a/core/ui/vault/chain/address/AddressQRCard.tsx
+++ b/core/ui/vault/chain/address/AddressQRCard.tsx
@@ -101,23 +101,8 @@ const ButtonsRow = styled(HStack)`
   margin-top: 8px;
 `
 
-const ShareButton = styled(Button)`
+const RowButton = styled(Button)`
   flex: 1;
-  border-radius: 40px;
-  font-size: 14px;
-`
-
-const CopyButton = styled(Button)`
-  flex: 1;
-  border-radius: 40px;
-  background: ${({ theme }) => theme.colors.buttonPrimary.toCssValue()};
-  color: ${getColor('contrast')};
-  font-size: 14px;
-
-  &:hover {
-    background: ${({ theme }) =>
-      theme.colors.buttonPrimary.withAlpha(0.8).toCssValue()};
-  }
 `
 
 export const AddressQRCard = ({
@@ -228,10 +213,10 @@ export const AddressQRCard = ({
       </AddressText>
 
       <ButtonsRow>
-        <ShareButton kind="secondary" onClick={handleShare}>
+        <RowButton kind="secondary" onClick={handleShare}>
           {t('share')}
-        </ShareButton>
-        <CopyButton onClick={handleCopy}>{t('copy_address')}</CopyButton>
+        </RowButton>
+        <RowButton onClick={handleCopy}>{t('copy_address')}</RowButton>
       </ButtonsRow>
     </Container>
   )

--- a/core/ui/vault/page/keygen/migrate/MigrateVaultPrompt.tsx
+++ b/core/ui/vault/page/keygen/migrate/MigrateVaultPrompt.tsx
@@ -35,7 +35,7 @@ export const MigrateVaultPrompt = ({
           </Text>
           <Text size={14}>{t('upgrade_now_prompt')}</Text>
         </VStack>
-        <MigrateButton kind="secondary">{t('upgrade_now')}</MigrateButton>
+        <Button status="success">{t('upgrade_now')}</Button>
       </VStack>
 
       <LightingBackground />
@@ -74,16 +74,6 @@ const Container = styled(UnstyledButton)`
 
   @media ${mediaQuery.tabletDeviceAndUp} {
     width: 450px;
-  }
-`
-
-const MigrateButton = styled(Button)`
-  background-color: ${getColor('primary')};
-  color: ${getColor('background')};
-
-  &:hover {
-    background-color: ${({ theme }) =>
-      theme.colors.primary.withAlpha(0.7).toCssValue()};
   }
 `
 

--- a/core/ui/vault/settings/referral/components/ManageReferralsForm.tsx
+++ b/core/ui/vault/settings/referral/components/ManageReferralsForm.tsx
@@ -20,12 +20,10 @@ import { PageContent } from '@lib/ui/page/PageContent'
 import { PageHeader } from '@lib/ui/page/PageHeader'
 import { OnFinishProp } from '@lib/ui/props'
 import { Text } from '@lib/ui/text'
-import { getColor } from '@lib/ui/theme/getters'
 import { attempt } from '@vultisig/lib-utils/attempt'
 import { useEffect, useState } from 'react'
 import { Trans } from 'react-i18next'
 import { useTranslation } from 'react-i18next'
-import styled from 'styled-components'
 
 import { useCoreNavigate } from '../../../../navigation/hooks/useCoreNavigate'
 import { useFriendReferralValidation } from './EditFriendReferralForm/hooks/useFriendReferralValidation'
@@ -127,16 +125,15 @@ export const ManageReferralsForm = ({ onFinish }: OnFinishProp) => {
             </VStack>
           </VStack>
           <VStack gap={8}>
-            <SaveReferralButton
+            <Button
+              kind="secondary"
               disabled={disabled}
               onClick={() => (friendReferral ? onFinish() : handleSave())}
             >
-              <Text as="span" color="contrast">
-                {friendReferral
-                  ? t('edit_friends_referral')
-                  : t('add_referral_code')}
-              </Text>
-            </SaveReferralButton>
+              {friendReferral
+                ? t('edit_friends_referral')
+                : t('add_referral_code')}
+            </Button>
             {friendReferral && (
               <Button
                 kind="secondary"
@@ -152,13 +149,3 @@ export const ManageReferralsForm = ({ onFinish }: OnFinishProp) => {
     </>
   )
 }
-
-const SaveReferralButton = styled(Button)`
-  background-color: rgba(17, 40, 74, 1);
-  font-weight: 600;
-  cursor: pointer;
-
-  &:hover {
-    background-color: ${getColor('buttonHover')};
-  }
-`

--- a/core/ui/vaultsOrganisation/manage/index.tsx
+++ b/core/ui/vaultsOrganisation/manage/index.tsx
@@ -6,9 +6,7 @@ import { useNavigateBack } from '@lib/ui/navigation/hooks/useNavigateBack'
 import { PageContent } from '@lib/ui/page/PageContent'
 import { PageFooter } from '@lib/ui/page/PageFooter'
 import { PageHeader } from '@lib/ui/page/PageHeader'
-import { getColor } from '@lib/ui/theme/getters'
 import { useTranslation } from 'react-i18next'
-import styled from 'styled-components'
 
 import { FoldersSection } from './components/FoldersSection'
 import { VaultsSection } from './components/VaultsSection'
@@ -30,24 +28,13 @@ export const ManageVaultsPage = () => {
         <VaultsSection />
       </PageContent>
       <PageFooter>
-        <AddFolderButton
+        <Button
           kind="secondary"
           onClick={() => navigate({ id: 'createVaultFolder' })}
         >
           {t('add_folder')}
-        </AddFolderButton>
+        </Button>
       </PageFooter>
     </>
   )
 }
-
-const AddFolderButton = styled(Button)`
-  border-radius: 40px;
-  border: none;
-  background: ${getColor('foreground')};
-  color: ${getColor('text')};
-
-  &:hover {
-    background: ${getColor('foregroundExtra')};
-  }
-`


### PR DESCRIPTION
Last of three PRs for #4548, on top of #4614 and #4615.

## What this does

Seven call sites wrapped the shared `Button` in `styled()` and then repainted it. Now that the Button matches the design system, those overrides are exactly what would pull it back out of spec — so they are the last piece of the drift.

**Three were repainting a kind that already exists:**

| | asked for | painted itself as | now |
|---|---|---|---|
| vault folder footer | `secondary` | foreground colours, 40px radius | `secondary` |
| referral save button | primary | `rgba(17, 40, 74)` with a blue hover | `secondary` |
| migrate prompt | `secondary` | success colours | `status="success"` |

`rgba(17, 40, 74)` is `#11284A` — the design system's secondary fill, hardcoded. It had a blue primary hover bolted on, which is the one thing about it that was actually wrong.

**Four were redundant.** The desktop download button, the fast vault confirm button and both address QR row buttons re-declared radius, font size and weight the Button already sets. The confirm button's 48px height and 24px radius were quietly off-spec — the design system says 46px and a full pill. The referral header wrapper set only `cursor: pointer`, which the Button has had all along.

What survives is layout only: `max-width`, `flex`, and a shared row button in the QR card.

## What I got wrong earlier, and corrected

My initial sweep listed six "text buttons that should become `kind=\"link\"`". Reading their actual usage rather than their CSS, **none of them is one.** The design system's link is a standalone 26px pill; these are all something else:

| | what it actually is |
|---|---|
| `MpcServerTypeManager` | an underlined link inside a 12px sentence |
| `BlockaidOverlay` dismiss | 10px de-emphasised action that turns red on hover |
| `BlockaidSiteScanMaliciousOverlay` continue | same, on a malicious-site warning |
| `SearchChain` cancel | inline cancel in a flex search row, needs `flex: none` |
| `CoinTokenInfoSection` contract | a copy-to-clipboard affordance with an icon |
| `LimitAssetSummary` edit | icon-only pencil |

The two Blockaid ones are worth calling out: their red hover is a deliberate danger signal on "dismiss this security warning". Converting them to a neutral link would remove that signal. They stay as they are.

## Eleven overrides left alone

Of the eighteen `styled(Button)` wrappers, eleven are legitimate:

- **Layout only** — `ScanQrView`, the keygen education overlay, both `FastVaultStartKeysignPrompt` buttons, `ShowExactErrorModal`. These set width and flex, nothing about the button's own look.
- **Genuinely different components** — `ToggleSwitch` (a segmented control built on Button), `DeFiActionButton` (computes its left padding from an inset icon), `ModeToggleButton` (12px radius, deliberately not a pill), `AddressBookModal` option (42px, between the sm and md sizes), `MultiCharacterInput` paste chip (24px radius).

The last group is worth a design conversation: each is a control the design system has no variant for. Either it gains one, or these stay bespoke. Not something to decide in a refactor PR.

## Verification

`yarn typecheck` reports the same 20 pre-existing errors before and after — all missing SDK modules, none in the touched files. The `Button.spec.tsx` suite stays green at 21 tests.

86 lines deleted, 17 added.

Refs #4548

🤖 Generated with [Claude Code](https://claude.com/claude-code)