### PR TITLE
refactor(ui): mpc and chain surfaces adopt the corner-radius scale

### DIFF
--- a/core/ui/chain/chainSelection/ChainSelectionScreen.styles.ts
+++ b/core/ui/chain/chainSelection/ChainSelectionScreen.styles.ts
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
@@ -26,7 +27,7 @@ export const ChainList = styled.div`
   flex-direction: column;
   margin-top: 8px;
   background-color: #061b3a;
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 export const ChainItem = styled(HStack)`

--- a/core/ui/chain/coin/addCustomToken/CustomTokenResult.tsx
+++ b/core/ui/chain/coin/addCustomToken/CustomTokenResult.tsx
@@ -6,6 +6,7 @@ import {
   useDeleteCoinMutation,
 } from '@core/ui/storage/coins'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CryptoIcon } from '@lib/ui/icons/CryptoIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -141,7 +142,7 @@ const ErrorStateWrapper = styled.div`
   padding: 24px 20px;
   max-width: 450px;
   margin-inline: auto;
-  border-radius: 16px;
+  ${borderRadius.lg};
   background: ${getColor('foreground')};
 
   & > button {
@@ -159,7 +160,7 @@ const LoadingWrapper = styled.div`
 const TokenResultCard = styled.div`
   position: relative;
   padding: 20px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   background: ${getColor('foreground')};
 `
 
@@ -175,5 +176,5 @@ const LoadingOverlay = styled.div`
   justify-content: center;
   align-items: center;
   background: ${getColor('foreground')};
-  border-radius: 16px;
+  ${borderRadius.lg};
 `

--- a/core/ui/chain/coin/icon/ChainEntityIcon.tsx
+++ b/core/ui/chain/coin/icon/ChainEntityIcon.tsx
@@ -1,5 +1,5 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
-import { round } from '@lib/ui/css/round'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { PictureIcon } from '@lib/ui/icons/PictureIcon'
 import { ContainImage } from '@lib/ui/images/ContainImage'
@@ -13,7 +13,7 @@ const Icon = styled(ContainImage)`
 `
 
 const Fallback = styled.div`
-  ${round};
+  ${borderRadius.pill};
   ${sameDimensions('1em')};
   background: ${getColor('mist')};
   ${centerContent};

--- a/core/ui/chain/coin/icon/WithChainIcon.tsx
+++ b/core/ui/chain/coin/icon/WithChainIcon.tsx
@@ -1,6 +1,6 @@
 import { ChainEntityIcon } from '@core/ui/chain/coin/icon/ChainEntityIcon'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
-import { round } from '@lib/ui/css/round'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { getColor } from '@lib/ui/theme/getters'
 import { ComponentProps } from 'react'
@@ -20,7 +20,7 @@ const Position = styled.div`
   bottom: -0.32em;
   right: -0.32em;
   font-size: 0.52em;
-  ${round};
+  ${borderRadius.pill};
   background-color: ${getColor('foreground')};
   border: 1px solid ${getColor('foreground')};
   ${centerContent};

--- a/core/ui/chain/coin/inputs/CoinOption.tsx
+++ b/core/ui/chain/coin/inputs/CoinOption.tsx
@@ -4,6 +4,7 @@ import {
   useCurrentVaultAddress,
   useCurrentVaultCoins,
 } from '@core/ui/vault/state/currentVaultCoins'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Skeleton } from '@lib/ui/loaders/Skeleton'
 import { panel } from '@lib/ui/panel/Panel'
@@ -123,7 +124,7 @@ const VaultCoinBalance = ({ value }: ValueProp<Coin>) => {
 const Container = styled(HStack)`
   ${panel()};
   padding: 12px 20px;
-  border-radius: 0px;
+  border-radius: 0;
   position: relative;
   background-color: ${getColor('foreground')};
   cursor: pointer;
@@ -149,6 +150,6 @@ const PillWrapper = styled.div`
   display: grid;
   place-items: center;
   padding: 8px 12px;
-  border-radius: 99px;
+  ${borderRadius.pill};
   border: 1px solid ${getColor('foregroundExtra')};
 `

--- a/core/ui/chain/coin/inputs/CoinPillButton.tsx
+++ b/core/ui/chain/coin/inputs/CoinPillButton.tsx
@@ -1,5 +1,6 @@
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ChevronRightIcon } from '@lib/ui/icons/ChevronRightIcon'
 import { HStack, hStack, VStack } from '@lib/ui/layout/Stack'
 import { OnClickProp, ValueProp } from '@lib/ui/props'
