### PR TITLE
refactor(ui): defi surfaces adopt the corner-radius scale

### DIFF
--- a/core/ui/defi/chain/banners/DefiTonBalanceBanner.tsx
+++ b/core/ui/defi/chain/banners/DefiTonBalanceBanner.tsx
@@ -1,6 +1,7 @@
 import { useCoinPricesQuery } from '@core/ui/chain/coin/price/queries/useCoinPricesQuery'
 import { useTonStakePositionQuery } from '@core/ui/chain/ton/staking/queries/useTonStakePositionQuery'
 import { useCurrentVaultAddress } from '@core/ui/vault/state/currentVaultCoins'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { Image } from '@lib/ui/image/Image'
 import { Spinner } from '@lib/ui/loaders/Spinner'
 import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
@@ -18,7 +19,7 @@ const TonBannerContainer = styled.div`
   position: relative;
   overflow: hidden;
   min-height: 122px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   border: 1px solid rgba(0, 152, 234, 0.17);
   background: linear-gradient(
     180deg,

--- a/core/ui/defi/chain/banners/DefiTronBalanceBanner.tsx
+++ b/core/ui/defi/chain/banners/DefiTronBalanceBanner.tsx
@@ -1,6 +1,7 @@
 import { useCoinPricesQuery } from '@core/ui/chain/coin/price/queries/useCoinPricesQuery'
 import { getChainLogoSrc } from '@core/ui/chain/metadata/getChainLogoSrc'
 import { useTronAccountResourcesQuery } from '@core/ui/vault/chain/tron/useTronAccountResourcesQuery'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { SafeImage } from '@lib/ui/images/SafeImage'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Spinner } from '@lib/ui/loaders/Spinner'
@@ -21,7 +22,7 @@ const TronBannerContainer = styled.div`
   position: relative;
   overflow: hidden;
   min-height: 122px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   border: 1px solid ${tronAccent};
   background: linear-gradient(
     180deg,

--- a/core/ui/defi/chain/banners/shared.tsx
+++ b/core/ui/defi/chain/banners/shared.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { VStack } from '@lib/ui/layout/Stack'
 import { mediaQuery } from '@lib/ui/responsive/mediaQuery'
@@ -10,7 +11,7 @@ export const BannerContainer = styled.div`
   position: relative;
   overflow: hidden;
   min-height: 122px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   border: 1px solid rgba(52, 230, 191, 0.17);
   background: linear-gradient(
     180deg,
@@ -26,13 +27,13 @@ export const BannerContent = styled(VStack)`
 
 export const ChainLogo = styled.img`
   ${sameDimensions(32)};
-  border-radius: 50%;
+  ${borderRadius.pill};
 `
 
 export const FallbackLogo = styled.div`
   width: 32px;
   height: 32px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: ${getColor('foregroundExtra')};
   display: flex;
   align-items: center;
@@ -62,7 +63,7 @@ export const Ring = styled.div`
   position: absolute;
   width: 210px;
   height: 210px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   border: 1.5px solid rgba(0, 255, 200, 0.35);
   right: -30px;
   top: -30px;
@@ -91,7 +92,7 @@ export const TerraBannerContainer = styled.div`
   position: relative;
   overflow: hidden;
   min-height: 122px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   border: 1px solid rgba(63, 168, 116, 0.17);
   background: linear-gradient(
     180deg,
@@ -120,7 +121,7 @@ export const MayachainBannerContainer = styled.div`
   position: relative;
   overflow: hidden;
   min-height: 122px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   border: 1px solid rgba(28, 157, 125, 0.17);
   background: linear-gradient(
     180deg,
@@ -165,7 +166,7 @@ export const BannerLogoGlow = styled.div`
     content: '';
     position: absolute;
     inset: 0;
-    border-radius: 50%;
+    ${borderRadius.pill};
     background: radial-gradient(
       50% 50% at 50% 50%,
       rgba(51, 204, 204, 0.35) 0%,
@@ -178,7 +179,7 @@ export const BannerLogoGlow = styled.div`
     content: '';
     position: absolute;
     inset: 24px;
-    border-radius: 50%;
+    ${borderRadius.pill};
     border: 1.5px solid rgba(0, 255, 200, 0.35);
     box-shadow: 0 0 40px rgba(0, 255, 200, 0.25);
   }
@@ -187,7 +188,7 @@ export const BannerLogoGlow = styled.div`
 export const BannerLogoImage = styled.img`
   ${sameDimensions(80)};
   position: relative;
-  border-radius: 50%;
+  ${borderRadius.pill};
 `
 
 export const ChainTitle = styled(Text)`

--- a/core/ui/defi/chain/components/bond/BondedSummaryCard.tsx
+++ b/core/ui/defi/chain/components/bond/BondedSummaryCard.tsx
@@ -1,6 +1,7 @@
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { useFormatFiatAmount } from '@core/ui/chain/hooks/useFormatFiatAmount'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Skeleton } from '@lib/ui/loaders/Skeleton'
 import { Text } from '@lib/ui/text'
