### PR TITLE
fix(ui): address CodeRabbit feedback on the button series

### DIFF
--- a/core/ui/qbtc/claim/components/QbtcClaimBanner.styles.tsx
+++ b/core/ui/qbtc/claim/components/QbtcClaimBanner.styles.tsx
@@ -126,7 +126,7 @@ export const BannerTextStack = styled.div`
 /**
  * The design system's mini primary pill, centred above the banner artwork.
  */
-export const BannerCta = styled(Button).attrs({ size: 'xs' as const })`
+export const BannerCta = styled(Button).attrs({ size: 'xs' })`
   align-self: center;
   white-space: nowrap;
   z-index: 2;

--- a/core/ui/vault/page/banners/shared/BannerPromoCtaButton.styles.tsx
+++ b/core/ui/vault/page/banners/shared/BannerPromoCtaButton.styles.tsx
@@ -6,8 +6,8 @@ import styled from 'styled-components'
  * home promo banners. Banners lay these out inline, so the label never wraps.
  */
 export const BannerPromoCtaButton = styled(Button).attrs({
-  size: 'xs' as const,
-  status: 'success' as const,
+  size: 'xs',
+  status: 'success',
 })`
   white-space: nowrap;
 `

--- a/lib/ui/buttons/Button/Button.spec.tsx
+++ b/lib/ui/buttons/Button/Button.spec.tsx
@@ -1,4 +1,6 @@
 import { darkTheme } from '@lib/ui/theme/darkTheme'
+import { stationTheme } from '@lib/ui/theme/stationTheme'
+import { ThemeColor } from '@lib/ui/theme/ThemeColors'
 import { ReactElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { ServerStyleSheet, ThemeProvider } from 'styled-components'
@@ -27,19 +29,28 @@ const hairline = 'inset0001pxrgba(255,255,255,0.03)'
 const raisedInset = 'inset01px1.9px0rgba(255,255,255,0.24)'
 const flatInset = 'inset01px1px0rgba(255,255,255,0.1)'
 
+const colourCases: [ThemeColor, string][] = [
+  ['buttonPrimary', '#0b4eff'],
+  ['buttonHover', '#1e6ad1'],
+  ['buttonSecondary', '#11284a'],
+  ['buttonSecondaryHover', '#1d385e'],
+  ['buttonNeutral', '#2155df'],
+  ['buttonNeutralHover', '#1e6ad1'],
+  ['buttonSuccessHover', '#0fbf93'],
+  ['buttonBackgroundDisabled', '#0b1a3a'],
+  ['buttonTextDisabled', '#718096'],
+]
+
 describe('design system colours', () => {
-  test.each([
-    ['buttonPrimary', '#0b4eff'],
-    ['buttonHover', '#1e6ad1'],
-    ['buttonSecondary', '#11284a'],
-    ['buttonSecondaryHover', '#1d385e'],
-    ['buttonNeutral', '#2155df'],
-    ['buttonNeutralHover', '#1e6ad1'],
-    ['buttonSuccessHover', '#0fbf93'],
-    ['buttonBackgroundDisabled', '#0b1a3a'],
-    ['buttonTextDisabled', '#718096'],
-  ] as const)('%s is %s', (token, hex) => {
+  test.each(colourCases)('%s is %s', (token, hex) => {
     expect(darkTheme.colors[token].toHex()).toBe(hex)
+  })
+
+  // Station has no design system entry for this one. It follows that theme's
+  // own convention, where hover is lighter and more saturated than the base.
+  test('station success hover is lighter than its base', () => {
+    expect(stationTheme.colors.buttonSuccessHover.toHex()).toBe('#47f0cb')
+    expect(stationTheme.colors.primary.toHex()).toBe('#33e6bf')
   })
 })
 

--- a/lib/ui/theme/stationTheme.ts
+++ b/lib/ui/theme/stationTheme.ts
@@ -46,7 +46,7 @@ export const stationTheme: DefaultTheme = {
     buttonSecondaryHover: new HSLA(240, 5, 25),
     buttonNeutral: new HSLA(224, 82, 60), // #4572ed
     buttonNeutralHover: new HSLA(224, 89, 66), // #5b84f5
-    buttonSuccessHover: new HSLA(167, 78, 45), // #1cba97
+    buttonSuccessHover: new HSLA(167, 85, 61), // #47f0cb
     buttonTextDisabled: new HSLA(240, 3, 54),
     primaryAccentTwo: new HSLA(224, 82, 60),
     primaryAccentFour: new HSLA(224, 89, 66),


### PR DESCRIPTION
Addresses the review on #4620. Three of the four findings held up; the fourth is a false positive and is answered inline on the PR.

## `as const` on `styled(Button).attrs` — valid

styled-components v6 types `.attrs()` contextually against the component's props, so `size: 'xs'` and `status: 'success'` narrow to the literal unions on their own. Verified by removing both and typechecking clean.

## `as const` in the spec's colour table — valid, different fix

That one was load-bearing: without it `token` widens to `string` and stops indexing `ThemeColors`. Declaring the case list as `[ThemeColor, string][]` gets the same narrowing from contextual typing, with no assertion.

## Station success hover — valid, and worse than reported

The report said the annotation and the value disagree, which is true: the comment claimed `#1cba97`, the value renders `#19cca5`.

But the value was the actual mistake. I had copied the dark theme's direction and made the hover *darker*, while station's own convention is the opposite — its hover is lighter and more saturated than the base:

```
buttonPrimary  #4572ed  →  buttonHover  #5b84f5
```

Applying that same delta to station's `#33e6bf` success gives `#47f0cb`, which is what this ships. A test now pins it so the annotation cannot drift from the value again.

## Verification

`Button.spec.tsx` grows to 23 tests, all green. `yarn typecheck` is clean.

Refs #4548

🤖 Generated with [Claude Code](https://claude.com/claude-code)