@@ -56,6 +57,6 @@ const Container = styled(UnstyledButton)`
   })}
   text-align: left;
   padding: 6px;
-  border-radius: 99px;
+  ${borderRadius.pill};
   background-color: ${getColor('foregroundExtra')};
 `

--- a/core/ui/chain/components/ChainsEmptyState.tsx
+++ b/core/ui/chain/components/ChainsEmptyState.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CryptoWalletPenIcon } from '@lib/ui/icons/CryptoWalletPenIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { VStack, vStack } from '@lib/ui/layout/Stack'
@@ -58,7 +59,7 @@ const Wrapper = styled.div`
     alignItems: 'center',
   })};
   padding: 32px 40px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   background: ${getColor('foreground')};
 
   ${({ theme }) =>
@@ -66,7 +67,6 @@ const Wrapper = styled.div`
     css`
       align-self: stretch;
       border: 1px solid ${theme.colors.foregroundSuper.toCssValue()};
-      border-radius: 20px;
       padding: 28px 20px;
     `}
 `

--- a/core/ui/chain/cosmos/staking/components/ActiveDelegationPicker.tsx
+++ b/core/ui/chain/cosmos/staking/components/ActiveDelegationPicker.tsx
@@ -1,5 +1,6 @@
 import { useCosmosDelegationsQuery } from '@core/ui/chain/cosmos/staking/queries/useCosmosDelegationsQuery'
 import { useCosmosValidatorsQuery } from '@core/ui/chain/cosmos/staking/queries/useCosmosValidatorsQuery'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Spinner } from '@lib/ui/loaders/Spinner'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
@@ -144,7 +145,7 @@ const Row = styled.button.attrs({ type: 'button' as const })`
   align-items: center;
   gap: 12px;
   padding: 12px;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('foreground')};
   border: 1px solid transparent;
   color: inherit;
@@ -168,5 +169,5 @@ const EmptyState = styled(VStack)`
   align-items: center;
   justify-content: center;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `

--- a/core/ui/chain/cosmos/staking/components/ValidatorAvatar.tsx
+++ b/core/ui/chain/cosmos/staking/components/ValidatorAvatar.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -84,7 +85,7 @@ export const ValidatorAvatar = ({
 const Circle = styled(HStack)<{ $size: number; $bg: string }>`
   width: ${({ $size }) => $size}px;
   height: ${({ $size }) => $size}px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: ${({ $bg }) => $bg};
   align-items: center;
   justify-content: center;

--- a/core/ui/chain/cosmos/staking/components/ValidatorPickerSheet.tsx
+++ b/core/ui/chain/cosmos/staking/components/ValidatorPickerSheet.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CircleCheckIcon } from '@lib/ui/icons/CircleCheckIcon'
 import { SearchIcon } from '@lib/ui/icons/SearchIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -181,7 +182,7 @@ const formatCommission = (rateDec: string): string => {
 const SearchWrapper = styled.div`
   position: relative;
   background: ${getColor('foreground')};
-  border-radius: 999px;
+  ${borderRadius.pill};
   height: 48px;
   display: flex;
   align-items: center;
@@ -234,7 +235,7 @@ const ValidatorRow = styled(HStack)<{ $selected: boolean }>`
   align-items: center;
   gap: 12px;
   padding: 12px;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${({ $selected }) =>
     $selected ? getColor('foregroundExtra') : getColor('foreground')};
   cursor: pointer;

--- a/core/ui/chain/security/blockaid/site/BlockaidSiteScanMaliciousOverlay.tsx
+++ b/core/ui/chain/security/blockaid/site/BlockaidSiteScanMaliciousOverlay.tsx
@@ -27,7 +27,7 @@ const Card = styled(VStack)`
   width: 100%;
   max-width: 400px;
   padding: 24px;
-  ${borderRadius.m};
+  ${borderRadius.md};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
 `

--- a/core/ui/chain/solana/staking/components/SolanaValidatorAvatar.tsx
+++ b/core/ui/chain/solana/staking/components/SolanaValidatorAvatar.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { getColor } from '@lib/ui/theme/getters'
 import { useState } from 'react'
 import styled from 'styled-components'
@@ -40,7 +41,7 @@ export const SolanaValidatorAvatar = ({
 const Image = styled.img<{ $size: number }>`
   width: ${({ $size }) => $size}px;
   height: ${({ $size }) => $size}px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   object-fit: cover;
   flex-shrink: 0;
 `
@@ -48,7 +49,7 @@ const Image = styled.img<{ $size: number }>`
 const Monogram = styled.div<{ $size: number }>`
   width: ${({ $size }) => $size}px;
   height: ${({ $size }) => $size}px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   flex-shrink: 0;
   display: flex;
   align-items: center;

--- a/core/ui/chain/solana/staking/components/SolanaValidatorPickerField.tsx
+++ b/core/ui/chain/solana/staking/components/SolanaValidatorPickerField.tsx
@@ -1,5 +1,6 @@
 import { useSolanaValidatorsQuery } from '@core/ui/chain/solana/staking/queries/useSolanaValidatorsQuery'
 import { Opener } from '@lib/ui/base/Opener'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CircleCheckIcon } from '@lib/ui/icons/CircleCheckIcon'
 import { IconFileEdit } from '@lib/ui/icons/IconFileEdit'
 import { HStack } from '@lib/ui/layout/Stack'
@@ -94,7 +95,7 @@ const FieldContainer = styled.button.attrs({ type: 'button' as const })`
   justify-content: space-between;
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
   cursor: pointer;
   background: transparent;
   color: inherit;

--- a/core/ui/chain/solana/staking/components/SolanaValidatorPickerSheet.tsx
+++ b/core/ui/chain/solana/staking/components/SolanaValidatorPickerSheet.tsx
@@ -1,6 +1,7 @@
 import { useSolanaApyInputsQuery } from '@core/ui/chain/solana/staking/queries/useSolanaApyInputsQuery'
 import { useSolanaValidatorsQuery } from '@core/ui/chain/solana/staking/queries/useSolanaValidatorsQuery'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CircleCheckIcon } from '@lib/ui/icons/CircleCheckIcon'
 import { SearchIcon } from '@lib/ui/icons/SearchIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -199,7 +200,7 @@ export const SolanaValidatorPickerSheet = ({
 const SearchWrapper = styled.div`
   position: relative;
   background: ${getColor('foreground')};
-  border-radius: 999px;
+  ${borderRadius.pill};
   height: 48px;
   display: flex;
   align-items: center;
@@ -249,7 +250,7 @@ const ValidatorRow = styled(HStack)<{ $selected: boolean }>`
   align-items: center;
   gap: 12px;
   padding: 12px;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${({ $selected }) =>
     $selected ? getColor('foregroundExtra') : getColor('foreground')};
   cursor: pointer;

--- a/core/ui/chain/ton/staking/TonStakePage.tsx
+++ b/core/ui/chain/ton/staking/TonStakePage.tsx
@@ -5,6 +5,7 @@ import { useCore } from '@core/ui/state/core'
 import { StakingAmountInput } from '@core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/StakingAmountInput'
 import { useCurrentVaultCoins } from '@core/ui/vault/state/currentVaultCoins'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ChevronRightIcon } from '@lib/ui/icons/ChevronRightIcon'
 import { CircleCheckIcon } from '@lib/ui/icons/CircleCheckIcon'
 import { PercentageSelector } from '@lib/ui/inputs/PercentageSelector'
@@ -278,7 +279,7 @@ const TonStakePageContent = ({ coin }: { coin: AccountCoin }) => {
 const Card = styled(VStack).attrs({ gap: 12, flexGrow: true })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 const CenteredAmount = styled.div`
@@ -295,7 +296,7 @@ const PoolField = styled.button.attrs({ type: 'button' })`
   justify-content: space-between;
   width: 100%;
   padding: 16px;
-  border-radius: 12px;
+  ${borderRadius.md};
   cursor: pointer;
   background: transparent;
   border: 1px solid ${getColor('foregroundExtra')};

--- a/core/ui/chain/ton/staking/components/TonPoolPicker.tsx
+++ b/core/ui/chain/ton/staking/components/TonPoolPicker.tsx
@@ -1,6 +1,7 @@
 import { ValidatorAvatar } from '@core/ui/chain/cosmos/staking/components/ValidatorAvatar'
 import { useTonStakingPoolsQuery } from '@core/ui/chain/ton/staking/queries/useTonStakingPoolsQuery'
 import { SearchInput } from '@core/ui/vault/chain/manage/shared/SearchInput'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CheckIcon } from '@lib/ui/icons/CheckIcon'
 import { ShieldCheckFilledIcon } from '@lib/ui/icons/ShieldCheckFilledIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -31,7 +32,7 @@ const Row = styled.button.attrs({ type: 'button' })<{ isSelected: boolean }>`
   gap: 12px;
   width: 100%;
   padding: 12px 14px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   cursor: pointer;
   background: ${getColor('foreground')};
   border: 1px solid

