### PR TITLE
refactor(ui): shared and platform surfaces adopt the corner-radius scale

### DIFF
--- a/clients/extension/src/components/dapps-button/DappsButton.tsx
+++ b/clients/extension/src/components/dapps-button/DappsButton.tsx
@@ -1,6 +1,6 @@
 import { useCurrentVaultAppSessionsQuery } from '@core/extension/storage/hooks/appSessions'
 import { IconButton } from '@lib/ui/buttons/IconButton'
-import { round } from '@lib/ui/css/round'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { ContainImage } from '@lib/ui/images/ContainImage'
@@ -13,7 +13,7 @@ import styled from 'styled-components'
 
 const Icon = styled(ContainImage)`
   ${sameDimensions('36px')};
-  ${round};
+  ${borderRadius.pill};
   border: 1px solid rgba(255, 255, 255, 0.1);
 `
 
@@ -28,7 +28,7 @@ const Badge = styled.div<{ isConnected: boolean }>`
   right: -0.1em;
   width: 1em;
   height: 1em;
-  ${round};
+  ${borderRadius.pill};
   background-color: ${({ isConnected }) =>
     isConnected ? getColor('success') : getColor('idle')};
   border: 4px solid ${getColor('foregroundExtra')};

--- a/clients/extension/src/pages/connected-dapps/index.tsx
+++ b/clients/extension/src/pages/connected-dapps/index.tsx
@@ -7,7 +7,7 @@ import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { useAssertCurrentVaultId } from '@core/ui/storage/currentVaultId'
 import { Button } from '@lib/ui/buttons/Button'
 import { IconButton } from '@lib/ui/buttons/IconButton'
-import { round } from '@lib/ui/css/round'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { DAppsIcon } from '@lib/ui/icons/DAppsIcon'
 import { LinkTwoOffIcon } from '@lib/ui/icons/LinkTwoOffIcon'
@@ -26,7 +26,7 @@ import styled from 'styled-components'
 
 const Icon = styled(ContainImage)`
   ${sameDimensions('2.7em')};
-  ${round};
+  ${borderRadius.pill};
   border: 1px solid rgba(255, 255, 255, 0.1);
 `
 export const ConnectedDappsPage = () => {

--- a/clients/extension/src/pages/station-migration/StationMigrationPage.tsx
+++ b/clients/extension/src/pages/station-migration/StationMigrationPage.tsx
@@ -14,6 +14,7 @@ import { useAssertWalletCore } from '@core/ui/chain/providers/WalletCoreProvider
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { currentProductBrand } from '@core/ui/product/brand'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { PasswordInput } from '@lib/ui/inputs/PasswordInput'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { ListItem } from '@lib/ui/list/item'
@@ -564,7 +565,7 @@ const SummaryGrid = styled.div`
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 1px;
   overflow: hidden;
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: ${getColor('mistExtra')};
 `
 
@@ -589,6 +590,6 @@ const WalletTitleRow = styled(HStack).attrs({
 const StatusBadge = styled.span`
   flex: 0 0 auto;
   padding: 5px 8px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   background: ${getColor('foregroundExtra')};
 `

--- a/core/inpage-provider/popup/view/resolvers/grantVaultAccess/index.tsx
+++ b/core/inpage-provider/popup/view/resolvers/grantVaultAccess/index.tsx
@@ -15,7 +15,7 @@ import { useVaults } from '@core/ui/storage/vaults'
 import { VaultSigners } from '@core/ui/vault/signers'
 import { getVaultSecurityTone } from '@core/ui/vaultsOrganisation/utils/getVaultSecurityTone'
 import { Button } from '@lib/ui/buttons/Button'
-import { round } from '@lib/ui/css/round'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { ContainImage } from '@lib/ui/images/ContainImage'
 import { SafeImage } from '@lib/ui/images/SafeImage'
@@ -46,7 +46,7 @@ type ConnectView = 'connect' | 'picker'
 
 const DappFavicon = styled(ContainImage)`
   ${sameDimensions(46)};
-  ${round};
+  ${borderRadius.pill};
   border: 1px solid rgba(255, 255, 255, 0.1);
 `
 
@@ -58,7 +58,7 @@ const VaultAvatar = styled.div<{
   tone: 'primary' | 'warning'
 }>`
   ${sameDimensions(28)};
-  ${round};
+  ${borderRadius.pill};
   align-items: center;
   display: flex;
   font-size: 14px;
