### PR TITLE
refactor(ui): lib/ui primitives adopt the corner-radius scale

### DIFF
--- a/lib/ui/base/Hoverable/index.tsx
+++ b/lib/ui/base/Hoverable/index.tsx
@@ -13,7 +13,7 @@ type HighlightProps = {
 
 const Highlight = styled.div<HighlightProps>`
   position: absolute;
-  ${borderRadius.s};
+  ${borderRadius.sm};
   ${props => absoluteOutline(props.horizontalOffset, props.verticalOffset)}
 `
 

--- a/lib/ui/buttons/Button/index.tsx
+++ b/lib/ui/buttons/Button/index.tsx
@@ -292,12 +292,6 @@ export const Button: FC<
   )
 }
 
-export const buttonSize: Record<ButtonSize, number> = {
-  xs: 26,
-  sm: 26,
-  md: 26,
-}
-
 export const buttonHeight: Record<ButtonSize, number> = {
   xs: 32,
   sm: 36,

--- a/lib/ui/buttons/IconButton/index.tsx
+++ b/lib/ui/buttons/IconButton/index.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { horizontalPadding } from '@lib/ui/css/horizontalPadding'
 import { Spinner } from '@lib/ui/loaders/Spinner'
 import { getColor } from '@lib/ui/theme/getters'
@@ -22,7 +23,7 @@ const StyledIconButton = styled(UnstyledButton)<{
   ${({ $disabled, $kind, $loading, $size, $status }) => css`
     align-items: center;
     border: none;
-    border-radius: ${iconButtonSize[$size]}px;
+    ${borderRadius.pill};
     cursor: pointer;
     display: flex;
     height: ${iconButtonSize[$size]}px;

--- a/lib/ui/buttons/MaxButton.tsx
+++ b/lib/ui/buttons/MaxButton.tsx
@@ -13,7 +13,7 @@ const maxButtonHeight = textInputHeight - maxButtonOffset * 2
 
 export const MaxButton = styled(UnstyledButton)`
   ${horizontalPadding(8)};
-  ${borderRadius.s};
+  ${borderRadius.sm};
   ${centerContent};
   height: ${toSizeUnit(maxButtonHeight)};
 

--- a/lib/ui/coachmark/Coachmark.tsx
+++ b/lib/ui/coachmark/Coachmark.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -107,7 +108,7 @@ const CloseButton = styled(UnstyledButton)`
   &:focus-visible {
     outline: 2px solid ${getColor('foregroundSuper')};
     outline-offset: 4px;
-    border-radius: 4px;
+    ${borderRadius.xs};
   }
 `
 

--- a/lib/ui/css/borderRadius.tsx
+++ b/lib/ui/css/borderRadius.tsx
@@ -3,31 +3,28 @@ import { css } from 'styled-components'
 /**
  * `pill` is a bound, not a size. CSS clamps a corner radius to half the
  * smaller dimension, and that clamp is what produces the capsule, so the
- * number only has to out-run any surface the app can render. Kept private so
- * no call site writes one of the "fully round" magic numbers itself.
+ * number only has to out-run any surface the app can render.
  */
 const pillPx = 100000
 
-const scale = {
-  xs: css`
-    border-radius: 4px;
-  `,
-  sm: css`
-    border-radius: 8px;
-  `,
-  md: css`
-    border-radius: 12px;
-  `,
-  lg: css`
-    border-radius: 16px;
-  `,
-  xl: css`
-    border-radius: 24px;
-  `,
-  pill: css`
-    border-radius: ${pillPx}px;
-  `,
-}
+/**
+ * The scale as raw numbers, for surfaces that round their corners
+ * individually - a bottom sheet rounding only its top two, for instance.
+ * Prefer `borderRadius`, which rounds all four and is what almost every
+ * surface wants.
+ */
+export const borderRadiusPx = {
+  xs: 4,
+  sm: 8,
+  md: 12,
+  lg: 16,
+  xl: 24,
+  pill: pillPx,
+} as const
+
+const radius = (px: number) => css`
+  border-radius: ${px}px;
+`
 
 /**
  * The app's corner-radius scale.
@@ -53,17 +50,20 @@ const scale = {
  * surface is square before reaching for it.
  */
 export const borderRadius = {
-  ...scale,
+  xs: radius(borderRadiusPx.xs),
+  sm: radius(borderRadiusPx.sm),
+  md: radius(borderRadiusPx.md),
+  lg: radius(borderRadiusPx.lg),
+  xl: radius(borderRadiusPx.xl),
+  pill: radius(borderRadiusPx.pill),
   /** @deprecated 8 - use `sm`. */
-  s: scale.sm,
+  s: radius(borderRadiusPx.sm),
   /** @deprecated 12 - use `md`. */
-  m: scale.md,
+  m: radius(borderRadiusPx.md),
   /**
    * @deprecated 20 - off the scale entirely. Pick `lg` (16) or `xl` (24) by
    * looking at the surface: there is no mechanical answer, and renaming this
    * to `lg` would silently shrink every call site by 4px.
    */
-  l: css`
-    border-radius: 20px;
-  `,
+  l: radius(20),
 }

--- a/lib/ui/css/textInput.tsx
+++ b/lib/ui/css/textInput.tsx
@@ -8,7 +8,7 @@ import { toSizeUnit } from './toSizeUnit'
 
 export const textInputHorizontalPadding = 12
 export const textInputHeight = 56
-export const textInputBorderRadius = borderRadius.s
+export const textInputBorderRadius = borderRadius.sm
 
 export const textInputFrame = css`
   height: ${toSizeUnit(textInputHeight)};

--- a/lib/ui/flow/ErrorFallbackContent/ErrorStatusIcon.tsx
+++ b/lib/ui/flow/ErrorFallbackContent/ErrorStatusIcon.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { getColor } from '@lib/ui/theme/getters'
 import { match } from '@vultisig/lib-utils/match'
 import styled from 'styled-components'
@@ -63,7 +64,7 @@ const Ring = styled.div<{ size: number }>`
   height: ${({ size }) => size}px;
   transform: translate(-50%, -50%);
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 50%;
+  ${borderRadius.pill};
   opacity: 0.5;
 `
 

--- a/lib/ui/flow/ErrorFallbackContent/ShowExactErrorModal.tsx
+++ b/lib/ui/flow/ErrorFallbackContent/ShowExactErrorModal.tsx
@@ -102,7 +102,7 @@ export const ShowExactErrorModal = ({
 const Wrapper = styled(VStack)`
   width: 100%;
   background: ${getColor('background')};
-  ${borderRadius.m};
+  ${borderRadius.md};
   padding: 20px;
 
   @media ${mediaQuery.tabletDeviceAndUp} {
@@ -111,7 +111,7 @@ const Wrapper = styled(VStack)`
 `
 
 const ErrorBox = styled.div`
-  border-radius: 24px;
+  ${borderRadius.xl};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   padding: 20px;

--- a/lib/ui/flow/ErrorFallbackContent/index.tsx
+++ b/lib/ui/flow/ErrorFallbackContent/index.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ChevronDownIcon } from '@lib/ui/icons/ChevronDownIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { TitleProp } from '@lib/ui/props'
@@ -101,7 +102,7 @@ export const ErrorFallbackContent = ({
 
 const ShowExactErrorCard = styled(HStack)`
   width: 100%;
-  border-radius: 16px;
+  ${borderRadius.lg};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   padding: 20px;

--- a/lib/ui/flow/MultistepProgressIndicator/index.tsx
+++ b/lib/ui/flow/MultistepProgressIndicator/index.tsx
@@ -1,4 +1,4 @@
-import { round } from '@lib/ui/css/round'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { HStack } from '@lib/ui/layout/Stack'
 import { IsActiveProp, ValueProp } from '@lib/ui/props'
@@ -21,7 +21,7 @@ const Step = styled.div<
     variant === 'dots'
       ? css`
           ${sameDimensions(8)};
-          ${round};
+          ${borderRadius.pill};
         `
       : css`
           flex: 1;

--- a/lib/ui/flow/ProgressLine.tsx
+++ b/lib/ui/flow/ProgressLine.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { vStack } from '@lib/ui/layout/Stack'
 import { ValueProp } from '@lib/ui/props'
 import { getColor } from '@lib/ui/theme/getters'
@@ -5,11 +6,9 @@ import { toPercents } from '@vultisig/lib-utils/toPercents'
 import { FC } from 'react'
 import styled from 'styled-components'
 
-import { round } from '../css/round'
-
 const Container = styled.div`
   width: 100%;
-  ${round};
+  ${borderRadius.pill};
   background: ${getColor('foreground')};
   height: 10px;
   overflow: hidden;

--- a/lib/ui/form/FormCheckBadge.tsx
+++ b/lib/ui/form/FormCheckBadge.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CheckmarkIcon } from '@lib/ui/icons/CheckmarkIcon'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
@@ -13,7 +14,7 @@ export const FormCheckBadge = () => {
 const Container = styled.div`
   width: 16px;
   height: 16px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   border: 0.6667px solid ${getColor('success')};
   background: ${getColor('background')};
   color: ${getColor('success')};

--- a/lib/ui/info/InfoItem.tsx
+++ b/lib/ui/info/InfoItem.tsx
@@ -8,7 +8,7 @@ import { ReactNode } from 'react'
 import styled from 'styled-components'
 
 const Container = styled(HStack)`
-  ${borderRadius.l};
+  ${borderRadius.xl};
   background-color: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   padding: 16px;

--- a/lib/ui/inputs/AmountTextInput/index.tsx
+++ b/lib/ui/inputs/AmountTextInput/index.tsx
@@ -20,7 +20,7 @@ export type AmountTextInputProps = Omit<
 }
 
 const UnitContainer = styled.div`
-  ${borderRadius.s};
+  ${borderRadius.sm};
 
   position: absolute;
   left: 12px;

--- a/lib/ui/inputs/MultiCharacterInput/index.tsx
+++ b/lib/ui/inputs/MultiCharacterInput/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import { capitalizeFirstLetter } from '@vultisig/lib-utils/capitalizeFirstLetter'
@@ -124,7 +125,7 @@ const DigitInput = styled.input.attrs({
   font-size: 18px;
   border: 2px solid transparent;
   background: ${getColor('foreground')};
-  border-radius: 24px;
+  ${borderRadius.xl};
   outline: none;
   color: ${getColor('text')};
 
@@ -163,6 +164,6 @@ const DigitInput = styled.input.attrs({
 
 const PasteButton = styled(Button)`
   width: fit-content;
-  border-radius: 24px;
+  ${borderRadius.xl};
   min-width: 72px;
 `

--- a/lib/ui/inputs/PercentageSelector/index.tsx
+++ b/lib/ui/inputs/PercentageSelector/index.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
 import { HStack } from '@lib/ui/layout/Stack'
 import { InputProps } from '@lib/ui/props'
@@ -48,7 +49,7 @@ export const PercentageSelector = ({
 const PercentageButton = styled(UnstyledButton)<{ $isActive: boolean }>`
   flex: 1;
   padding: 4px 16px;
-  border-radius: 99px;
+  ${borderRadius.pill};
   border: 1px solid ${getColor('foregroundExtra')};
   background-color: ${({ $isActive, theme }) =>
     $isActive

--- a/lib/ui/inputs/RadioOptionsList/index.tsx
+++ b/lib/ui/inputs/RadioOptionsList/index.tsx
@@ -25,7 +25,7 @@ const OptionItem = styled.label<{ isSelected: boolean }>`
   align-items: center;
   min-height: 56px;
   font-size: 16px;
-  ${borderRadius.m};
+  ${borderRadius.md};
   ${interactive}
   color: ${getColor('textShy')};
   ${horizontalPadding(16)}

--- a/lib/ui/inputs/Slider/index.tsx
+++ b/lib/ui/inputs/Slider/index.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { InputProps } from '@lib/ui/props'
 import { getColor } from '@lib/ui/theme/getters'
 import { useRef } from 'react'
@@ -128,7 +129,7 @@ const Track = styled.div`
   width: 100%;
   height: 4px;
   background-color: ${getColor('foregroundSuper')};
-  border-radius: 2px;
+  ${borderRadius.pill};
 `
 
 const TrackFill = styled.div`
@@ -137,7 +138,7 @@ const TrackFill = styled.div`
   left: 0;
   height: 100%;
   background-color: ${getColor('buttonPrimary')};
-  border-radius: 2px;
+  ${borderRadius.pill};
   pointer-events: none;
 `
 
@@ -158,7 +159,7 @@ const Thumb = styled.div`
   transform: translateY(-50%);
   width: ${thumbWidth}px;
   height: 24px;
-  border-radius: 100px;
+  ${borderRadius.pill};
   background: ${getColor('contrast')};
   box-shadow:
     0 0.5px 4px 0 rgba(0, 0, 0, 0.12),
@@ -179,7 +180,7 @@ const Dot = styled.div<{ $active: boolean }>`
   position: absolute;
   width: 6px;
   height: 6px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background-color: ${({ $active, theme }) =>
     $active
       ? theme.colors.buttonPrimary.toCssValue()

--- a/lib/ui/inputs/Stepper.tsx
+++ b/lib/ui/inputs/Stepper.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ComponentProps } from 'react'
 import styled from 'styled-components'
 
@@ -77,14 +78,14 @@ const StepControl = styled(UnstyledButton)`
   })};
 
   padding: 16px;
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
   width: 97px;
 `
 
 const Input = styled(TextInput)`
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid ${getColor('foregroundExtra')};
   text-align: center;
 `

--- a/lib/ui/inputs/checkbox/Checkbox.tsx
+++ b/lib/ui/inputs/checkbox/Checkbox.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
 import { interactive } from '@lib/ui/css/interactive'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
@@ -22,7 +23,7 @@ const Box = styled.div<{ isChecked: boolean }>`
   ${sameDimensions(20)}
   ${centerContent};
   box-sizing: border-box;
-  border-radius: 100%;
+  ${borderRadius.pill};
   color: ${getColor('primary')};
   background: ${getColor('foregroundExtra')};
   font-size: 16px;

--- a/lib/ui/inputs/switch/index.tsx
+++ b/lib/ui/inputs/switch/index.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { Spinner } from '@lib/ui/loaders/Spinner'
 import { getColor } from '@lib/ui/theme/getters'
 import { FC, isValidElement, KeyboardEvent, ReactNode } from 'react'
@@ -15,7 +16,7 @@ const StyledSpinner = styled(Spinner)`
 
 const StyledSlider = styled.span<{ checked?: boolean }>`
   background-color: ${getColor('mistExtra')};
-  border-radius: 24px;
+  ${borderRadius.pill};
   height: 24px;
   position: relative;
   transition: 0.2s;
@@ -23,7 +24,7 @@ const StyledSlider = styled.span<{ checked?: boolean }>`
 
   &:before {
     background-color: ${getColor('white')};
-    border-radius: 50%;
+    ${borderRadius.pill};
     content: '';
     height: 20px;
     left: 2px;
@@ -56,7 +57,7 @@ const StyledSwitch = styled.div<{
   hoverable?: boolean
 }>`
   align-items: center;
-  border-radius: 24px;
+  ${borderRadius.pill};
   display: flex;
   gap: 8px;
   position: relative;

--- a/lib/ui/inputs/toggle-switch/ToggleSwitch.tsx
+++ b/lib/ui/inputs/toggle-switch/ToggleSwitch.tsx
@@ -1,5 +1,5 @@
-import { Button, buttonSize } from '@lib/ui/buttons/Button'
-import { toSizeUnit } from '@lib/ui/css/toSizeUnit'
+import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, StackProps } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import { ComponentType, ReactNode } from 'react'
@@ -84,7 +84,7 @@ export const ToggleSwitch = <T extends string | number>({
 
 const DefaultContainer = styled(HStack)`
   background-color: ${getColor('foregroundExtra')};
-  border-radius: ${toSizeUnit(buttonSize.md)};
+  ${borderRadius.xl};
   padding: 8px;
 `
 

--- a/lib/ui/inputs/upload/DropZoneContainer.tsx
+++ b/lib/ui/inputs/upload/DropZoneContainer.tsx
@@ -10,7 +10,7 @@ export const DropZoneContainer = styled.div`
   width: 100%;
   max-height: 400px;
   ${centerContent};
-  ${borderRadius.m};
+  ${borderRadius.md};
   padding: 20px;
   border: 1px dashed ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};

--- a/lib/ui/layout/Collapse/index.tsx
+++ b/lib/ui/layout/Collapse/index.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { AnimatedVisibility } from '@lib/ui/layout/AnimatedVisibility'
 import { CollapsableStateIndicator } from '@lib/ui/layout/CollapsableStateIndicator'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -8,7 +9,7 @@ import styled from 'styled-components'
 
 const CollapseWrapper = styled(VStack)`
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 16px;
+  ${borderRadius.lg};
 `
 
 const CollapseHeader = styled(HStack)`

--- a/lib/ui/list/item/DnDItemContainer.tsx
+++ b/lib/ui/list/item/DnDItemContainer.tsx
@@ -8,7 +8,7 @@ import styled, { css } from 'styled-components'
 
 export const DnDItemHighlight = styled.div`
   position: absolute;
-  ${borderRadius.m};
+  ${borderRadius.md};
   ${absoluteOutline(0, 0)}
 
   border: 2px solid ${getColor('primary')};

--- a/lib/ui/loaders/Skeleton/Skeleton.stories.tsx
+++ b/lib/ui/loaders/Skeleton/Skeleton.stories.tsx
@@ -11,7 +11,6 @@ const meta: Meta<typeof Skeleton> = {
     children: { table: { disable: true } },
   },
   args: {
-    variant: 'rectangular',
     width: '120px',
     height: '16px',
   },
@@ -24,7 +23,7 @@ export const Rectangular: Story = {}
 
 export const Circular: Story = {
   args: {
-    variant: 'circular',
+    borderRadius: '50%',
     width: '60px',
     height: '60px',
   },

--- a/lib/ui/loaders/Skeleton/index.tsx
+++ b/lib/ui/loaders/Skeleton/index.tsx
@@ -1,3 +1,4 @@
+import { borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { getColor } from '@lib/ui/theme/getters'
 import { ThemeColors } from '@lib/ui/theme/ThemeColors'
 import { keyframes } from 'styled-components'
@@ -19,17 +20,15 @@ const skeletonAnimation = keyframes`
 
 export const Skeleton = styled.div<{
   fill?: keyof ThemeColors
-  variant?: 'rectangular' | 'circular'
   height?: string
   width?: string
   borderRadius?: string
 }>`
   background-color: ${({ fill }) =>
     fill ? getColor(fill) : 'rgba(255, 255, 255, 0.05)'};
-  ${({ variant = 'rectangular' }) =>
-    variant === 'circular' ? 'border-radius: 50%' : ''};
   animation: ${skeletonAnimation} 1.5s ease-in-out 0.5s infinite;
   height: ${({ height }) => height ?? '100%'};
   width: ${({ width }) => width ?? '100%'};
-  border-radius: ${({ borderRadius }) => borderRadius ?? '4px'};
+  border-radius: ${({ borderRadius }) =>
+    borderRadius ?? `${borderRadiusPx.xs}px`};
 `

--- a/lib/ui/loaders/Spinner.tsx
+++ b/lib/ui/loaders/Spinner.tsx
@@ -1,4 +1,5 @@
 import { Animation } from '@lib/ui/animations/Animation'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { ComponentProps, FC } from 'react'
 import styled, { keyframes } from 'styled-components'
@@ -29,7 +30,7 @@ const SecondarySpinner = styled.span`
   display: inline-block;
 
   border: 0.08em solid;
-  border-radius: 100%;
+  ${borderRadius.pill};
   border-top-color: transparent;
 
   animation: ${animationForRotation} 1s infinite linear;

--- a/lib/ui/modal/ModalContainer.tsx
+++ b/lib/ui/modal/ModalContainer.tsx
@@ -31,7 +31,7 @@ const Container = styled(FocusLock)<ContainerProps>`
     width
       ? css`
           width: ${toSizeUnit(width)};
-          ${borderRadius.m};
+          ${borderRadius.md};
           max-height: calc(100% - ${toSizeUnit(offset * 2)});
           ${placement === 'top' &&
           css`

--- a/lib/ui/modal/ResponsiveModal.tsx
+++ b/lib/ui/modal/ResponsiveModal.tsx
@@ -1,3 +1,4 @@
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { BodyPortal } from '@lib/ui/dom/BodyPortal'
 import { VStack } from '@lib/ui/layout/Stack'
 import {
@@ -38,7 +39,8 @@ const MobileDrawer = styled(VStack)<{
   height: ${({ $fullScreen }) => ($fullScreen ? '100dvh' : 'auto')};
   max-height: ${({ $fullScreen }) => ($fullScreen ? 'none' : '90vh')};
   overflow: hidden;
-  border-radius: ${({ $fullScreen }) => ($fullScreen ? 0 : '24px 24px 0 0')};
+  border-radius: ${({ $fullScreen }) =>
+    $fullScreen ? 0 : `${borderRadiusPx.xl}px ${borderRadiusPx.xl}px 0 0`};
   overscroll-behavior: contain;
   z-index: 1000;
 
@@ -52,7 +54,7 @@ const MobileDrawerHeader = styled.div`
   justify-content: center;
   padding: 12px 0;
   background: ${getColor('background')};
-  border-radius: 24px 24px 0 0;
+  border-radius: ${borderRadiusPx.xl}px ${borderRadiusPx.xl}px 0 0;
   touch-action: none;
   cursor: grab;
 `
@@ -60,7 +62,7 @@ const MobileDrawerHeader = styled.div`
 const MobileDrawerGrabber = styled.div`
   width: 44px;
   height: 4px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   background: ${getColor('foregroundSuper')};
 `
 

--- a/lib/ui/panel/Panel.tsx
+++ b/lib/ui/panel/Panel.tsx
@@ -18,7 +18,7 @@ const panelBackground = css`
 `
 
 export const panel = ({ withSections }: PanelProps = {}) => css`
-  ${borderRadius.m};
+  ${borderRadius.md};
 
   ${withSections
     ? css`

--- a/lib/ui/search/SearchField.tsx
+++ b/lib/ui/search/SearchField.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { SearchIcon } from '@lib/ui/icons/SearchIcon'
 import { StationMagnifierIcon } from '@lib/ui/icons/StationFigmaIcons'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -72,8 +73,8 @@ export const SearchField: React.FC<SearchFieldProps> = ({
 const Wrapper = styled(HStack)`
   position: relative;
   background-color: ${getColor('foreground')};
-  border-radius: ${({ theme }) =>
-    theme.iconStyle === 'station' ? '99px' : '10px'};
+  ${({ theme }) =>
+    theme.iconStyle === 'station' ? borderRadius.pill : borderRadius.md};
   height: 48px;
   flex: none;
 
@@ -103,7 +104,7 @@ const StyledInput = styled.input.attrs({ autoComplete: 'off' })`
   padding-left: 32px;
   line-height: ${({ theme }) => (theme.iconStyle === 'station' ? 18 : 20)}px;
   font-size: ${({ theme }) => (theme.iconStyle === 'station' ? 13 : 16)}px;
-  border-radius: 4px;
+  ${borderRadius.xs};
   outline: none;
   transition: border-color 0.2s;
   background-color: transparent;

--- a/lib/ui/selection/SelectableItem.tsx
+++ b/lib/ui/selection/SelectableItem.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CheckmarkIcon } from '@lib/ui/icons/CheckmarkIcon'
 import { IconWrapper as BaseIconWrapper } from '@lib/ui/icons/IconWrapper'
 import { vStack } from '@lib/ui/layout/Stack'
@@ -15,7 +16,7 @@ const IconWrapper = styled.div<IsActiveProp>`
   })};
   position: relative;
   align-self: stretch;
-  border-radius: 24px;
+  ${borderRadius.xl};
   background: rgba(11, 26, 58, 0.5);
   height: 74px;
   padding: 17px;
@@ -36,6 +37,8 @@ const CheckBadge = styled(BaseIconWrapper)`
   right: 0;
   height: 24px;
   padding: 8px;
+  /* A notched badge shape, not a surface radius: both values exceed half
+     the element and clamp, fully rounding two opposite corners. */
   border-radius: 40px 0 25px 0;
   background: ${getColor('foregroundSuper')};
   font-weight: 600;

--- a/lib/ui/sheet/PromptSheet.tsx
+++ b/lib/ui/sheet/PromptSheet.tsx
@@ -1,3 +1,4 @@
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { BodyPortal } from '@lib/ui/dom/BodyPortal'
 import { useKeyDown } from '@lib/ui/hooks/useKeyDown'
 import { OnCloseProp } from '@lib/ui/props'
@@ -40,7 +41,7 @@ const Card = styled.div`
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   border-bottom: 0;
-  border-radius: 34px 34px 0 0;
+  border-radius: ${borderRadiusPx.xl}px ${borderRadiusPx.xl}px 0 0;
   box-shadow: 0px 15px 75px rgba(0, 0, 0, 0.18);
   overflow: hidden;
   width: 100%;
@@ -48,7 +49,7 @@ const Card = styled.div`
 
   @media ${mediaQuery.tabletDeviceAndUp} {
     border-bottom: 1px solid ${getColor('foregroundExtra')};
-    border-radius: 34px;
+    ${borderRadius.xl};
     max-width: 380px;
     max-height: calc(100dvh - 32px);
   }
@@ -75,7 +76,7 @@ const Grabber = styled.div`
   transform: translateX(-50%);
   width: 36px;
   height: 5px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   background: ${getColor('foregroundSuper')};
 
   @media ${mediaQuery.tabletDeviceAndUp} {
@@ -96,7 +97,7 @@ export const PromptSheetIcon = styled.div`
   position: relative;
   width: 40px;
   height: 40px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   overflow: hidden;
   background: ${getColor('background')};
   border: 1px solid ${getColor('foregroundSuperContrast')};

--- a/lib/ui/status/EmptyState/EmptyState.tsx
+++ b/lib/ui/status/EmptyState/EmptyState.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CryptoIcon } from '@lib/ui/icons/CryptoIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { VStack, vStack } from '@lib/ui/layout/Stack'
@@ -43,7 +44,7 @@ const EmptyWrapper = styled.div`
     alignItems: 'center',
   })};
   padding: 32px 40px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   background: ${getColor('foreground')};
 
   ${({ theme }) =>
@@ -51,7 +52,6 @@ const EmptyWrapper = styled.div`
     css`
       align-self: stretch;
       border: 1px solid ${theme.colors.foregroundSuper.toCssValue()};
-      border-radius: 20px;
       padding: 28px 20px;
     `}
 `

--- a/lib/ui/status/ErrorBlock/index.tsx
+++ b/lib/ui/status/ErrorBlock/index.tsx
@@ -7,7 +7,7 @@ import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
 
 const Container = styled(HStack)`
-  ${borderRadius.m};
+  ${borderRadius.md};
   background: ${getColor('dangerBackground')};
   border: 1px solid
     ${({ theme: { colors } }) =>

--- a/lib/ui/status/InfoBlock/index.tsx
+++ b/lib/ui/status/InfoBlock/index.tsx
@@ -10,7 +10,7 @@ import { ElementType, ReactNode } from 'react'
 import styled from 'styled-components'
 
 const Container = styled(HStack)`
-  ${borderRadius.m};
+  ${borderRadius.md};
   background-color: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   padding: 16px;

--- a/lib/ui/status/WarningBlock/index.tsx
+++ b/lib/ui/status/WarningBlock/index.tsx
@@ -10,7 +10,7 @@ import { ElementType, ReactNode } from 'react'
 import styled from 'styled-components'
 
 const Container = styled(HStack)`
-  ${borderRadius.m};
+  ${borderRadius.md};
   background-color: ${getColor('idleDark')};
   border: 1px solid ${getColor('idle')};
   padding: 16px;

--- a/lib/ui/toast/ToastItem.tsx
+++ b/lib/ui/toast/ToastItem.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { BodyPortal } from '@lib/ui/dom/BodyPortal'
 import { pageBottomInsetVar } from '@lib/ui/page/PageContent'
 import { ChildrenProp, ValueProp } from '@lib/ui/props'
@@ -72,7 +73,7 @@ const Card = styled.div`
 
   width: 100%;
   padding: 16px;
-  border-radius: 24px;
+  ${borderRadius.xl};
   border: 1px solid ${getColor('foregroundSuper')};
   background: ${getColor('foregroundExtra')};
   text-align: center;

--- a/lib/ui/tooltips/Tooltip.tsx
+++ b/lib/ui/tooltips/Tooltip.tsx
@@ -15,6 +15,7 @@ import {
   useRole,
   useTransitionStyles,
 } from '@floating-ui/react'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { getColor } from '@lib/ui/theme/getters'
 import { ReactNode, useRef, useState } from 'react'
 import styled from 'styled-components'
@@ -30,7 +31,7 @@ type TooltipProps = {
 }
 
 const Container = styled.div`
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: ${getColor('contrast')};
   color: ${getColor('background')};
   padding: 12px;


### PR DESCRIPTION
A.2 of #4622. 41 files, all in `lib/ui`.

This is the leverage PR of the series and it runs **before** any app sweep on purpose: every surface that inherits from `Panel`, `ResponsiveModal`, `PromptSheet`, `Hoverable`, `textInput` and friends is fixed here for free. Sweeping the app first would mean touching the same files twice.

## Most of this is token-for-value, no visual change

A radius already sitting on a scale step keeps its pixels and just stops being a magic number - 4 becomes `xs`, 8 `sm`, 12 `md`, 16 `lg`, 24 `xl`. That is the bulk of the diff and it should read as noise.

## The off-scale values that actually move

| | from | to | where |
|---|---|---|---|
| sheet | 34 | 24 | `PromptSheet`, mobile sheet and tablet card |
| container | 26 | 24 | `ToggleSwitch` |
| card | 20 | 16 | `EmptyState` station variant |
| container | 20 | 24 | `InfoItem` |
| input | 10 | 12 | `SearchField`, default theme |

`EmptyState` is the one worth a look: the station variant differed from the default by exactly 4px, so its override now drops the radius line entirely and inherits `lg`. Both variants are the same card.

`InfoItem` was the only `borderRadius.l` (20) call site in `lib/ui`. It resolves upward to `xl` because it is a container, not a row - the other two `.l` sites live in the vault directories and get decided in #4623.

## Five spellings of "fully rounded" become one

`999px`, `100px`, `50%`, `100%` and `round` all collapse into `pill`. Two more were written as dimensions rather than radii and were easy to miss:

- `IconButton` set its radius to `iconButtonSize[$size]` on an element whose height and min-width are that same value - a circle spelled as a size.
- The `Slider` track was 2px on a 4px-tall element, already clamping to a capsule.

Both are exactly equivalent under `pill`.

## Two bits of dead code

The `Skeleton` `variant` prop is removed. It was passed nowhere in the tree, and its `circular` branch was dead twice over - the unconditional `border-radius` rule below it always won, so `variant="circular"` rendered a rectangle. The story that demonstrated it now uses the `borderRadius` prop instead.

`buttonSize` goes with `ToggleSwitch`, which was its only consumer. Worth flagging because it caused the one bug in this PR: `buttonSize.md` is **26**, not the button height, so the container never clamped to a capsule. The first pass turned it into a `pill` on that assumption, which would have shipped a visibly rounder control. It is a 26 -> 24 move onto the scale instead.

## Deliberate survivors

- **The shared Button** (`:69` 30px, `:115` 99px) - owned by #4548, just merged. Not touched, and `Button.spec.tsx` still asserts 30px. The lint PR at the end of the series will need an inline exception here or a follow-up in the button series.
- **The notched badge in `SelectableItem`** (`40px 0 25px 0`) - a shape, not a surface radius. Both values exceed half the element and clamp, fully rounding two opposite corners. Left as-is with a comment saying why.
- **`Stack` / `List` / `IconButton` radius props** - generic primitives whose callers pass a value. The magic numbers are at the call sites and get migrated in the sweep PRs that own them.

## One API left alone on purpose

`Skeleton` still takes `borderRadius?: string`, and four call sites pass off-scale strings (`"14px"`, `"10px"`, `"8px"`). Narrowing it to a scale key would break those files, which live in directories owned by other PRs in this series - so it stays a string here and the call sites get fixed where they live.

## Validation

`yarn check` clean, `yarn test` 942 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