--- a/core/ui/mpc/devices/peers/option/PeerOption.tsx
+++ b/core/ui/mpc/devices/peers/option/PeerOption.tsx
@@ -1,6 +1,6 @@
 import { useMpcPeersSelectionRecord } from '@core/ui/mpc/state/mpcSelectedPeers'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
-import { round } from '@lib/ui/css/round'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { CheckIcon } from '@lib/ui/icons/CheckIcon'
 import { HStack } from '@lib/ui/layout/Stack'
@@ -14,7 +14,7 @@ import styled from 'styled-components'
 import { PeerOptionContainer } from './PeerOptionContainer'
 
 const IconContainer = styled.div`
-  ${round};
+  ${borderRadius.pill};
   ${sameDimensions(24)};
   ${centerContent};
   background-color: ${getColor('primary')};

--- a/core/ui/mpc/devices/peers/option/PeerOptionContainer.tsx
+++ b/core/ui/mpc/devices/peers/option/PeerOptionContainer.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { hStack } from '@lib/ui/layout/Stack'
 import { IsActiveProp } from '@lib/ui/props'
 import { getColor } from '@lib/ui/theme/getters'
@@ -6,7 +7,7 @@ import styled, { css } from 'styled-components'
 
 export const peerOption = css`
   padding: 16px;
-  border-radius: 16px;
+  ${borderRadius.lg};
 
   border: 1px dashed ${getColor('foregroundExtra')};
 
@@ -20,7 +21,7 @@ export const peerOptionActive = css`
 
 export const PeerOptionContainer = styled(UnstyledButton)<IsActiveProp>`
   padding: 16px;
-  border-radius: 16px;
+  ${borderRadius.lg};
 
   border: 1px dashed ${getColor('foregroundExtra')};
 

--- a/core/ui/mpc/fast/FastVaultPasswordModal.tsx
+++ b/core/ui/mpc/fast/FastVaultPasswordModal.tsx
@@ -2,6 +2,7 @@ import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { Button } from '@lib/ui/buttons/Button'
 import { IconButton } from '@lib/ui/buttons/IconButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CrossIcon } from '@lib/ui/icons/CrossIcon'
 import { FocusLockIcon } from '@lib/ui/icons/FocusLockIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
@@ -206,7 +207,7 @@ const CloseButton = styled(IconButton)`
   position: absolute;
   right: 12px;
   top: 12px;
-  border-radius: 99px;
+  ${borderRadius.pill};
   background: ${getColor('foregroundExtra')};
 `
 
@@ -219,7 +220,7 @@ const ModalWrapper = styled(VStack)`
   justify-content: center;
   align-items: center;
   gap: 24px;
-  border-radius: 24px;
+  ${borderRadius.xl};
   border: 1px solid #11284a;
   background: #02122b;
 `

--- a/core/ui/mpc/keygen/create/steps/StepProgressIndicator.tsx
+++ b/core/ui/mpc/keygen/create/steps/StepProgressIndicator.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { SvgProps } from '@lib/ui/props'
 import { getColor } from '@lib/ui/theme/getters'
 import { FC } from 'react'
@@ -93,7 +94,7 @@ const stepStateStyles: Record<StepState, ReturnType<typeof css>> = {
 const StepCircle = styled.div<{ $state: StepState }>`
   width: ${stepCircleSize}px;
   height: ${stepCircleSize}px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   display: flex;
   align-items: center;
   justify-content: center;
@@ -107,7 +108,7 @@ const StepCircle = styled.div<{ $state: StepState }>`
 const Dash = styled.div<{ $active: boolean }>`
   width: 24px;
   height: 2px;
-  border-radius: 1px;
+  ${borderRadius.pill};
   background: rgba(255, 255, 255, 0.15);
   margin-left: 12px;
 `

--- a/core/ui/mpc/keygen/education/devices/KeygenPeerDiscoveryEducationOverlay.tsx
+++ b/core/ui/mpc/keygen/education/devices/KeygenPeerDiscoveryEducationOverlay.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ArrowWallDownIcon } from '@lib/ui/icons/ArrowWallDownIcon'
 import { QrCodeIcon } from '@lib/ui/icons/QrCodeIcon'
 import { VStack } from '@lib/ui/layout/Stack'