@@ -81,7 +81,7 @@ const VaultAvatar = styled.div<{
 const ChangePill = styled.span`
   align-items: center;
   border: 1.5px solid ${getColor('foregroundExtra')};
-  border-radius: 99px;
+  ${borderRadius.pill};
   color: ${getColor('textShy')};
   display: inline-flex;
   font-size: 12px;

--- a/core/inpage-provider/popup/view/resolvers/sendTx/components/DappRequestHeader.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/components/DappRequestHeader.tsx
@@ -1,4 +1,5 @@
 import { DappRequestRow } from '@core/inpage-provider/popup/view/resolvers/sendTx/components/DappRequestRow'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -8,7 +9,7 @@ import styled from 'styled-components'
 const Panel = styled(VStack)`
   background-color: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 16px;
+  ${borderRadius.lg};
   gap: 16px;
   padding: 20px;
 `

--- a/core/inpage-provider/popup/view/resolvers/sendTx/components/DappRequestRow.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/components/DappRequestRow.tsx
@@ -1,4 +1,5 @@
 import { usePopupContext } from '@core/inpage-provider/popup/view/state/context'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { BrowserExtensionIcon } from '@lib/ui/icons/BrowserExtensionIcon'
 import { SafeImage } from '@lib/ui/images/SafeImage'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -8,7 +9,7 @@ import { attempt } from '@vultisig/lib-utils/attempt'
 import styled from 'styled-components'
 
 const Image = styled.img`
-  border-radius: 50%;
+  ${borderRadius.pill};
   height: 32px;
   width: 32px;
 `
@@ -16,7 +17,7 @@ const Image = styled.img`
 const FallbackIcon = styled(HStack)`
   align-items: center;
   background-color: ${getColor('foregroundExtra')};
-  border-radius: 50%;
+  ${borderRadius.pill};
   color: ${getColor('text')};
   font-size: 18px;
   height: 32px;

--- a/core/inpage-provider/popup/view/resolvers/sendTx/components/SwapAmountDisplay.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/components/SwapAmountDisplay.tsx
@@ -1,12 +1,12 @@
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
-import { round } from '@lib/ui/css/round'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { Coin } from '@vultisig/core-chain/coin/Coin'
 import styled from 'styled-components'
 
 const RoundedCoinIconWrapper = styled.div`
-  ${round};
+  ${borderRadius.pill};
   display: inline-flex;
 `
 

--- a/core/inpage-provider/popup/view/resolvers/signMessage/components/Collapse.tsx
+++ b/core/inpage-provider/popup/view/resolvers/signMessage/components/Collapse.tsx
@@ -1,4 +1,5 @@
 import { Section } from '@core/inpage-provider/popup/view/resolvers/signMessage/styles'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CollapsableStateIndicator } from '@lib/ui/layout/CollapsableStateIndicator'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
@@ -16,7 +17,7 @@ type CollapseProps = {
 
 const OutlineSection = styled(VStack)`
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 16px;
+  ${borderRadius.lg};
 `
 
 export const Collapse: FC<CollapseProps> = ({

--- a/core/inpage-provider/popup/view/resolvers/signMessage/styles.ts
+++ b/core/inpage-provider/popup/view/resolvers/signMessage/styles.ts
@@ -1,10 +1,11 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
 
 export const Description = styled(VStack)`
   border: 1px dashed ${getColor('foregroundExtra')};
-  border-radius: 16px;
+  ${borderRadius.lg};
   gap: 8px;
   padding: 12px;
 `
@@ -27,13 +28,13 @@ export const Image = styled.img`
 export const Section = styled(VStack)`
   background-color: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 16px;
+  ${borderRadius.lg};
 `
 
 export const Verify = styled(HStack)`
   background-color: ${getColor('background')};
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 16px;
+  ${borderRadius.lg};
   height: 28px;
   padding-left: 6px;
   padding-right: 8px;

--- a/core/ui/address-book/AddressBookChainInput.tsx
+++ b/core/ui/address-book/AddressBookChainInput.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ChevronRightIcon } from '@lib/ui/icons/ChevronRightIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { panel } from '@lib/ui/panel/Panel'
@@ -22,7 +23,7 @@ const ChainSelector = styled(HStack)`
   ${panel()};
   cursor: pointer;
   padding: 12px 16px;
-  border-radius: 8px;
+  ${borderRadius.sm};
   align-items: center;
   gap: 12px;
   height: 56px;

--- a/core/ui/address-book/item/index.tsx
+++ b/core/ui/address-book/item/index.tsx
@@ -88,7 +88,7 @@ export const AddressBookListItem: FC<AddressBookListItemProps> = ({
 const StyledListItem = styled(ListItem)`
   background-color: transparent;
   border: 1px solid ${getColor('foregroundExtra')};
-  ${borderRadius.m};
+  ${borderRadius.md};
   padding: 16px 20px;
   max-height: 68px;
 `

--- a/core/ui/dapp/DappRequestBanner.tsx
+++ b/core/ui/dapp/DappRequestBanner.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { BrowserExtensionIcon } from '@lib/ui/icons/BrowserExtensionIcon'
 import { SafeImage } from '@lib/ui/images/SafeImage'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -11,13 +12,13 @@ import styled from 'styled-components'
 const Panel = styled(VStack)`
   background-color: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 16px;
+  ${borderRadius.lg};
   gap: 16px;
   padding: 20px;
 `
 
 const Image = styled.img`
-  border-radius: 50%;
+  ${borderRadius.pill};
   height: 32px;
   width: 32px;
 `
@@ -25,7 +26,7 @@ const Image = styled.img`
 const FallbackIcon = styled(HStack)`
   align-items: center;
   background-color: ${getColor('foregroundExtra')};
-  border-radius: 50%;
+  ${borderRadius.pill};
   color: ${getColor('text')};
   font-size: 18px;
   height: 32px;

--- a/core/ui/errors/RootErrorFallback.tsx
+++ b/core/ui/errors/RootErrorFallback.tsx
@@ -20,7 +20,7 @@ const StackTrace = styled.pre`
     size: 12,
     weight: '400',
   })}
-  ${borderRadius.m};
+  ${borderRadius.md};
   background: ${getColor('foreground')};
   padding: 20px;
   max-height: 240px;

--- a/core/ui/notifications/KeysignNotificationBanner.tsx
+++ b/core/ui/notifications/KeysignNotificationBanner.tsx
@@ -1,3 +1,4 @@
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { LightningIcon } from '@lib/ui/icons/LightningIcon'
 import { ShieldIcon } from '@lib/ui/icons/ShieldIcon'
 import { Text } from '@lib/ui/text'
@@ -15,7 +16,6 @@ import styled from 'styled-components'
 const autoDismissMs = 30_000
 /** Figma 70608:121371 — total frame height (padding included via border-box). */
 export const bannerHeightPx = 198
-const bottomCornerRadiusPx = 24
 const swipeDismissThresholdPx = 50
 
 export const transitionDuration = '0.35s'
@@ -56,7 +56,7 @@ const BannerRoot = styled.div<{
     ${getColor('primaryAccentTwo')} 20.77%,
     ${getColor('primaryAccentFour')} 109.97%
   );
-  border-radius: 0 0 ${bottomCornerRadiusPx}px ${bottomCornerRadiusPx}px;
+  border-radius: 0 0 ${borderRadiusPx.xl}px ${borderRadiusPx.xl}px;
   box-sizing: border-box;
   cursor: pointer;
   display: flex;
@@ -121,7 +121,7 @@ const VaultPill = styled.div`
   align-items: center;
   background: ${({ theme }) =>
     theme.colors.background.getVariant({ a: () => 0.5 }).toCssValue()};
-  border-radius: 999px;
+  ${borderRadius.pill};
   display: inline-flex;
   flex-shrink: 0;
   gap: 4px;

--- a/core/ui/notifications/choose-vaults/ChooseVaultsContent.tsx
+++ b/core/ui/notifications/choose-vaults/ChooseVaultsContent.tsx
@@ -1,4 +1,5 @@
 import { VaultSecurityType } from '@core/ui/vault/VaultSecurityType'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { LightningIcon } from '@lib/ui/icons/LightningIcon'
 import { ShieldIcon } from '@lib/ui/icons/ShieldIcon'
 import { Switch } from '@lib/ui/inputs/switch'
@@ -83,7 +84,7 @@ export const ChooseVaultsContent: FC<BodyProps> = ({
 
 const VaultListCard = styled(VStack)`
   background-color: ${getColor('foreground')};
-  border-radius: 24px;
+  ${borderRadius.xl};
   overflow: hidden;
 `
 
@@ -118,7 +119,7 @@ const VaultTypeIconFrame = styled.div`
   align-items: center;
   background-color: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 50%;
+  ${borderRadius.pill};
   display: flex;
   flex-shrink: 0;
   justify-content: center;

--- a/core/ui/notifications/choose-vaults/ChooseVaultsPage.tsx
+++ b/core/ui/notifications/choose-vaults/ChooseVaultsPage.tsx
@@ -3,6 +3,7 @@ import {
   ChooseVaultsContent,
   VaultNotificationItem,
 } from '@core/ui/notifications/choose-vaults/ChooseVaultsContent'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { VStack } from '@lib/ui/layout/Stack'
 import { PageContent } from '@lib/ui/page/PageContent'
 import { PageHeader } from '@lib/ui/page/PageHeader'
@@ -52,7 +53,7 @@ export const ChooseVaultsPage: FC<ChooseVaultsPageProps> = ({
 const DoneButton = styled.button`
   background-color: ${getColor('foreground')};
   border: none;
-  border-radius: 99px;
+  ${borderRadius.pill};
   cursor: pointer;
   padding: 6px 12px;
 `

--- a/core/ui/notifications/settings/NotificationSettingsContent.tsx
+++ b/core/ui/notifications/settings/NotificationSettingsContent.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { LightningIcon } from '@lib/ui/icons/LightningIcon'
 import { ShieldIcon } from '@lib/ui/icons/ShieldIcon'
 import { Switch } from '@lib/ui/inputs/switch'
@@ -35,7 +36,7 @@ type NotificationSettingsContentProps = {
 const VaultTypeIcon = styled.div<{ $isFast: boolean }>`
   width: 40px;
   height: 40px;
-  border-radius: 99px;
+  ${borderRadius.pill};
   background: ${getColor('foregroundDark')};
   border: 1px solid ${getColor('foregroundExtra')};
   display: flex;
@@ -72,7 +73,7 @@ const VaultSection = styled.div`
 
 const VaultListCard = styled.div`
   background: ${getColor('foreground')};
-  border-radius: 12px;
+  ${borderRadius.md};
   overflow: hidden;
   width: 100%;
 `

--- a/core/ui/preferences/currency/index.tsx
+++ b/core/ui/preferences/currency/index.tsx
@@ -3,6 +3,7 @@ import {
   useFiatCurrency,
   useSetFiatCurrencyMutation,
 } from '@core/ui/storage/fiatCurrency'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CheckIcon } from '@lib/ui/icons/CheckIcon'
 import { VStack } from '@lib/ui/layout/Stack'
 import { List } from '@lib/ui/list'
@@ -49,7 +50,7 @@ export const CurrencyPage = () => {
 
 const CircleCheckIcon = styled(CheckIcon)`
   background-color: ${getColor('buttonPrimary')};
-  border-radius: 50%;
+  ${borderRadius.pill};
   font-size: 16px;
   padding: 2px;
 `

--- a/core/ui/preferences/language/index.tsx
+++ b/core/ui/preferences/language/index.tsx
@@ -1,6 +1,7 @@
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { languageName, languageRegion, languages } from '@core/ui/i18n/Language'
 import { useLanguage, useSetLanguageMutation } from '@core/ui/storage/language'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CheckIcon } from '@lib/ui/icons/CheckIcon'
 import { VStack } from '@lib/ui/layout/Stack'
 import { List } from '@lib/ui/list'
@@ -43,7 +44,7 @@ export const LanguagePage = () => {
 
 const CircleCheckIcon = styled(CheckIcon)`
   background-color: ${getColor('buttonPrimary')};
-  border-radius: 50%;
+  ${borderRadius.pill};
   font-size: 16px;
   padding: 2px;
 `

--- a/core/ui/qr/PrintableQrCode.tsx
+++ b/core/ui/qr/PrintableQrCode.tsx
@@ -1,4 +1,5 @@
 import { ProductLogo } from '@core/ui/product/ProductLogo'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -49,14 +50,14 @@ const QrCardFrame = styled.div`
   height: ${qrCardHeight}px;
   padding: 18px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 24px;
+  ${borderRadius.xl};
 `
 
 const InfoCard = styled(VStack)`
   width: ${cardInnerWidth}px;
   padding: 20px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 24px;
+  ${borderRadius.xl};
   gap: 16px;
 `
 
@@ -82,7 +83,7 @@ const BrandLogoSquare = styled.div`
   justify-content: center;
   width: 33px;
   height: 33px;
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: linear-gradient(180deg, #4879fd 0%, #0d39b1 100%);
   box-shadow: inset 0 0.82px 0.82px 0 rgba(255, 255, 255, 0.35);
   color: ${getColor('white')};

--- a/core/ui/qr/components/ScanQrView.tsx
+++ b/core/ui/qr/components/ScanQrView.tsx
@@ -3,6 +3,7 @@ import { QrScanner } from '@core/ui/qr/components/QrScanner'
 import { useCameraPermissionQuery } from '@core/ui/qr/hooks/useCameraPermissionQuery'
 import { Match } from '@lib/ui/base/Match'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ErrorFallbackContent } from '@lib/ui/flow/ErrorFallbackContent'
 import { Center } from '@lib/ui/layout/Center'
 import { VStack } from '@lib/ui/layout/Stack'
@@ -27,7 +28,7 @@ const ScannerGlobalStyle = createGlobalStyle`
 const GlassContainer = styled(VStack)`
   flex-grow: 1;
   border: 1px solid ${getColor('primaryAccentTwo')};
-  border-radius: 24px;
+  ${borderRadius.xl};
   background: ${({ theme }) => theme.colors.background.toRgba(0.3)};
   box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
   overflow: hidden;

--- a/core/ui/settings/share-app/ShareAppModal.tsx
+++ b/core/ui/settings/share-app/ShareAppModal.tsx
@@ -1,3 +1,4 @@
+import { borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { vStack } from '@lib/ui/layout/Stack'
 import { Modal } from '@lib/ui/modal'
 import { Backdrop } from '@lib/ui/modal/Backdrop'
@@ -48,7 +49,7 @@ const Wrapper = styled.div`
   })};
 
   padding: 20px;
-  border-radius: 16px 16px 0 0;
+  border-radius: ${borderRadiusPx.xl}px ${borderRadiusPx.xl}px 0 0;
   background: ${getColor('background')};
 `
 

--- a/core/ui/settings/share-app/ShareAppPrompt.tsx
+++ b/core/ui/settings/share-app/ShareAppPrompt.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CopyIcon } from '@lib/ui/icons/CopyIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { hStack } from '@lib/ui/layout/Stack'
@@ -50,7 +51,7 @@ const Wrapper = styled.div`
     alignItems: 'center',
   })};
 
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
 `

--- a/core/ui/transaction-history/TransactionHistoryCard/styles.ts
+++ b/core/ui/transaction-history/TransactionHistoryCard/styles.ts
@@ -1,3 +1,4 @@
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { getColor, matchColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
@@ -11,7 +12,7 @@ export const Card = styled(VStack).attrs({
   gap: 12,
 })`
   padding: 16px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   width: 100%;
@@ -72,7 +73,7 @@ export const IconSlot = styled.div`
   align-items: center;
   justify-content: center;
   overflow: hidden;
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 /** USD + crypto stack. Minimal gap (Figma ~0 between lines in some frames). */
@@ -89,7 +90,7 @@ export const AddressPill = styled(HStack).attrs({
   gap: 4,
 })`
   padding: 8px 16px;
-  border-radius: 99px;
+  ${borderRadius.pill};
   background: ${getColor('buttonSecondary')};
   border: 1px solid ${getColor('foregroundExtra')};
   flex-shrink: 0;
@@ -111,7 +112,7 @@ export const ProviderPill = styled(HStack).attrs({
   gap: 6,
 })`
   padding: 8px 12px;
-  border-radius: 12px 0 16px 0;
+  border-radius: ${borderRadiusPx.md}px 0 ${borderRadiusPx.lg}px 0;
   background: ${getColor('buttonSecondary')};
   border-top: 1px solid ${getColor('foregroundExtra')};
   border-left: 1px solid ${getColor('foregroundExtra')};

--- a/core/ui/transaction-history/TransactionHistoryTag/styles.ts
+++ b/core/ui/transaction-history/TransactionHistoryTag/styles.ts
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
@@ -9,7 +10,7 @@ export const TagPill = styled(HStack).attrs({
 })`
   width: fit-content;
   padding: 8px 12px;
-  border-radius: 99px;
+  ${borderRadius.pill};
   border: 1px solid ${getColor('info')};
   background: ${({ theme }) => theme.colors.info.withAlpha(0.1).toCssValue()};
   color: ${getColor('info')};

--- a/core/ui/transaction-history/detail/TransactionDetailPage.tsx
+++ b/core/ui/transaction-history/detail/TransactionDetailPage.tsx
@@ -28,8 +28,8 @@ import {
 } from '@core/ui/vault/swap/limit/tracking/presentation'
 import { useLimitOrderTracking } from '@core/ui/vault/swap/limit/tracking/useLimitOrderTracking'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
-import { round } from '@lib/ui/css/round'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { ChevronRightIcon } from '@lib/ui/icons/ChevronRightIcon'
 import { SquareArrowOutUpRightIcon } from '@lib/ui/icons/SquareArrowOutUpRightIcon'
@@ -631,7 +631,7 @@ export const TransactionDetailPage = () => {
 const AmountCard = styled(VStack)`
   background-color: ${({ theme }) => theme.colors.foreground.toCssValue()};
   border: 1px solid ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};
-  border-radius: 16px;
+  ${borderRadius.lg};
   padding: 24px 16px;
   width: 100%;
 `
@@ -639,7 +639,7 @@ const AmountCard = styled(VStack)`
 const SwapCoinCard = styled(VStack)`
   background-color: ${({ theme }) => theme.colors.foreground.toCssValue()};
   border: 1px solid ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};
-  border-radius: 16px;
+  ${borderRadius.lg};
   flex: 1;
   padding: 24px 16px;
 `
@@ -650,13 +650,13 @@ const SwapChevronWrapper = styled(HStack)`
   left: 50%;
   transform: translate(-50%, -50%);
   z-index: 1;
-  border-radius: 50%;
+  ${borderRadius.pill};
   padding: 7px;
   background-color: ${({ theme }) => theme.colors.background.toCssValue()};
 `
 
 const SwapChevronCircle = styled.div`
-  ${round};
+  ${borderRadius.pill};
   ${sameDimensions(24)};
   ${centerContent};
   background: ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};

--- a/core/ui/transaction-history/progress/PendingTransactionProgressCard.tsx
+++ b/core/ui/transaction-history/progress/PendingTransactionProgressCard.tsx
@@ -7,6 +7,7 @@ import { getLimitOrderBuyCoin } from '@core/ui/mpc/keysign/join/tx/limitOrderBuy
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { useCurrentVaultCoins } from '@core/ui/vault/state/currentVaultCoins'
 import { toNativeSwapLimitAmount } from '@core/ui/vault/swap/keysignPayload/getSwapToAmountLimit'
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { ArrowDownIcon } from '@lib/ui/icons/ArrowDownIcon'
 import { WalletIcon } from '@lib/ui/icons/WalletIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -398,7 +399,7 @@ export const PendingTransactionProgressCard = ({
 
 const ProgressCard = styled.div`
   padding: 16px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   cursor: pointer;
@@ -418,7 +419,7 @@ const TopRow = styled(HStack).attrs({
 
 const InProgressBadge = styled.div`
   padding: 6px 12px;
-  border-radius: 99px;
+  ${borderRadius.pill};
   background: ${({ theme }) =>
     theme.colors.foregroundExtra.withAlpha(0.5).toCssValue()};
   border: 1px solid ${getColor('foregroundExtra')};
@@ -505,7 +506,7 @@ const StepperIcon = styled.div`
   position: relative;
   width: 28px;
   height: 28px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: ${getColor('foregroundExtra')};
   display: flex;
   align-items: center;
@@ -520,7 +521,7 @@ const ProviderPill = styled(HStack).attrs({
   gap: 6,
 })`
   padding: 8px 12px;
-  border-radius: 12px 0 16px 0;
+  border-radius: ${borderRadiusPx.md}px 0 ${borderRadiusPx.lg}px 0;
   background: ${getColor('buttonSecondary')};
   border-top: 1px solid ${getColor('foregroundExtra')};
   border-left: 1px solid ${getColor('foregroundExtra')};
@@ -547,7 +548,7 @@ const StepperDivider = styled.div`
 const DestinationWalletIcon = styled.div`
   width: 28px;
   height: 28px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: ${getColor('foregroundExtra')};
   display: flex;
   align-items: center;

--- a/core/ui/vaultsOrganisation/components/VaultListRow.tsx
+++ b/core/ui/vaultsOrganisation/components/VaultListRow.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -83,7 +84,7 @@ const Row = styled.div.withConfig({
   align-items: center;
   background: ${({ theme, selected }) =>
     selected && theme.colors.foregroundDark.withAlpha(0.65).toCssValue()};
-  border-radius: 18px;
+  ${borderRadius.lg};
   border: 1px solid
     ${({ theme }) => theme.colors.foregroundExtra.withAlpha(0.7).toCssValue()};
   display: flex;
@@ -150,7 +151,7 @@ const IconBadge = styled.div.withConfig({
   shouldForwardProp: prop => prop !== 'tone',
 })<{ tone: LeadingIconProps['tone'] }>`
   align-items: center;
-  border-radius: 99px;
+  ${borderRadius.pill};
   display: flex;
   font-size: 16px;
   height: 40px;

--- a/core/ui/vaultsOrganisation/components/VaultSignersPill.tsx
+++ b/core/ui/vaultsOrganisation/components/VaultSignersPill.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
 import { hasServer, isServer } from '@vultisig/core-mpc/devices/localPartyId'
@@ -13,7 +14,7 @@ const PillContainer = styled.div`
   justify-content: center;
   align-items: center;
   gap: 10px;
-  border-radius: 8px;
+  ${borderRadius.sm};
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
 `

--- a/core/ui/vaultsOrganisation/folder/create/index.tsx
+++ b/core/ui/vaultsOrganisation/folder/create/index.tsx
@@ -15,6 +15,7 @@ import { useVaultsTotalBalances } from '@core/ui/vaultsOrganisation/hooks/useVau
 import { getVaultSecurityTone } from '@core/ui/vaultsOrganisation/utils/getVaultSecurityTone'
 import { Button } from '@lib/ui/buttons/Button'
 import { IconButton } from '@lib/ui/buttons/IconButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { getFormProps } from '@lib/ui/form/utils/getFormProps'
 import { CloseIcon } from '@lib/ui/icons/CloseIcon'
 import { FolderLockIcon } from '@lib/ui/icons/FolderLockIcon'
@@ -237,7 +238,7 @@ const SwitchWrapper = styled.div`
 `
 
 const EmptyStateCard = styled(VStack)`
-  border-radius: 20px;
+  ${borderRadius.xl};
   padding: 24px;
   background: ${({ theme }) =>
     theme.colors.foreground.withAlpha(0.35).toCssValue()};

--- a/core/ui/vaultsOrganisation/folder/update/index.tsx
+++ b/core/ui/vaultsOrganisation/folder/update/index.tsx
@@ -20,6 +20,7 @@ import { useVaultsTotalBalances } from '@core/ui/vaultsOrganisation/hooks/useVau
 import { getVaultSecurityTone } from '@core/ui/vaultsOrganisation/utils/getVaultSecurityTone'
 import { Button } from '@lib/ui/buttons/Button'
 import { IconButton } from '@lib/ui/buttons/IconButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { DnDList } from '@lib/ui/dnd/DnDList'
 import { getFormProps } from '@lib/ui/form/utils/getFormProps'
 import { CloseIcon } from '@lib/ui/icons/CloseIcon'
@@ -86,7 +87,7 @@ const InputOverlay = styled.div`
 `
 
 const EmptyStateCard = styled(VStack)`
-  border-radius: 20px;
+  ${borderRadius.xl};
   padding: 24px;
   background: ${({ theme }) =>
     theme.colors.foreground.withAlpha(0.35).toCssValue()};

--- a/core/ui/vult/discount/featureGate/FeatureTierGate.tsx
+++ b/core/ui/vult/discount/featureGate/FeatureTierGate.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { WalletIcon } from '@lib/ui/icons/WalletIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Spinner } from '@lib/ui/loaders/Spinner'
@@ -163,7 +164,7 @@ const DialogFrame = styled.div`
     height: auto;
     max-height: calc(100vh - 80px);
     border: 1px solid ${getColor('mistExtra')};
-    border-radius: 38px;
+    ${borderRadius.xl};
     box-shadow: 0 15px 75px rgba(0, 0, 0, 0.18);
   }
 `
@@ -174,7 +175,7 @@ const IconBadge = styled.div`
   justify-content: center;
   width: 40px;
   height: 40px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: #03132c;
   border: 1.5px solid rgba(255, 255, 255, 0.15);
   box-shadow: 0 8px 18px rgba(12, 78, 255, 0.18);
@@ -200,7 +201,7 @@ const RequirementCard = styled(VStack)`
   align-self: stretch;
   gap: 12px;
   padding: 24px 20px 16px;
-  border-radius: 24px 24px 20px 20px;
+  ${borderRadius.xl};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
 `
@@ -211,7 +212,7 @@ const BalanceRow = styled(HStack)`
   margin-top: 10px;
   gap: 12px;
   padding: 16px;
-  border-radius: 14px;
+  ${borderRadius.lg};
   background: #0d2240;
   border: 1px solid ${getColor('foregroundExtra')};
 
@@ -229,7 +230,7 @@ const GetVultButton = styled(UnstyledButton)<{ $gradient: string }>`
   align-self: stretch;
   margin-top: -22px;
   padding: 32px 32px 14px;
-  border-radius: 0 0 24px 24px;
+  border-radius: 0 0 ${borderRadiusPx.xl}px ${borderRadiusPx.xl}px;
   background: ${({ $gradient }) => $gradient};
   color: #f0f4fc;
   font-size: 14px;

--- a/core/ui/vult/discount/featureGate/TierBadge.tsx
+++ b/core/ui/vult/discount/featureGate/TierBadge.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import styled from 'styled-components'
 
 import { TierBadgeContent } from './useTierBadge'
@@ -16,7 +17,7 @@ export const TierBadge = ({ badge }: TierBadgeProps) =>
 
 const Pill = styled.span<{ $color: string }>`
   border: 1px solid ${({ $color }) => $color};
-  border-radius: 99px;
+  ${borderRadius.pill};
   color: ${({ $color }) => $color};
   font-size: 10px;
   font-weight: 600;

--- a/core/ui/vult/discount/tier/bps.tsx
+++ b/core/ui/vult/discount/tier/bps.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ValueProp } from '@lib/ui/props'
 import {
   VultDiscountTier,
@@ -11,7 +12,7 @@ const Container = styled.div`
   padding: 8px 16px;
   justify-content: center;
   align-items: center;
-  border-radius: 99px;
+  ${borderRadius.pill};
   border: 1px solid rgba(72, 121, 253, 0.32);
 
   color: #f0f4fc;

--- a/core/ui/vult/discount/tier/container.tsx
+++ b/core/ui/vult/discount/tier/container.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ValueProp } from '@lib/ui/props'
 import { VultDiscountTier } from '@vultisig/core-chain/swap/affiliate/config'
 import styled from 'styled-components'
@@ -27,7 +28,7 @@ export const DiscountTierContainer = styled.div<{ $clickable?: boolean }>`
   align-self: stretch;
   position: relative;
   overflow: hidden;
-  border-radius: 16px;
+  ${borderRadius.lg};
   background: #061b3a;
   cursor: ${({ $clickable }) => ($clickable ? 'pointer' : 'default')};
 `
@@ -39,7 +40,7 @@ export const DiscountTierDarkSection = styled.div`
   position: relative;
   z-index: 1;
   overflow: hidden;
-  border-radius: 16px;
+  ${borderRadius.lg};
   background: #061b3a;
 `
 


### PR DESCRIPTION
A.3 of #4622. 35 files across `core/ui` (the non-product directories), `core/inpage-provider` and both clients.

First of the sweeps. Most of it is token-for-value with no visual change; the parts worth reading are below.

## Off-scale values that move

| | from | to | where |
|---|---|---|---|
| modal card | 38 | 24 | `FeatureTierGate`, tablet breakpoint |
| card | 24/20 mixed | 24 | `FeatureTierGate` requirement card |
| inner tile | 14 | 16 | `FeatureTierGate` balance row |
| list row | 18 | 16 | `VaultListRow` |
| empty-state card | 20 | 24 | folder create and folder update |
| sheet | 16 | 24 | `ShareAppModal` |

`ShareAppModal` is the first sheet to converge: it rounded its top corners at 16 while `ResponsiveModal` and the rest use 24. Sheets take `xl`.

The `FeatureTierGate` requirement card was `24px 24px 20px 20px` - a 4px difference between its top and bottom corners. It is one surface, so all four corners now match at 24.

## A named constant, one hop from use

`KeysignNotificationBanner` kept its radius in `const bottomCornerRadiusPx = 24` and interpolated it. That is the shape a regex-based lint rule never catches, which is exactly why it is worth removing now rather than after the guard lands. It reads from `borderRadiusPx.xl` instead.

## Surfaces that round individual corners

Four of these, and they keep their asymmetry - it is deliberate in every case (a bottom sheet, a card tucked under a button, two notched history cards). They compose from `borderRadiusPx` rather than the css block:

```
ShareAppModal                     xl xl 0 0
FeatureTierGate GetVultButton     0 0 xl xl
PendingTransactionProgressCard    md 0 lg 0
TransactionHistoryCard            md 0 lg 0
```

## Pill spellings collapsed

`99px` x7, `999px` x2, `50%` x11 and the `round` token x7, all to `pill`. Every `50%` site was checked square first.

## Deliberate skips

- `clients/extension/tests/e2e/fixtures/dapp-page.fixture.ts` - the HTML of a **mock third-party dapp page** used by the e2e suite. Not our UI; its radii should not track our scale.
- `clients/desktop/src/versioning/CheckUpdatePage.tsx:117` (416px) - a decorative glow blob, out of scope per #4622.
- `KeysignNotificationBanner:29` (`border-radius: inherit`) - not a value.

## Validation

`yarn check` clean, `yarn test` 942 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
