### PR TITLE
feat(ui): adopt the new primary/secondary button design app-wide

### DIFF
--- a/clients/desktop/src/versioning/CheckUpdatePage.tsx
+++ b/clients/desktop/src/versioning/CheckUpdatePage.tsx
@@ -7,7 +7,6 @@ import { PageHeader } from '@lib/ui/page/PageHeader'
 import { PageSlice } from '@lib/ui/page/PageSlice'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
 import { Text } from '@lib/ui/text'
-import { getColor } from '@lib/ui/theme/getters'
 import { desktopDownloadUrl } from '@vultisig/core-config'
 import { extractErrorMsg } from '@vultisig/lib-utils/error/extractErrorMsg'
 import { useTranslation } from 'react-i18next'
@@ -143,10 +142,5 @@ const CenteredText = styled(Text)`
 `
 
 const DownloadButton = styled(Button)`
-  padding: 14px 32px;
-  border-radius: 99px;
-  background-color: ${getColor('buttonPrimary')};
-  font-weight: 600;
-  font-size: 14px;
   max-width: 148px;
 `

--- a/core/ui/defi/chain/components/bond/BondNodeItem.tsx
+++ b/core/ui/defi/chain/components/bond/BondNodeItem.tsx
@@ -3,6 +3,7 @@ import {
   formatDateShort,
   formatStatusLabel,
 } from '@core/ui/defi/shared/formatters'
+import { Button } from '@lib/ui/buttons/Button'
 import { BrokenChainLink3Icon } from '@lib/ui/icons/BrokenChainLink3Icon'
 import { CalendarIcon } from '@lib/ui/icons/CalendarIcon'
 import { ChainLinkIcon3 } from '@lib/ui/icons/ChainLinkIcon3'
@@ -15,9 +16,9 @@ import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
 import { Coin } from '@vultisig/core-chain/coin/Coin'
 import { formatAmount } from '@vultisig/lib-utils/formatAmount'
 import { formatWalletAddress } from '@vultisig/lib-utils/formatWalletAddress'