@@ -62,7 +63,7 @@ export const KeygenPeerDiscoveryEducationOverlay: FC<OnFinishProp> = ({
 const OverlayContent = styled(VStack)`
   width: min(92vw, 760px);
   height: 426px;
-  border-radius: 44px;
+  ${borderRadius.xl};
   overflow: hidden;
   background-color: ${getColor('foreground')};
 `
@@ -84,6 +85,7 @@ const OverlayWrapper = styled(VStack)`
 
 const PhonePreview = styled(VStack)`
   height: 320px;
+  /* Drawn phone hardware, not an app surface: off the scale on purpose. */
   border-radius: 36px;
   background: linear-gradient(180deg, #082956 0%, #041b3d 100%);
   box-shadow:
@@ -105,6 +107,7 @@ const PhoneMock = styled(VStack)`
   width: min(100%, 430px);
   height: 100%;
   align-self: center;
+  /* Drawn phone hardware, not an app surface: off the scale on purpose. */
   border-radius: 34px;
   background-color: #00183d;
   border: 4px solid rgba(73, 113, 177, 0.62);
@@ -123,14 +126,14 @@ const PhoneNotch = styled.div`
   top: 14px;
   width: 64px;
   height: 10px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   background-color: rgba(146, 160, 188, 0.5);
 `
 
 const PhoneAvatar = styled.div`
   width: 18px;
   height: 18px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   background-color: rgba(155, 170, 196, 0.85);
 `
 
@@ -143,7 +146,7 @@ const PhoneActionsRow = styled.div`
 
 const PhoneActionButton = styled.div<{ $isPrimary?: boolean }>`
   height: 44px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   display: grid;
   align-items: center;
   justify-content: center;
@@ -170,7 +173,7 @@ const PhoneActionButton = styled.div<{ $isPrimary?: boolean }>`
 const ImportIconBadge = styled.span`
   width: 12px;
   height: 12px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   display: flex;
   align-items: center;
   justify-content: center;
@@ -186,7 +189,7 @@ const ImportIconBadge = styled.span`
 const PhoneMainButton = styled.div`
   width: 100%;
   height: 52px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   background-color: #1f44ad;
   color: rgba(198, 214, 255, 0.38);
   display: flex;

--- a/core/ui/mpc/keygen/peers/SecureVaultPeerDiscoveryScreen.tsx
+++ b/core/ui/mpc/keygen/peers/SecureVaultPeerDiscoveryScreen.tsx
@@ -4,6 +4,7 @@ import { Animation } from '@lib/ui/animations/Animation'
 import { Match } from '@lib/ui/base/Match'
 import { Button } from '@lib/ui/buttons/Button'
 import { IconButton } from '@lib/ui/buttons/IconButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
 import { getFormProps } from '@lib/ui/form/utils/getFormProps'
 import { ChevronLeftIcon } from '@lib/ui/icons/ChevronLeftIcon'
@@ -335,7 +336,7 @@ const QrScaleContainer = styled.div`
 `
 
 const QrFrame = styled.div<{ $isLocalMode: boolean }>`
-  border-radius: 33px;
+  ${borderRadius.xl};
   max-width: 297px;
   padding: 8px;
   transition: background-color 0.2s ease;
@@ -354,7 +355,7 @@ const QrFrame = styled.div<{ $isLocalMode: boolean }>`
 const QrFrameInner = styled.div`
   background-color: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 24px;
+  ${borderRadius.xl};
   padding: 16px;
 `
 
@@ -362,7 +363,7 @@ const QrCodeContainer = styled.div`
   ${centerContent};
   aspect-ratio: 1;
   background-color: ${getColor('contrast')};
-  border-radius: 16px;
+  ${borderRadius.lg};
   overflow: hidden;
   width: 100%;
   padding: 11px;
@@ -405,7 +406,7 @@ const PeersList = styled.div`
 
 const PeerCard = styled.div<{ $status: 'connected' | 'pending' }>`
   align-items: center;
-  border-radius: 24px;
+  ${borderRadius.xl};
   display: flex;
   gap: 12px;
   min-height: 68px;
@@ -425,7 +426,7 @@ const PeerCard = styled.div<{ $status: 'connected' | 'pending' }>`
 
 const StatusIcon = styled.div<{ $status: 'connected' | 'pending' }>`
   ${centerContent};
-  border-radius: 50%;
+  ${borderRadius.pill};
   flex-shrink: 0;
   font-size: 16px;
   height: 32px;
@@ -458,7 +459,7 @@ const PeerInfo = styled.div`
 const OrderBadge = styled.div`
   ${centerContent};
   background-color: ${getColor('foregroundExtra')};
-  border-radius: 99px;
+  ${borderRadius.pill};
   color: ${getColor('textShyExtra')};
   flex-shrink: 0;
   font-size: 13px;
@@ -496,7 +497,7 @@ const ModePromptText = styled(Text)`
 const ModeToggleButton = styled(Button)`
   width: 100%;
   max-width: fit-content;
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 const BottomFade = styled.div`

--- a/core/ui/mpc/keygen/reshare/ReshareOptionCard.tsx
+++ b/core/ui/mpc/keygen/reshare/ReshareOptionCard.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
@@ -16,7 +17,7 @@ const Card = styled.button`
   align-items: center;
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 20px;
+  ${borderRadius.xl};
   cursor: pointer;
   display: flex;
   gap: 16px;

--- a/core/ui/mpc/keygen/reshare/ReshareThresholdNotMetCard.tsx
+++ b/core/ui/mpc/keygen/reshare/ReshareThresholdNotMetCard.tsx
@@ -1,3 +1,4 @@
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -23,7 +24,7 @@ const Card = styled.div`
   z-index: 1;
   background: ${getColor('background')};
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 24px 24px 20px 20px;
+  ${borderRadius.xl};
   padding: 24px 20px;
 `
 
@@ -38,14 +39,14 @@ const PluginStoreStrip = styled(HStack)`
   margin-top: -22px;
   padding: 32px 32px 14px;
   background: ${getColor('foreground')};
-  border-radius: 0 0 24px 24px;
+  border-radius: 0 0 ${borderRadiusPx.xl}px ${borderRadiusPx.xl}px;
 `
 
 const IconBadge = styled.div`
   align-items: center;
   background: ${getColor('background')};
   border: 1px solid ${getColor('mistExtra')};
-  border-radius: 50%;
+  ${borderRadius.pill};
   color: ${getColor('idle')};
   display: flex;
   flex-shrink: 0;

--- a/core/ui/mpc/keygen/reshare/ReshareWarningSheet.tsx
+++ b/core/ui/mpc/keygen/reshare/ReshareWarningSheet.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { BodyPortal } from '@lib/ui/dom/BodyPortal'
 import { useKeyDown } from '@lib/ui/hooks/useKeyDown'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
@@ -33,21 +34,21 @@ const Sheet = styled(VStack)`
   background: ${getColor('background')};
   border: 1px solid ${getColor('foregroundExtra')};
   border-bottom: none;
-  border-radius: 24px 24px 0 0;
+  border-radius: ${borderRadiusPx.xl}px ${borderRadiusPx.xl}px 0 0;
   max-width: 500px;
   padding: 8px 16px 32px;
   width: 100%;
 
   @media ${mediaQuery.mobileDeviceAndUp} {
     border-bottom: 1px solid ${getColor('foregroundExtra')};
-    border-radius: 24px;
+    ${borderRadius.xl};
     margin-bottom: 16px;
   }
 `
 
 const Grabber = styled.div`
   background: ${getColor('foregroundExtra')};
-  border-radius: 999px;
+  ${borderRadius.pill};
   height: 5px;
   margin: 0 auto 16px;
   width: 36px;
@@ -60,7 +61,7 @@ const Header = styled(VStack)`
 const WarningCard = styled.div`
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 20px;
+  ${borderRadius.xl};
   padding: 20px;
 `
 

--- a/core/ui/mpc/keygen/reshare/plugin/PreviewInfo.tsx
+++ b/core/ui/mpc/keygen/reshare/plugin/PreviewInfo.tsx
@@ -5,6 +5,7 @@ import {
 } from '@core/ui/mpc/fast/FastVaultPasswordModal'
 import { Plugin } from '@core/ui/plugins/core/get'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CircleInfoIcon } from '@lib/ui/icons/CircleInfoIcon'
 import { LogoBoxIcon } from '@lib/ui/icons/LogoBoxIcon'
 import { PlusIcon } from '@lib/ui/icons/PlusIcon'
@@ -190,7 +191,7 @@ const StyledPageContent = styled(PageContent)`
 const Plus = styled(PlusIcon)`
   background-color: ${getColor('success')};
   border: 6px solid ${getColor('background')};
-  border-radius: 50%;
+  ${borderRadius.pill};
   color: ${getColor('background')};
   bottom: -12px;
   font-size: 44px;

--- a/core/ui/mpc/keysign/custom/CustomMessageVerifyContent.tsx
+++ b/core/ui/mpc/keysign/custom/CustomMessageVerifyContent.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { VStack, vStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -53,7 +54,7 @@ const ReviewItem = styled.div`
   })};
 
   padding: 16px 20px;
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid ${getColor('foregroundExtra')};
   background: rgba(11, 26, 58, 0.5);
   min-width: 0;