@@ -90,7 +91,11 @@ export const BondedSummaryCard = ({
         </BondSectionHeader>
         <Divider />
         {isPending || isSkeleton ? (
-          <Skeleton width="100%" height="44px" borderRadius="10px" />
+          <Skeleton
+            width="100%"
+            height="44px"
+            borderRadius={`${borderRadiusPx.md}px`}
+          />
         ) : (
           action
         )}

--- a/core/ui/defi/chain/components/bond/CardPrimitives.tsx
+++ b/core/ui/defi/chain/components/bond/CardPrimitives.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { Panel } from '@lib/ui/panel/Panel'
 import { getColor } from '@lib/ui/theme/getters'
@@ -5,7 +6,7 @@ import styled from 'styled-components'
 
 export const BondCard = styled(Panel)`
   padding: 16px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
 `

--- a/core/ui/defi/chain/components/stake/StakeCard.tsx
+++ b/core/ui/defi/chain/components/stake/StakeCard.tsx
@@ -2,6 +2,7 @@ import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { useFormatFiatAmount } from '@core/ui/chain/hooks/useFormatFiatAmount'
 import { formatDateShort } from '@core/ui/defi/shared/formatters'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { ArrowUpRightIcon } from '@lib/ui/icons/ArrowUpRightIcon'
 import { CalendarIcon } from '@lib/ui/icons/CalendarIcon'
 import { CircleInfoIcon } from '@lib/ui/icons/CircleInfoIcon'
@@ -24,7 +25,7 @@ import styled from 'styled-components'
 
 const Card = styled(Panel)`
   padding: 20px;
-  border-radius: 24px;
+  ${borderRadius.xl};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
 `
@@ -289,8 +290,16 @@ export const StakeCard = ({
         <ActionsRow>
           {isSkeleton ? (
             <>
-              <Skeleton width="48%" height="42px" borderRadius="10px" />
-              <Skeleton width="48%" height="42px" borderRadius="10px" />
+              <Skeleton
+                width="48%"
+                height="42px"
+                borderRadius={`${borderRadiusPx.md}px`}
+              />
+              <Skeleton
+                width="48%"
+                height="42px"
+                borderRadius={`${borderRadiusPx.md}px`}
+              />
             </>
           ) : (
             <>

--- a/core/ui/defi/chain/cosmos/CosmosDelegationCard.tsx
+++ b/core/ui/defi/chain/cosmos/CosmosDelegationCard.tsx
@@ -2,6 +2,7 @@ import { ValidatorAvatar } from '@core/ui/chain/cosmos/staking/components/Valida
 import { useFormatFiatAmount } from '@core/ui/chain/hooks/useFormatFiatAmount'
 import { ChainAction } from '@core/ui/vault/deposit/ChainAction'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { PercentIcon } from '@lib/ui/icons/PercentIcon'
 import { TrophyIcon } from '@lib/ui/icons/TrophyIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -186,7 +187,7 @@ export const CosmosDelegationCard = ({
 const Card = styled(VStack).attrs({ gap: 12 })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('foreground')};
 `
 

--- a/core/ui/defi/chain/cosmos/CosmosDelegationsView.tsx
+++ b/core/ui/defi/chain/cosmos/CosmosDelegationsView.tsx
@@ -11,6 +11,7 @@ import { useFormatFiatAmount } from '@core/ui/chain/hooks/useFormatFiatAmount'
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { useCurrentVaultCoins } from '@core/ui/vault/state/currentVaultCoins'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Spinner } from '@lib/ui/loaders/Spinner'
 import { Text } from '@lib/ui/text'
@@ -239,7 +240,7 @@ export const CosmosDelegationsView = ({
 const SummaryCard = styled(VStack).attrs({ gap: 16 })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('foreground')};
 `
 

--- a/core/ui/defi/chain/manage/DefiPositionTile.tsx
+++ b/core/ui/defi/chain/manage/DefiPositionTile.tsx
@@ -3,6 +3,7 @@ import { shouldDisplayChainLogo } from '@core/ui/chain/coin/icon/utils/shouldDis
 import { WithChainIcon } from '@core/ui/chain/coin/icon/WithChainIcon'
 import { getChainLogoSrc } from '@core/ui/chain/metadata/getChainLogoSrc'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CheckmarkIcon } from '@lib/ui/icons/CheckmarkIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { vStack } from '@lib/ui/layout/Stack'
@@ -42,7 +43,7 @@ const PositionIconWrapper = styled.div<IsActiveProp>`
   })};
   position: relative;
   align-self: stretch;
-  border-radius: 24px;
+  ${borderRadius.xl};
   background: rgba(11, 26, 58, 0.5);
   height: 74px;
   padding: 17px;
@@ -62,6 +63,8 @@ const CheckBadge = styled(IconWrapper)`
   right: 0;
   height: 24px;
   padding: 8px;
+  /* A notched badge shape, not a surface radius: both values exceed half
+     the element and clamp, fully rounding two opposite corners. */
   border-radius: 40px 0 25px 0;
   background: ${getColor('foregroundSuper')};
   font-weight: 600;

--- a/core/ui/defi/chain/solana/SolanaDelegationCard.tsx
+++ b/core/ui/defi/chain/solana/SolanaDelegationCard.tsx
@@ -1,6 +1,7 @@
 import { useFormatFiatAmount } from '@core/ui/chain/hooks/useFormatFiatAmount'
 import { SolanaValidatorAvatar } from '@core/ui/chain/solana/staking/components/SolanaValidatorAvatar'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { PercentIcon } from '@lib/ui/icons/PercentIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
@@ -85,7 +86,7 @@ export const SolanaDelegationCard = ({
       gap={12}
       style={{
         padding: 16,
-        borderRadius: 16,
+        borderRadius: borderRadiusPx.lg,
         background: 'rgba(255,255,255,0.04)',
       }}
     >

--- a/core/ui/defi/chain/solana/SolanaStakeDefiView.tsx
+++ b/core/ui/defi/chain/solana/SolanaStakeDefiView.tsx
@@ -12,6 +12,7 @@ import {
 } from '@core/ui/storage/solanaMoveStakeDestinations'
 import { useCurrentVaultCoins } from '@core/ui/vault/state/currentVaultCoins'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { SafeImage } from '@lib/ui/images/SafeImage'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Spinner } from '@lib/ui/loaders/Spinner'
@@ -45,13 +46,13 @@ import { SolanaDelegationCard } from './SolanaDelegationCard'
 const TotalStakedLogo = styled.img`
   width: 48px;
   height: 48px;
-  border-radius: 50%;
+  ${borderRadius.pill};
 `
 
 const TotalStakedLogoFallback = styled.div`
   width: 48px;
   height: 48px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   display: flex;
   align-items: center;
   justify-content: center;
@@ -179,7 +180,7 @@ export const SolanaStakeDefiView = () => {
         gap={12}
         style={{
           padding: 16,
-          borderRadius: 16,
+          borderRadius: borderRadiusPx.lg,
           background: 'rgba(255,255,255,0.04)',
         }}
       >

--- a/core/ui/defi/chain/tabs/BondedPositions.tsx
+++ b/core/ui/defi/chain/tabs/BondedPositions.tsx
@@ -5,6 +5,7 @@ import { useDefiPositions } from '@core/ui/storage/defiPositions'
 import { useHasVaultCoin } from '@core/ui/vault/state/useHasVaultCoin'
 import { Button } from '@lib/ui/buttons/Button'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ArrowUpRightIcon } from '@lib/ui/icons/ArrowUpRightIcon'
 import { ChevronDownIcon } from '@lib/ui/icons/ChevronDownIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -38,7 +39,7 @@ const collapsibleVariants = {
 } as const
 
 const SectionContainer = styled.div`
-  border-radius: 16px;
+  ${borderRadius.lg};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   overflow: hidden;

--- a/core/ui/defi/chain/tabs/DefiPositionEmptyState.tsx
+++ b/core/ui/defi/chain/tabs/DefiPositionEmptyState.tsx
@@ -1,5 +1,6 @@
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CircleDashedIcon } from '@lib/ui/icons/CircleDashedIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { VStack } from '@lib/ui/layout/Stack'
@@ -60,7 +61,7 @@ const EmptyWrapper = styled.div`
   gap: 20px;
   padding: 40px 20px;
   background-color: ${getColor('foreground')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 const CtaWrapper = styled.div`

--- a/core/ui/defi/chain/tabs/DefiPositionErrorState.tsx
+++ b/core/ui/defi/chain/tabs/DefiPositionErrorState.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { TriangleAlertIcon } from '@lib/ui/icons/TriangleAlertIcon'
 import { VStack } from '@lib/ui/layout/Stack'
@@ -58,7 +59,7 @@ const ErrorWrapper = styled.div`
   gap: 20px;
   padding: 40px 20px;
   background-color: ${getColor('foreground')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 const CtaWrapper = styled.div`

--- a/core/ui/defi/chain/tabs/LpPositions.tsx
+++ b/core/ui/defi/chain/tabs/LpPositions.tsx
@@ -13,6 +13,7 @@ import {
 import { ChainAction } from '@core/ui/vault/deposit/ChainAction'
 import { useCurrentVaultAddresses } from '@core/ui/vault/state/currentVaultCoins'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CircleMinusIcon } from '@lib/ui/icons/CircleMinusIcon'
 import { CirclePlusIcon } from '@lib/ui/icons/CirclePlusIcon'
 import { PercentIcon } from '@lib/ui/icons/PercentIcon'
@@ -34,7 +35,7 @@ import { DefiPositionErrorState } from './DefiPositionErrorState'
 
 const Card = styled(Panel)`
   padding: 20px;
-  border-radius: 24px;
+  ${borderRadius.xl};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
 `

--- a/core/ui/defi/components/DeFiActionButton.tsx
+++ b/core/ui/defi/components/DeFiActionButton.tsx
@@ -1,7 +1,7 @@
 import { Button, buttonHeight } from '@lib/ui/buttons/Button'
 import { ButtonProps } from '@lib/ui/buttons/ButtonProps'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
-import { round } from '@lib/ui/css/round'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { toSizeUnit } from '@lib/ui/css/toSizeUnit'
 import { getColor } from '@lib/ui/theme/getters'
@@ -22,7 +22,7 @@ const IconContainer = styled.div`
   top: 50%;
   transform: translateY(-50%);
   ${sameDimensions(iconContainerSize)}
-  ${round}
+  ${borderRadius.pill};
   background: rgba(255, 255, 255, 0.12);
   ${centerContent};
   color: ${getColor('text')};

--- a/core/ui/defi/manage/DefiItem.tsx
+++ b/core/ui/defi/manage/DefiItem.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CheckmarkIcon } from '@lib/ui/icons/CheckmarkIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { StationCheckmarkSmallIcon } from '@lib/ui/icons/StationFigmaIcons'
@@ -82,7 +83,7 @@ const IconContainer = styled.div<IconContainerProps>`
   })};
   position: relative;
   align-self: stretch;
-  border-radius: 24px;
+  ${borderRadius.xl};
   background: rgba(11, 26, 58, 0.5);
   height: 74px;
   padding: 17px;
@@ -118,6 +119,8 @@ const CheckBadge = styled(IconWrapper)`
   right: 0;
   height: 24px;
   padding: 8px;
+  /* A notched badge shape, not a surface radius: both values exceed half
+     the element and clamp, fully rounding two opposite corners. */
   border-radius: 40px 0 25px 0;
   background: ${getColor('foregroundSuper')};
   font-weight: 600;

--- a/core/ui/defi/page/components/DefiPortfolioBalance.tsx
+++ b/core/ui/defi/page/components/DefiPortfolioBalance.tsx
@@ -2,6 +2,7 @@ import { AnimatedFiatAmount } from '@core/ui/chain/components/AnimatedFiatAmount
 import { useDefiPortfolioBalance } from '@core/ui/defi/page/hooks/useDefiPortfolios'
 import { BalanceVisibilityAware } from '@core/ui/vault/balance/visibility/BalanceVisibilityAware'
 import { ManageVaultBalanceVisibility } from '@core/ui/vault/page/balance/visibility/ManageVaultBalanceVisibility'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Spinner } from '@lib/ui/loaders/Spinner'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
@@ -61,7 +62,7 @@ const Container = styled.div`
   align-items: center;
   gap: 16px;
   padding: 24px 20px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   margin: 0 20px;
   height: 136px;
 
@@ -72,7 +73,7 @@ const Container = styled.div`
 
 const BlurEffect = styled.div`
   position: absolute;
-  border-radius: 16px;
+  ${borderRadius.lg};
   border-radius: 350px;
   top: -30px;
   height: 200px;

--- a/core/ui/defi/page/components/DefiPortfolioHeader.tsx
+++ b/core/ui/defi/page/components/DefiPortfolioHeader.tsx
@@ -1,5 +1,6 @@
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { IconButton } from '@lib/ui/buttons/IconButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HousePenIcon } from '@lib/ui/icons/HousePenIcon'
 import { hStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
@@ -110,7 +111,7 @@ const ActiveIndicator = styled.div`
   right: 0;
   height: 1.5px;
   background: ${getColor('primaryAccentFour')};
-  border-radius: 1px;
+  ${borderRadius.pill};
 `
 
 const TrailingGroup = styled(motion.div)`

--- a/core/ui/defi/protocols/circle/components/InfoBanner.tsx
+++ b/core/ui/defi/protocols/circle/components/InfoBanner.tsx
@@ -1,4 +1,5 @@
 import { IconButton } from '@lib/ui/buttons/IconButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { useBoolean } from '@lib/ui/hooks/useBoolean'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { NavigationXIcon } from '@lib/ui/icons/NavigationXIcon'
@@ -38,5 +39,5 @@ const BannerWrapper = styled.div`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `

--- a/core/ui/defi/protocols/circle/deposited/CircleDepositedPanel.tsx
+++ b/core/ui/defi/protocols/circle/deposited/CircleDepositedPanel.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { UniformColumnGrid } from '@lib/ui/css/uniformColumnGrid'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { PercentIcon } from '@lib/ui/icons/PercentIcon'
@@ -89,7 +90,7 @@ export const CircleDepositedPanel = () => {
 const Container = styled.div`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 16px;
+  ${borderRadius.lg};
   ${vStack({
     gap: 16,
   })}

--- a/core/ui/defi/protocols/circle/shared/CircleAmountForm.tsx
+++ b/core/ui/defi/protocols/circle/shared/CircleAmountForm.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { getFormProps } from '@lib/ui/form/utils/getFormProps'
 import { HeroAmountInput } from '@lib/ui/inputs/HeroAmountInput'
 import { PercentageSelector } from '@lib/ui/inputs/PercentageSelector'
@@ -105,7 +106,7 @@ const Form = styled.form`
 const AmountContainer = styled.div`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
   ${vStack({ gap: 12 })}
   flex-grow: 1;
   display: flex;


### PR DESCRIPTION
A.5 of #4622, the last sweep in part 1. 22 files in `core/ui/defi`.

Quieter than the other sweeps - defi was already close to the scale. Almost everything here is token-for-value at 12, 16 and 24 with no visual change.

## Radii that were passed as values, not declared

These are the ones a `border-radius` grep never finds, which is why they had drifted furthest:

- `SolanaStakeDefiView` and `SolanaDelegationCard` pass `borderRadius: 16` in a React `style` prop - now `borderRadiusPx.lg`.
- Three `Skeleton` placeholders pass `borderRadius="10px"`, an off-scale value on the loading state of cards that are themselves on the scale. They move to `md` (12), so the skeleton matches the card it stands in for.

`Skeleton` still takes a string here rather than a scale key - that API note is in A.2 and unchanged.

## One capsule in disguise

`DefiPortfolioHeader` underlines the active tab with a 1.5px-tall bar at `border-radius: 1px`, already clamping to a capsule. It becomes `pill`.

## Notched badges

`DefiPositionTile` and `DefiItem` both carry the same `40px 0 25px 0` shape as `SelectableItem` in A.2 - a badge outline rather than a surface radius. Left as-is with the same comment, so all three read the same way when the lint guard lands.

## Deliberate skips

`DefiPortfolioBalance` (350px) and the defi banner background (260px) are decorative glow blobs, out of scope per #4622.

## Validation

`yarn check` clean, `yarn test` 942 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
