### PR TITLE
feat(ui): corner-radius token scale

### DIFF
--- a/lib/ui/css/borderRadius.tsx
+++ b/lib/ui/css/borderRadius.tsx
@@ -1,17 +1,68 @@
 import { css } from 'styled-components'
 
-type BorderRadiusSize = 'xs' | 's' | 'm' | 'l'
+/**
+ * `pill` is a bound, not a size. CSS clamps a corner radius to half the
+ * smaller dimension, and that clamp is what produces the capsule, so the
+ * number only has to out-run any surface the app can render. Kept private so
+ * no call site writes one of the "fully round" magic numbers itself.
+ */
+const pillPx = 100000
 
-export const borderRadius: Record<BorderRadiusSize, ReturnType<typeof css>> = {
+const scale = {
   xs: css`
     border-radius: 4px;
   `,
-  s: css`
+  sm: css`
     border-radius: 8px;
   `,
-  m: css`
+  md: css`
     border-radius: 12px;
   `,
+  lg: css`
+    border-radius: 16px;
+  `,
+  xl: css`
+    border-radius: 24px;
+  `,
+  pill: css`
+    border-radius: ${pillPx}px;
+  `,
+}
+
+/**
+ * The app's corner-radius scale.
+ *
+ * Steps are named by size, not by surface: `md` means "12 from the scale",
+ * nothing more. Which surface class takes which step is documentation, not a
+ * contract, so a surface that genuinely reads differently can pick another
+ * step without the token name lying about it:
+ *
+ * - `xs` (4) progress tracks, skeleton bars, hairline chips
+ * - `sm` (8) small inline tags
+ * - `md` (12) list rows, compact containers
+ * - `lg` (16) input fields, inner icon tiles
+ * - `xl` (24) cards, banners, list containers, sheets and modals
+ * - `pill` any capsule control
+ *
+ * The scale stops at 24 and has no separate sheet step - sheets take `xl`,
+ * which is already the radius most of them render at.
+ *
+ * There is no circle step either. On a square surface `pill` renders a circle;
+ * on a non-square one it renders a stadium, which is the right shape for a
+ * capsule and a bug for anything that meant to be an ellipse. Check the
+ * surface is square before reaching for it.
+ */
+export const borderRadius = {
+  ...scale,
+  /** @deprecated 8 - use `sm`. */
+  s: scale.sm,
+  /** @deprecated 12 - use `md`. */
+  m: scale.md,
+  /**
+   * @deprecated 20 - off the scale entirely. Pick `lg` (16) or `xl` (24) by
+   * looking at the surface: there is no mechanical answer, and renaming this
+   * to `lg` would silently shrink every call site by 4px.
+   */
   l: css`
     border-radius: 20px;
   `,

--- a/lib/ui/css/round.tsx
+++ b/lib/ui/css/round.tsx
@@ -1,5 +1,10 @@
 import { css } from 'styled-components'
 
+/**
+ * @deprecated Use `borderRadius.pill`. 1000px stops rounding a surface wider
+ * than 2000px, and it is one of five spellings of "fully rounded" in the tree;
+ * the token collapses them and raises the bound past anything renderable.
+ */
 export const round = css`
   border-radius: 1000px;
 `


### PR DESCRIPTION
A.1 of #4622. The scale, and nothing else.

## What

| token | value | surface class |
|-------|-------|---------------|
| `xs` | 4 | progress tracks, skeleton bars, hairline chips |
| `sm` | 8 | small inline tags |
| `md` | 12 | list rows, compact containers |
| `lg` | 16 | input fields, inner icon tiles |
| `xl` | 24 | cards, banners, list containers, sheets and modals |
| `pill` | fully rounded | any capsule control |

`16` and `24` are the 2nd and 5th most common radii in the tree (47 and 28 uses) and neither had a token, which is most of why the scale was being bypassed - adoption today is ~50 of 402 declarations.

## Zero visual diff

No call site changes. `s` and `m` stay as aliases of `sm` and `md`, same values. `round` is untouched and still 1000px - it only gains a `@deprecated` pointing at `pill`, so every one of its 17 call sites keeps rendering exactly what it renders now. The pill migration happens in the sweep PRs, where it gets a visual pass.

## The mapping is documentation, not a contract

Steps are named by size, not by surface: `md` means "12 from the scale", nothing more. The surface-class table above ships as JSDoc on the token so the eleven sweep PRs that follow **apply** it rather than re-deciding per file - but a surface that genuinely reads differently can pick another step without the token name lying about it.

Two things the scale deliberately does not have:

- **No sheet step.** The scale stops at 24 and sheets take `xl`, which is already the radius most of them render at. The 16 and 34 outliers converge onto it rather than the scale growing a step to accommodate hand-set values.
- **No circle step.** On a square surface `pill` and `50%` render identically in CSS. On a non-square one `pill` renders a stadium - correct for a capsule, wrong for anything that meant an ellipse. The JSDoc says to check squareness before reaching for it.

## `l` is deprecated, not renamed

`borderRadius.l` is 20px and the new scale has no 20 step. Renaming it to `lg` would shrink all 16 sites from 20 to 16 with nothing visible in review, so it stays at 20 with a note telling the next reader to pick `lg` or `xl` by looking at the surface:

```
3 token sites:
  lib/ui/info/InfoItem.tsx:11
  core/ui/vault/settings/backup/BackupOption.tsx:27
  core/ui/vault/send/amount/AmountSwitch.tsx:61
13 raw `border-radius: 20px` declarations
```

Those get resolved one at a time by the sweep PRs that own their directories.

## Why `pill` is 100000px

It is a bound, not a size. CSS clamps a corner radius to half the smaller dimension, and that clamp is what makes the capsule - so the number just has to out-run any surface the app can render. The old 1000px stops rounding anything wider than 2000px, which a full-width bar on a large display can reach. Kept private so no call site writes a "fully round" magic number itself.

## Validation

`yarn check` clean - typecheck, lint, knip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)