--- a/core/ui/mpc/keysign/peers/KeysignResendNotificationButton.tsx
+++ b/core/ui/mpc/keysign/peers/KeysignResendNotificationButton.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ResendNotificationBellIcon } from '@lib/ui/icons/ResendNotificationBellIcon'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -19,7 +20,7 @@ const BadgeButton = styled(UnstyledButton)<{ $interactive: boolean }>`
   box-sizing: border-box;
   min-height: 32px;
   padding: 8px 12px;
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid
     ${({ theme }) => theme.colors.white.withAlpha(0.03).toCssValue()};
   background: ${resendBadgeBackground};

--- a/core/ui/mpc/keysign/tx/LimitOrderCancelDoneHint.tsx
+++ b/core/ui/mpc/keysign/tx/LimitOrderCancelDoneHint.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { InfoCircleIcon } from '@lib/ui/icons/InfoCircleIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
@@ -7,7 +8,7 @@ import styled from 'styled-components'
 
 const Container = styled(HStack)`
   background: ${getColor('foreground')};
-  border-radius: 16px;
+  ${borderRadius.lg};
   padding: 16px;
 `
 

--- a/core/ui/mpc/keysign/tx/LimitOrdersDoneHint.tsx
+++ b/core/ui/mpc/keysign/tx/LimitOrdersDoneHint.tsx
@@ -1,4 +1,5 @@
 import { IconButton } from '@lib/ui/buttons/IconButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CrossIcon } from '@lib/ui/icons/CrossIcon'
 import { InfoCircleIcon } from '@lib/ui/icons/InfoCircleIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -10,7 +11,7 @@ import styled from 'styled-components'
 
 const Container = styled(HStack)`
   background: ${getColor('foreground')};