-import { ButtonHTMLAttributes, CSSProperties, ReactNode } from 'react'
+import { CSSProperties, ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 
 type Props = {
   coin: Coin
@@ -57,68 +58,6 @@ const InfoIcon = styled.div`
 const ButtonRow = styled(HStack)`
   gap: 12px;
   flex-wrap: wrap;
-`
-
-const ActionButton = styled.button.attrs({ type: 'button' })<
-  ButtonHTMLAttributes<HTMLButtonElement> & {
-    variant: 'primary' | 'secondary'
-  }
->`
-  position: relative;
-  display: flex;
-  font-size: 14px;
-  align-items: center;
-  justify-content: center;
-  gap: 10px;
-  border-radius: 999px;
-  height: 48px;
-  padding: 0 26px;
-  font-weight: 600;
-  border: 1px solid transparent;
-  cursor: pointer;
-  transition: opacity 0.2s ease;
-  color: ${getColor('contrast')};
-
-  ${({ variant }) =>
-    variant === 'primary'
-      ? css`
-          background: ${getColor('buttonPrimary')};
-          box-shadow: 0px 8px 24px rgba(31, 39, 61, 0.35);
-        `
-      : css`
-          background: rgba(11, 19, 38, 0.95);
-          border-color: ${getColor('buttonPrimary')};
-        `}
-
-  ${({ disabled }) =>
-    disabled &&
-    css`
-      opacity: 0.4;
-      cursor: default;
-    `}
-`
-
-const ActionIcon = styled.span<{ variant: 'primary' | 'secondary' }>`
-  position: absolute;
-  left: 16px;
-  top: 50%;
-  transform: translateY(-50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  margin-left: -12px;
-  color: ${getColor('contrast')};
-  ${({ variant }) =>
-    variant === 'primary'
-      ? css`
-          background: rgba(255, 255, 255, 0.2);
-        `
-      : css`
-          background: rgba(255, 255, 255, 0.12);
-        `}
 `
 
 export const BondNodeItem = ({
@@ -253,31 +192,26 @@ export const BondNodeItem = ({
       {/* Action Buttons */}
       <ButtonRow>
         {renderAction(
-          <ActionButton
-            variant="secondary"
+          <Button
+            kind="secondary"
             onClick={onUnbond}
             disabled={unbondDisabled}
             style={{ flex: 1 }}
+            icon={<BrokenChainLink3Icon />}
           >
-            <ActionIcon variant="secondary">
-              <BrokenChainLink3Icon />
-            </ActionIcon>
             {t('unbond')}
-          </ActionButton>,
+          </Button>,
           { flex: 1 }
         )}
         {renderAction(
-          <ActionButton
-            variant="primary"
+          <Button
             onClick={onBond}
             disabled={bondDisabled}
             style={{ flex: 1 }}
+            icon={<ChainLinkIcon3 />}
           >
-            <ActionIcon variant="primary">
-              <ChainLinkIcon3 />
-            </ActionIcon>
             {t('bond')}
-          </ActionButton>,
+          </Button>,
           { flex: 1 }
         )}
       </ButtonRow>

--- a/core/ui/defi/chain/components/stake/StakeCard.tsx
+++ b/core/ui/defi/chain/components/stake/StakeCard.tsx
@@ -1,6 +1,7 @@
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { useFormatFiatAmount } from '@core/ui/chain/hooks/useFormatFiatAmount'
 import { formatDateShort } from '@core/ui/defi/shared/formatters'
+import { Button } from '@lib/ui/buttons/Button'
 import { ArrowUpRightIcon } from '@lib/ui/icons/ArrowUpRightIcon'
 import { CalendarIcon } from '@lib/ui/icons/CalendarIcon'
 import { CircleInfoIcon } from '@lib/ui/icons/CircleInfoIcon'
@@ -17,9 +18,9 @@ import { Tooltip } from '@lib/ui/tooltips/Tooltip'
 import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
 import { Coin } from '@vultisig/core-chain/coin/Coin'
 import { formatAmount } from '@vultisig/lib-utils/formatAmount'
-import { ButtonHTMLAttributes, CSSProperties, ReactNode } from 'react'
+import { CSSProperties, ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 
 const Card = styled(Panel)`
   padding: 20px;
@@ -62,68 +63,6 @@ const ActionsRow = styled(HStack)`
   width: 100%;
   gap: 12px;
   flex-wrap: wrap;
-`
-
-const ActionButton = styled.button.attrs({ type: 'button' })<
-  ButtonHTMLAttributes<HTMLButtonElement> & {
-    variant: 'primary' | 'secondary'
-  }
->`
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 10px;
-  border-radius: 999px;
-  height: 48px;
-  padding: 0 26px;
-  font-size: 16px;
-  font-weight: 600;
-  border: 1px solid transparent;
-  cursor: pointer;
-  transition: opacity 0.2s ease;
-  color: ${getColor('contrast')};
-
-  ${({ variant }) =>
-    variant === 'primary'
-      ? css`
-          background: ${getColor('buttonPrimary')};
-          box-shadow: 0px 8px 24px rgba(31, 39, 61, 0.35);
-        `
-      : css`
-          background: rgba(11, 19, 38, 0.95);
-          border-color: ${getColor('buttonPrimary')};
-        `}
-
-  ${({ disabled }) =>
-    disabled &&
-    css`
-      opacity: 0.4;
-      cursor: default;
-    `}
-`
-
-const ActionIcon = styled.span<{ variant: 'primary' | 'secondary' }>`
-  position: absolute;
-  left: 16px;
-  top: 50%;
-  transform: translateY(-50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  margin-left: -12px;
-  color: ${getColor('contrast')};
-  ${({ variant }) =>
-    variant === 'primary'
-      ? css`
-          background: rgba(255, 255, 255, 0.2);
-        `
-      : css`
-          background: rgba(255, 255, 255, 0.12);
-        `}
 `
 
 type Props = {
@@ -317,22 +256,16 @@ export const StakeCard = ({
         <StatRow>
           {rewards !== undefined && rewards > 0
             ? renderAction(
-                <ActionButton
-                  variant="primary"
+                <Button
                   onClick={onWithdrawRewards}
                   disabled={actionsDisabled}
-                  style={{ width: '100%' }}
+                  icon={<CircleMinusIcon />}
                 >
-                  <ActionIcon variant="primary">
-                    <CircleMinusIcon />
-                  </ActionIcon>
-                  <Text as="span" size={14} weight="600" color="contrast">
-                    {t('withdraw')}{' '}
-                    {formatAmount(rewards, {
-                      ticker: rewardTicker ?? coin.ticker,
-                    })}
-                  </Text>
-                </ActionButton>,
+                  {t('withdraw')}{' '}
+                  {formatAmount(rewards, {
+                    ticker: rewardTicker ?? coin.ticker,
+                  })}
+                </Button>,
                 { width: '100%' }
               )
             : null}
@@ -341,17 +274,13 @@ export const StakeCard = ({
         {onTransfer && (
           <ActionsRow>
             {renderAction(
-              <ActionButton
-                variant="primary"
+              <Button
                 onClick={onTransfer}
                 disabled={actionsDisabled || isPendingAction}
-                style={{ width: '100%' }}
+                icon={<ArrowUpRightIcon />}
               >
-                <ActionIcon variant="primary">
-                  <ArrowUpRightIcon />
-                </ActionIcon>
                 {t('transfer')}
-              </ActionButton>,
+              </Button>,
               { width: '100%' }
             )}
           </ActionsRow>
@@ -366,31 +295,26 @@ export const StakeCard = ({
           ) : (
             <>
               {renderAction(
-                <ActionButton
-                  variant="secondary"
+                <Button
+                  kind="secondary"
                   onClick={onUnstake}
                   style={{ flex: 1 }}
                   disabled={unstakeDisabled}
+                  icon={<CircleMinusIcon />}
                 >
-                  <ActionIcon variant="secondary">
-                    <CircleMinusIcon />
-                  </ActionIcon>
                   {_unstakeLabel ?? t('unstake')}
-                </ActionButton>,
+                </Button>,
                 { flex: 1 }
               )}
               {renderAction(
-                <ActionButton
-                  variant="primary"
+                <Button
                   onClick={onStake}
                   style={{ flex: 1 }}
                   disabled={stakeDisabled}
+                  icon={<CirclePlusIcon />}
                 >
-                  <ActionIcon variant="primary">
-                    <CirclePlusIcon />
-                  </ActionIcon>
                   {_stakeLabel ?? t('stake')}
-                </ActionButton>,
+                </Button>,
                 { flex: 1 }
               )}
             </>

--- a/core/ui/defi/chain/tabs/LpPositions.tsx
+++ b/core/ui/defi/chain/tabs/LpPositions.tsx
@@ -12,6 +12,7 @@ import {
 } from '@core/ui/storage/defiPositions'
 import { ChainAction } from '@core/ui/vault/deposit/ChainAction'
 import { useCurrentVaultAddresses } from '@core/ui/vault/state/currentVaultCoins'
+import { Button } from '@lib/ui/buttons/Button'
 import { CircleMinusIcon } from '@lib/ui/icons/CircleMinusIcon'
 import { CirclePlusIcon } from '@lib/ui/icons/CirclePlusIcon'
 import { PercentIcon } from '@lib/ui/icons/PercentIcon'
@@ -22,7 +23,7 @@ import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { useTranslation } from 'react-i18next'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 
 import { resolveDefiPositionIcon } from '../config/defiPositionResolver'
 import { useMayaLpPositionsQuery } from '../queries/useMayaLpPositionsQuery'
@@ -79,69 +80,6 @@ const ActionsRow = styled(HStack)`
     min-width: 0;
     display: flex;
   }
-`
-
-const ActionButton = styled.button.attrs({ type: 'button' })<{
-  variant: 'primary' | 'secondary'
-}>`
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 10px;
-  border-radius: 999px;
-  height: 48px;
-  padding: 0 26px;
-  font-size: 16px;
-  font-weight: 600;
-  border: 1px solid transparent;
-  cursor: pointer;
-  transition: opacity 0.2s ease;
-  color: ${getColor('contrast')};
-  flex: 1;
-  min-width: 140px;
-
-  ${({ variant }) =>
-    variant === 'primary'
-      ? css`
-          background: ${getColor('buttonPrimary')};
-          box-shadow: 0px 8px 24px rgba(31, 39, 61, 0.35);
-        `
-      : css`
-          background: rgba(11, 19, 38, 0.95);
-          border-color: ${getColor('buttonPrimary')};
-        `}
-
-  ${({ disabled }) =>
-    disabled &&
-    css`
-      opacity: 0.4;
-      cursor: default;
-      pointer-events: none;
-    `}
-`
-
-const ActionIcon = styled.span<{ variant: 'primary' | 'secondary' }>`
-  position: absolute;
-  left: 16px;
-  top: 50%;
-  transform: translateY(-50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  margin-left: -12px;
-  color: ${getColor('contrast')};
-  ${({ variant }) =>
-    variant === 'primary'
-      ? css`
-          background: rgba(255, 255, 255, 0.2);
-        `
-      : css`
-          background: rgba(255, 255, 255, 0.12);
-        `}
 `
 
 const formatCryptoAmount = (value: number, decimals = 4) =>
@@ -338,26 +276,21 @@ export const LpPositions = () => {
               </VStack>
 
               <ActionsRow>
-                <ActionButton
-                  variant="secondary"
+                <Button
+                  kind="secondary"
                   disabled={!hasPosition}
                   onClick={() => handleRemove(position, positionData)}
+                  icon={<CircleMinusIcon />}
                 >
-                  <ActionIcon variant="secondary">
-                    <CircleMinusIcon />
-                  </ActionIcon>
                   {t('defi_remove')}
-                </ActionButton>
+                </Button>
 
-                <ActionButton
-                  variant="primary"
+                <Button
                   onClick={() => handleAdd(position)}
+                  icon={<CirclePlusIcon />}
                 >
-                  <ActionIcon variant="primary">
-                    <CirclePlusIcon />
-                  </ActionIcon>
                   {t('defi_add')}
-                </ActionButton>
+                </Button>
               </ActionsRow>
             </VStack>
           </Card>

--- a/core/ui/mpc/fast/FastVaultPasswordModal.tsx
+++ b/core/ui/mpc/fast/FastVaultPasswordModal.tsx
@@ -182,7 +182,7 @@ export const FastVaultPasswordModal: React.FC<FastVaultPasswordModalProps> = ({
             />
           )}
 
-          <ConfirmButton
+          <Button
             data-testid="fast-vault-submit"
             disabled={mutationIsPending || !isValid}
             loading={mutationIsPending}
@@ -190,7 +190,7 @@ export const FastVaultPasswordModal: React.FC<FastVaultPasswordModalProps> = ({
             kind="primary"
           >
             {t('confirm')}
-          </ConfirmButton>
+          </Button>
         </VStack>
       </ModalWrapper>
     </Backdrop>
@@ -222,12 +222,4 @@ const ModalWrapper = styled(VStack)`
   border-radius: 24px;
   border: 1px solid #11284a;
   background: #02122b;
-`
-
-const ConfirmButton = styled(Button)`
-  width: 100%;
-  height: 48px;
-  border-radius: 24px;
-  font-size: 14px;
-  font-weight: 600;
 `

--- a/core/ui/mpc/keygen/create/steps/ReferralHeaderButton.tsx
+++ b/core/ui/mpc/keygen/create/steps/ReferralHeaderButton.tsx
@@ -17,19 +17,15 @@ export const ReferralHeaderButton = ({
   const { t } = useTranslation()
 
   return (
-    <StyledButton size="sm" kind="secondary" onClick={onClick}>
+    <Button size="sm" kind="secondary" onClick={onClick}>
       <HStack alignItems="center" gap={4}>
         {hasReferral && <CheckIcon />}
 
         {hasReferral ? t('fastVaultSetup.referralAdded') : t('add_referral')}
       </HStack>
-    </StyledButton>
+    </Button>
   )
 }
-
-const StyledButton = styled(Button)`
-  cursor: pointer;
-`
 
 const CheckIcon = styled(CircleCheckIcon)`
   font-size: 14px;

--- a/core/ui/qbtc/claim/components/QbtcClaimBanner.styles.tsx
+++ b/core/ui/qbtc/claim/components/QbtcClaimBanner.styles.tsx
@@ -126,7 +126,7 @@ export const BannerTextStack = styled.div`
 /**
  * The design system's mini primary pill, centred above the banner artwork.
  */
-export const BannerCta = styled(Button).attrs({ size: 'xs' as const })`
+export const BannerCta = styled(Button).attrs({ size: 'xs' })`
   align-self: center;
   white-space: nowrap;
   z-index: 2;

--- a/core/ui/qbtc/claim/components/QbtcClaimBanner.styles.tsx
+++ b/core/ui/qbtc/claim/components/QbtcClaimBanner.styles.tsx
@@ -1,6 +1,5 @@
-import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { Button } from '@lib/ui/buttons/Button'
 import { vStack } from '@lib/ui/layout/Stack'
-import { text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
 
@@ -124,37 +123,11 @@ export const BannerTextStack = styled.div`
   text-align: center;
 `
 
-export const BannerCta = styled(UnstyledButton)`
-  ${text({
-    size: 12,
-    weight: 500,
-    height: 16 / 12,
-  })};
-
-  position: relative;
-  z-index: 2;
+/**
+ * The design system's mini primary pill, centred above the banner artwork.
+ */
+export const BannerCta = styled(Button).attrs({ size: 'xs' as const })`
   align-self: center;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 8px 16px;
-  border-radius: 30px;
-  background: ${getColor('buttonPrimary')};
-  color: ${getColor('text')};
   white-space: nowrap;
-  box-shadow:
-    inset 0 -1px 0.5px 0 #0f1c3e,
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.1);
-  transition:
-    transform 0.2s,
-    opacity 0.2s;
-
-  &:hover {
-    transform: scale(1.02);
-    opacity: 0.9;
-  }
-
-  &:active {
-    transform: scale(0.98);
-  }
+  z-index: 2;
 `

--- a/core/ui/vault/chain/address/AddressQRCard.tsx
+++ b/core/ui/vault/chain/address/AddressQRCard.tsx
@@ -101,23 +101,8 @@ const ButtonsRow = styled(HStack)`
   margin-top: 8px;
 `
 
-const ShareButton = styled(Button)`
+const RowButton = styled(Button)`
   flex: 1;
-  border-radius: 40px;
-  font-size: 14px;
-`
-
-const CopyButton = styled(Button)`
-  flex: 1;
-  border-radius: 40px;
-  background: ${({ theme }) => theme.colors.buttonPrimary.toCssValue()};
-  color: ${getColor('contrast')};
-  font-size: 14px;
-
-  &:hover {
-    background: ${({ theme }) =>
-      theme.colors.buttonPrimary.withAlpha(0.8).toCssValue()};
-  }
 `
 
 export const AddressQRCard = ({
@@ -228,10 +213,10 @@ export const AddressQRCard = ({
       </AddressText>
 
       <ButtonsRow>
-        <ShareButton kind="secondary" onClick={handleShare}>
+        <RowButton kind="secondary" onClick={handleShare}>
           {t('share')}
-        </ShareButton>
-        <CopyButton onClick={handleCopy}>{t('copy_address')}</CopyButton>
+        </RowButton>
+        <RowButton onClick={handleCopy}>{t('copy_address')}</RowButton>
       </ButtonsRow>
     </Container>
   )

--- a/core/ui/vault/chain/tron/TronResourcesInfoModal.tsx
+++ b/core/ui/vault/chain/tron/TronResourcesInfoModal.tsx
@@ -1,6 +1,7 @@
 import { ChainEntityIcon } from '@core/ui/chain/coin/icon/ChainEntityIcon'
 import { getChainLogoSrc } from '@core/ui/chain/metadata/getChainLogoSrc'
 import { useCore } from '@core/ui/state/core'
+import { Button } from '@lib/ui/buttons/Button'
 import CaretDownIcon from '@lib/ui/icons/CaretDownIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { TronBandwidthIcon } from '@lib/ui/icons/TronBandwidthIcon'
@@ -164,11 +165,9 @@ export const TronResourcesInfoModal = ({
           </RowWrapper>
         </AccordionWrapper>
 
-        <LearnMoreButton onClick={() => openUrl(tronDocsUrl)}>
-          <Text size={14} weight="600" color="contrast">
-            {t('learnMore')}
-          </Text>
-        </LearnMoreButton>
+        <Button kind="secondary" onClick={() => openUrl(tronDocsUrl)}>
+          {t('learnMore')}
+        </Button>
       </ContentContainer>
     </ResponsiveModal>
   )
@@ -240,23 +239,4 @@ const Divider = styled.div`
   height: 1px;
   width: 100%;
   background: linear-gradient(90deg, #061b3a 0%, #284570 49.5%, #061b3a 100%);
-`
-
-const LearnMoreButton = styled.button`
-  display: flex;
-  width: 100%;
-  padding: 14px 32px;
-  justify-content: center;
-  align-items: center;
-  gap: 8px;
-  border-radius: 99px;
-  border: 1px solid ${getColor('foregroundExtra')};
-  background: ${getColor('foreground')};
-  box-shadow: 0 1px 1px 0 rgba(255, 255, 255, 0.1) inset;
-  cursor: pointer;
-  transition: background 0.2s;
-
-  &:hover {
-    background: ${getColor('foregroundExtra')};
-  }
 `

--- a/core/ui/vault/page/banners/shared/BannerPromoCtaButton.styles.tsx
+++ b/core/ui/vault/page/banners/shared/BannerPromoCtaButton.styles.tsx
@@ -1,43 +1,13 @@
-import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
-import { text } from '@lib/ui/text'
-import { getColor } from '@lib/ui/theme/getters'
+import { Button } from '@lib/ui/buttons/Button'
 import styled from 'styled-components'
 
-export const BannerPromoCtaButton = styled(UnstyledButton)`
-  ${text({
-    size: 12,
-    weight: 500,
-    height: 16 / 12,
-  })};
-
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-  padding: 8px 16px;
-  border-radius: 30px;
-  background: ${getColor('primary')};
-  color: ${getColor('background')};
+/**
+ * The design system's mini success pill, used as the call to action inside the
+ * home promo banners. Banners lay these out inline, so the label never wraps.
+ */
+export const BannerPromoCtaButton = styled(Button).attrs({
+  size: 'xs' as const,
+  status: 'success' as const,
+})`
   white-space: nowrap;
-  box-shadow:
-    inset 0 -1px 0.5px 0 rgba(15, 28, 62, 1),
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.1);
-  transition:
-    transform 0.2s,
-    opacity 0.2s;
-
-  &:hover:not(:disabled) {
-    transform: scale(1.02);
-    opacity: 0.9;
-  }
-
-  &:active:not(:disabled) {
-    transform: scale(0.98);
-  }
-
-  &:disabled {
-    opacity: 0.55;
-    cursor: default;
-  }
 `

--- a/core/ui/vault/page/banners/shared/BannerPromoCtaButton.styles.tsx
+++ b/core/ui/vault/page/banners/shared/BannerPromoCtaButton.styles.tsx
@@ -6,8 +6,8 @@ import styled from 'styled-components'
  * home promo banners. Banners lay these out inline, so the label never wraps.
  */
 export const BannerPromoCtaButton = styled(Button).attrs({
-  size: 'xs' as const,
-  status: 'success' as const,
+  size: 'xs',
+  status: 'success',
 })`
   white-space: nowrap;
 `

--- a/core/ui/vault/page/keygen/migrate/MigrateVaultPrompt.tsx
+++ b/core/ui/vault/page/keygen/migrate/MigrateVaultPrompt.tsx
@@ -35,7 +35,7 @@ export const MigrateVaultPrompt = ({
           </Text>
           <Text size={14}>{t('upgrade_now_prompt')}</Text>
         </VStack>
-        <MigrateButton kind="secondary">{t('upgrade_now')}</MigrateButton>
+        <Button status="success">{t('upgrade_now')}</Button>
       </VStack>
 
       <LightingBackground />
@@ -74,16 +74,6 @@ const Container = styled(UnstyledButton)`
 
   @media ${mediaQuery.tabletDeviceAndUp} {
     width: 450px;
-  }
-`
-
-const MigrateButton = styled(Button)`
-  background-color: ${getColor('primary')};
-  color: ${getColor('background')};
-
-  &:hover {
-    background-color: ${({ theme }) =>
-      theme.colors.primary.withAlpha(0.7).toCssValue()};
   }
 `
 

--- a/core/ui/vault/settings/referral/components/ManageReferralsForm.tsx
+++ b/core/ui/vault/settings/referral/components/ManageReferralsForm.tsx
@@ -20,12 +20,10 @@ import { PageContent } from '@lib/ui/page/PageContent'
 import { PageHeader } from '@lib/ui/page/PageHeader'
 import { OnFinishProp } from '@lib/ui/props'
 import { Text } from '@lib/ui/text'
-import { getColor } from '@lib/ui/theme/getters'
 import { attempt } from '@vultisig/lib-utils/attempt'
 import { useEffect, useState } from 'react'
 import { Trans } from 'react-i18next'
 import { useTranslation } from 'react-i18next'
-import styled from 'styled-components'
 
 import { useCoreNavigate } from '../../../../navigation/hooks/useCoreNavigate'
 import { useFriendReferralValidation } from './EditFriendReferralForm/hooks/useFriendReferralValidation'
@@ -127,16 +125,15 @@ export const ManageReferralsForm = ({ onFinish }: OnFinishProp) => {
             </VStack>
           </VStack>
           <VStack gap={8}>
-            <SaveReferralButton
+            <Button
+              kind="secondary"
               disabled={disabled}
               onClick={() => (friendReferral ? onFinish() : handleSave())}
             >
-              <Text as="span" color="contrast">
-                {friendReferral
-                  ? t('edit_friends_referral')
-                  : t('add_referral_code')}
-              </Text>
-            </SaveReferralButton>
+              {friendReferral
+                ? t('edit_friends_referral')
+                : t('add_referral_code')}
+            </Button>
             {friendReferral && (
               <Button
                 kind="secondary"
@@ -152,13 +149,3 @@ export const ManageReferralsForm = ({ onFinish }: OnFinishProp) => {
     </>
   )
 }
-
-const SaveReferralButton = styled(Button)`
-  background-color: rgba(17, 40, 74, 1);
-  font-weight: 600;
-  cursor: pointer;
-
-  &:hover {
-    background-color: ${getColor('buttonHover')};
-  }
-`

--- a/core/ui/vaultsOrganisation/manage/index.tsx
+++ b/core/ui/vaultsOrganisation/manage/index.tsx
@@ -6,9 +6,7 @@ import { useNavigateBack } from '@lib/ui/navigation/hooks/useNavigateBack'
 import { PageContent } from '@lib/ui/page/PageContent'
 import { PageFooter } from '@lib/ui/page/PageFooter'
 import { PageHeader } from '@lib/ui/page/PageHeader'
-import { getColor } from '@lib/ui/theme/getters'
 import { useTranslation } from 'react-i18next'
-import styled from 'styled-components'
 
 import { FoldersSection } from './components/FoldersSection'
 import { VaultsSection } from './components/VaultsSection'
@@ -30,24 +28,13 @@ export const ManageVaultsPage = () => {
         <VaultsSection />
       </PageContent>
       <PageFooter>
-        <AddFolderButton
+        <Button
           kind="secondary"
           onClick={() => navigate({ id: 'createVaultFolder' })}
         >
           {t('add_folder')}
-        </AddFolderButton>
+        </Button>
       </PageFooter>
     </>
   )
 }
-
-const AddFolderButton = styled(Button)`
-  border-radius: 40px;
-  border: none;
-  background: ${getColor('foreground')};
-  color: ${getColor('text')};
-
-  &:hover {
-    background: ${getColor('foregroundExtra')};
-  }
-`

--- a/lib/ui/buttons/Button/Button.spec.tsx
+++ b/lib/ui/buttons/Button/Button.spec.tsx
@@ -1,0 +1,145 @@
+import { darkTheme } from '@lib/ui/theme/darkTheme'
+import { ReactElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { ServerStyleSheet, ThemeProvider } from 'styled-components'
+import { describe, expect, test } from 'vitest'
+
+import { Button } from '.'
+
+// Values below are read straight off the "Button" component set in the
+// Vultisig design system (Web platform, dark theme). They are asserted here so
+// the shared Button cannot silently drift away from the spec again.
+const styleOf = (ui: ReactElement) => {
+  const sheet = new ServerStyleSheet()
+  try {
+    renderToStaticMarkup(
+      sheet.collectStyles(<ThemeProvider theme={darkTheme}>{ui}</ThemeProvider>)
+    )
+    return sheet.getStyleTags().replace(/\s+/g, '')
+  } finally {
+    sheet.seal()
+  }
+}
+
+const hairline = 'border:1pxsolidrgba(255,255,255,0.03)'
+const raisedInset = 'inset01px1.9px0rgba(255,255,255,0.24)'
+const flatInset = 'inset01px1px0rgba(255,255,255,0.1)'
+
+describe('design system colours', () => {
+  test.each([
+    ['buttonPrimary', '#0b4eff'],
+    ['buttonHover', '#1e6ad1'],
+    ['buttonSecondary', '#11284a'],
+    ['buttonSecondaryHover', '#1d385e'],
+    ['buttonNeutral', '#2155df'],
+    ['buttonNeutralHover', '#1e6ad1'],
+    ['buttonSuccessHover', '#0fbf93'],
+    ['buttonBackgroundDisabled', '#0b1a3a'],
+    ['buttonTextDisabled', '#718096'],
+  ] as const)('%s is %s', (token, hex) => {
+    expect(darkTheme.colors[token].toHex()).toBe(hex)
+  })
+})
+
+describe('primary', () => {
+  test('md default is a 46px pill with a hairline and the raised inset', () => {
+    const css = styleOf(<Button>Get started</Button>)
+
+    expect(css).toContain('height:46px')
+    expect(css).toContain('padding-left:24px')
+    expect(css).toContain('font-size:14px')
+    expect(css).toContain('line-height:18px')
+    expect(css).toContain('gap:8px')
+    expect(css).toContain(hairline)
+    expect(css).toContain(raisedInset)
+  })
+
+  test('sm default is a 36px pill with no hairline', () => {
+    const css = styleOf(<Button size="sm">Get started</Button>)
+
+    expect(css).toContain('height:36px')
+    expect(css).toContain('padding-left:16px')
+    expect(css).toContain('font-size:12px')
+    expect(css).toContain('line-height:16px')
+    expect(css).toContain('gap:4px')
+    expect(css).not.toContain(hairline)
+  })
+
+  test('md neutral and success sit 4px shorter', () => {
+    expect(styleOf(<Button status="neutral">x</Button>)).toContain(
+      'height:42px'
+    )
+    expect(styleOf(<Button status="success">x</Button>)).toContain(
+      'height:42px'
+    )
+  })
+
+  test('success carries no hairline while neutral does', () => {
+    expect(styleOf(<Button status="success">x</Button>)).not.toContain(hairline)
+    expect(styleOf(<Button status="neutral">x</Button>)).toContain(hairline)
+  })
+
+  test('hover drops to the flat inset', () => {
+    expect(styleOf(<Button>x</Button>)).toContain(flatInset)
+  })
+
+  test('disabled is the flat inset with no hairline', () => {
+    const css = styleOf(<Button disabled>x</Button>)
+
+    expect(css).toContain(
+      darkTheme.colors.buttonBackgroundDisabled.toCssValue()
+    )
+    expect(css).toContain(flatInset)
+    expect(css).not.toContain(hairline)
+  })
+})
+
+describe('secondary', () => {
+  test('rests as a filled pill with a hairline and the flat inset', () => {
+    const css = styleOf(<Button kind="secondary">x</Button>)
+
+    expect(css).toContain('height:46px')
+    expect(css).toContain(darkTheme.colors.buttonSecondary.toCssValue())
+    expect(css).toContain(hairline)
+    expect(css).toContain(flatInset)
+  })
+
+  test('disabled is transparent behind a 60% neutral border', () => {
+    const css = styleOf(
+      <Button kind="secondary" disabled>
+        x
+      </Button>
+    )
+
+    expect(css).toContain('background-color:transparent')
+    expect(css).toContain(
+      darkTheme.colors.buttonNeutral
+        .getVariant({ a: () => 0.6 })
+        .toCssValue()
+        .replace(/\s+/g, '')
+    )
+  })
+})
+
+describe('link', () => {
+  test('renders one 26px size for both sm and md', () => {
+    const md = styleOf(<Button kind="link">x</Button>)
+    const sm = styleOf(
+      <Button kind="link" size="sm">
+        x
+      </Button>
+    )
+
+    expect(md).toContain('height:26px')
+    expect(sm).toContain('height:26px')
+    expect(md).toContain('font-size:14px')
+    expect(sm).toContain('font-size:14px')
+    expect(md).toContain('padding-left:4px')
+  })
+
+  test('hover tints the background instead of recolouring the label', () => {
+    const css = styleOf(<Button kind="link">x</Button>)
+
+    expect(css).toContain(darkTheme.colors.buttonLinkHover.toCssValue())
+  })
+})

--- a/lib/ui/buttons/Button/Button.spec.tsx
+++ b/lib/ui/buttons/Button/Button.spec.tsx
@@ -83,6 +83,29 @@ describe('primary', () => {
     expect(styleOf(<Button>x</Button>)).toContain(flatInset)
   })
 
+  test('only the default hierarchy rests on the raised inset', () => {
+    expect(styleOf(<Button>x</Button>)).toContain(raisedInset)
+    expect(styleOf(<Button status="neutral">x</Button>)).not.toContain(
+      raisedInset
+    )
+    expect(styleOf(<Button status="success">x</Button>)).not.toContain(
+      raisedInset
+    )
+  })
+
+  test('xs is the 32px mini pill', () => {
+    const css = styleOf(<Button size="xs">x</Button>)
+
+    expect(css).toContain('height:32px')
+    expect(css).toContain('border-radius:30px')
+    expect(css).toContain('padding-left:16px')
+    expect(css).toContain('font-size:12px')
+    expect(css).toContain('line-height:16px')
+    expect(css).toContain('gap:4px')
+    expect(css).toContain('width:fit-content')
+    expect(css).not.toContain(hairline)
+  })
+
   test('disabled is the flat inset with no hairline', () => {
     const css = styleOf(<Button disabled>x</Button>)
 

--- a/lib/ui/buttons/Button/Button.spec.tsx
+++ b/lib/ui/buttons/Button/Button.spec.tsx
@@ -21,7 +21,9 @@ const styleOf = (ui: ReactElement) => {
   }
 }
 
-const hairline = 'border:1pxsolidrgba(255,255,255,0.03)'
+// The hairline is an inside stroke in the design system, so it ships as an
+// inset ring sharing a box with the shadows rather than as a CSS border.
+const hairline = 'inset0001pxrgba(255,255,255,0.03)'
 const raisedInset = 'inset01px1.9px0rgba(255,255,255,0.24)'
 const flatInset = 'inset01px1px0rgba(255,255,255,0.1)'
 

--- a/lib/ui/buttons/Button/Button.spec.tsx
+++ b/lib/ui/buttons/Button/Button.spec.tsx
@@ -1,4 +1,6 @@
 import { darkTheme } from '@lib/ui/theme/darkTheme'
+import { stationTheme } from '@lib/ui/theme/stationTheme'
+import { ThemeColor } from '@lib/ui/theme/ThemeColors'
 import { ReactElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { ServerStyleSheet, ThemeProvider } from 'styled-components'
@@ -27,19 +29,28 @@ const hairline = 'inset0001pxrgba(255,255,255,0.03)'
 const raisedInset = 'inset01px1.9px0rgba(255,255,255,0.24)'
 const flatInset = 'inset01px1px0rgba(255,255,255,0.1)'
 
+const colourCases: [ThemeColor, string][] = [
+  ['buttonPrimary', '#0b4eff'],
+  ['buttonHover', '#1e6ad1'],
+  ['buttonSecondary', '#11284a'],
+  ['buttonSecondaryHover', '#1d385e'],
+  ['buttonNeutral', '#2155df'],
+  ['buttonNeutralHover', '#1e6ad1'],
+  ['buttonSuccessHover', '#0fbf93'],
+  ['buttonBackgroundDisabled', '#0b1a3a'],
+  ['buttonTextDisabled', '#718096'],
+]
+
 describe('design system colours', () => {
-  test.each([
-    ['buttonPrimary', '#0b4eff'],
-    ['buttonHover', '#1e6ad1'],
-    ['buttonSecondary', '#11284a'],
-    ['buttonSecondaryHover', '#1d385e'],
-    ['buttonNeutral', '#2155df'],
-    ['buttonNeutralHover', '#1e6ad1'],
-    ['buttonSuccessHover', '#0fbf93'],
-    ['buttonBackgroundDisabled', '#0b1a3a'],
-    ['buttonTextDisabled', '#718096'],
-  ] as const)('%s is %s', (token, hex) => {
+  test.each(colourCases)('%s is %s', (token, hex) => {
     expect(darkTheme.colors[token].toHex()).toBe(hex)
+  })
+
+  // Station has no design system entry for this one. It follows that theme's
+  // own convention, where hover is lighter and more saturated than the base.
+  test('station success hover is lighter than its base', () => {
+    expect(stationTheme.colors.buttonSuccessHover.toHex()).toBe('#47f0cb')
+    expect(stationTheme.colors.primary.toHex()).toBe('#33e6bf')
   })
 })
 

--- a/lib/ui/buttons/Button/Button.spec.tsx
+++ b/lib/ui/buttons/Button/Button.spec.tsx
@@ -85,6 +85,16 @@ describe('primary', () => {
     expect(styleOf(<Button>x</Button>)).toContain(flatInset)
   })
 
+  // Deliberate deviation from the design system, which draws this edge fully
+  // opaque. On our background that erases the button's last row and reads as
+  // the button shrinking by a pixel on hover.
+  test('the bottom edge never goes fully opaque', () => {
+    const css = styleOf(<Button>x</Button>)
+
+    expect(css).toContain('inset0-1px0.5px0rgba(15,28,62,0.48)')
+    expect(css).not.toContain('rgba(15,28,62,1)')
+  })
+
   test('only the default hierarchy rests on the raised inset', () => {
     expect(styleOf(<Button>x</Button>)).toContain(raisedInset)
     expect(styleOf(<Button status="neutral">x</Button>)).not.toContain(

--- a/lib/ui/buttons/Button/Button.stories.tsx
+++ b/lib/ui/buttons/Button/Button.stories.tsx
@@ -105,6 +105,11 @@ export const Gallery: Story = {
               Get started
             </Button>
           ))}
+          {SIZES.map(size => (
+            <Button key={size} kind="secondary" size={size} disabled>
+              Disabled
+            </Button>
+          ))}
         </div>
       </section>
 
@@ -129,6 +134,11 @@ export const Gallery: Story = {
           {SIZES.map(size => (
             <Button key={size} kind="link" size={size}>
               Get started
+            </Button>
+          ))}
+          {SIZES.map(size => (
+            <Button key={size} kind="link" size={size} disabled>
+              Disabled
             </Button>
           ))}
         </div>

--- a/lib/ui/buttons/Button/index.tsx
+++ b/lib/ui/buttons/Button/index.tsx
@@ -16,27 +16,30 @@ type ButtonSize = Extract<Size, 'xs' | 'sm' | 'md'>
 // Only a resting default-hierarchy primary sits proud. Every other filled
 // state — the other hierarchies, hover, disabled, and all of secondary —
 // drops to the flatter inset pair.
-const raisedInset = css`
-  box-shadow:
-    inset 0 1px 1.9px 0 rgba(255, 255, 255, 0.24),
-    inset 0 -1px 1.6px 0 rgba(15, 28, 62, 0.48);
-`
+const raisedInset = [
+  'inset 0 1px 1.9px 0 rgba(255, 255, 255, 0.24)',
+  'inset 0 -1px 1.6px 0 rgba(15, 28, 62, 0.48)',
+]
 
-const flatInset = css`
-  box-shadow:
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.1),
-    inset 0 -1px 0.5px 0 rgba(15, 28, 62, 1);
-`
+const flatInset = [
+  'inset 0 1px 1px 0 rgba(255, 255, 255, 0.1)',
+  'inset 0 -1px 0.5px 0 rgba(15, 28, 62, 1)',
+]
 
-const restingInset: Record<PrimaryButtonStatus, typeof flatInset> = {
+const restingInset: Record<PrimaryButtonStatus, string[]> = {
   default: raisedInset,
   danger: raisedInset,
   neutral: flatInset,
   success: flatInset,
 }
 
-const hairlineBorder = css`
-  border: 1px solid rgba(255, 255, 255, 0.03);
+// The design system draws the hairline as an inside stroke, so it shares a box
+// with the inner shadows. A CSS border would sit outside them and leave a
+// bright 1px rim showing under the bottom shadow.
+const hairlineRing = 'inset 0 0 0 1px rgba(255, 255, 255, 0.03)'
+
+const insetLayers = (layers: string[]) => css`
+  box-shadow: ${layers.join(', ')};
 `
 
 const pillHeight = (value: number) => css`
@@ -136,16 +139,18 @@ const StyledButton = styled(UnstyledButton)<{
 
         ${$disabled || $loading
           ? css`
-              ${flatInset}
+              ${insetLayers(flatInset)}
               background-color: ${getColor('buttonBackgroundDisabled')};
               color: ${getColor('buttonTextDisabled')};
               cursor: default;
             `
           : css`
-              ${restingInset[$status]}
-
               /* Only the md pill carries a hairline, and success never does */
-              ${$size === 'md' && $status !== 'success' ? hairlineBorder : ''}
+              ${insetLayers(
+                $size === 'md' && $status !== 'success'
+                  ? [...restingInset[$status], hairlineRing]
+                  : restingInset[$status]
+              )}
 
               ${match($status, {
                 default: () => css`
@@ -167,7 +172,11 @@ const StyledButton = styled(UnstyledButton)<{
               })}
 
               &:hover {
-                ${flatInset}
+                ${insetLayers(
+                  $size === 'md' && $status !== 'success'
+                    ? [...flatInset, hairlineRing]
+                    : flatInset
+                )}
 
                 ${match($status, {
                   default: () => css`
@@ -208,20 +217,21 @@ const StyledButton = styled(UnstyledButton)<{
       `,
       secondary: () => css`
         ${pillMetrics($size, $status)}
-        ${flatInset}
 
         ${$disabled || $loading
           ? css`
-              background-color: transparent;
-              border: 1px solid
-                ${theme.colors.buttonNeutral
+              ${insetLayers([
+                ...flatInset,
+                `inset 0 0 0 1px ${theme.colors.buttonNeutral
                   .getVariant({ a: () => 0.6 })
-                  .toCssValue()};
+                  .toCssValue()}`,
+              ])}
+              background-color: transparent;
               color: ${getColor('buttonTextDisabled')};
               cursor: default;
             `
           : css`
-              ${hairlineBorder}
+              ${insetLayers([...flatInset, hairlineRing])}
               background-color: ${getColor('buttonSecondary')};
               color: ${getColor('text')};
 

--- a/lib/ui/buttons/Button/index.tsx
+++ b/lib/ui/buttons/Button/index.tsx
@@ -21,9 +21,14 @@ const raisedInset = [
   'inset 0 -1px 1.6px 0 rgba(15, 28, 62, 0.48)',
 ]
 
+// The design system draws this bottom edge fully opaque. On our near-navy
+// background an opaque #0f1c3e line is all but indistinguishable from the page,
+// so the button's last row disappears and it reads as losing a pixel on hover.
+// Holding it at the resting alpha keeps the silhouette while staying crisper
+// than the resting edge, which is what the tighter blur is there for.
 const flatInset = [
   'inset 0 1px 1px 0 rgba(255, 255, 255, 0.1)',
-  'inset 0 -1px 0.5px 0 rgba(15, 28, 62, 1)',
+  'inset 0 -1px 0.5px 0 rgba(15, 28, 62, 0.48)',
 ]
 
 const restingInset: Record<PrimaryButtonStatus, string[]> = {

--- a/lib/ui/buttons/Button/index.tsx
+++ b/lib/ui/buttons/Button/index.tsx
@@ -30,24 +30,35 @@ const hairlineBorder = css`
   border: 1px solid rgba(255, 255, 255, 0.03);
 `
 
-const pillMetrics = (size: ButtonSize) =>
+const pillHeight = (value: number) => css`
+  height: ${value}px;
+  min-height: ${value}px;
+  min-width: ${value}px;
+`
+
+// The design system gives the neutral and success hierarchies 12px of vertical
+// padding against the default hierarchy's 14px, so they sit 4px shorter at md.
+const mediumHeight: Record<PrimaryButtonStatus, number> = {
+  default: 46,
+  danger: 46,
+  neutral: 42,
+  success: 42,
+}
+
+const pillMetrics = (size: ButtonSize, status: PrimaryButtonStatus) =>
   match(size, {
     sm: () => css`
       font-size: 12px;
       gap: 4px;
-      height: 36px;
       line-height: 16px;
-      min-height: 36px;
-      min-width: 36px;
+      ${pillHeight(36)}
       ${horizontalPadding(16)}
     `,
     md: () => css`
       font-size: 14px;
       gap: 8px;
-      height: 46px;
       line-height: 18px;
-      min-height: 46px;
-      min-width: 46px;
+      ${pillHeight(mediumHeight[status])}
       ${horizontalPadding(24)}
     `,
   })
@@ -102,7 +113,7 @@ const StyledButton = styled(UnstyledButton)<{
             `}
       `,
       primary: () => css`
-        ${pillMetrics($size)}
+        ${pillMetrics($size, $status)}
 
         ${$disabled || $loading
           ? css`
@@ -112,8 +123,10 @@ const StyledButton = styled(UnstyledButton)<{
               cursor: default;
             `
           : css`
-              ${hairlineBorder}
               ${raisedInset}
+
+              /* Only the md pill carries a hairline, and success never does */
+              ${$size === 'md' && $status !== 'success' ? hairlineBorder : ''}
 
               ${match($status, {
                 default: () => css`
@@ -148,14 +161,14 @@ const StyledButton = styled(UnstyledButton)<{
                     background-color: ${getColor('danger')};
                   `,
                   success: () => css`
-                    background-color: ${getColor('primary')};
+                    background-color: ${getColor('buttonSuccessHover')};
                   `,
                 })}
               }
             `}
       `,
       outlined: () => css`
-        ${pillMetrics($size)}
+        ${pillMetrics($size, $status)}
 
         ${$disabled || $loading
           ? css`
@@ -175,7 +188,7 @@ const StyledButton = styled(UnstyledButton)<{
             `}
       `,
       secondary: () => css`
-        ${pillMetrics($size)}
+        ${pillMetrics($size, $status)}
         ${flatInset}
 
         ${$disabled || $loading

--- a/lib/ui/buttons/Button/index.tsx
+++ b/lib/ui/buttons/Button/index.tsx
@@ -10,10 +10,12 @@ import styled, { css } from 'styled-components'
 import { Size } from '../../core/Size'
 import { ButtonProps, PrimaryButtonStatus } from '../ButtonProps'
 
-type ButtonSize = Extract<Size, 'sm' | 'md'>
+// `xs` is the design system's "Mini" size.
+type ButtonSize = Extract<Size, 'xs' | 'sm' | 'md'>
 
-// A resting primary button sits proud; every other filled state (primary
-// hover/disabled, secondary) drops to the flatter inset pair.
+// Only a resting default-hierarchy primary sits proud. Every other filled
+// state — the other hierarchies, hover, disabled, and all of secondary —
+// drops to the flatter inset pair.
 const raisedInset = css`
   box-shadow:
     inset 0 1px 1.9px 0 rgba(255, 255, 255, 0.24),
@@ -25,6 +27,13 @@ const flatInset = css`
     inset 0 1px 1px 0 rgba(255, 255, 255, 0.1),
     inset 0 -1px 0.5px 0 rgba(15, 28, 62, 1);
 `
+
+const restingInset: Record<PrimaryButtonStatus, typeof flatInset> = {
+  default: raisedInset,
+  danger: raisedInset,
+  neutral: flatInset,
+  success: flatInset,
+}
 
 const hairlineBorder = css`
   border: 1px solid rgba(255, 255, 255, 0.03);
@@ -38,6 +47,7 @@ const pillHeight = (value: number) => css`
 
 // The design system gives the neutral and success hierarchies 12px of vertical
 // padding against the default hierarchy's 14px, so they sit 4px shorter at md.
+// xs and sm are one height for every hierarchy.
 const mediumHeight: Record<PrimaryButtonStatus, number> = {
   default: 46,
   danger: 46,
@@ -47,6 +57,15 @@ const mediumHeight: Record<PrimaryButtonStatus, number> = {
 
 const pillMetrics = (size: ButtonSize, status: PrimaryButtonStatus) =>
   match(size, {
+    xs: () => css`
+      border-radius: 30px;
+      font-size: 12px;
+      gap: 4px;
+      line-height: 16px;
+      width: fit-content;
+      ${pillHeight(32)}
+      ${horizontalPadding(16)}
+    `,
     sm: () => css`
       font-size: 12px;
       gap: 4px;
@@ -123,7 +142,7 @@ const StyledButton = styled(UnstyledButton)<{
               cursor: default;
             `
           : css`
-              ${raisedInset}
+              ${restingInset[$status]}
 
               /* Only the md pill carries a hairline, and success never does */
               ${$size === 'md' && $status !== 'success' ? hairlineBorder : ''}
@@ -259,11 +278,13 @@ export const Button: FC<
 }
 
 export const buttonSize: Record<ButtonSize, number> = {
+  xs: 26,
   sm: 26,
   md: 26,
 }
 
 export const buttonHeight: Record<ButtonSize, number> = {
+  xs: 32,
   sm: 36,
   md: 46,
 }

--- a/lib/ui/buttons/Button/index.tsx
+++ b/lib/ui/buttons/Button/index.tsx
@@ -12,14 +12,56 @@ import { ButtonProps, PrimaryButtonStatus } from '../ButtonProps'
 
 type ButtonSize = Extract<Size, 'sm' | 'md'>
 
-const ButtonShadow = styled.div`
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  border-radius: inherit;
+// A resting primary button sits proud; every other filled state (primary
+// hover/disabled, secondary) drops to the flatter inset pair.
+const raisedInset = css`
   box-shadow:
-    inset 0px -1px 0.5px 0px #0f1c3e,
-    inset 0px 1px 1px 0px rgba(255, 255, 255, 0.1);
+    inset 0 1px 1.9px 0 rgba(255, 255, 255, 0.24),
+    inset 0 -1px 1.6px 0 rgba(15, 28, 62, 0.48);
+`
+
+const flatInset = css`
+  box-shadow:
+    inset 0 1px 1px 0 rgba(255, 255, 255, 0.1),
+    inset 0 -1px 0.5px 0 rgba(15, 28, 62, 1);
+`
+
+const hairlineBorder = css`
+  border: 1px solid rgba(255, 255, 255, 0.03);
+`
+
+const pillMetrics = (size: ButtonSize) =>
+  match(size, {
+    sm: () => css`
+      font-size: 12px;
+      gap: 4px;
+      height: 36px;
+      line-height: 16px;
+      min-height: 36px;
+      min-width: 36px;
+      ${horizontalPadding(16)}
+    `,
+    md: () => css`
+      font-size: 14px;
+      gap: 8px;
+      height: 46px;
+      line-height: 18px;
+      min-height: 46px;
+      min-width: 46px;
+      ${horizontalPadding(24)}
+    `,
+  })
+
+// The link kind is one size in the design system — both `sm` and `md` render
+// the same 26px pill.
+const linkMetrics = css`
+  font-size: 14px;
+  gap: 8px;
+  height: 26px;
+  line-height: 18px;
+  min-height: 26px;
+  min-width: 26px;
+  ${horizontalPadding(4)}
 `
 
 const StyledButton = styled(UnstyledButton)<{
@@ -29,39 +71,21 @@ const StyledButton = styled(UnstyledButton)<{
   $size: ButtonSize
   $status: PrimaryButtonStatus
 }>`
-  ${({ $disabled, $kind, $loading, $size, $status }) => css`
+  ${({ $disabled, $kind, $loading, $size, $status, theme }) => css`
     align-items: center;
     border: none;
+    border-radius: 99px;
     cursor: pointer;
     display: flex;
-    gap: 8px;
+    font-weight: 500;
     justify-content: center;
+    position: relative;
     transition: all 0.2s;
     width: 100%;
-    position: relative;
 
     ${match($kind, {
       link: () => css`
-        ${match($size, {
-          sm: () => css`
-            border-radius: 26px;
-            font-size: 12px;
-            font-weight: 500;
-            height: 26px;
-            min-height: 26px;
-            min-width: 26px;
-            ${horizontalPadding(4)}
-          `,
-          md: () => css`
-            border-radius: 28px;
-            font-size: 14px;
-            font-weight: 500;
-            height: 28px;
-            min-height: 28px;
-            min-width: 28px;
-            ${horizontalPadding(4)}
-          `,
-        })}
+        ${linkMetrics}
 
         ${$disabled || $loading
           ? css`
@@ -73,39 +97,24 @@ const StyledButton = styled(UnstyledButton)<{
               color: ${getColor('text')};
 
               &:hover {
-                color: ${getColor('buttonHover')};
+                background-color: ${getColor('buttonLinkHover')};
               }
             `}
       `,
       primary: () => css`
-        ${match($size, {
-          sm: () => css`
-            border-radius: 36px;
-            font-size: 12px;
-            font-weight: 500;
-            height: 36px;
-            min-height: 36px;
-            min-width: 36px;
-            ${horizontalPadding(16)}
-          `,
-          md: () => css`
-            border-radius: 46px;
-            font-size: 14px;
-            font-weight: 500;
-            height: 46px;
-            min-height: 46px;
-            min-width: 46px;
-            ${horizontalPadding(24)}
-          `,
-        })}
+        ${pillMetrics($size)}
 
         ${$disabled || $loading
           ? css`
+              ${flatInset}
               background-color: ${getColor('buttonBackgroundDisabled')};
               color: ${getColor('buttonTextDisabled')};
               cursor: default;
             `
           : css`
+              ${hairlineBorder}
+              ${raisedInset}
+
               ${match($status, {
                 default: () => css`
                   color: ${getColor('text')};
@@ -126,6 +135,8 @@ const StyledButton = styled(UnstyledButton)<{
               })}
 
               &:hover {
+                ${flatInset}
+
                 ${match($status, {
                   default: () => css`
                     background-color: ${getColor('buttonHover')};
@@ -144,26 +155,7 @@ const StyledButton = styled(UnstyledButton)<{
             `}
       `,
       outlined: () => css`
-        ${match($size, {
-          sm: () => css`
-            border-radius: 36px;
-            font-size: 12px;
-            font-weight: 500;
-            height: 36px;
-            min-height: 36px;
-            min-width: 36px;
-            ${horizontalPadding(16)}
-          `,
-          md: () => css`
-            border-radius: 46px;
-            font-size: 14px;
-            font-weight: 500;
-            height: 46px;
-            min-height: 46px;
-            min-width: 46px;
-            ${horizontalPadding(24)}
-          `,
-        })}
+        ${pillMetrics($size)}
 
         ${$disabled || $loading
           ? css`
@@ -183,36 +175,22 @@ const StyledButton = styled(UnstyledButton)<{
             `}
       `,
       secondary: () => css`
-        ${match($size, {
-          sm: () => css`
-            border-radius: 36px;
-            font-size: 12px;
-            font-weight: 500;
-            height: 36px;
-            min-height: 36px;
-            min-width: 36px;
-            ${horizontalPadding(16)}
-          `,
-          md: () => css`
-            border-radius: 46px;
-            font-size: 14px;
-            font-weight: 500;
-            height: 46px;
-            min-height: 46px;
-            min-width: 46px;
-            ${horizontalPadding(24)}
-          `,
-        })}
+        ${pillMetrics($size)}
+        ${flatInset}
 
         ${$disabled || $loading
           ? css`
-              background-color: ${getColor('buttonBackgroundDisabled')};
+              background-color: transparent;
+              border: 1px solid
+                ${theme.colors.buttonNeutral
+                  .getVariant({ a: () => 0.6 })
+                  .toCssValue()};
               color: ${getColor('buttonTextDisabled')};
               cursor: default;
             `
           : css`
+              ${hairlineBorder}
               background-color: ${getColor('buttonSecondary')};
-              border: 1px solid rgba(255, 255, 255, 0.03);
               color: ${getColor('text')};
 
               &:hover {
@@ -249,8 +227,6 @@ export const Button: FC<
     ...rest,
   }
 
-  const showShadow = kind === 'primary' && !disabled && !loading
-
   return typeof disabled === 'string' ? (
     <Tooltip
       content={disabled}
@@ -258,7 +234,6 @@ export const Button: FC<
         <StyledButton {...options} {...htmlProps} {...styledProps}>
           {loading ? <Spinner /> : icon}
           {children}
-          {showShadow && <ButtonShadow />}
         </StyledButton>
       )}
     />
@@ -266,14 +241,13 @@ export const Button: FC<
     <StyledButton {...htmlProps} {...styledProps}>
       {loading ? <Spinner /> : icon}
       {children}
-      {showShadow && <ButtonShadow />}
     </StyledButton>
   )
 }
 
 export const buttonSize: Record<ButtonSize, number> = {
   sm: 26,
-  md: 28,
+  md: 26,
 }
 
 export const buttonHeight: Record<ButtonSize, number> = {

--- a/lib/ui/theme/ThemeColors.ts
+++ b/lib/ui/theme/ThemeColors.ts
@@ -35,6 +35,7 @@ export type ThemeColors = {
   buttonSecondaryHover: HSLA
   buttonNeutral: HSLA
   buttonNeutralHover: HSLA
+  buttonSuccessHover: HSLA
   buttonTextDisabled: HSLA
   primaryAccentTwo: HSLA
   primaryAccentFour: HSLA

--- a/lib/ui/theme/darkTheme.ts
+++ b/lib/ui/theme/darkTheme.ts
@@ -42,16 +42,18 @@ export const darkTheme: DefaultTheme = {
     mist: new HSLA(0, 0, 100, 0.06),
     mistExtra: new HSLA(0, 0, 100, 0.13),
 
-    buttonBackgroundDisabled: new HSLA(217, 57, 14),
+    // Button tokens are the exact values of the design system button set
+    buttonBackgroundDisabled: new HSLA(220.85, 68.12, 13.53), // #0b1a3a
     buttonLinkHover: new HSLA(0, 0, 100, 0.04),
     // Primary/Accent 3
-    buttonPrimary: new HSLA(224, 100, 52),
-    buttonHover: new HSLA(215, 75, 47),
-    buttonSecondary: new HSLA(216, 63, 18),
-    buttonSecondaryHover: new HSLA(215, 53, 24),
-    buttonNeutral: new HSLA(224, 75, 50),
-    buttonNeutralHover: new HSLA(215, 75, 47),
-    buttonTextDisabled: new HSLA(216, 15, 52),
+    buttonPrimary: new HSLA(223.52, 100, 52.16), // #0b4eff
+    buttonHover: new HSLA(214.53, 74.9, 46.86), // #1e6ad1
+    buttonSecondary: new HSLA(215.79, 62.64, 17.84), // #11284a
+    buttonSecondaryHover: new HSLA(215.08, 52.85, 24.12), // #1d385e
+    buttonNeutral: new HSLA(223.58, 74.8, 50.2), // #2155df
+    buttonNeutralHover: new HSLA(214.53, 74.9, 46.86), // #1e6ad1
+    buttonSuccessHover: new HSLA(165, 85.44, 40.39), // #0fbf93
+    buttonTextDisabled: new HSLA(215.68, 14.98, 51.57), // #718096
     primaryAccentTwo: new HSLA(224, 96, 40),
     primaryAccentFour: new HSLA(224, 96, 64),
 

--- a/lib/ui/theme/stationTheme.ts
+++ b/lib/ui/theme/stationTheme.ts
@@ -46,7 +46,7 @@ export const stationTheme: DefaultTheme = {
     buttonSecondaryHover: new HSLA(240, 5, 25),
     buttonNeutral: new HSLA(224, 82, 60), // #4572ed
     buttonNeutralHover: new HSLA(224, 89, 66), // #5b84f5
-    buttonSuccessHover: new HSLA(167, 78, 45), // #1cba97
+    buttonSuccessHover: new HSLA(167, 85, 61), // #47f0cb
     buttonTextDisabled: new HSLA(240, 3, 54),
     primaryAccentTwo: new HSLA(224, 82, 60),
     primaryAccentFour: new HSLA(224, 89, 66),

--- a/lib/ui/theme/stationTheme.ts
+++ b/lib/ui/theme/stationTheme.ts
@@ -46,6 +46,7 @@ export const stationTheme: DefaultTheme = {
     buttonSecondaryHover: new HSLA(240, 5, 25),
     buttonNeutral: new HSLA(224, 82, 60), // #4572ed
     buttonNeutralHover: new HSLA(224, 89, 66), // #5b84f5
+    buttonSuccessHover: new HSLA(167, 78, 45), // #1cba97
     buttonTextDisabled: new HSLA(240, 3, 54),
     primaryAccentTwo: new HSLA(224, 82, 60),
     primaryAccentFour: new HSLA(224, 89, 66),


### PR DESCRIPTION
Closes #4548.

Rolls up four PRs that were reviewed and merged onto this branch:

| | |
|---|---|
| #4614 | bring the shared `Button` in line with the design system |
| #4615 | migrate the hand-rolled button variants onto it |
| #4617 | stop the remaining call sites from overriding it |
| #4619 | two rendering bugs found in the built extension |

**19 files, +401 / −539.** The series deletes more than it adds, which is the point: most of the work was removing buttons people had rebuilt by hand.

## Where the spec came from

Read directly off the `Button` component set in the Vultisig design system rather than from a screenshot. The set is keyed on `Variant`, `Size`, `State`, `Platform` and `Hierarchy`.

`Platform` mattered. The set has **App** and **Web** geometry, and the desktop app and extension already matched **Web** exactly — 46/36 heights, 24/16 side padding, 14/12 labels. App would have meant 42px small buttons and side padding growing from 32 to 40 on hover. Web is what this implements.

## What was wrong with the shared Button

| | before | design system |
|---|---|---|
| primary inner shadow | `1px/0.1 + 0.5px/1.0` | `1.9px/0.24 + 1.6px/0.48` |
| primary hairline | none | 1px inside stroke |
| secondary inner shadow | none | `1px/0.1 + 0.5px/…` |
| secondary disabled | filled grey pill | transparent pill, 60% neutral border |
| link height at md | 28px | 26px |
| link label at sm | 12px | 14px |
| link hover | recoloured the label | tints the background |
| success hover | reused the resting colour | `#0fbf93` |
| icon gap at sm | 8px | 4px |
| line-height | unset | 18px / 16px |

The shadow the code put on primary buttons turned out to be the *secondary* shadow — the two were swapped.

Every `button*` colour token now carries the exact design system value. `HSLA` accepts decimals, so each round-trips to the precise hex. They were already within three units per channel, so nothing shifts visibly; the tokens are now the spec rather than an approximation. `buttonSuccessHover` is new, because the success button previously had no hover state at all.

## What the migration removed

`StakeCard`, `BondNodeItem` and `LpPositions` each carried a byte-identical hand-rolled `ActionButton` — a 48px pill whose secondary variant was a dark panel behind a blue accent border. That secondary is exactly the drift this issue was filed about.

The two banner CTAs turned out to be the design system's **Mini** size, hand-rebuilt in two places because the shared Button had no such size. It is now `xs`.

Seven more call sites wrapped the Button in `styled()` and repainted it — three of them re-implementing a kind that already existed, including one that hardcoded `rgba(17, 40, 74)`, the secondary fill, with a blue primary hover bolted on.

## Two places the spec looks inconsistent but is not

Followed literally, because the evidence says they are deliberate:

1. **The md primary carries a hairline; the sm primary does not**, and success never does. Consistent across default, hover and disabled.
2. **Neutral and success sit at 42px against the default hierarchy's 46px.** Driven by 12px vs 14px of vertical padding, and it holds across all three states.

## Three places it needs a designer

1. **The hover bottom edge is drawn fully opaque** at `rgba(15, 28, 62, 1)`. Against this app's `#03112c` background that line is nearly the page colour, so the button's last row stops reading as button and the pill appears to lose a pixel on hover. Measured off a screen recording: the last row goes from `#0f3aa8` at rest to `#0e2b5a` on hover, about a third of the contrast. #4619 holds it at the resting alpha instead. **This is the one deliberate deviation in the series** — it is pinned by a test, and reverting is one number. It is invisible in Figma because the Figma canvas is not the background this ships against.

2. **Mini + success contradicts itself** — 16px side padding at rest, 12px in hover and disabled. Every other Mini variant is 16px in all three states, and a disabled button should not have different geometry from its resting state. Shipped as 16px throughout.

3. **`kind="outlined"` is used in six places and does not exist in the design system at all.** Left untouched.

## Deliberately not migrated

Nine controls that are not primary/secondary buttons and would have broken if forced through the shared one: two ~32px header chips, three icon-only buttons in a recipient sheet, a green-bordered address book chip, a gradient banner surface, a segmented toggle built on Button, and an option row sized between sm and md.

My first sweep also listed six "text buttons that should become `kind=\"link\"`". Reading their usage rather than their CSS, none of them is one — the design system's link is a standalone 26px pill, and these are inline sentence links, de-emphasised danger actions that turn red on hover, and copy affordances. Two of them are the "dismiss this security warning" actions in the Blockaid overlays, where the red hover is a deliberate signal.

## Verification

`Button.spec.tsx` renders the button through styled-components and asserts the generated CSS against the design system — 22 tests covering geometry, both shadow pairs, the hairline rule, every colour token and the one deviation. I checked the suite is not vacuous by deliberately breaking the neutral height and confirming the matching test failed.

`yarn typecheck` is clean. The extension was built and the shipped bundle checked directly: the inset ring is present, the CSS border is gone, and the opaque bottom edge no longer appears anywhere.

Closes #4548

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added extra-small button sizing for compact actions.
  * Standardized actions across staking, bonding, vault, referral, and claim flows with shared button styles.
* **Style**
  * Refined button dimensions, colors, hover states, disabled states, shadows, and success styling across themes.
  * Updated link and secondary button presentation for greater consistency.
* **Tests**
  * Added comprehensive coverage for button sizes, variants, statuses, themes, and disabled states.
* **Documentation**
  * Expanded button examples to include disabled secondary and link variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->