-  border-radius: 16px;
+  ${borderRadius.lg};
   padding: 16px;
 `
 

--- a/core/ui/mpc/keysign/tx/components/AddToAddressBookButton.tsx
+++ b/core/ui/mpc/keysign/tx/components/AddToAddressBookButton.tsx
@@ -3,6 +3,7 @@ import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { useCore } from '@core/ui/state/core'
 import { useAddressBookItems } from '@core/ui/storage/addressBook'
 import { useVaultNameForAddress } from '@core/ui/vault/hooks/useVaultNameForAddress'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { PlusIcon } from '@lib/ui/icons/PlusIcon'
 import { getColor } from '@lib/ui/theme/getters'
 import { Chain } from '@vultisig/core-chain/Chain'
@@ -23,7 +24,7 @@ const StyledButton = styled.button`
   transition: all 0.2s;
   white-space: nowrap;
 
-  border-radius: 20px;
+  ${borderRadius.pill};
   border: 0.5px solid ${getColor('success')};
   background: #042436;
 

--- a/core/ui/mpc/keysign/tx/components/SignTonDisplay.tsx
+++ b/core/ui/mpc/keysign/tx/components/SignTonDisplay.tsx
@@ -12,6 +12,7 @@ import {
   HorizontalLine,
   IconWrapper,
 } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerify.styled'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { toSizeUnit } from '@lib/ui/css/toSizeUnit'
 import { ArrowDownIcon } from '@lib/ui/icons/ArrowDownIcon'
 import { Collapse } from '@lib/ui/layout/Collapse'
@@ -50,7 +51,7 @@ const StyledTitle = styled.span<Styles>`
 `
 
 const RoundedCoinIconWrapper = styled.div`
-  border-radius: 99px;
+  ${borderRadius.pill};
   display: inline-flex;
   overflow: hidden;
 `

--- a/core/ui/mpc/keysign/tx/swap/SwapCoinItem.tsx
+++ b/core/ui/mpc/keysign/tx/swap/SwapCoinItem.tsx
@@ -1,6 +1,7 @@
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { useCoinPriceQuery } from '@core/ui/chain/coin/price/queries/useCoinPriceQuery'
 import { useFormatFiatAmount } from '@core/ui/chain/hooks/useFormatFiatAmount'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { VStack } from '@lib/ui/layout/Stack'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
 import { Text } from '@lib/ui/text'
@@ -52,7 +53,7 @@ export const SwapCoinItem = ({
 const SwapVStackItem = styled(VStack)`
   background-color: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 16px;
+  ${borderRadius.lg};
   flex: 1;
   min-width: 169px;
   padding: 24px 16px;

--- a/core/ui/mpc/keysign/tx/swap/SwapKeysignTxOverview.tsx
+++ b/core/ui/mpc/keysign/tx/swap/SwapKeysignTxOverview.tsx
@@ -12,8 +12,8 @@ import { SwapFeeFiatValue } from '@core/ui/vault/swap/form/info/SwapTotalFeeFiat
 import { getSwapToAmountLimit } from '@core/ui/vault/swap/keysignPayload/getSwapToAmountLimit'
 import { getSwapProviderFees } from '@core/ui/vault/swap/queries/resolveSwapFees'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
-import { round } from '@lib/ui/css/round'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { ChevronRightIcon } from '@lib/ui/icons/ChevronRightIcon'
 import { AnimatedVisibility } from '@lib/ui/layout/AnimatedVisibility'
@@ -316,14 +316,14 @@ const AddressWrapper = styled(Text)`
 `
 
 const SwapInfoWrapper = styled(SeparatedByLine)`
-  border-radius: 16px;
+  ${borderRadius.lg};
   border: 1px solid ${getColor('foregroundExtra')};
   background-color: ${getColor('foreground')};
   padding: 24px;
 `
 
 const IconWrapper = styled(HStack)`
-  border-radius: 25.5px;
+  ${borderRadius.pill};
   padding: 7px;
   position: absolute;
   background-color: ${getColor('background')};
@@ -344,7 +344,7 @@ const IconWrapper = styled(HStack)`
 `
 
 const IconInternalWrapper = styled.div`
-  ${round};
+  ${borderRadius.pill};
   ${sameDimensions(24)};
   background: ${getColor('foregroundExtra')};
   ${centerContent};

--- a/core/ui/mpc/server/MpcLocalServerIndicator.tsx
+++ b/core/ui/mpc/server/MpcLocalServerIndicator.tsx
@@ -14,7 +14,7 @@ const Container = styled.div`
   padding: 12px;
   color: ${getColor('primaryAlt')};
   border: 1px solid;
-  ${borderRadius.m};
+  ${borderRadius.md};
 `
 
 export const MpcLocalServerIndicator = () => {


### PR DESCRIPTION
A.4 of #4622. 35 files across `core/ui/mpc` and `core/ui/chain`.

## Off-scale values that move

| | from | to | where |
|---|---|---|---|
| overlay card | 44 | 24 | `KeygenPeerDiscoveryEducationOverlay` |
| QR frame | 33 | 24 | `SecureVaultPeerDiscoveryScreen` |
| card | 20 | 24 | `ReshareWarningSheet` warning card |
| card | 20 | 24 | `ReshareOptionCard` |
| card | 24/20 mixed | 24 | `ReshareThresholdNotMetCard` |
| card | 20 | 16 | `ChainsEmptyState` station variant |

`ChainsEmptyState` is the same shape as the `EmptyState` fix in A.2: the station variant differed from the default by exactly 4px, so the override drops its radius line and inherits `lg`. One card, one radius.

`ReshareThresholdNotMetCard` was `24px 24px 20px 20px` - a 4px difference between top and bottom corners of a single surface, now uniform at 24.

## Four capsules that were not spelled as capsules

These read as arbitrary numbers but were already clamping to a full round, so `pill` is exactly equivalent:

- `AddToAddressBookButton` - 20 on a 28px-tall button
- `SwapKeysignTxOverview` icon badge - 25.5 with 7px padding around an icon
- `StepProgressIndicator` dash - 1 on a 2px-tall element
- plus the usual `999px` / `99px` / `50%` / `round` spellings

## Two deliberate survivors

`KeygenPeerDiscoveryEducationOverlay` draws a phone to explain device pairing. `PhonePreview` (36) and `PhoneMock` (34) are **illustrations of physical hardware**, not app surfaces - their corners belong to the drawn device, not to our scale. Both now carry a comment saying so, and the lint guard at the end of the series will need an exception here.

The overlay card that contains the illustration is a real surface and does move, 44 -> 24.

## One small tidy

`CoinOption` squares off its inherited panel radius for a flush list. `0px` becomes `0` - the absence of a radius rather than a value the scale should have an opinion about.

## Validation

`yarn check` clean, `yarn test` 942 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
