### PR TITLE
feat(ui): corner-radius token scale, and the shared surfaces onto it (part 1/2)

### DIFF
--- a/clients/extension/src/components/dapps-button/DappsButton.tsx
+++ b/clients/extension/src/components/dapps-button/DappsButton.tsx
@@ -1,6 +1,6 @@
 import { useCurrentVaultAppSessionsQuery } from '@core/extension/storage/hooks/appSessions'
 import { IconButton } from '@lib/ui/buttons/IconButton'
-import { round } from '@lib/ui/css/round'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { ContainImage } from '@lib/ui/images/ContainImage'
@@ -13,7 +13,7 @@ import styled from 'styled-components'
 
 const Icon = styled(ContainImage)`
   ${sameDimensions('36px')};
-  ${round};
+  ${borderRadius.pill};
   border: 1px solid rgba(255, 255, 255, 0.1);
 `
 
@@ -28,7 +28,7 @@ const Badge = styled.div<{ isConnected: boolean }>`
   right: -0.1em;
   width: 1em;
   height: 1em;
-  ${round};
+  ${borderRadius.pill};
   background-color: ${({ isConnected }) =>
     isConnected ? getColor('success') : getColor('idle')};
   border: 4px solid ${getColor('foregroundExtra')};

--- a/clients/extension/src/pages/connected-dapps/index.tsx
+++ b/clients/extension/src/pages/connected-dapps/index.tsx
@@ -7,7 +7,7 @@ import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { useAssertCurrentVaultId } from '@core/ui/storage/currentVaultId'
 import { Button } from '@lib/ui/buttons/Button'
 import { IconButton } from '@lib/ui/buttons/IconButton'
-import { round } from '@lib/ui/css/round'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { DAppsIcon } from '@lib/ui/icons/DAppsIcon'
 import { LinkTwoOffIcon } from '@lib/ui/icons/LinkTwoOffIcon'
@@ -26,7 +26,7 @@ import styled from 'styled-components'
 
 const Icon = styled(ContainImage)`
   ${sameDimensions('2.7em')};
-  ${round};
+  ${borderRadius.pill};
   border: 1px solid rgba(255, 255, 255, 0.1);
 `
 export const ConnectedDappsPage = () => {

--- a/clients/extension/src/pages/station-migration/StationMigrationPage.tsx
+++ b/clients/extension/src/pages/station-migration/StationMigrationPage.tsx
@@ -14,6 +14,7 @@ import { useAssertWalletCore } from '@core/ui/chain/providers/WalletCoreProvider
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { currentProductBrand } from '@core/ui/product/brand'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { PasswordInput } from '@lib/ui/inputs/PasswordInput'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { ListItem } from '@lib/ui/list/item'
@@ -564,7 +565,7 @@ const SummaryGrid = styled.div`
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 1px;
   overflow: hidden;
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: ${getColor('mistExtra')};
 `
 
@@ -589,6 +590,6 @@ const WalletTitleRow = styled(HStack).attrs({
 const StatusBadge = styled.span`
   flex: 0 0 auto;
   padding: 5px 8px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   background: ${getColor('foregroundExtra')};
 `

--- a/core/inpage-provider/popup/view/resolvers/grantVaultAccess/index.tsx
+++ b/core/inpage-provider/popup/view/resolvers/grantVaultAccess/index.tsx
@@ -15,7 +15,7 @@ import { useVaults } from '@core/ui/storage/vaults'
 import { VaultSigners } from '@core/ui/vault/signers'
 import { getVaultSecurityTone } from '@core/ui/vaultsOrganisation/utils/getVaultSecurityTone'
 import { Button } from '@lib/ui/buttons/Button'
-import { round } from '@lib/ui/css/round'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { ContainImage } from '@lib/ui/images/ContainImage'
 import { SafeImage } from '@lib/ui/images/SafeImage'
@@ -46,7 +46,7 @@ type ConnectView = 'connect' | 'picker'
 
 const DappFavicon = styled(ContainImage)`
   ${sameDimensions(46)};
-  ${round};
+  ${borderRadius.pill};
   border: 1px solid rgba(255, 255, 255, 0.1);
 `
 
@@ -58,7 +58,7 @@ const VaultAvatar = styled.div<{
   tone: 'primary' | 'warning'
 }>`
   ${sameDimensions(28)};
-  ${round};
+  ${borderRadius.pill};
   align-items: center;
   display: flex;
   font-size: 14px;
@@ -81,7 +81,7 @@ const VaultAvatar = styled.div<{
 const ChangePill = styled.span`
   align-items: center;
   border: 1.5px solid ${getColor('foregroundExtra')};
-  border-radius: 99px;
+  ${borderRadius.pill};
   color: ${getColor('textShy')};
   display: inline-flex;
   font-size: 12px;

--- a/core/inpage-provider/popup/view/resolvers/sendTx/components/DappRequestHeader.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/components/DappRequestHeader.tsx
@@ -1,4 +1,5 @@
 import { DappRequestRow } from '@core/inpage-provider/popup/view/resolvers/sendTx/components/DappRequestRow'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -8,7 +9,7 @@ import styled from 'styled-components'
 const Panel = styled(VStack)`
   background-color: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 16px;
+  ${borderRadius.lg};
   gap: 16px;
   padding: 20px;
 `

--- a/core/inpage-provider/popup/view/resolvers/sendTx/components/DappRequestRow.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/components/DappRequestRow.tsx
@@ -1,4 +1,5 @@
 import { usePopupContext } from '@core/inpage-provider/popup/view/state/context'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { BrowserExtensionIcon } from '@lib/ui/icons/BrowserExtensionIcon'
 import { SafeImage } from '@lib/ui/images/SafeImage'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -8,7 +9,7 @@ import { attempt } from '@vultisig/lib-utils/attempt'
 import styled from 'styled-components'
 
 const Image = styled.img`
-  border-radius: 50%;
+  ${borderRadius.pill};
   height: 32px;
   width: 32px;
 `
@@ -16,7 +17,7 @@ const Image = styled.img`
 const FallbackIcon = styled(HStack)`
   align-items: center;
   background-color: ${getColor('foregroundExtra')};
-  border-radius: 50%;
+  ${borderRadius.pill};
   color: ${getColor('text')};
   font-size: 18px;
   height: 32px;

--- a/core/inpage-provider/popup/view/resolvers/sendTx/components/SwapAmountDisplay.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/components/SwapAmountDisplay.tsx
@@ -1,12 +1,12 @@
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
-import { round } from '@lib/ui/css/round'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { Coin } from '@vultisig/core-chain/coin/Coin'
 import styled from 'styled-components'
 
 const RoundedCoinIconWrapper = styled.div`
-  ${round};
+  ${borderRadius.pill};
   display: inline-flex;
 `
 

--- a/core/inpage-provider/popup/view/resolvers/signMessage/components/Collapse.tsx
+++ b/core/inpage-provider/popup/view/resolvers/signMessage/components/Collapse.tsx
@@ -1,4 +1,5 @@
 import { Section } from '@core/inpage-provider/popup/view/resolvers/signMessage/styles'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CollapsableStateIndicator } from '@lib/ui/layout/CollapsableStateIndicator'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
@@ -16,7 +17,7 @@ type CollapseProps = {
 
 const OutlineSection = styled(VStack)`
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 16px;
+  ${borderRadius.lg};
 `
 
 export const Collapse: FC<CollapseProps> = ({

--- a/core/inpage-provider/popup/view/resolvers/signMessage/styles.ts
+++ b/core/inpage-provider/popup/view/resolvers/signMessage/styles.ts
@@ -1,10 +1,11 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
 
 export const Description = styled(VStack)`
   border: 1px dashed ${getColor('foregroundExtra')};
-  border-radius: 16px;
+  ${borderRadius.lg};
   gap: 8px;
   padding: 12px;
 `
@@ -27,13 +28,13 @@ export const Image = styled.img`
 export const Section = styled(VStack)`
   background-color: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 16px;
+  ${borderRadius.lg};
 `
 
 export const Verify = styled(HStack)`
   background-color: ${getColor('background')};
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 16px;
+  ${borderRadius.lg};
   height: 28px;
   padding-left: 6px;
   padding-right: 8px;

--- a/core/ui/address-book/AddressBookChainInput.tsx
+++ b/core/ui/address-book/AddressBookChainInput.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ChevronRightIcon } from '@lib/ui/icons/ChevronRightIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { panel } from '@lib/ui/panel/Panel'
@@ -22,7 +23,7 @@ const ChainSelector = styled(HStack)`
   ${panel()};
   cursor: pointer;
   padding: 12px 16px;
-  border-radius: 8px;
+  ${borderRadius.sm};
   align-items: center;
   gap: 12px;
   height: 56px;

--- a/core/ui/address-book/item/index.tsx
+++ b/core/ui/address-book/item/index.tsx
@@ -88,7 +88,7 @@ export const AddressBookListItem: FC<AddressBookListItemProps> = ({
 const StyledListItem = styled(ListItem)`
   background-color: transparent;
   border: 1px solid ${getColor('foregroundExtra')};
-  ${borderRadius.m};
+  ${borderRadius.md};
   padding: 16px 20px;
   max-height: 68px;
 `

--- a/core/ui/chain/chainSelection/ChainSelectionScreen.styles.ts
+++ b/core/ui/chain/chainSelection/ChainSelectionScreen.styles.ts
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
@@ -26,7 +27,7 @@ export const ChainList = styled.div`
   flex-direction: column;
   margin-top: 8px;
   background-color: #061b3a;
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 export const ChainItem = styled(HStack)`

--- a/core/ui/chain/coin/addCustomToken/CustomTokenResult.tsx
+++ b/core/ui/chain/coin/addCustomToken/CustomTokenResult.tsx
@@ -6,6 +6,7 @@ import {
   useDeleteCoinMutation,
 } from '@core/ui/storage/coins'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CryptoIcon } from '@lib/ui/icons/CryptoIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -141,7 +142,7 @@ const ErrorStateWrapper = styled.div`
   padding: 24px 20px;
   max-width: 450px;
   margin-inline: auto;
-  border-radius: 16px;
+  ${borderRadius.lg};
   background: ${getColor('foreground')};
 
   & > button {
@@ -159,7 +160,7 @@ const LoadingWrapper = styled.div`
 const TokenResultCard = styled.div`
   position: relative;
   padding: 20px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   background: ${getColor('foreground')};
 `
 
@@ -175,5 +176,5 @@ const LoadingOverlay = styled.div`
   justify-content: center;
   align-items: center;
   background: ${getColor('foreground')};
-  border-radius: 16px;
+  ${borderRadius.lg};
 `

--- a/core/ui/chain/coin/icon/ChainEntityIcon.tsx
+++ b/core/ui/chain/coin/icon/ChainEntityIcon.tsx
@@ -1,5 +1,5 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
-import { round } from '@lib/ui/css/round'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { PictureIcon } from '@lib/ui/icons/PictureIcon'
 import { ContainImage } from '@lib/ui/images/ContainImage'
@@ -13,7 +13,7 @@ const Icon = styled(ContainImage)`
 `
 
 const Fallback = styled.div`
-  ${round};
+  ${borderRadius.pill};
   ${sameDimensions('1em')};
   background: ${getColor('mist')};
   ${centerContent};

--- a/core/ui/chain/coin/icon/WithChainIcon.tsx
+++ b/core/ui/chain/coin/icon/WithChainIcon.tsx
@@ -1,6 +1,6 @@
 import { ChainEntityIcon } from '@core/ui/chain/coin/icon/ChainEntityIcon'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
-import { round } from '@lib/ui/css/round'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { getColor } from '@lib/ui/theme/getters'
 import { ComponentProps } from 'react'
@@ -20,7 +20,7 @@ const Position = styled.div`
   bottom: -0.32em;
   right: -0.32em;
   font-size: 0.52em;
-  ${round};
+  ${borderRadius.pill};
   background-color: ${getColor('foreground')};
   border: 1px solid ${getColor('foreground')};
   ${centerContent};

--- a/core/ui/chain/coin/inputs/CoinOption.tsx
+++ b/core/ui/chain/coin/inputs/CoinOption.tsx
@@ -4,6 +4,7 @@ import {
   useCurrentVaultAddress,
   useCurrentVaultCoins,
 } from '@core/ui/vault/state/currentVaultCoins'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Skeleton } from '@lib/ui/loaders/Skeleton'
 import { panel } from '@lib/ui/panel/Panel'
@@ -123,7 +124,7 @@ const VaultCoinBalance = ({ value }: ValueProp<Coin>) => {
 const Container = styled(HStack)`
   ${panel()};
   padding: 12px 20px;
-  border-radius: 0px;
+  border-radius: 0;
   position: relative;
   background-color: ${getColor('foreground')};
   cursor: pointer;
@@ -149,6 +150,6 @@ const PillWrapper = styled.div`
   display: grid;
   place-items: center;
   padding: 8px 12px;
-  border-radius: 99px;
+  ${borderRadius.pill};
   border: 1px solid ${getColor('foregroundExtra')};
 `

--- a/core/ui/chain/coin/inputs/CoinPillButton.tsx
+++ b/core/ui/chain/coin/inputs/CoinPillButton.tsx
@@ -1,5 +1,6 @@
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ChevronRightIcon } from '@lib/ui/icons/ChevronRightIcon'
 import { HStack, hStack, VStack } from '@lib/ui/layout/Stack'
 import { OnClickProp, ValueProp } from '@lib/ui/props'
@@ -56,6 +57,6 @@ const Container = styled(UnstyledButton)`
   })}
   text-align: left;
   padding: 6px;
-  border-radius: 99px;
+  ${borderRadius.pill};
   background-color: ${getColor('foregroundExtra')};
 `

--- a/core/ui/chain/components/ChainsEmptyState.tsx
+++ b/core/ui/chain/components/ChainsEmptyState.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CryptoWalletPenIcon } from '@lib/ui/icons/CryptoWalletPenIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { VStack, vStack } from '@lib/ui/layout/Stack'
@@ -58,7 +59,7 @@ const Wrapper = styled.div`
     alignItems: 'center',
   })};
   padding: 32px 40px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   background: ${getColor('foreground')};
 
   ${({ theme }) =>
@@ -66,7 +67,6 @@ const Wrapper = styled.div`
     css`
       align-self: stretch;
       border: 1px solid ${theme.colors.foregroundSuper.toCssValue()};
-      border-radius: 20px;
       padding: 28px 20px;
     `}
 `

--- a/core/ui/chain/cosmos/staking/components/ActiveDelegationPicker.tsx
+++ b/core/ui/chain/cosmos/staking/components/ActiveDelegationPicker.tsx
@@ -1,5 +1,6 @@
 import { useCosmosDelegationsQuery } from '@core/ui/chain/cosmos/staking/queries/useCosmosDelegationsQuery'
 import { useCosmosValidatorsQuery } from '@core/ui/chain/cosmos/staking/queries/useCosmosValidatorsQuery'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Spinner } from '@lib/ui/loaders/Spinner'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
@@ -144,7 +145,7 @@ const Row = styled.button.attrs({ type: 'button' as const })`
   align-items: center;
   gap: 12px;
   padding: 12px;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('foreground')};
   border: 1px solid transparent;
   color: inherit;
@@ -168,5 +169,5 @@ const EmptyState = styled(VStack)`
   align-items: center;
   justify-content: center;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `

--- a/core/ui/chain/cosmos/staking/components/ValidatorAvatar.tsx
+++ b/core/ui/chain/cosmos/staking/components/ValidatorAvatar.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -84,7 +85,7 @@ export const ValidatorAvatar = ({
 const Circle = styled(HStack)<{ $size: number; $bg: string }>`
   width: ${({ $size }) => $size}px;
   height: ${({ $size }) => $size}px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: ${({ $bg }) => $bg};
   align-items: center;
   justify-content: center;

--- a/core/ui/chain/cosmos/staking/components/ValidatorPickerSheet.tsx
+++ b/core/ui/chain/cosmos/staking/components/ValidatorPickerSheet.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CircleCheckIcon } from '@lib/ui/icons/CircleCheckIcon'
 import { SearchIcon } from '@lib/ui/icons/SearchIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -181,7 +182,7 @@ const formatCommission = (rateDec: string): string => {
 const SearchWrapper = styled.div`
   position: relative;
   background: ${getColor('foreground')};
-  border-radius: 999px;
+  ${borderRadius.pill};
   height: 48px;
   display: flex;
   align-items: center;
@@ -234,7 +235,7 @@ const ValidatorRow = styled(HStack)<{ $selected: boolean }>`
   align-items: center;
   gap: 12px;
   padding: 12px;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${({ $selected }) =>
     $selected ? getColor('foregroundExtra') : getColor('foreground')};
   cursor: pointer;

--- a/core/ui/chain/security/blockaid/site/BlockaidSiteScanMaliciousOverlay.tsx
+++ b/core/ui/chain/security/blockaid/site/BlockaidSiteScanMaliciousOverlay.tsx
@@ -27,7 +27,7 @@ const Card = styled(VStack)`
   width: 100%;
   max-width: 400px;
   padding: 24px;
-  ${borderRadius.m};
+  ${borderRadius.md};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
 `

--- a/core/ui/chain/solana/staking/components/SolanaValidatorAvatar.tsx
+++ b/core/ui/chain/solana/staking/components/SolanaValidatorAvatar.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { getColor } from '@lib/ui/theme/getters'
 import { useState } from 'react'
 import styled from 'styled-components'
@@ -40,7 +41,7 @@ export const SolanaValidatorAvatar = ({
 const Image = styled.img<{ $size: number }>`
   width: ${({ $size }) => $size}px;
   height: ${({ $size }) => $size}px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   object-fit: cover;
   flex-shrink: 0;
 `
@@ -48,7 +49,7 @@ const Image = styled.img<{ $size: number }>`
 const Monogram = styled.div<{ $size: number }>`
   width: ${({ $size }) => $size}px;
   height: ${({ $size }) => $size}px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   flex-shrink: 0;
   display: flex;
   align-items: center;

--- a/core/ui/chain/solana/staking/components/SolanaValidatorPickerField.tsx
+++ b/core/ui/chain/solana/staking/components/SolanaValidatorPickerField.tsx
@@ -1,5 +1,6 @@
 import { useSolanaValidatorsQuery } from '@core/ui/chain/solana/staking/queries/useSolanaValidatorsQuery'
 import { Opener } from '@lib/ui/base/Opener'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CircleCheckIcon } from '@lib/ui/icons/CircleCheckIcon'
 import { IconFileEdit } from '@lib/ui/icons/IconFileEdit'
 import { HStack } from '@lib/ui/layout/Stack'
@@ -94,7 +95,7 @@ const FieldContainer = styled.button.attrs({ type: 'button' as const })`
   justify-content: space-between;
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
   cursor: pointer;
   background: transparent;
   color: inherit;

--- a/core/ui/chain/solana/staking/components/SolanaValidatorPickerSheet.tsx
+++ b/core/ui/chain/solana/staking/components/SolanaValidatorPickerSheet.tsx
@@ -1,6 +1,7 @@
 import { useSolanaApyInputsQuery } from '@core/ui/chain/solana/staking/queries/useSolanaApyInputsQuery'
 import { useSolanaValidatorsQuery } from '@core/ui/chain/solana/staking/queries/useSolanaValidatorsQuery'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CircleCheckIcon } from '@lib/ui/icons/CircleCheckIcon'
 import { SearchIcon } from '@lib/ui/icons/SearchIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -199,7 +200,7 @@ export const SolanaValidatorPickerSheet = ({
 const SearchWrapper = styled.div`
   position: relative;
   background: ${getColor('foreground')};
-  border-radius: 999px;
+  ${borderRadius.pill};
   height: 48px;
   display: flex;
   align-items: center;
@@ -249,7 +250,7 @@ const ValidatorRow = styled(HStack)<{ $selected: boolean }>`
   align-items: center;
   gap: 12px;
   padding: 12px;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${({ $selected }) =>
     $selected ? getColor('foregroundExtra') : getColor('foreground')};
   cursor: pointer;

--- a/core/ui/chain/ton/staking/TonStakePage.tsx
+++ b/core/ui/chain/ton/staking/TonStakePage.tsx
@@ -5,6 +5,7 @@ import { useCore } from '@core/ui/state/core'
 import { StakingAmountInput } from '@core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/StakingAmountInput'
 import { useCurrentVaultCoins } from '@core/ui/vault/state/currentVaultCoins'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ChevronRightIcon } from '@lib/ui/icons/ChevronRightIcon'
 import { CircleCheckIcon } from '@lib/ui/icons/CircleCheckIcon'
 import { PercentageSelector } from '@lib/ui/inputs/PercentageSelector'
@@ -278,7 +279,7 @@ const TonStakePageContent = ({ coin }: { coin: AccountCoin }) => {
 const Card = styled(VStack).attrs({ gap: 12, flexGrow: true })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 const CenteredAmount = styled.div`
@@ -295,7 +296,7 @@ const PoolField = styled.button.attrs({ type: 'button' })`
   justify-content: space-between;
   width: 100%;
   padding: 16px;
-  border-radius: 12px;
+  ${borderRadius.md};
   cursor: pointer;
   background: transparent;
   border: 1px solid ${getColor('foregroundExtra')};

--- a/core/ui/chain/ton/staking/components/TonPoolPicker.tsx
+++ b/core/ui/chain/ton/staking/components/TonPoolPicker.tsx
@@ -1,6 +1,7 @@
 import { ValidatorAvatar } from '@core/ui/chain/cosmos/staking/components/ValidatorAvatar'
 import { useTonStakingPoolsQuery } from '@core/ui/chain/ton/staking/queries/useTonStakingPoolsQuery'
 import { SearchInput } from '@core/ui/vault/chain/manage/shared/SearchInput'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CheckIcon } from '@lib/ui/icons/CheckIcon'
 import { ShieldCheckFilledIcon } from '@lib/ui/icons/ShieldCheckFilledIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -31,7 +32,7 @@ const Row = styled.button.attrs({ type: 'button' })<{ isSelected: boolean }>`
   gap: 12px;
   width: 100%;
   padding: 12px 14px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   cursor: pointer;
   background: ${getColor('foreground')};
   border: 1px solid

--- a/core/ui/dapp/DappRequestBanner.tsx
+++ b/core/ui/dapp/DappRequestBanner.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { BrowserExtensionIcon } from '@lib/ui/icons/BrowserExtensionIcon'
 import { SafeImage } from '@lib/ui/images/SafeImage'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -11,13 +12,13 @@ import styled from 'styled-components'
 const Panel = styled(VStack)`
   background-color: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 16px;
+  ${borderRadius.lg};
   gap: 16px;
   padding: 20px;
 `
 
 const Image = styled.img`
-  border-radius: 50%;
+  ${borderRadius.pill};
   height: 32px;
   width: 32px;
 `
@@ -25,7 +26,7 @@ const Image = styled.img`
 const FallbackIcon = styled(HStack)`
   align-items: center;
   background-color: ${getColor('foregroundExtra')};
-  border-radius: 50%;
+  ${borderRadius.pill};
   color: ${getColor('text')};
   font-size: 18px;
   height: 32px;

--- a/core/ui/defi/chain/banners/DefiTonBalanceBanner.tsx
+++ b/core/ui/defi/chain/banners/DefiTonBalanceBanner.tsx
@@ -1,6 +1,7 @@
 import { useCoinPricesQuery } from '@core/ui/chain/coin/price/queries/useCoinPricesQuery'
 import { useTonStakePositionQuery } from '@core/ui/chain/ton/staking/queries/useTonStakePositionQuery'
 import { useCurrentVaultAddress } from '@core/ui/vault/state/currentVaultCoins'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { Image } from '@lib/ui/image/Image'
 import { Spinner } from '@lib/ui/loaders/Spinner'
 import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
@@ -18,7 +19,7 @@ const TonBannerContainer = styled.div`
   position: relative;
   overflow: hidden;
   min-height: 122px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   border: 1px solid rgba(0, 152, 234, 0.17);
   background: linear-gradient(
     180deg,

--- a/core/ui/defi/chain/banners/DefiTronBalanceBanner.tsx
+++ b/core/ui/defi/chain/banners/DefiTronBalanceBanner.tsx
@@ -1,6 +1,7 @@
 import { useCoinPricesQuery } from '@core/ui/chain/coin/price/queries/useCoinPricesQuery'
 import { getChainLogoSrc } from '@core/ui/chain/metadata/getChainLogoSrc'
 import { useTronAccountResourcesQuery } from '@core/ui/vault/chain/tron/useTronAccountResourcesQuery'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { SafeImage } from '@lib/ui/images/SafeImage'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Spinner } from '@lib/ui/loaders/Spinner'
@@ -21,7 +22,7 @@ const TronBannerContainer = styled.div`
   position: relative;
   overflow: hidden;
   min-height: 122px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   border: 1px solid ${tronAccent};
   background: linear-gradient(
     180deg,

--- a/core/ui/defi/chain/banners/shared.tsx
+++ b/core/ui/defi/chain/banners/shared.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { VStack } from '@lib/ui/layout/Stack'
 import { mediaQuery } from '@lib/ui/responsive/mediaQuery'
@@ -10,7 +11,7 @@ export const BannerContainer = styled.div`
   position: relative;
   overflow: hidden;
   min-height: 122px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   border: 1px solid rgba(52, 230, 191, 0.17);
   background: linear-gradient(
     180deg,
@@ -26,13 +27,13 @@ export const BannerContent = styled(VStack)`
 
 export const ChainLogo = styled.img`
   ${sameDimensions(32)};
-  border-radius: 50%;
+  ${borderRadius.pill};
 `
 
 export const FallbackLogo = styled.div`
   width: 32px;
   height: 32px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: ${getColor('foregroundExtra')};
   display: flex;
   align-items: center;
@@ -62,7 +63,7 @@ export const Ring = styled.div`
   position: absolute;
   width: 210px;
   height: 210px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   border: 1.5px solid rgba(0, 255, 200, 0.35);
   right: -30px;
   top: -30px;
@@ -91,7 +92,7 @@ export const TerraBannerContainer = styled.div`
   position: relative;
   overflow: hidden;
   min-height: 122px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   border: 1px solid rgba(63, 168, 116, 0.17);
   background: linear-gradient(
     180deg,
@@ -120,7 +121,7 @@ export const MayachainBannerContainer = styled.div`
   position: relative;
   overflow: hidden;
   min-height: 122px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   border: 1px solid rgba(28, 157, 125, 0.17);
   background: linear-gradient(
     180deg,
@@ -165,7 +166,7 @@ export const BannerLogoGlow = styled.div`
     content: '';
     position: absolute;
     inset: 0;
-    border-radius: 50%;
+    ${borderRadius.pill};
     background: radial-gradient(
       50% 50% at 50% 50%,
       rgba(51, 204, 204, 0.35) 0%,
@@ -178,7 +179,7 @@ export const BannerLogoGlow = styled.div`
     content: '';
     position: absolute;
     inset: 24px;
-    border-radius: 50%;
+    ${borderRadius.pill};
     border: 1.5px solid rgba(0, 255, 200, 0.35);
     box-shadow: 0 0 40px rgba(0, 255, 200, 0.25);
   }
@@ -187,7 +188,7 @@ export const BannerLogoGlow = styled.div`
 export const BannerLogoImage = styled.img`
   ${sameDimensions(80)};
   position: relative;
-  border-radius: 50%;
+  ${borderRadius.pill};
 `
 
 export const ChainTitle = styled(Text)`

--- a/core/ui/defi/chain/components/bond/BondedSummaryCard.tsx
+++ b/core/ui/defi/chain/components/bond/BondedSummaryCard.tsx
@@ -1,6 +1,7 @@
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { useFormatFiatAmount } from '@core/ui/chain/hooks/useFormatFiatAmount'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Skeleton } from '@lib/ui/loaders/Skeleton'
 import { Text } from '@lib/ui/text'
@@ -90,7 +91,11 @@ export const BondedSummaryCard = ({
         </BondSectionHeader>
         <Divider />
         {isPending || isSkeleton ? (
-          <Skeleton width="100%" height="44px" borderRadius="10px" />
+          <Skeleton
+            width="100%"
+            height="44px"
+            borderRadius={`${borderRadiusPx.md}px`}
+          />
         ) : (
           action
         )}

--- a/core/ui/defi/chain/components/bond/CardPrimitives.tsx
+++ b/core/ui/defi/chain/components/bond/CardPrimitives.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { Panel } from '@lib/ui/panel/Panel'
 import { getColor } from '@lib/ui/theme/getters'
@@ -5,7 +6,7 @@ import styled from 'styled-components'
 
 export const BondCard = styled(Panel)`
   padding: 16px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
 `

--- a/core/ui/defi/chain/components/stake/StakeCard.tsx
+++ b/core/ui/defi/chain/components/stake/StakeCard.tsx
@@ -2,6 +2,7 @@ import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { useFormatFiatAmount } from '@core/ui/chain/hooks/useFormatFiatAmount'
 import { formatDateShort } from '@core/ui/defi/shared/formatters'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { ArrowUpRightIcon } from '@lib/ui/icons/ArrowUpRightIcon'
 import { CalendarIcon } from '@lib/ui/icons/CalendarIcon'
 import { CircleInfoIcon } from '@lib/ui/icons/CircleInfoIcon'
@@ -24,7 +25,7 @@ import styled from 'styled-components'
 
 const Card = styled(Panel)`
   padding: 20px;
-  border-radius: 24px;
+  ${borderRadius.xl};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
 `
@@ -289,8 +290,16 @@ export const StakeCard = ({
         <ActionsRow>
           {isSkeleton ? (
             <>
-              <Skeleton width="48%" height="42px" borderRadius="10px" />
-              <Skeleton width="48%" height="42px" borderRadius="10px" />
+              <Skeleton
+                width="48%"
+                height="42px"
+                borderRadius={`${borderRadiusPx.md}px`}
+              />
+              <Skeleton
+                width="48%"
+                height="42px"
+                borderRadius={`${borderRadiusPx.md}px`}
+              />
             </>
           ) : (
             <>

--- a/core/ui/defi/chain/cosmos/CosmosDelegationCard.tsx
+++ b/core/ui/defi/chain/cosmos/CosmosDelegationCard.tsx
@@ -2,6 +2,7 @@ import { ValidatorAvatar } from '@core/ui/chain/cosmos/staking/components/Valida
 import { useFormatFiatAmount } from '@core/ui/chain/hooks/useFormatFiatAmount'
 import { ChainAction } from '@core/ui/vault/deposit/ChainAction'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { PercentIcon } from '@lib/ui/icons/PercentIcon'
 import { TrophyIcon } from '@lib/ui/icons/TrophyIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -186,7 +187,7 @@ export const CosmosDelegationCard = ({
 const Card = styled(VStack).attrs({ gap: 12 })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('foreground')};
 `
 

--- a/core/ui/defi/chain/cosmos/CosmosDelegationsView.tsx
+++ b/core/ui/defi/chain/cosmos/CosmosDelegationsView.tsx
@@ -11,6 +11,7 @@ import { useFormatFiatAmount } from '@core/ui/chain/hooks/useFormatFiatAmount'
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { useCurrentVaultCoins } from '@core/ui/vault/state/currentVaultCoins'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Spinner } from '@lib/ui/loaders/Spinner'
 import { Text } from '@lib/ui/text'
@@ -239,7 +240,7 @@ export const CosmosDelegationsView = ({
 const SummaryCard = styled(VStack).attrs({ gap: 16 })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('foreground')};
 `
 

--- a/core/ui/defi/chain/manage/DefiPositionTile.tsx
+++ b/core/ui/defi/chain/manage/DefiPositionTile.tsx
@@ -3,6 +3,7 @@ import { shouldDisplayChainLogo } from '@core/ui/chain/coin/icon/utils/shouldDis
 import { WithChainIcon } from '@core/ui/chain/coin/icon/WithChainIcon'
 import { getChainLogoSrc } from '@core/ui/chain/metadata/getChainLogoSrc'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CheckmarkIcon } from '@lib/ui/icons/CheckmarkIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { vStack } from '@lib/ui/layout/Stack'
@@ -42,7 +43,7 @@ const PositionIconWrapper = styled.div<IsActiveProp>`
   })};
   position: relative;
   align-self: stretch;
-  border-radius: 24px;
+  ${borderRadius.xl};
   background: rgba(11, 26, 58, 0.5);
   height: 74px;
   padding: 17px;
@@ -62,6 +63,8 @@ const CheckBadge = styled(IconWrapper)`
   right: 0;
   height: 24px;
   padding: 8px;
+  /* A notched badge shape, not a surface radius: both values exceed half
+     the element and clamp, fully rounding two opposite corners. */
   border-radius: 40px 0 25px 0;
   background: ${getColor('foregroundSuper')};
   font-weight: 600;

--- a/core/ui/defi/chain/solana/SolanaDelegationCard.tsx
+++ b/core/ui/defi/chain/solana/SolanaDelegationCard.tsx
@@ -1,6 +1,7 @@
 import { useFormatFiatAmount } from '@core/ui/chain/hooks/useFormatFiatAmount'
 import { SolanaValidatorAvatar } from '@core/ui/chain/solana/staking/components/SolanaValidatorAvatar'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { PercentIcon } from '@lib/ui/icons/PercentIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
@@ -85,7 +86,7 @@ export const SolanaDelegationCard = ({
       gap={12}
       style={{
         padding: 16,
-        borderRadius: 16,
+        borderRadius: borderRadiusPx.lg,
         background: 'rgba(255,255,255,0.04)',
       }}
     >

--- a/core/ui/defi/chain/solana/SolanaStakeDefiView.tsx
+++ b/core/ui/defi/chain/solana/SolanaStakeDefiView.tsx
@@ -12,6 +12,7 @@ import {
 } from '@core/ui/storage/solanaMoveStakeDestinations'
 import { useCurrentVaultCoins } from '@core/ui/vault/state/currentVaultCoins'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { SafeImage } from '@lib/ui/images/SafeImage'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Spinner } from '@lib/ui/loaders/Spinner'
@@ -45,13 +46,13 @@ import { SolanaDelegationCard } from './SolanaDelegationCard'
 const TotalStakedLogo = styled.img`
   width: 48px;
   height: 48px;
-  border-radius: 50%;
+  ${borderRadius.pill};
 `
 
 const TotalStakedLogoFallback = styled.div`
   width: 48px;
   height: 48px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   display: flex;
   align-items: center;
   justify-content: center;
@@ -179,7 +180,7 @@ export const SolanaStakeDefiView = () => {
         gap={12}
         style={{
           padding: 16,
-          borderRadius: 16,
+          borderRadius: borderRadiusPx.lg,
           background: 'rgba(255,255,255,0.04)',
         }}
       >

--- a/core/ui/defi/chain/tabs/BondedPositions.tsx
+++ b/core/ui/defi/chain/tabs/BondedPositions.tsx
@@ -5,6 +5,7 @@ import { useDefiPositions } from '@core/ui/storage/defiPositions'
 import { useHasVaultCoin } from '@core/ui/vault/state/useHasVaultCoin'
 import { Button } from '@lib/ui/buttons/Button'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ArrowUpRightIcon } from '@lib/ui/icons/ArrowUpRightIcon'
 import { ChevronDownIcon } from '@lib/ui/icons/ChevronDownIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -38,7 +39,7 @@ const collapsibleVariants = {
 } as const
 
 const SectionContainer = styled.div`
-  border-radius: 16px;
+  ${borderRadius.lg};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   overflow: hidden;

--- a/core/ui/defi/chain/tabs/DefiPositionEmptyState.tsx
+++ b/core/ui/defi/chain/tabs/DefiPositionEmptyState.tsx
@@ -1,5 +1,6 @@
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CircleDashedIcon } from '@lib/ui/icons/CircleDashedIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { VStack } from '@lib/ui/layout/Stack'
@@ -60,7 +61,7 @@ const EmptyWrapper = styled.div`
   gap: 20px;
   padding: 40px 20px;
   background-color: ${getColor('foreground')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 const CtaWrapper = styled.div`

--- a/core/ui/defi/chain/tabs/DefiPositionErrorState.tsx
+++ b/core/ui/defi/chain/tabs/DefiPositionErrorState.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { TriangleAlertIcon } from '@lib/ui/icons/TriangleAlertIcon'
 import { VStack } from '@lib/ui/layout/Stack'
@@ -58,7 +59,7 @@ const ErrorWrapper = styled.div`
   gap: 20px;
   padding: 40px 20px;
   background-color: ${getColor('foreground')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 const CtaWrapper = styled.div`

--- a/core/ui/defi/chain/tabs/LpPositions.tsx
+++ b/core/ui/defi/chain/tabs/LpPositions.tsx
@@ -13,6 +13,7 @@ import {
 import { ChainAction } from '@core/ui/vault/deposit/ChainAction'
 import { useCurrentVaultAddresses } from '@core/ui/vault/state/currentVaultCoins'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CircleMinusIcon } from '@lib/ui/icons/CircleMinusIcon'
 import { CirclePlusIcon } from '@lib/ui/icons/CirclePlusIcon'
 import { PercentIcon } from '@lib/ui/icons/PercentIcon'
@@ -34,7 +35,7 @@ import { DefiPositionErrorState } from './DefiPositionErrorState'
 
 const Card = styled(Panel)`
   padding: 20px;
-  border-radius: 24px;
+  ${borderRadius.xl};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
 `

--- a/core/ui/defi/components/DeFiActionButton.tsx
+++ b/core/ui/defi/components/DeFiActionButton.tsx
@@ -1,7 +1,7 @@
 import { Button, buttonHeight } from '@lib/ui/buttons/Button'
 import { ButtonProps } from '@lib/ui/buttons/ButtonProps'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
-import { round } from '@lib/ui/css/round'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { toSizeUnit } from '@lib/ui/css/toSizeUnit'
 import { getColor } from '@lib/ui/theme/getters'
@@ -22,7 +22,7 @@ const IconContainer = styled.div`
   top: 50%;
   transform: translateY(-50%);
   ${sameDimensions(iconContainerSize)}
-  ${round}
+  ${borderRadius.pill};
   background: rgba(255, 255, 255, 0.12);
   ${centerContent};
   color: ${getColor('text')};

--- a/core/ui/defi/manage/DefiItem.tsx
+++ b/core/ui/defi/manage/DefiItem.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CheckmarkIcon } from '@lib/ui/icons/CheckmarkIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { StationCheckmarkSmallIcon } from '@lib/ui/icons/StationFigmaIcons'
@@ -82,7 +83,7 @@ const IconContainer = styled.div<IconContainerProps>`
   })};
   position: relative;
   align-self: stretch;
-  border-radius: 24px;
+  ${borderRadius.xl};
   background: rgba(11, 26, 58, 0.5);
   height: 74px;
   padding: 17px;
@@ -118,6 +119,8 @@ const CheckBadge = styled(IconWrapper)`
   right: 0;
   height: 24px;
   padding: 8px;
+  /* A notched badge shape, not a surface radius: both values exceed half
+     the element and clamp, fully rounding two opposite corners. */
   border-radius: 40px 0 25px 0;
   background: ${getColor('foregroundSuper')};
   font-weight: 600;

--- a/core/ui/defi/page/components/DefiPortfolioBalance.tsx
+++ b/core/ui/defi/page/components/DefiPortfolioBalance.tsx
@@ -2,6 +2,7 @@ import { AnimatedFiatAmount } from '@core/ui/chain/components/AnimatedFiatAmount
 import { useDefiPortfolioBalance } from '@core/ui/defi/page/hooks/useDefiPortfolios'
 import { BalanceVisibilityAware } from '@core/ui/vault/balance/visibility/BalanceVisibilityAware'
 import { ManageVaultBalanceVisibility } from '@core/ui/vault/page/balance/visibility/ManageVaultBalanceVisibility'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Spinner } from '@lib/ui/loaders/Spinner'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
@@ -61,7 +62,7 @@ const Container = styled.div`
   align-items: center;
   gap: 16px;
   padding: 24px 20px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   margin: 0 20px;
   height: 136px;
 
@@ -72,7 +73,7 @@ const Container = styled.div`
 
 const BlurEffect = styled.div`
   position: absolute;
-  border-radius: 16px;
+  ${borderRadius.lg};
   border-radius: 350px;
   top: -30px;
   height: 200px;

--- a/core/ui/defi/page/components/DefiPortfolioHeader.tsx
+++ b/core/ui/defi/page/components/DefiPortfolioHeader.tsx
@@ -1,5 +1,6 @@
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { IconButton } from '@lib/ui/buttons/IconButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HousePenIcon } from '@lib/ui/icons/HousePenIcon'
 import { hStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
@@ -110,7 +111,7 @@ const ActiveIndicator = styled.div`
   right: 0;
   height: 1.5px;
   background: ${getColor('primaryAccentFour')};
-  border-radius: 1px;
+  ${borderRadius.pill};
 `
 
 const TrailingGroup = styled(motion.div)`

--- a/core/ui/defi/protocols/circle/components/InfoBanner.tsx
+++ b/core/ui/defi/protocols/circle/components/InfoBanner.tsx
@@ -1,4 +1,5 @@
 import { IconButton } from '@lib/ui/buttons/IconButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { useBoolean } from '@lib/ui/hooks/useBoolean'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { NavigationXIcon } from '@lib/ui/icons/NavigationXIcon'
@@ -38,5 +39,5 @@ const BannerWrapper = styled.div`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `

--- a/core/ui/defi/protocols/circle/deposited/CircleDepositedPanel.tsx
+++ b/core/ui/defi/protocols/circle/deposited/CircleDepositedPanel.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { UniformColumnGrid } from '@lib/ui/css/uniformColumnGrid'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { PercentIcon } from '@lib/ui/icons/PercentIcon'
@@ -89,7 +90,7 @@ export const CircleDepositedPanel = () => {
 const Container = styled.div`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 16px;
+  ${borderRadius.lg};
   ${vStack({
     gap: 16,
   })}

--- a/core/ui/defi/protocols/circle/shared/CircleAmountForm.tsx
+++ b/core/ui/defi/protocols/circle/shared/CircleAmountForm.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { getFormProps } from '@lib/ui/form/utils/getFormProps'
 import { HeroAmountInput } from '@lib/ui/inputs/HeroAmountInput'
 import { PercentageSelector } from '@lib/ui/inputs/PercentageSelector'
@@ -105,7 +106,7 @@ const Form = styled.form`
 const AmountContainer = styled.div`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
   ${vStack({ gap: 12 })}
   flex-grow: 1;
   display: flex;

--- a/core/ui/errors/RootErrorFallback.tsx
+++ b/core/ui/errors/RootErrorFallback.tsx
@@ -20,7 +20,7 @@ const StackTrace = styled.pre`
     size: 12,
     weight: '400',
   })}
-  ${borderRadius.m};
+  ${borderRadius.md};
   background: ${getColor('foreground')};
   padding: 20px;
   max-height: 240px;

--- a/core/ui/mpc/devices/peers/option/PeerOption.tsx
+++ b/core/ui/mpc/devices/peers/option/PeerOption.tsx
@@ -1,6 +1,6 @@
 import { useMpcPeersSelectionRecord } from '@core/ui/mpc/state/mpcSelectedPeers'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
-import { round } from '@lib/ui/css/round'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { CheckIcon } from '@lib/ui/icons/CheckIcon'
 import { HStack } from '@lib/ui/layout/Stack'
@@ -14,7 +14,7 @@ import styled from 'styled-components'
 import { PeerOptionContainer } from './PeerOptionContainer'
 
 const IconContainer = styled.div`
-  ${round};
+  ${borderRadius.pill};
   ${sameDimensions(24)};
   ${centerContent};
   background-color: ${getColor('primary')};

--- a/core/ui/mpc/devices/peers/option/PeerOptionContainer.tsx
+++ b/core/ui/mpc/devices/peers/option/PeerOptionContainer.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { hStack } from '@lib/ui/layout/Stack'
 import { IsActiveProp } from '@lib/ui/props'
 import { getColor } from '@lib/ui/theme/getters'
@@ -6,7 +7,7 @@ import styled, { css } from 'styled-components'
 
 export const peerOption = css`
   padding: 16px;
-  border-radius: 16px;
+  ${borderRadius.lg};
 
   border: 1px dashed ${getColor('foregroundExtra')};
 
@@ -20,7 +21,7 @@ export const peerOptionActive = css`
 
 export const PeerOptionContainer = styled(UnstyledButton)<IsActiveProp>`
   padding: 16px;
-  border-radius: 16px;
+  ${borderRadius.lg};
 
   border: 1px dashed ${getColor('foregroundExtra')};
 

--- a/core/ui/mpc/fast/FastVaultPasswordModal.tsx
+++ b/core/ui/mpc/fast/FastVaultPasswordModal.tsx
@@ -2,6 +2,7 @@ import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { Button } from '@lib/ui/buttons/Button'
 import { IconButton } from '@lib/ui/buttons/IconButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CrossIcon } from '@lib/ui/icons/CrossIcon'
 import { FocusLockIcon } from '@lib/ui/icons/FocusLockIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
@@ -206,7 +207,7 @@ const CloseButton = styled(IconButton)`
   position: absolute;
   right: 12px;
   top: 12px;
-  border-radius: 99px;
+  ${borderRadius.pill};
   background: ${getColor('foregroundExtra')};
 `
 
@@ -219,7 +220,7 @@ const ModalWrapper = styled(VStack)`
   justify-content: center;
   align-items: center;
   gap: 24px;
-  border-radius: 24px;
+  ${borderRadius.xl};
   border: 1px solid #11284a;
   background: #02122b;
 `

--- a/core/ui/mpc/keygen/create/steps/StepProgressIndicator.tsx
+++ b/core/ui/mpc/keygen/create/steps/StepProgressIndicator.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { SvgProps } from '@lib/ui/props'
 import { getColor } from '@lib/ui/theme/getters'
 import { FC } from 'react'
@@ -93,7 +94,7 @@ const stepStateStyles: Record<StepState, ReturnType<typeof css>> = {
 const StepCircle = styled.div<{ $state: StepState }>`
   width: ${stepCircleSize}px;
   height: ${stepCircleSize}px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   display: flex;
   align-items: center;
   justify-content: center;
@@ -107,7 +108,7 @@ const StepCircle = styled.div<{ $state: StepState }>`
 const Dash = styled.div<{ $active: boolean }>`
   width: 24px;
   height: 2px;
-  border-radius: 1px;
+  ${borderRadius.pill};
   background: rgba(255, 255, 255, 0.15);
   margin-left: 12px;
 `

--- a/core/ui/mpc/keygen/education/devices/KeygenPeerDiscoveryEducationOverlay.tsx
+++ b/core/ui/mpc/keygen/education/devices/KeygenPeerDiscoveryEducationOverlay.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ArrowWallDownIcon } from '@lib/ui/icons/ArrowWallDownIcon'
 import { QrCodeIcon } from '@lib/ui/icons/QrCodeIcon'
 import { VStack } from '@lib/ui/layout/Stack'
@@ -62,7 +63,7 @@ export const KeygenPeerDiscoveryEducationOverlay: FC<OnFinishProp> = ({
 const OverlayContent = styled(VStack)`
   width: min(92vw, 760px);
   height: 426px;
-  border-radius: 44px;
+  ${borderRadius.xl};
   overflow: hidden;
   background-color: ${getColor('foreground')};
 `
@@ -84,6 +85,7 @@ const OverlayWrapper = styled(VStack)`
 
 const PhonePreview = styled(VStack)`
   height: 320px;
+  /* Drawn phone hardware, not an app surface: off the scale on purpose. */
   border-radius: 36px;
   background: linear-gradient(180deg, #082956 0%, #041b3d 100%);
   box-shadow:
@@ -105,6 +107,7 @@ const PhoneMock = styled(VStack)`
   width: min(100%, 430px);
   height: 100%;
   align-self: center;
+  /* Drawn phone hardware, not an app surface: off the scale on purpose. */
   border-radius: 34px;
   background-color: #00183d;
   border: 4px solid rgba(73, 113, 177, 0.62);
@@ -123,14 +126,14 @@ const PhoneNotch = styled.div`
   top: 14px;
   width: 64px;
   height: 10px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   background-color: rgba(146, 160, 188, 0.5);
 `
 
 const PhoneAvatar = styled.div`
   width: 18px;
   height: 18px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   background-color: rgba(155, 170, 196, 0.85);
 `
 
@@ -143,7 +146,7 @@ const PhoneActionsRow = styled.div`
 
 const PhoneActionButton = styled.div<{ $isPrimary?: boolean }>`
   height: 44px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   display: grid;
   align-items: center;
   justify-content: center;
@@ -170,7 +173,7 @@ const PhoneActionButton = styled.div<{ $isPrimary?: boolean }>`
 const ImportIconBadge = styled.span`
   width: 12px;
   height: 12px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   display: flex;
   align-items: center;
   justify-content: center;
@@ -186,7 +189,7 @@ const ImportIconBadge = styled.span`
 const PhoneMainButton = styled.div`
   width: 100%;
   height: 52px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   background-color: #1f44ad;
   color: rgba(198, 214, 255, 0.38);
   display: flex;

--- a/core/ui/mpc/keygen/peers/SecureVaultPeerDiscoveryScreen.tsx
+++ b/core/ui/mpc/keygen/peers/SecureVaultPeerDiscoveryScreen.tsx
@@ -4,6 +4,7 @@ import { Animation } from '@lib/ui/animations/Animation'
 import { Match } from '@lib/ui/base/Match'
 import { Button } from '@lib/ui/buttons/Button'
 import { IconButton } from '@lib/ui/buttons/IconButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
 import { getFormProps } from '@lib/ui/form/utils/getFormProps'
 import { ChevronLeftIcon } from '@lib/ui/icons/ChevronLeftIcon'
@@ -335,7 +336,7 @@ const QrScaleContainer = styled.div`
 `
 
 const QrFrame = styled.div<{ $isLocalMode: boolean }>`
-  border-radius: 33px;
+  ${borderRadius.xl};
   max-width: 297px;
   padding: 8px;
   transition: background-color 0.2s ease;
@@ -354,7 +355,7 @@ const QrFrame = styled.div<{ $isLocalMode: boolean }>`
 const QrFrameInner = styled.div`
   background-color: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 24px;
+  ${borderRadius.xl};
   padding: 16px;
 `
 
@@ -362,7 +363,7 @@ const QrCodeContainer = styled.div`
   ${centerContent};
   aspect-ratio: 1;
   background-color: ${getColor('contrast')};
-  border-radius: 16px;
+  ${borderRadius.lg};
   overflow: hidden;
   width: 100%;
   padding: 11px;
@@ -405,7 +406,7 @@ const PeersList = styled.div`
 
 const PeerCard = styled.div<{ $status: 'connected' | 'pending' }>`
   align-items: center;
-  border-radius: 24px;
+  ${borderRadius.xl};
   display: flex;
   gap: 12px;
   min-height: 68px;
@@ -425,7 +426,7 @@ const PeerCard = styled.div<{ $status: 'connected' | 'pending' }>`
 
 const StatusIcon = styled.div<{ $status: 'connected' | 'pending' }>`
   ${centerContent};
-  border-radius: 50%;
+  ${borderRadius.pill};
   flex-shrink: 0;
   font-size: 16px;
   height: 32px;
@@ -458,7 +459,7 @@ const PeerInfo = styled.div`
 const OrderBadge = styled.div`
   ${centerContent};
   background-color: ${getColor('foregroundExtra')};
-  border-radius: 99px;
+  ${borderRadius.pill};
   color: ${getColor('textShyExtra')};
   flex-shrink: 0;
   font-size: 13px;
@@ -496,7 +497,7 @@ const ModePromptText = styled(Text)`
 const ModeToggleButton = styled(Button)`
   width: 100%;
   max-width: fit-content;
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 const BottomFade = styled.div`

--- a/core/ui/mpc/keygen/reshare/ReshareOptionCard.tsx
+++ b/core/ui/mpc/keygen/reshare/ReshareOptionCard.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
@@ -16,7 +17,7 @@ const Card = styled.button`
   align-items: center;
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 20px;
+  ${borderRadius.xl};
   cursor: pointer;
   display: flex;
   gap: 16px;

--- a/core/ui/mpc/keygen/reshare/ReshareThresholdNotMetCard.tsx
+++ b/core/ui/mpc/keygen/reshare/ReshareThresholdNotMetCard.tsx
@@ -1,3 +1,4 @@
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -23,7 +24,7 @@ const Card = styled.div`
   z-index: 1;
   background: ${getColor('background')};
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 24px 24px 20px 20px;
+  ${borderRadius.xl};
   padding: 24px 20px;
 `
 
@@ -38,14 +39,14 @@ const PluginStoreStrip = styled(HStack)`
   margin-top: -22px;
   padding: 32px 32px 14px;
   background: ${getColor('foreground')};
-  border-radius: 0 0 24px 24px;
+  border-radius: 0 0 ${borderRadiusPx.xl}px ${borderRadiusPx.xl}px;
 `
 
 const IconBadge = styled.div`
   align-items: center;
   background: ${getColor('background')};
   border: 1px solid ${getColor('mistExtra')};
-  border-radius: 50%;
+  ${borderRadius.pill};
   color: ${getColor('idle')};
   display: flex;
   flex-shrink: 0;

--- a/core/ui/mpc/keygen/reshare/ReshareWarningSheet.tsx
+++ b/core/ui/mpc/keygen/reshare/ReshareWarningSheet.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { BodyPortal } from '@lib/ui/dom/BodyPortal'
 import { useKeyDown } from '@lib/ui/hooks/useKeyDown'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
@@ -33,21 +34,21 @@ const Sheet = styled(VStack)`
   background: ${getColor('background')};
   border: 1px solid ${getColor('foregroundExtra')};
   border-bottom: none;
-  border-radius: 24px 24px 0 0;
+  border-radius: ${borderRadiusPx.xl}px ${borderRadiusPx.xl}px 0 0;
   max-width: 500px;
   padding: 8px 16px 32px;
   width: 100%;
 
   @media ${mediaQuery.mobileDeviceAndUp} {
     border-bottom: 1px solid ${getColor('foregroundExtra')};
-    border-radius: 24px;
+    ${borderRadius.xl};
     margin-bottom: 16px;
   }
 `
 
 const Grabber = styled.div`
   background: ${getColor('foregroundExtra')};
-  border-radius: 999px;
+  ${borderRadius.pill};
   height: 5px;
   margin: 0 auto 16px;
   width: 36px;
@@ -60,7 +61,7 @@ const Header = styled(VStack)`
 const WarningCard = styled.div`
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 20px;
+  ${borderRadius.xl};
   padding: 20px;
 `
 

--- a/core/ui/mpc/keygen/reshare/plugin/PreviewInfo.tsx
+++ b/core/ui/mpc/keygen/reshare/plugin/PreviewInfo.tsx
@@ -5,6 +5,7 @@ import {
 } from '@core/ui/mpc/fast/FastVaultPasswordModal'
 import { Plugin } from '@core/ui/plugins/core/get'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CircleInfoIcon } from '@lib/ui/icons/CircleInfoIcon'
 import { LogoBoxIcon } from '@lib/ui/icons/LogoBoxIcon'
 import { PlusIcon } from '@lib/ui/icons/PlusIcon'
@@ -190,7 +191,7 @@ const StyledPageContent = styled(PageContent)`
 const Plus = styled(PlusIcon)`
   background-color: ${getColor('success')};
   border: 6px solid ${getColor('background')};
-  border-radius: 50%;
+  ${borderRadius.pill};
   color: ${getColor('background')};
   bottom: -12px;
   font-size: 44px;

--- a/core/ui/mpc/keysign/custom/CustomMessageVerifyContent.tsx
+++ b/core/ui/mpc/keysign/custom/CustomMessageVerifyContent.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { VStack, vStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -53,7 +54,7 @@ const ReviewItem = styled.div`
   })};
 
   padding: 16px 20px;
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid ${getColor('foregroundExtra')};
   background: rgba(11, 26, 58, 0.5);
   min-width: 0;

--- a/core/ui/mpc/keysign/peers/KeysignResendNotificationButton.tsx
+++ b/core/ui/mpc/keysign/peers/KeysignResendNotificationButton.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ResendNotificationBellIcon } from '@lib/ui/icons/ResendNotificationBellIcon'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -19,7 +20,7 @@ const BadgeButton = styled(UnstyledButton)<{ $interactive: boolean }>`
   box-sizing: border-box;
   min-height: 32px;
   padding: 8px 12px;
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid
     ${({ theme }) => theme.colors.white.withAlpha(0.03).toCssValue()};
   background: ${resendBadgeBackground};

--- a/core/ui/mpc/keysign/tx/LimitOrderCancelDoneHint.tsx
+++ b/core/ui/mpc/keysign/tx/LimitOrderCancelDoneHint.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { InfoCircleIcon } from '@lib/ui/icons/InfoCircleIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
@@ -7,7 +8,7 @@ import styled from 'styled-components'
 
 const Container = styled(HStack)`
   background: ${getColor('foreground')};
-  border-radius: 16px;
+  ${borderRadius.lg};
   padding: 16px;
 `
 

--- a/core/ui/mpc/keysign/tx/LimitOrdersDoneHint.tsx
+++ b/core/ui/mpc/keysign/tx/LimitOrdersDoneHint.tsx
@@ -1,4 +1,5 @@
 import { IconButton } from '@lib/ui/buttons/IconButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CrossIcon } from '@lib/ui/icons/CrossIcon'
 import { InfoCircleIcon } from '@lib/ui/icons/InfoCircleIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -10,7 +11,7 @@ import styled from 'styled-components'
 
 const Container = styled(HStack)`
   background: ${getColor('foreground')};
-  border-radius: 16px;
+  ${borderRadius.lg};
   padding: 16px;
 `
 

--- a/core/ui/mpc/keysign/tx/components/AddToAddressBookButton.tsx
+++ b/core/ui/mpc/keysign/tx/components/AddToAddressBookButton.tsx
@@ -3,6 +3,7 @@ import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { useCore } from '@core/ui/state/core'
 import { useAddressBookItems } from '@core/ui/storage/addressBook'
 import { useVaultNameForAddress } from '@core/ui/vault/hooks/useVaultNameForAddress'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { PlusIcon } from '@lib/ui/icons/PlusIcon'
 import { getColor } from '@lib/ui/theme/getters'
 import { Chain } from '@vultisig/core-chain/Chain'
@@ -23,7 +24,7 @@ const StyledButton = styled.button`
   transition: all 0.2s;
   white-space: nowrap;
 
-  border-radius: 20px;
+  ${borderRadius.pill};
   border: 0.5px solid ${getColor('success')};
   background: #042436;
 

--- a/core/ui/mpc/keysign/tx/components/SignTonDisplay.tsx
+++ b/core/ui/mpc/keysign/tx/components/SignTonDisplay.tsx
@@ -12,6 +12,7 @@ import {
   HorizontalLine,
   IconWrapper,
 } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerify.styled'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { toSizeUnit } from '@lib/ui/css/toSizeUnit'
 import { ArrowDownIcon } from '@lib/ui/icons/ArrowDownIcon'
 import { Collapse } from '@lib/ui/layout/Collapse'
@@ -50,7 +51,7 @@ const StyledTitle = styled.span<Styles>`
 `
 
 const RoundedCoinIconWrapper = styled.div`
-  border-radius: 99px;
+  ${borderRadius.pill};
   display: inline-flex;
   overflow: hidden;
 `

--- a/core/ui/mpc/keysign/tx/swap/SwapCoinItem.tsx
+++ b/core/ui/mpc/keysign/tx/swap/SwapCoinItem.tsx
@@ -1,6 +1,7 @@
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { useCoinPriceQuery } from '@core/ui/chain/coin/price/queries/useCoinPriceQuery'
 import { useFormatFiatAmount } from '@core/ui/chain/hooks/useFormatFiatAmount'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { VStack } from '@lib/ui/layout/Stack'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
 import { Text } from '@lib/ui/text'
@@ -52,7 +53,7 @@ export const SwapCoinItem = ({
 const SwapVStackItem = styled(VStack)`
   background-color: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 16px;
+  ${borderRadius.lg};
   flex: 1;
   min-width: 169px;
   padding: 24px 16px;

--- a/core/ui/mpc/keysign/tx/swap/SwapKeysignTxOverview.tsx
+++ b/core/ui/mpc/keysign/tx/swap/SwapKeysignTxOverview.tsx
@@ -12,8 +12,8 @@ import { SwapFeeFiatValue } from '@core/ui/vault/swap/form/info/SwapTotalFeeFiat
 import { getSwapToAmountLimit } from '@core/ui/vault/swap/keysignPayload/getSwapToAmountLimit'
 import { getSwapProviderFees } from '@core/ui/vault/swap/queries/resolveSwapFees'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
-import { round } from '@lib/ui/css/round'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { ChevronRightIcon } from '@lib/ui/icons/ChevronRightIcon'
 import { AnimatedVisibility } from '@lib/ui/layout/AnimatedVisibility'
@@ -316,14 +316,14 @@ const AddressWrapper = styled(Text)`
 `
 
 const SwapInfoWrapper = styled(SeparatedByLine)`
-  border-radius: 16px;
+  ${borderRadius.lg};
   border: 1px solid ${getColor('foregroundExtra')};
   background-color: ${getColor('foreground')};
   padding: 24px;
 `
 
 const IconWrapper = styled(HStack)`
-  border-radius: 25.5px;
+  ${borderRadius.pill};
   padding: 7px;
   position: absolute;
   background-color: ${getColor('background')};
@@ -344,7 +344,7 @@ const IconWrapper = styled(HStack)`
 `
 
 const IconInternalWrapper = styled.div`
-  ${round};
+  ${borderRadius.pill};
   ${sameDimensions(24)};
   background: ${getColor('foregroundExtra')};
   ${centerContent};

--- a/core/ui/mpc/server/MpcLocalServerIndicator.tsx
+++ b/core/ui/mpc/server/MpcLocalServerIndicator.tsx
@@ -14,7 +14,7 @@ const Container = styled.div`
   padding: 12px;
   color: ${getColor('primaryAlt')};
   border: 1px solid;
-  ${borderRadius.m};
+  ${borderRadius.md};
 `
 
 export const MpcLocalServerIndicator = () => {

--- a/core/ui/notifications/KeysignNotificationBanner.tsx
+++ b/core/ui/notifications/KeysignNotificationBanner.tsx
@@ -1,3 +1,4 @@
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { LightningIcon } from '@lib/ui/icons/LightningIcon'
 import { ShieldIcon } from '@lib/ui/icons/ShieldIcon'
 import { Text } from '@lib/ui/text'
@@ -15,7 +16,6 @@ import styled from 'styled-components'
 const autoDismissMs = 30_000
 /** Figma 70608:121371 — total frame height (padding included via border-box). */
 export const bannerHeightPx = 198
-const bottomCornerRadiusPx = 24
 const swipeDismissThresholdPx = 50
 
 export const transitionDuration = '0.35s'
@@ -56,7 +56,7 @@ const BannerRoot = styled.div<{
     ${getColor('primaryAccentTwo')} 20.77%,
     ${getColor('primaryAccentFour')} 109.97%
   );
-  border-radius: 0 0 ${bottomCornerRadiusPx}px ${bottomCornerRadiusPx}px;
+  border-radius: 0 0 ${borderRadiusPx.xl}px ${borderRadiusPx.xl}px;
   box-sizing: border-box;
   cursor: pointer;
   display: flex;
@@ -121,7 +121,7 @@ const VaultPill = styled.div`
   align-items: center;
   background: ${({ theme }) =>
     theme.colors.background.getVariant({ a: () => 0.5 }).toCssValue()};
-  border-radius: 999px;
+  ${borderRadius.pill};
   display: inline-flex;
   flex-shrink: 0;
   gap: 4px;

--- a/core/ui/notifications/choose-vaults/ChooseVaultsContent.tsx
+++ b/core/ui/notifications/choose-vaults/ChooseVaultsContent.tsx
@@ -1,4 +1,5 @@
 import { VaultSecurityType } from '@core/ui/vault/VaultSecurityType'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { LightningIcon } from '@lib/ui/icons/LightningIcon'
 import { ShieldIcon } from '@lib/ui/icons/ShieldIcon'
 import { Switch } from '@lib/ui/inputs/switch'
@@ -83,7 +84,7 @@ export const ChooseVaultsContent: FC<BodyProps> = ({
 
 const VaultListCard = styled(VStack)`
   background-color: ${getColor('foreground')};
-  border-radius: 24px;
+  ${borderRadius.xl};
   overflow: hidden;
 `
 
@@ -118,7 +119,7 @@ const VaultTypeIconFrame = styled.div`
   align-items: center;
   background-color: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 50%;
+  ${borderRadius.pill};
   display: flex;
   flex-shrink: 0;
   justify-content: center;

--- a/core/ui/notifications/choose-vaults/ChooseVaultsPage.tsx
+++ b/core/ui/notifications/choose-vaults/ChooseVaultsPage.tsx
@@ -3,6 +3,7 @@ import {
   ChooseVaultsContent,
   VaultNotificationItem,
 } from '@core/ui/notifications/choose-vaults/ChooseVaultsContent'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { VStack } from '@lib/ui/layout/Stack'
 import { PageContent } from '@lib/ui/page/PageContent'
 import { PageHeader } from '@lib/ui/page/PageHeader'
@@ -52,7 +53,7 @@ export const ChooseVaultsPage: FC<ChooseVaultsPageProps> = ({
 const DoneButton = styled.button`
   background-color: ${getColor('foreground')};
   border: none;
-  border-radius: 99px;
+  ${borderRadius.pill};
   cursor: pointer;
   padding: 6px 12px;
 `

--- a/core/ui/notifications/settings/NotificationSettingsContent.tsx
+++ b/core/ui/notifications/settings/NotificationSettingsContent.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { LightningIcon } from '@lib/ui/icons/LightningIcon'
 import { ShieldIcon } from '@lib/ui/icons/ShieldIcon'
 import { Switch } from '@lib/ui/inputs/switch'
@@ -35,7 +36,7 @@ type NotificationSettingsContentProps = {
 const VaultTypeIcon = styled.div<{ $isFast: boolean }>`
   width: 40px;
   height: 40px;
-  border-radius: 99px;
+  ${borderRadius.pill};
   background: ${getColor('foregroundDark')};
   border: 1px solid ${getColor('foregroundExtra')};
   display: flex;
@@ -72,7 +73,7 @@ const VaultSection = styled.div`
 
 const VaultListCard = styled.div`
   background: ${getColor('foreground')};
-  border-radius: 12px;
+  ${borderRadius.md};
   overflow: hidden;
   width: 100%;
 `

--- a/core/ui/preferences/currency/index.tsx
+++ b/core/ui/preferences/currency/index.tsx
@@ -3,6 +3,7 @@ import {
   useFiatCurrency,
   useSetFiatCurrencyMutation,
 } from '@core/ui/storage/fiatCurrency'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CheckIcon } from '@lib/ui/icons/CheckIcon'
 import { VStack } from '@lib/ui/layout/Stack'
 import { List } from '@lib/ui/list'
@@ -49,7 +50,7 @@ export const CurrencyPage = () => {
 
 const CircleCheckIcon = styled(CheckIcon)`
   background-color: ${getColor('buttonPrimary')};
-  border-radius: 50%;
+  ${borderRadius.pill};
   font-size: 16px;
   padding: 2px;
 `

--- a/core/ui/preferences/language/index.tsx
+++ b/core/ui/preferences/language/index.tsx
@@ -1,6 +1,7 @@
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { languageName, languageRegion, languages } from '@core/ui/i18n/Language'
 import { useLanguage, useSetLanguageMutation } from '@core/ui/storage/language'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CheckIcon } from '@lib/ui/icons/CheckIcon'
 import { VStack } from '@lib/ui/layout/Stack'
 import { List } from '@lib/ui/list'
@@ -43,7 +44,7 @@ export const LanguagePage = () => {
 
 const CircleCheckIcon = styled(CheckIcon)`
   background-color: ${getColor('buttonPrimary')};
-  border-radius: 50%;
+  ${borderRadius.pill};
   font-size: 16px;
   padding: 2px;
 `

--- a/core/ui/qr/PrintableQrCode.tsx
+++ b/core/ui/qr/PrintableQrCode.tsx
@@ -1,4 +1,5 @@
 import { ProductLogo } from '@core/ui/product/ProductLogo'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -49,14 +50,14 @@ const QrCardFrame = styled.div`
   height: ${qrCardHeight}px;
   padding: 18px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 24px;
+  ${borderRadius.xl};
 `
 
 const InfoCard = styled(VStack)`
   width: ${cardInnerWidth}px;
   padding: 20px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 24px;
+  ${borderRadius.xl};
   gap: 16px;
 `
 
@@ -82,7 +83,7 @@ const BrandLogoSquare = styled.div`
   justify-content: center;
   width: 33px;
   height: 33px;
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: linear-gradient(180deg, #4879fd 0%, #0d39b1 100%);
   box-shadow: inset 0 0.82px 0.82px 0 rgba(255, 255, 255, 0.35);
   color: ${getColor('white')};

--- a/core/ui/qr/components/ScanQrView.tsx
+++ b/core/ui/qr/components/ScanQrView.tsx
@@ -3,6 +3,7 @@ import { QrScanner } from '@core/ui/qr/components/QrScanner'
 import { useCameraPermissionQuery } from '@core/ui/qr/hooks/useCameraPermissionQuery'
 import { Match } from '@lib/ui/base/Match'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ErrorFallbackContent } from '@lib/ui/flow/ErrorFallbackContent'
 import { Center } from '@lib/ui/layout/Center'
 import { VStack } from '@lib/ui/layout/Stack'
@@ -27,7 +28,7 @@ const ScannerGlobalStyle = createGlobalStyle`
 const GlassContainer = styled(VStack)`
   flex-grow: 1;
   border: 1px solid ${getColor('primaryAccentTwo')};
-  border-radius: 24px;
+  ${borderRadius.xl};
   background: ${({ theme }) => theme.colors.background.toRgba(0.3)};
   box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
   overflow: hidden;

--- a/core/ui/settings/share-app/ShareAppModal.tsx
+++ b/core/ui/settings/share-app/ShareAppModal.tsx
@@ -1,3 +1,4 @@
+import { borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { vStack } from '@lib/ui/layout/Stack'
 import { Modal } from '@lib/ui/modal'
 import { Backdrop } from '@lib/ui/modal/Backdrop'
@@ -48,7 +49,7 @@ const Wrapper = styled.div`
   })};
 
   padding: 20px;
-  border-radius: 16px 16px 0 0;
+  border-radius: ${borderRadiusPx.xl}px ${borderRadiusPx.xl}px 0 0;
   background: ${getColor('background')};
 `
 

--- a/core/ui/settings/share-app/ShareAppPrompt.tsx
+++ b/core/ui/settings/share-app/ShareAppPrompt.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CopyIcon } from '@lib/ui/icons/CopyIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { hStack } from '@lib/ui/layout/Stack'
@@ -50,7 +51,7 @@ const Wrapper = styled.div`
     alignItems: 'center',
   })};
 
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
 `

--- a/core/ui/transaction-history/TransactionHistoryCard/styles.ts
+++ b/core/ui/transaction-history/TransactionHistoryCard/styles.ts
@@ -1,3 +1,4 @@
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { getColor, matchColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
@@ -11,7 +12,7 @@ export const Card = styled(VStack).attrs({
   gap: 12,
 })`
   padding: 16px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   width: 100%;
@@ -72,7 +73,7 @@ export const IconSlot = styled.div`
   align-items: center;
   justify-content: center;
   overflow: hidden;
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 /** USD + crypto stack. Minimal gap (Figma ~0 between lines in some frames). */
@@ -89,7 +90,7 @@ export const AddressPill = styled(HStack).attrs({
   gap: 4,
 })`
   padding: 8px 16px;
-  border-radius: 99px;
+  ${borderRadius.pill};
   background: ${getColor('buttonSecondary')};
   border: 1px solid ${getColor('foregroundExtra')};
   flex-shrink: 0;
@@ -111,7 +112,7 @@ export const ProviderPill = styled(HStack).attrs({
   gap: 6,
 })`
   padding: 8px 12px;
-  border-radius: 12px 0 16px 0;
+  border-radius: ${borderRadiusPx.md}px 0 ${borderRadiusPx.lg}px 0;
   background: ${getColor('buttonSecondary')};
   border-top: 1px solid ${getColor('foregroundExtra')};
   border-left: 1px solid ${getColor('foregroundExtra')};

--- a/core/ui/transaction-history/TransactionHistoryTag/styles.ts
+++ b/core/ui/transaction-history/TransactionHistoryTag/styles.ts
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
@@ -9,7 +10,7 @@ export const TagPill = styled(HStack).attrs({
 })`
   width: fit-content;
   padding: 8px 12px;
-  border-radius: 99px;
+  ${borderRadius.pill};
   border: 1px solid ${getColor('info')};
   background: ${({ theme }) => theme.colors.info.withAlpha(0.1).toCssValue()};
   color: ${getColor('info')};

--- a/core/ui/transaction-history/detail/TransactionDetailPage.tsx
+++ b/core/ui/transaction-history/detail/TransactionDetailPage.tsx
@@ -28,8 +28,8 @@ import {
 } from '@core/ui/vault/swap/limit/tracking/presentation'
 import { useLimitOrderTracking } from '@core/ui/vault/swap/limit/tracking/useLimitOrderTracking'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
-import { round } from '@lib/ui/css/round'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { ChevronRightIcon } from '@lib/ui/icons/ChevronRightIcon'
 import { SquareArrowOutUpRightIcon } from '@lib/ui/icons/SquareArrowOutUpRightIcon'
@@ -631,7 +631,7 @@ export const TransactionDetailPage = () => {
 const AmountCard = styled(VStack)`
   background-color: ${({ theme }) => theme.colors.foreground.toCssValue()};
   border: 1px solid ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};
-  border-radius: 16px;
+  ${borderRadius.lg};
   padding: 24px 16px;
   width: 100%;
 `
@@ -639,7 +639,7 @@ const AmountCard = styled(VStack)`
 const SwapCoinCard = styled(VStack)`
   background-color: ${({ theme }) => theme.colors.foreground.toCssValue()};
   border: 1px solid ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};
-  border-radius: 16px;
+  ${borderRadius.lg};
   flex: 1;
   padding: 24px 16px;
 `
@@ -650,13 +650,13 @@ const SwapChevronWrapper = styled(HStack)`
   left: 50%;
   transform: translate(-50%, -50%);
   z-index: 1;
-  border-radius: 50%;
+  ${borderRadius.pill};
   padding: 7px;
   background-color: ${({ theme }) => theme.colors.background.toCssValue()};
 `
 
 const SwapChevronCircle = styled.div`
-  ${round};
+  ${borderRadius.pill};
   ${sameDimensions(24)};
   ${centerContent};
   background: ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};

--- a/core/ui/transaction-history/progress/PendingTransactionProgressCard.tsx
+++ b/core/ui/transaction-history/progress/PendingTransactionProgressCard.tsx
@@ -7,6 +7,7 @@ import { getLimitOrderBuyCoin } from '@core/ui/mpc/keysign/join/tx/limitOrderBuy
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { useCurrentVaultCoins } from '@core/ui/vault/state/currentVaultCoins'
 import { toNativeSwapLimitAmount } from '@core/ui/vault/swap/keysignPayload/getSwapToAmountLimit'
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { ArrowDownIcon } from '@lib/ui/icons/ArrowDownIcon'
 import { WalletIcon } from '@lib/ui/icons/WalletIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -398,7 +399,7 @@ export const PendingTransactionProgressCard = ({
 
 const ProgressCard = styled.div`
   padding: 16px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   cursor: pointer;
@@ -418,7 +419,7 @@ const TopRow = styled(HStack).attrs({
 
 const InProgressBadge = styled.div`
   padding: 6px 12px;
-  border-radius: 99px;
+  ${borderRadius.pill};
   background: ${({ theme }) =>
     theme.colors.foregroundExtra.withAlpha(0.5).toCssValue()};
   border: 1px solid ${getColor('foregroundExtra')};
@@ -505,7 +506,7 @@ const StepperIcon = styled.div`
   position: relative;
   width: 28px;
   height: 28px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: ${getColor('foregroundExtra')};
   display: flex;
   align-items: center;
@@ -520,7 +521,7 @@ const ProviderPill = styled(HStack).attrs({
   gap: 6,
 })`
   padding: 8px 12px;
-  border-radius: 12px 0 16px 0;
+  border-radius: ${borderRadiusPx.md}px 0 ${borderRadiusPx.lg}px 0;
   background: ${getColor('buttonSecondary')};
   border-top: 1px solid ${getColor('foregroundExtra')};
   border-left: 1px solid ${getColor('foregroundExtra')};
@@ -547,7 +548,7 @@ const StepperDivider = styled.div`
 const DestinationWalletIcon = styled.div`
   width: 28px;
   height: 28px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: ${getColor('foregroundExtra')};
   display: flex;
   align-items: center;

--- a/core/ui/vaultsOrganisation/components/VaultListRow.tsx
+++ b/core/ui/vaultsOrganisation/components/VaultListRow.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -83,7 +84,7 @@ const Row = styled.div.withConfig({
   align-items: center;
   background: ${({ theme, selected }) =>
     selected && theme.colors.foregroundDark.withAlpha(0.65).toCssValue()};
-  border-radius: 18px;
+  ${borderRadius.lg};
   border: 1px solid
     ${({ theme }) => theme.colors.foregroundExtra.withAlpha(0.7).toCssValue()};
   display: flex;
@@ -150,7 +151,7 @@ const IconBadge = styled.div.withConfig({
   shouldForwardProp: prop => prop !== 'tone',
 })<{ tone: LeadingIconProps['tone'] }>`
   align-items: center;
-  border-radius: 99px;
+  ${borderRadius.pill};
   display: flex;
   font-size: 16px;
   height: 40px;

--- a/core/ui/vaultsOrganisation/components/VaultSignersPill.tsx
+++ b/core/ui/vaultsOrganisation/components/VaultSignersPill.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
 import { hasServer, isServer } from '@vultisig/core-mpc/devices/localPartyId'
@@ -13,7 +14,7 @@ const PillContainer = styled.div`
   justify-content: center;
   align-items: center;
   gap: 10px;
-  border-radius: 8px;
+  ${borderRadius.sm};
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
 `

--- a/core/ui/vaultsOrganisation/folder/create/index.tsx
+++ b/core/ui/vaultsOrganisation/folder/create/index.tsx
@@ -15,6 +15,7 @@ import { useVaultsTotalBalances } from '@core/ui/vaultsOrganisation/hooks/useVau
 import { getVaultSecurityTone } from '@core/ui/vaultsOrganisation/utils/getVaultSecurityTone'
 import { Button } from '@lib/ui/buttons/Button'
 import { IconButton } from '@lib/ui/buttons/IconButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { getFormProps } from '@lib/ui/form/utils/getFormProps'
 import { CloseIcon } from '@lib/ui/icons/CloseIcon'
 import { FolderLockIcon } from '@lib/ui/icons/FolderLockIcon'
@@ -237,7 +238,7 @@ const SwitchWrapper = styled.div`
 `
 
 const EmptyStateCard = styled(VStack)`
-  border-radius: 20px;
+  ${borderRadius.xl};
   padding: 24px;
   background: ${({ theme }) =>
     theme.colors.foreground.withAlpha(0.35).toCssValue()};

--- a/core/ui/vaultsOrganisation/folder/update/index.tsx
+++ b/core/ui/vaultsOrganisation/folder/update/index.tsx
@@ -20,6 +20,7 @@ import { useVaultsTotalBalances } from '@core/ui/vaultsOrganisation/hooks/useVau
 import { getVaultSecurityTone } from '@core/ui/vaultsOrganisation/utils/getVaultSecurityTone'
 import { Button } from '@lib/ui/buttons/Button'
 import { IconButton } from '@lib/ui/buttons/IconButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { DnDList } from '@lib/ui/dnd/DnDList'
 import { getFormProps } from '@lib/ui/form/utils/getFormProps'
 import { CloseIcon } from '@lib/ui/icons/CloseIcon'
@@ -86,7 +87,7 @@ const InputOverlay = styled.div`
 `
 
 const EmptyStateCard = styled(VStack)`
-  border-radius: 20px;
+  ${borderRadius.xl};
   padding: 24px;
   background: ${({ theme }) =>
     theme.colors.foreground.withAlpha(0.35).toCssValue()};

--- a/core/ui/vult/discount/featureGate/FeatureTierGate.tsx
+++ b/core/ui/vult/discount/featureGate/FeatureTierGate.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { WalletIcon } from '@lib/ui/icons/WalletIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Spinner } from '@lib/ui/loaders/Spinner'
@@ -163,7 +164,7 @@ const DialogFrame = styled.div`
     height: auto;
     max-height: calc(100vh - 80px);
     border: 1px solid ${getColor('mistExtra')};
-    border-radius: 38px;
+    ${borderRadius.xl};
     box-shadow: 0 15px 75px rgba(0, 0, 0, 0.18);
   }
 `
@@ -174,7 +175,7 @@ const IconBadge = styled.div`
   justify-content: center;
   width: 40px;
   height: 40px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: #03132c;
   border: 1.5px solid rgba(255, 255, 255, 0.15);
   box-shadow: 0 8px 18px rgba(12, 78, 255, 0.18);
@@ -200,7 +201,7 @@ const RequirementCard = styled(VStack)`
   align-self: stretch;
   gap: 12px;
   padding: 24px 20px 16px;
-  border-radius: 24px 24px 20px 20px;
+  ${borderRadius.xl};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
 `
@@ -211,7 +212,7 @@ const BalanceRow = styled(HStack)`
   margin-top: 10px;
   gap: 12px;
   padding: 16px;
-  border-radius: 14px;
+  ${borderRadius.lg};
   background: #0d2240;
   border: 1px solid ${getColor('foregroundExtra')};
 
@@ -229,7 +230,7 @@ const GetVultButton = styled(UnstyledButton)<{ $gradient: string }>`
   align-self: stretch;
   margin-top: -22px;
   padding: 32px 32px 14px;
-  border-radius: 0 0 24px 24px;
+  border-radius: 0 0 ${borderRadiusPx.xl}px ${borderRadiusPx.xl}px;
   background: ${({ $gradient }) => $gradient};
   color: #f0f4fc;
   font-size: 14px;

--- a/core/ui/vult/discount/featureGate/TierBadge.tsx
+++ b/core/ui/vult/discount/featureGate/TierBadge.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import styled from 'styled-components'
 
 import { TierBadgeContent } from './useTierBadge'
@@ -16,7 +17,7 @@ export const TierBadge = ({ badge }: TierBadgeProps) =>
 
 const Pill = styled.span<{ $color: string }>`
   border: 1px solid ${({ $color }) => $color};
-  border-radius: 99px;
+  ${borderRadius.pill};
   color: ${({ $color }) => $color};
   font-size: 10px;
   font-weight: 600;

--- a/core/ui/vult/discount/tier/bps.tsx
+++ b/core/ui/vult/discount/tier/bps.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ValueProp } from '@lib/ui/props'
 import {
   VultDiscountTier,
@@ -11,7 +12,7 @@ const Container = styled.div`
   padding: 8px 16px;
   justify-content: center;
   align-items: center;
-  border-radius: 99px;
+  ${borderRadius.pill};
   border: 1px solid rgba(72, 121, 253, 0.32);
 
   color: #f0f4fc;

--- a/core/ui/vult/discount/tier/container.tsx
+++ b/core/ui/vult/discount/tier/container.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ValueProp } from '@lib/ui/props'
 import { VultDiscountTier } from '@vultisig/core-chain/swap/affiliate/config'
 import styled from 'styled-components'
@@ -27,7 +28,7 @@ export const DiscountTierContainer = styled.div<{ $clickable?: boolean }>`
   align-self: stretch;
   position: relative;
   overflow: hidden;
-  border-radius: 16px;
+  ${borderRadius.lg};
   background: #061b3a;
   cursor: ${({ $clickable }) => ($clickable ? 'pointer' : 'default')};
 `
@@ -39,7 +40,7 @@ export const DiscountTierDarkSection = styled.div`
   position: relative;
   z-index: 1;
   overflow: hidden;
-  border-radius: 16px;
+  ${borderRadius.lg};
   background: #061b3a;
 `
 

--- a/lib/ui/base/Hoverable/index.tsx
+++ b/lib/ui/base/Hoverable/index.tsx
@@ -13,7 +13,7 @@ type HighlightProps = {
 
 const Highlight = styled.div<HighlightProps>`
   position: absolute;
-  ${borderRadius.s};
+  ${borderRadius.sm};
   ${props => absoluteOutline(props.horizontalOffset, props.verticalOffset)}
 `
 

--- a/lib/ui/buttons/Button/index.tsx
+++ b/lib/ui/buttons/Button/index.tsx
@@ -292,12 +292,6 @@ export const Button: FC<
   )
 }
 
-export const buttonSize: Record<ButtonSize, number> = {
-  xs: 26,
-  sm: 26,
-  md: 26,
-}
-
 export const buttonHeight: Record<ButtonSize, number> = {
   xs: 32,
   sm: 36,

--- a/lib/ui/buttons/IconButton/index.tsx
+++ b/lib/ui/buttons/IconButton/index.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { horizontalPadding } from '@lib/ui/css/horizontalPadding'
 import { Spinner } from '@lib/ui/loaders/Spinner'
 import { getColor } from '@lib/ui/theme/getters'
@@ -22,7 +23,7 @@ const StyledIconButton = styled(UnstyledButton)<{
   ${({ $disabled, $kind, $loading, $size, $status }) => css`
     align-items: center;
     border: none;
-    border-radius: ${iconButtonSize[$size]}px;
+    ${borderRadius.pill};
     cursor: pointer;
     display: flex;
     height: ${iconButtonSize[$size]}px;

--- a/lib/ui/buttons/IconButton/index.tsx
+++ b/lib/ui/buttons/IconButton/index.tsx
@@ -1,5 +1,4 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
-import { borderRadius } from '@lib/ui/css/borderRadius'
 import { horizontalPadding } from '@lib/ui/css/horizontalPadding'
 import { Spinner } from '@lib/ui/loaders/Spinner'
 import { getColor } from '@lib/ui/theme/getters'
@@ -9,6 +8,7 @@ import { FC } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Size } from '../../core/Size'
+import { borderRadius } from '../../css/borderRadius'
 import { ButtonProps, PrimaryButtonStatus } from '../ButtonProps'
 
 type ButtonSize = Extract<Size, 'xs' | 'sm' | 'md' | 'lg' | 'xl'>

--- a/lib/ui/buttons/MaxButton.tsx
+++ b/lib/ui/buttons/MaxButton.tsx
@@ -13,7 +13,7 @@ const maxButtonHeight = textInputHeight - maxButtonOffset * 2
 
 export const MaxButton = styled(UnstyledButton)`
   ${horizontalPadding(8)};
-  ${borderRadius.s};
+  ${borderRadius.sm};
   ${centerContent};
   height: ${toSizeUnit(maxButtonHeight)};
 

--- a/lib/ui/coachmark/Coachmark.tsx
+++ b/lib/ui/coachmark/Coachmark.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -107,7 +108,7 @@ const CloseButton = styled(UnstyledButton)`
   &:focus-visible {
     outline: 2px solid ${getColor('foregroundSuper')};
     outline-offset: 4px;
-    border-radius: 4px;
+    ${borderRadius.xs};
   }
 `
 

--- a/lib/ui/coachmark/Coachmark.tsx
+++ b/lib/ui/coachmark/Coachmark.tsx
@@ -1,11 +1,12 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
-import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
 import { useId } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
+
+import { borderRadius } from '../css/borderRadius'
 
 type CoachmarkProps = {
   title: string

--- a/lib/ui/css/borderRadius.tsx
+++ b/lib/ui/css/borderRadius.tsx
@@ -3,31 +3,28 @@ import { css } from 'styled-components'
 /**
  * `pill` is a bound, not a size. CSS clamps a corner radius to half the
  * smaller dimension, and that clamp is what produces the capsule, so the
- * number only has to out-run any surface the app can render. Kept private so
- * no call site writes one of the "fully round" magic numbers itself.
+ * number only has to out-run any surface the app can render.
  */
 const pillPx = 100000
 
-const scale = {
-  xs: css`
-    border-radius: 4px;
-  `,
-  sm: css`
-    border-radius: 8px;
-  `,
-  md: css`
-    border-radius: 12px;
-  `,
-  lg: css`
-    border-radius: 16px;
-  `,
-  xl: css`
-    border-radius: 24px;
-  `,
-  pill: css`
-    border-radius: ${pillPx}px;
-  `,
-}
+/**
+ * The scale as raw numbers, for surfaces that round their corners
+ * individually - a bottom sheet rounding only its top two, for instance.
+ * Prefer `borderRadius`, which rounds all four and is what almost every
+ * surface wants.
+ */
+export const borderRadiusPx = {
+  xs: 4,
+  sm: 8,
+  md: 12,
+  lg: 16,
+  xl: 24,
+  pill: pillPx,
+} as const
+
+const radius = (px: number) => css`
+  border-radius: ${px}px;
+`
 
 /**
  * The app's corner-radius scale.
@@ -53,17 +50,20 @@ const scale = {
  * surface is square before reaching for it.
  */
 export const borderRadius = {
-  ...scale,
+  xs: radius(borderRadiusPx.xs),
+  sm: radius(borderRadiusPx.sm),
+  md: radius(borderRadiusPx.md),
+  lg: radius(borderRadiusPx.lg),
+  xl: radius(borderRadiusPx.xl),
+  pill: radius(borderRadiusPx.pill),
   /** @deprecated 8 - use `sm`. */
-  s: scale.sm,
+  s: radius(borderRadiusPx.sm),
   /** @deprecated 12 - use `md`. */
-  m: scale.md,
+  m: radius(borderRadiusPx.md),
   /**
    * @deprecated 20 - off the scale entirely. Pick `lg` (16) or `xl` (24) by
    * looking at the surface: there is no mechanical answer, and renaming this
    * to `lg` would silently shrink every call site by 4px.
    */
-  l: css`
-    border-radius: 20px;
-  `,
+  l: radius(20),
 }

--- a/lib/ui/css/borderRadius.tsx
+++ b/lib/ui/css/borderRadius.tsx
@@ -1,17 +1,68 @@
 import { css } from 'styled-components'
 
-type BorderRadiusSize = 'xs' | 's' | 'm' | 'l'
+/**
+ * `pill` is a bound, not a size. CSS clamps a corner radius to half the
+ * smaller dimension, and that clamp is what produces the capsule, so the
+ * number only has to out-run any surface the app can render. Kept private so
+ * no call site writes one of the "fully round" magic numbers itself.
+ */
+const pillPx = 100000
 
-export const borderRadius: Record<BorderRadiusSize, ReturnType<typeof css>> = {
+const scale = {
   xs: css`
     border-radius: 4px;
   `,
-  s: css`
+  sm: css`
     border-radius: 8px;
   `,
-  m: css`
+  md: css`
     border-radius: 12px;
   `,
+  lg: css`
+    border-radius: 16px;
+  `,
+  xl: css`
+    border-radius: 24px;
+  `,
+  pill: css`
+    border-radius: ${pillPx}px;
+  `,
+}
+
+/**
+ * The app's corner-radius scale.
+ *
+ * Steps are named by size, not by surface: `md` means "12 from the scale",
+ * nothing more. Which surface class takes which step is documentation, not a
+ * contract, so a surface that genuinely reads differently can pick another
+ * step without the token name lying about it:
+ *
+ * - `xs` (4) progress tracks, skeleton bars, hairline chips
+ * - `sm` (8) small inline tags
+ * - `md` (12) list rows, compact containers
+ * - `lg` (16) input fields, inner icon tiles
+ * - `xl` (24) cards, banners, list containers, sheets and modals
+ * - `pill` any capsule control
+ *
+ * The scale stops at 24 and has no separate sheet step - sheets take `xl`,
+ * which is already the radius most of them render at.
+ *
+ * There is no circle step either. On a square surface `pill` renders a circle;
+ * on a non-square one it renders a stadium, which is the right shape for a
+ * capsule and a bug for anything that meant to be an ellipse. Check the
+ * surface is square before reaching for it.
+ */
+export const borderRadius = {
+  ...scale,
+  /** @deprecated 8 - use `sm`. */
+  s: scale.sm,
+  /** @deprecated 12 - use `md`. */
+  m: scale.md,
+  /**
+   * @deprecated 20 - off the scale entirely. Pick `lg` (16) or `xl` (24) by
+   * looking at the surface: there is no mechanical answer, and renaming this
+   * to `lg` would silently shrink every call site by 4px.
+   */
   l: css`
     border-radius: 20px;
   `,

--- a/lib/ui/css/round.tsx
+++ b/lib/ui/css/round.tsx
@@ -1,5 +1,10 @@
 import { css } from 'styled-components'
 
+/**
+ * @deprecated Use `borderRadius.pill`. 1000px stops rounding a surface wider
+ * than 2000px, and it is one of five spellings of "fully rounded" in the tree;
+ * the token collapses them and raises the bound past anything renderable.
+ */
 export const round = css`
   border-radius: 1000px;
 `

--- a/lib/ui/css/textInput.tsx
+++ b/lib/ui/css/textInput.tsx
@@ -8,7 +8,7 @@ import { toSizeUnit } from './toSizeUnit'
 
 export const textInputHorizontalPadding = 12
 export const textInputHeight = 56
-export const textInputBorderRadius = borderRadius.s
+export const textInputBorderRadius = borderRadius.sm
 
 export const textInputFrame = css`
   height: ${toSizeUnit(textInputHeight)};

--- a/lib/ui/flow/ErrorFallbackContent/ErrorStatusIcon.tsx
+++ b/lib/ui/flow/ErrorFallbackContent/ErrorStatusIcon.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { getColor } from '@lib/ui/theme/getters'
 import { match } from '@vultisig/lib-utils/match'
 import styled from 'styled-components'
@@ -63,7 +64,7 @@ const Ring = styled.div<{ size: number }>`
   height: ${({ size }) => size}px;
   transform: translate(-50%, -50%);
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 50%;
+  ${borderRadius.pill};
   opacity: 0.5;
 `
 

--- a/lib/ui/flow/ErrorFallbackContent/ErrorStatusIcon.tsx
+++ b/lib/ui/flow/ErrorFallbackContent/ErrorStatusIcon.tsx
@@ -1,7 +1,8 @@
-import { borderRadius } from '@lib/ui/css/borderRadius'
 import { getColor } from '@lib/ui/theme/getters'
 import { match } from '@vultisig/lib-utils/match'
 import styled from 'styled-components'
+
+import { borderRadius } from '../../css/borderRadius'
 
 export type ErrorStatusVariant = 'error' | 'warning'
 

--- a/lib/ui/flow/ErrorFallbackContent/ShowExactErrorModal.tsx
+++ b/lib/ui/flow/ErrorFallbackContent/ShowExactErrorModal.tsx
@@ -102,7 +102,7 @@ export const ShowExactErrorModal = ({
 const Wrapper = styled(VStack)`
   width: 100%;
   background: ${getColor('background')};
-  ${borderRadius.m};
+  ${borderRadius.md};
   padding: 20px;
 
   @media ${mediaQuery.tabletDeviceAndUp} {
@@ -111,7 +111,7 @@ const Wrapper = styled(VStack)`
 `
 
 const ErrorBox = styled.div`
-  border-radius: 24px;
+  ${borderRadius.xl};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   padding: 20px;

--- a/lib/ui/flow/ErrorFallbackContent/index.tsx
+++ b/lib/ui/flow/ErrorFallbackContent/index.tsx
@@ -1,4 +1,3 @@
-import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ChevronDownIcon } from '@lib/ui/icons/ChevronDownIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { TitleProp } from '@lib/ui/props'
@@ -9,6 +8,7 @@ import { ReactNode, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
+import { borderRadius } from '../../css/borderRadius'
 import { ErrorStatusIcon, ErrorStatusVariant } from './ErrorStatusIcon'
 import { ShowExactErrorModal } from './ShowExactErrorModal'
 

--- a/lib/ui/flow/ErrorFallbackContent/index.tsx
+++ b/lib/ui/flow/ErrorFallbackContent/index.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ChevronDownIcon } from '@lib/ui/icons/ChevronDownIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { TitleProp } from '@lib/ui/props'
@@ -101,7 +102,7 @@ export const ErrorFallbackContent = ({
 
 const ShowExactErrorCard = styled(HStack)`
   width: 100%;
-  border-radius: 16px;
+  ${borderRadius.lg};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   padding: 20px;

--- a/lib/ui/flow/MultistepProgressIndicator/index.tsx
+++ b/lib/ui/flow/MultistepProgressIndicator/index.tsx
@@ -1,4 +1,4 @@
-import { round } from '@lib/ui/css/round'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { HStack } from '@lib/ui/layout/Stack'
 import { IsActiveProp, ValueProp } from '@lib/ui/props'
@@ -21,7 +21,7 @@ const Step = styled.div<
     variant === 'dots'
       ? css`
           ${sameDimensions(8)};
-          ${round};
+          ${borderRadius.pill};
         `
       : css`
           flex: 1;

--- a/lib/ui/flow/MultistepProgressIndicator/index.tsx
+++ b/lib/ui/flow/MultistepProgressIndicator/index.tsx
@@ -1,10 +1,11 @@
-import { borderRadius } from '@lib/ui/css/borderRadius'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { HStack } from '@lib/ui/layout/Stack'
 import { IsActiveProp, ValueProp } from '@lib/ui/props'
 import { matchColor } from '@lib/ui/theme/getters'
 import { range } from '@vultisig/lib-utils/array/range'
 import styled, { css } from 'styled-components'
+
+import { borderRadius } from '../../css/borderRadius'
 
 type MultistepProgressIndicatorProps = ValueProp<number> & {
   steps: number

--- a/lib/ui/flow/ProgressLine.tsx
+++ b/lib/ui/flow/ProgressLine.tsx
@@ -1,10 +1,11 @@
-import { borderRadius } from '@lib/ui/css/borderRadius'
 import { vStack } from '@lib/ui/layout/Stack'
 import { ValueProp } from '@lib/ui/props'
 import { getColor } from '@lib/ui/theme/getters'
 import { toPercents } from '@vultisig/lib-utils/toPercents'
 import { FC } from 'react'
 import styled from 'styled-components'
+
+import { borderRadius } from '../css/borderRadius'
 
 const Container = styled.div`
   width: 100%;

--- a/lib/ui/flow/ProgressLine.tsx
+++ b/lib/ui/flow/ProgressLine.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { vStack } from '@lib/ui/layout/Stack'
 import { ValueProp } from '@lib/ui/props'
 import { getColor } from '@lib/ui/theme/getters'
@@ -5,11 +6,9 @@ import { toPercents } from '@vultisig/lib-utils/toPercents'
 import { FC } from 'react'
 import styled from 'styled-components'
 
-import { round } from '../css/round'
-
 const Container = styled.div`
   width: 100%;
-  ${round};
+  ${borderRadius.pill};
   background: ${getColor('foreground')};
   height: 10px;
   overflow: hidden;

--- a/lib/ui/form/FormCheckBadge.tsx
+++ b/lib/ui/form/FormCheckBadge.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CheckmarkIcon } from '@lib/ui/icons/CheckmarkIcon'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
@@ -13,7 +14,7 @@ export const FormCheckBadge = () => {
 const Container = styled.div`
   width: 16px;
   height: 16px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   border: 0.6667px solid ${getColor('success')};
   background: ${getColor('background')};
   color: ${getColor('success')};

--- a/lib/ui/form/FormCheckBadge.tsx
+++ b/lib/ui/form/FormCheckBadge.tsx
@@ -1,7 +1,8 @@
-import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CheckmarkIcon } from '@lib/ui/icons/CheckmarkIcon'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
+
+import { borderRadius } from '../css/borderRadius'
 
 export const FormCheckBadge = () => {
   return (

--- a/lib/ui/info/InfoItem.tsx
+++ b/lib/ui/info/InfoItem.tsx
@@ -8,7 +8,7 @@ import { ReactNode } from 'react'
 import styled from 'styled-components'
 
 const Container = styled(HStack)`
-  ${borderRadius.l};
+  ${borderRadius.xl};
   background-color: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   padding: 16px;

--- a/lib/ui/inputs/AmountTextInput/index.tsx
+++ b/lib/ui/inputs/AmountTextInput/index.tsx
@@ -20,7 +20,7 @@ export type AmountTextInputProps = Omit<
 }
 
 const UnitContainer = styled.div`
-  ${borderRadius.s};
+  ${borderRadius.sm};
 
   position: absolute;
   left: 12px;

--- a/lib/ui/inputs/MultiCharacterInput/index.tsx
+++ b/lib/ui/inputs/MultiCharacterInput/index.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@lib/ui/buttons/Button'
-import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import { capitalizeFirstLetter } from '@vultisig/lib-utils/capitalizeFirstLetter'
@@ -7,6 +6,7 @@ import { match } from '@vultisig/lib-utils/match'
 import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
 
+import { borderRadius } from '../../css/borderRadius'
 import { Spinner } from '../../loaders/Spinner'
 import { InputProps, UiProps } from '../../props'
 import { Text } from '../../text'

--- a/lib/ui/inputs/MultiCharacterInput/index.tsx
+++ b/lib/ui/inputs/MultiCharacterInput/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import { capitalizeFirstLetter } from '@vultisig/lib-utils/capitalizeFirstLetter'
@@ -124,7 +125,7 @@ const DigitInput = styled.input.attrs({
   font-size: 18px;
   border: 2px solid transparent;
   background: ${getColor('foreground')};
-  border-radius: 24px;
+  ${borderRadius.xl};
   outline: none;
   color: ${getColor('text')};
 
@@ -163,6 +164,6 @@ const DigitInput = styled.input.attrs({
 
 const PasteButton = styled(Button)`
   width: fit-content;
-  border-radius: 24px;
+  ${borderRadius.xl};
   min-width: 72px;
 `

--- a/lib/ui/inputs/PercentageSelector/index.tsx
+++ b/lib/ui/inputs/PercentageSelector/index.tsx
@@ -1,5 +1,4 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
-import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
 import { HStack } from '@lib/ui/layout/Stack'
 import { InputProps } from '@lib/ui/props'
@@ -7,6 +6,8 @@ import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
 import { multiplyBigInt } from '@vultisig/lib-utils/bigint/bigIntMultiplyByNumber'
 import styled from 'styled-components'
+
+import { borderRadius } from '../../css/borderRadius'
 
 type PercentageSelectorProps = InputProps<bigint | null> & {
   max: bigint

--- a/lib/ui/inputs/PercentageSelector/index.tsx
+++ b/lib/ui/inputs/PercentageSelector/index.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
 import { HStack } from '@lib/ui/layout/Stack'
 import { InputProps } from '@lib/ui/props'
@@ -48,7 +49,7 @@ export const PercentageSelector = ({
 const PercentageButton = styled(UnstyledButton)<{ $isActive: boolean }>`
   flex: 1;
   padding: 4px 16px;
-  border-radius: 99px;
+  ${borderRadius.pill};
   border: 1px solid ${getColor('foregroundExtra')};
   background-color: ${({ $isActive, theme }) =>
     $isActive

--- a/lib/ui/inputs/RadioOptionsList/index.tsx
+++ b/lib/ui/inputs/RadioOptionsList/index.tsx
@@ -25,7 +25,7 @@ const OptionItem = styled.label<{ isSelected: boolean }>`
   align-items: center;
   min-height: 56px;
   font-size: 16px;
-  ${borderRadius.m};
+  ${borderRadius.md};
   ${interactive}
   color: ${getColor('textShy')};
   ${horizontalPadding(16)}

--- a/lib/ui/inputs/Slider/index.tsx
+++ b/lib/ui/inputs/Slider/index.tsx
@@ -1,9 +1,9 @@
-import { borderRadius } from '@lib/ui/css/borderRadius'
 import { InputProps } from '@lib/ui/props'
 import { getColor } from '@lib/ui/theme/getters'
 import { useRef } from 'react'
 import styled from 'styled-components'
 
+import { borderRadius } from '../../css/borderRadius'
 import { Text } from '../../text'
 
 const thumbWidth = 38

--- a/lib/ui/inputs/Slider/index.tsx
+++ b/lib/ui/inputs/Slider/index.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { InputProps } from '@lib/ui/props'
 import { getColor } from '@lib/ui/theme/getters'
 import { useRef } from 'react'
@@ -128,7 +129,7 @@ const Track = styled.div`
   width: 100%;
   height: 4px;
   background-color: ${getColor('foregroundSuper')};
-  border-radius: 2px;
+  ${borderRadius.pill};
 `
 
 const TrackFill = styled.div`
@@ -137,7 +138,7 @@ const TrackFill = styled.div`
   left: 0;
   height: 100%;
   background-color: ${getColor('buttonPrimary')};
-  border-radius: 2px;
+  ${borderRadius.pill};
   pointer-events: none;
 `
 
@@ -158,7 +159,7 @@ const Thumb = styled.div`
   transform: translateY(-50%);
   width: ${thumbWidth}px;
   height: 24px;
-  border-radius: 100px;
+  ${borderRadius.pill};
   background: ${getColor('contrast')};
   box-shadow:
     0 0.5px 4px 0 rgba(0, 0, 0, 0.12),
@@ -179,7 +180,7 @@ const Dot = styled.div<{ $active: boolean }>`
   position: absolute;
   width: 6px;
   height: 6px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background-color: ${({ $active, theme }) =>
     $active
       ? theme.colors.buttonPrimary.toCssValue()

--- a/lib/ui/inputs/Stepper.tsx
+++ b/lib/ui/inputs/Stepper.tsx
@@ -1,8 +1,8 @@
-import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ComponentProps } from 'react'
 import styled from 'styled-components'
 
 import { UnstyledButton } from '../buttons/UnstyledButton'
+import { borderRadius } from '../css/borderRadius'
 import { CircleMinusIcon } from '../icons/CircleMinusIcon'
 import { CirclePlusIcon } from '../icons/CirclePlusIcon'
 import { HStack, VStack, vStack } from '../layout/Stack'

--- a/lib/ui/inputs/Stepper.tsx
+++ b/lib/ui/inputs/Stepper.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ComponentProps } from 'react'
 import styled from 'styled-components'
 
@@ -77,14 +78,14 @@ const StepControl = styled(UnstyledButton)`
   })};
 
   padding: 16px;
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
   width: 97px;
 `
 
 const Input = styled(TextInput)`
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid ${getColor('foregroundExtra')};
   text-align: center;
 `

--- a/lib/ui/inputs/checkbox/Checkbox.tsx
+++ b/lib/ui/inputs/checkbox/Checkbox.tsx
@@ -1,4 +1,3 @@
-import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
 import { interactive } from '@lib/ui/css/interactive'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
@@ -9,6 +8,7 @@ import { getColor } from '@lib/ui/theme/getters'
 import { ReactNode } from 'react'
 import styled, { css } from 'styled-components'
 
+import { borderRadius } from '../../css/borderRadius'
 import {
   InvisibleHTMLCheckbox,
   InvisibleHTMLCheckboxProps,

--- a/lib/ui/inputs/checkbox/Checkbox.tsx
+++ b/lib/ui/inputs/checkbox/Checkbox.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
 import { interactive } from '@lib/ui/css/interactive'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
@@ -22,7 +23,7 @@ const Box = styled.div<{ isChecked: boolean }>`
   ${sameDimensions(20)}
   ${centerContent};
   box-sizing: border-box;
-  border-radius: 100%;
+  ${borderRadius.pill};
   color: ${getColor('primary')};
   background: ${getColor('foregroundExtra')};
   font-size: 16px;

--- a/lib/ui/inputs/switch/index.tsx
+++ b/lib/ui/inputs/switch/index.tsx
@@ -1,8 +1,9 @@
-import { borderRadius } from '@lib/ui/css/borderRadius'
 import { Spinner } from '@lib/ui/loaders/Spinner'
 import { getColor } from '@lib/ui/theme/getters'
 import { FC, isValidElement, KeyboardEvent, ReactNode } from 'react'
 import styled, { css } from 'styled-components'
+
+import { borderRadius } from '../../css/borderRadius'
 
 const StyledLabel = styled.span`
   opacity: 1;

--- a/lib/ui/inputs/switch/index.tsx
+++ b/lib/ui/inputs/switch/index.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { Spinner } from '@lib/ui/loaders/Spinner'
 import { getColor } from '@lib/ui/theme/getters'
 import { FC, isValidElement, KeyboardEvent, ReactNode } from 'react'
@@ -15,7 +16,7 @@ const StyledSpinner = styled(Spinner)`
 
 const StyledSlider = styled.span<{ checked?: boolean }>`
   background-color: ${getColor('mistExtra')};
-  border-radius: 24px;
+  ${borderRadius.pill};
   height: 24px;
   position: relative;
   transition: 0.2s;
@@ -23,7 +24,7 @@ const StyledSlider = styled.span<{ checked?: boolean }>`
 
   &:before {
     background-color: ${getColor('white')};
-    border-radius: 50%;
+    ${borderRadius.pill};
     content: '';
     height: 20px;
     left: 2px;
@@ -56,7 +57,7 @@ const StyledSwitch = styled.div<{
   hoverable?: boolean
 }>`
   align-items: center;
-  border-radius: 24px;
+  ${borderRadius.pill};
   display: flex;
   gap: 8px;
   position: relative;

--- a/lib/ui/inputs/toggle-switch/ToggleSwitch.tsx
+++ b/lib/ui/inputs/toggle-switch/ToggleSwitch.tsx
@@ -1,5 +1,5 @@
-import { Button, buttonSize } from '@lib/ui/buttons/Button'
-import { toSizeUnit } from '@lib/ui/css/toSizeUnit'
+import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, StackProps } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import { ComponentType, ReactNode } from 'react'
@@ -84,7 +84,7 @@ export const ToggleSwitch = <T extends string | number>({
 
 const DefaultContainer = styled(HStack)`
   background-color: ${getColor('foregroundExtra')};
-  border-radius: ${toSizeUnit(buttonSize.md)};
+  ${borderRadius.xl};
   padding: 8px;
 `
 

--- a/lib/ui/inputs/toggle-switch/ToggleSwitch.tsx
+++ b/lib/ui/inputs/toggle-switch/ToggleSwitch.tsx
@@ -1,11 +1,11 @@
-import { Button } from '@lib/ui/buttons/Button'
-import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, StackProps } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import { ComponentType, ReactNode } from 'react'
 import styled, { css } from 'styled-components'
 
+import { Button } from '../../buttons/Button'
 import { ButtonProps } from '../../buttons/ButtonProps'
+import { borderRadius } from '../../css/borderRadius'
 import { ChildrenProp, UiProps } from '../../props'
 
 export type ToggleSwitchOption<T extends string | number> = {

--- a/lib/ui/inputs/upload/DropZoneContainer.tsx
+++ b/lib/ui/inputs/upload/DropZoneContainer.tsx
@@ -10,7 +10,7 @@ export const DropZoneContainer = styled.div`
   width: 100%;
   max-height: 400px;
   ${centerContent};
-  ${borderRadius.m};
+  ${borderRadius.md};
   padding: 20px;
   border: 1px dashed ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};

--- a/lib/ui/layout/Collapse/index.tsx
+++ b/lib/ui/layout/Collapse/index.tsx
@@ -1,4 +1,3 @@
-import { borderRadius } from '@lib/ui/css/borderRadius'
 import { AnimatedVisibility } from '@lib/ui/layout/AnimatedVisibility'
 import { CollapsableStateIndicator } from '@lib/ui/layout/CollapsableStateIndicator'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -6,6 +5,8 @@ import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
 import { FC, ReactNode, useState } from 'react'
 import styled from 'styled-components'
+
+import { borderRadius } from '../../css/borderRadius'
 
 const CollapseWrapper = styled(VStack)`
   border: 1px solid ${getColor('foregroundExtra')};

--- a/lib/ui/layout/Collapse/index.tsx
+++ b/lib/ui/layout/Collapse/index.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { AnimatedVisibility } from '@lib/ui/layout/AnimatedVisibility'
 import { CollapsableStateIndicator } from '@lib/ui/layout/CollapsableStateIndicator'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -8,7 +9,7 @@ import styled from 'styled-components'
 
 const CollapseWrapper = styled(VStack)`
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 16px;
+  ${borderRadius.lg};
 `
 
 const CollapseHeader = styled(HStack)`

--- a/lib/ui/list/item/DnDItemContainer.tsx
+++ b/lib/ui/list/item/DnDItemContainer.tsx
@@ -8,7 +8,7 @@ import styled, { css } from 'styled-components'
 
 export const DnDItemHighlight = styled.div`
   position: absolute;
-  ${borderRadius.m};
+  ${borderRadius.md};
   ${absoluteOutline(0, 0)}
 
   border: 2px solid ${getColor('primary')};

--- a/lib/ui/loaders/Skeleton/Skeleton.stories.tsx
+++ b/lib/ui/loaders/Skeleton/Skeleton.stories.tsx
@@ -11,7 +11,6 @@ const meta: Meta<typeof Skeleton> = {
     children: { table: { disable: true } },
   },
   args: {
-    variant: 'rectangular',
     width: '120px',
     height: '16px',
   },
@@ -24,7 +23,7 @@ export const Rectangular: Story = {}
 
 export const Circular: Story = {
   args: {
-    variant: 'circular',
+    borderRadius: '50%',
     width: '60px',
     height: '60px',
   },

--- a/lib/ui/loaders/Skeleton/index.tsx
+++ b/lib/ui/loaders/Skeleton/index.tsx
@@ -1,3 +1,4 @@
+import { borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { getColor } from '@lib/ui/theme/getters'
 import { ThemeColors } from '@lib/ui/theme/ThemeColors'
 import { keyframes } from 'styled-components'
@@ -19,17 +20,15 @@ const skeletonAnimation = keyframes`
 
 export const Skeleton = styled.div<{
   fill?: keyof ThemeColors
-  variant?: 'rectangular' | 'circular'
   height?: string
   width?: string
   borderRadius?: string
 }>`
   background-color: ${({ fill }) =>
     fill ? getColor(fill) : 'rgba(255, 255, 255, 0.05)'};
-  ${({ variant = 'rectangular' }) =>
-    variant === 'circular' ? 'border-radius: 50%' : ''};
   animation: ${skeletonAnimation} 1.5s ease-in-out 0.5s infinite;
   height: ${({ height }) => height ?? '100%'};
   width: ${({ width }) => width ?? '100%'};
-  border-radius: ${({ borderRadius }) => borderRadius ?? '4px'};
+  border-radius: ${({ borderRadius }) =>
+    borderRadius ?? `${borderRadiusPx.xs}px`};
 `

--- a/lib/ui/loaders/Skeleton/index.tsx
+++ b/lib/ui/loaders/Skeleton/index.tsx
@@ -1,8 +1,9 @@
-import { borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { getColor } from '@lib/ui/theme/getters'
 import { ThemeColors } from '@lib/ui/theme/ThemeColors'
 import { keyframes } from 'styled-components'
 import styled from 'styled-components'
+
+import { borderRadiusPx } from '../../css/borderRadius'
 
 const skeletonAnimation = keyframes`
   0% {

--- a/lib/ui/loaders/Spinner.tsx
+++ b/lib/ui/loaders/Spinner.tsx
@@ -1,10 +1,10 @@
 import { Animation } from '@lib/ui/animations/Animation'
-import { borderRadius } from '@lib/ui/css/borderRadius'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { ComponentProps, FC } from 'react'
 import styled, { keyframes } from 'styled-components'
 
 import { Match } from '../base/Match'
+import { borderRadius } from '../css/borderRadius'
 
 type SpinnerKind = 'primary' | 'secondary'
 

--- a/lib/ui/loaders/Spinner.tsx
+++ b/lib/ui/loaders/Spinner.tsx
@@ -1,4 +1,5 @@
 import { Animation } from '@lib/ui/animations/Animation'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { ComponentProps, FC } from 'react'
 import styled, { keyframes } from 'styled-components'
@@ -29,7 +30,7 @@ const SecondarySpinner = styled.span`
   display: inline-block;
 
   border: 0.08em solid;
-  border-radius: 100%;
+  ${borderRadius.pill};
   border-top-color: transparent;
 
   animation: ${animationForRotation} 1s infinite linear;

--- a/lib/ui/modal/ModalContainer.tsx
+++ b/lib/ui/modal/ModalContainer.tsx
@@ -31,7 +31,7 @@ const Container = styled(FocusLock)<ContainerProps>`
     width
       ? css`
           width: ${toSizeUnit(width)};
-          ${borderRadius.m};
+          ${borderRadius.md};
           max-height: calc(100% - ${toSizeUnit(offset * 2)});
           ${placement === 'top' &&
           css`

--- a/lib/ui/modal/ResponsiveModal.tsx
+++ b/lib/ui/modal/ResponsiveModal.tsx
@@ -1,3 +1,4 @@
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { BodyPortal } from '@lib/ui/dom/BodyPortal'
 import { VStack } from '@lib/ui/layout/Stack'
 import {
@@ -38,7 +39,8 @@ const MobileDrawer = styled(VStack)<{
   height: ${({ $fullScreen }) => ($fullScreen ? '100dvh' : 'auto')};
   max-height: ${({ $fullScreen }) => ($fullScreen ? 'none' : '90vh')};
   overflow: hidden;
-  border-radius: ${({ $fullScreen }) => ($fullScreen ? 0 : '24px 24px 0 0')};
+  border-radius: ${({ $fullScreen }) =>
+    $fullScreen ? 0 : `${borderRadiusPx.xl}px ${borderRadiusPx.xl}px 0 0`};
   overscroll-behavior: contain;
   z-index: 1000;
 
@@ -52,7 +54,7 @@ const MobileDrawerHeader = styled.div`
   justify-content: center;
   padding: 12px 0;
   background: ${getColor('background')};
-  border-radius: 24px 24px 0 0;
+  border-radius: ${borderRadiusPx.xl}px ${borderRadiusPx.xl}px 0 0;
   touch-action: none;
   cursor: grab;
 `
@@ -60,7 +62,7 @@ const MobileDrawerHeader = styled.div`
 const MobileDrawerGrabber = styled.div`
   width: 44px;
   height: 4px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   background: ${getColor('foregroundSuper')};
 `
 

--- a/lib/ui/modal/ResponsiveModal.tsx
+++ b/lib/ui/modal/ResponsiveModal.tsx
@@ -1,4 +1,3 @@
-import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { BodyPortal } from '@lib/ui/dom/BodyPortal'
 import { VStack } from '@lib/ui/layout/Stack'
 import {
@@ -10,6 +9,7 @@ import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { ReactNode, useRef, useState } from 'react'
 import styled from 'styled-components'
 
+import { borderRadius, borderRadiusPx } from '../css/borderRadius'
 import { Modal, ModalProps } from './index'
 
 type ResponsiveModalProps = {

--- a/lib/ui/panel/Panel.tsx
+++ b/lib/ui/panel/Panel.tsx
@@ -18,7 +18,7 @@ const panelBackground = css`
 `
 
 export const panel = ({ withSections }: PanelProps = {}) => css`
-  ${borderRadius.m};
+  ${borderRadius.md};
 
   ${withSections
     ? css`

--- a/lib/ui/search/SearchField.tsx
+++ b/lib/ui/search/SearchField.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { SearchIcon } from '@lib/ui/icons/SearchIcon'
 import { StationMagnifierIcon } from '@lib/ui/icons/StationFigmaIcons'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -72,8 +73,8 @@ export const SearchField: React.FC<SearchFieldProps> = ({
 const Wrapper = styled(HStack)`
   position: relative;
   background-color: ${getColor('foreground')};
-  border-radius: ${({ theme }) =>
-    theme.iconStyle === 'station' ? '99px' : '10px'};
+  ${({ theme }) =>
+    theme.iconStyle === 'station' ? borderRadius.pill : borderRadius.md};
   height: 48px;
   flex: none;
 
@@ -103,7 +104,7 @@ const StyledInput = styled.input.attrs({ autoComplete: 'off' })`
   padding-left: 32px;
   line-height: ${({ theme }) => (theme.iconStyle === 'station' ? 18 : 20)}px;
   font-size: ${({ theme }) => (theme.iconStyle === 'station' ? 13 : 16)}px;
-  border-radius: 4px;
+  ${borderRadius.xs};
   outline: none;
   transition: border-color 0.2s;
   background-color: transparent;

--- a/lib/ui/search/SearchField.tsx
+++ b/lib/ui/search/SearchField.tsx
@@ -1,4 +1,3 @@
-import { borderRadius } from '@lib/ui/css/borderRadius'
 import { SearchIcon } from '@lib/ui/icons/SearchIcon'
 import { StationMagnifierIcon } from '@lib/ui/icons/StationFigmaIcons'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -7,6 +6,8 @@ import { getColor } from '@lib/ui/theme/getters'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled, { css, useTheme } from 'styled-components'
+
+import { borderRadius } from '../css/borderRadius'
 
 type SearchFieldProps = UiProps & {
   autoFocus?: boolean

--- a/lib/ui/selection/SelectableItem.tsx
+++ b/lib/ui/selection/SelectableItem.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CheckmarkIcon } from '@lib/ui/icons/CheckmarkIcon'
 import { IconWrapper as BaseIconWrapper } from '@lib/ui/icons/IconWrapper'
 import { vStack } from '@lib/ui/layout/Stack'
@@ -15,7 +16,7 @@ const IconWrapper = styled.div<IsActiveProp>`
   })};
   position: relative;
   align-self: stretch;
-  border-radius: 24px;
+  ${borderRadius.xl};
   background: rgba(11, 26, 58, 0.5);
   height: 74px;
   padding: 17px;
@@ -36,6 +37,8 @@ const CheckBadge = styled(BaseIconWrapper)`
   right: 0;
   height: 24px;
   padding: 8px;
+  /* A notched badge shape, not a surface radius: both values exceed half
+     the element and clamp, fully rounding two opposite corners. */
   border-radius: 40px 0 25px 0;
   background: ${getColor('foregroundSuper')};
   font-weight: 600;

--- a/lib/ui/selection/SelectableItem.tsx
+++ b/lib/ui/selection/SelectableItem.tsx
@@ -1,5 +1,4 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
-import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CheckmarkIcon } from '@lib/ui/icons/CheckmarkIcon'
 import { IconWrapper as BaseIconWrapper } from '@lib/ui/icons/IconWrapper'
 import { vStack } from '@lib/ui/layout/Stack'
@@ -8,6 +7,8 @@ import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
 import { ReactNode } from 'react'
 import styled, { css } from 'styled-components'
+
+import { borderRadius } from '../css/borderRadius'
 
 const IconWrapper = styled.div<IsActiveProp>`
   ${vStack({

--- a/lib/ui/sheet/PromptSheet.tsx
+++ b/lib/ui/sheet/PromptSheet.tsx
@@ -1,3 +1,4 @@
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { BodyPortal } from '@lib/ui/dom/BodyPortal'
 import { useKeyDown } from '@lib/ui/hooks/useKeyDown'
 import { OnCloseProp } from '@lib/ui/props'
@@ -40,7 +41,7 @@ const Card = styled.div`
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   border-bottom: 0;
-  border-radius: 34px 34px 0 0;
+  border-radius: ${borderRadiusPx.xl}px ${borderRadiusPx.xl}px 0 0;
   box-shadow: 0px 15px 75px rgba(0, 0, 0, 0.18);
   overflow: hidden;
   width: 100%;
@@ -48,7 +49,7 @@ const Card = styled.div`
 
   @media ${mediaQuery.tabletDeviceAndUp} {
     border-bottom: 1px solid ${getColor('foregroundExtra')};
-    border-radius: 34px;
+    ${borderRadius.xl};
     max-width: 380px;
     max-height: calc(100dvh - 32px);
   }
@@ -75,7 +76,7 @@ const Grabber = styled.div`
   transform: translateX(-50%);
   width: 36px;
   height: 5px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   background: ${getColor('foregroundSuper')};
 
   @media ${mediaQuery.tabletDeviceAndUp} {
@@ -96,7 +97,7 @@ export const PromptSheetIcon = styled.div`
   position: relative;
   width: 40px;
   height: 40px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   overflow: hidden;
   background: ${getColor('background')};
   border: 1px solid ${getColor('foregroundSuperContrast')};

--- a/lib/ui/sheet/PromptSheet.tsx
+++ b/lib/ui/sheet/PromptSheet.tsx
@@ -1,4 +1,3 @@
-import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { BodyPortal } from '@lib/ui/dom/BodyPortal'
 import { useKeyDown } from '@lib/ui/hooks/useKeyDown'
 import { OnCloseProp } from '@lib/ui/props'
@@ -6,6 +5,8 @@ import { mediaQuery } from '@lib/ui/responsive/mediaQuery'
 import { getColor } from '@lib/ui/theme/getters'
 import { ReactNode, useId, useRef } from 'react'
 import styled from 'styled-components'
+
+import { borderRadius, borderRadiusPx } from '../css/borderRadius'
 
 type PromptSheetProps = OnCloseProp & {
   eyebrow?: ReactNode

--- a/lib/ui/status/EmptyState/EmptyState.tsx
+++ b/lib/ui/status/EmptyState/EmptyState.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CryptoIcon } from '@lib/ui/icons/CryptoIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { VStack, vStack } from '@lib/ui/layout/Stack'
@@ -43,7 +44,7 @@ const EmptyWrapper = styled.div`
     alignItems: 'center',
   })};
   padding: 32px 40px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   background: ${getColor('foreground')};
 
   ${({ theme }) =>
@@ -51,7 +52,6 @@ const EmptyWrapper = styled.div`
     css`
       align-self: stretch;
       border: 1px solid ${theme.colors.foregroundSuper.toCssValue()};
-      border-radius: 20px;
       padding: 28px 20px;
     `}
 `

--- a/lib/ui/status/EmptyState/EmptyState.tsx
+++ b/lib/ui/status/EmptyState/EmptyState.tsx
@@ -1,4 +1,3 @@
-import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CryptoIcon } from '@lib/ui/icons/CryptoIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { VStack, vStack } from '@lib/ui/layout/Stack'
@@ -6,6 +5,8 @@ import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
 import { ReactNode } from 'react'
 import styled, { css } from 'styled-components'
+
+import { borderRadius } from '../../css/borderRadius'
 
 type EmptyStateProps = {
   icon?: ReactNode

--- a/lib/ui/status/ErrorBlock/index.tsx
+++ b/lib/ui/status/ErrorBlock/index.tsx
@@ -7,7 +7,7 @@ import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
 
 const Container = styled(HStack)`
-  ${borderRadius.m};
+  ${borderRadius.md};
   background: ${getColor('dangerBackground')};
   border: 1px solid
     ${({ theme: { colors } }) =>

--- a/lib/ui/status/InfoBlock/index.tsx
+++ b/lib/ui/status/InfoBlock/index.tsx
@@ -10,7 +10,7 @@ import { ElementType, ReactNode } from 'react'
 import styled from 'styled-components'
 
 const Container = styled(HStack)`
-  ${borderRadius.m};
+  ${borderRadius.md};
   background-color: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   padding: 16px;

--- a/lib/ui/status/WarningBlock/index.tsx
+++ b/lib/ui/status/WarningBlock/index.tsx
@@ -10,7 +10,7 @@ import { ElementType, ReactNode } from 'react'
 import styled from 'styled-components'
 
 const Container = styled(HStack)`
-  ${borderRadius.m};
+  ${borderRadius.md};
   background-color: ${getColor('idleDark')};
   border: 1px solid ${getColor('idle')};
   padding: 16px;

--- a/lib/ui/toast/ToastItem.tsx
+++ b/lib/ui/toast/ToastItem.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { BodyPortal } from '@lib/ui/dom/BodyPortal'
 import { pageBottomInsetVar } from '@lib/ui/page/PageContent'
 import { ChildrenProp, ValueProp } from '@lib/ui/props'
@@ -72,7 +73,7 @@ const Card = styled.div`
 
   width: 100%;
   padding: 16px;
-  border-radius: 24px;
+  ${borderRadius.xl};
   border: 1px solid ${getColor('foregroundSuper')};
   background: ${getColor('foregroundExtra')};
   text-align: center;

--- a/lib/ui/toast/ToastItem.tsx
+++ b/lib/ui/toast/ToastItem.tsx
@@ -1,4 +1,3 @@
-import { borderRadius } from '@lib/ui/css/borderRadius'
 import { BodyPortal } from '@lib/ui/dom/BodyPortal'
 import { pageBottomInsetVar } from '@lib/ui/page/PageContent'
 import { ChildrenProp, ValueProp } from '@lib/ui/props'
@@ -7,6 +6,7 @@ import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
 import styled, { keyframes } from 'styled-components'
 
+import { borderRadius } from '../css/borderRadius'
 import { hStack, vStack } from '../layout/Stack'
 import { ToastStatus } from './ToastStatus'
 import { ToastStatusIcon } from './ToastStatusIcon'

--- a/lib/ui/tooltips/Tooltip.tsx
+++ b/lib/ui/tooltips/Tooltip.tsx
@@ -15,10 +15,11 @@ import {
   useRole,
   useTransitionStyles,
 } from '@floating-ui/react'
-import { borderRadius } from '@lib/ui/css/borderRadius'
 import { getColor } from '@lib/ui/theme/getters'
 import { ReactNode, useRef, useState } from 'react'
 import styled from 'styled-components'
+
+import { borderRadius } from '../css/borderRadius'
 
 type RenderOpenerProps = {
   ref: (node: ReferenceType | null) => void

--- a/lib/ui/tooltips/Tooltip.tsx
+++ b/lib/ui/tooltips/Tooltip.tsx
@@ -15,6 +15,7 @@ import {
   useRole,
   useTransitionStyles,
 } from '@floating-ui/react'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { getColor } from '@lib/ui/theme/getters'
 import { ReactNode, useRef, useState } from 'react'
 import styled from 'styled-components'
@@ -30,7 +31,7 @@ type TooltipProps = {
 }
 
 const Container = styled.div`
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: ${getColor('contrast')};
   color: ${getColor('background')};
   padding: 12px;


### PR DESCRIPTION
Part 1 of 2 of #4550, tracked in #4622. 134 files.

Establishes the corner-radius token scale and migrates every surface outside the vault product area onto it. Part 2 (#4636, tracked in #4623) carries the vault directories and lands separately, so each base PR stays inside the 150-file review limit. It is stacked on this branch because it needs the token from here, and GitHub retargets it to `main` once this merges - so **merge this one first**.

## The scale

| token | value | surface class |
|-------|-------|---------------|
| `xs` | 4 | progress tracks, skeleton bars, hairline chips |
| `sm` | 8 | small inline tags |
| `md` | 12 | list rows, compact containers |
| `lg` | 16 | input fields, inner icon tiles |
| `xl` | 24 | cards, banners, list containers, sheets and modals |
| `pill` | fully rounded | any capsule control |

The mapping ships as JSDoc on the token itself, so the sweeps apply a written decision rather than re-deciding per file. Names are by size, not by surface: a surface that genuinely reads differently can pick another step without the token name lying about it.

## The five PRs

| | | files |
|---|---|---|
| #4624 | the scale, zero call-site changes | 2 |
| #4625 | `lib/ui` primitives | 41 |
| #4627 | shared `core/ui`, inpage provider, both clients | 35 |
| #4628 | `core/ui/mpc` and `core/ui/chain` | 35 |
| #4629 | `core/ui/defi` | 22 |

`lib/ui` deliberately runs before the app sweeps: fixing `Panel`, `ResponsiveModal`, `PromptSheet`, `Hoverable` and `textInput` fixes everything downstream for free, and doing it the other way round means touching the same files twice.

## Governing rule

**A radius already on a scale step keeps its pixels.** The migration removes magic numbers; it does not restyle surfaces that already match. That is most of the diff and it should read as noise.

Only off-scale values move, and every one of them is listed in its own PR. Across part 1:

```
44 -> 24   keygen education overlay
38 -> 24   FeatureTierGate tablet card
34 -> 24   PromptSheet, mobile sheet and tablet card
33 -> 24   pairing QR frame
26 -> 24   ToggleSwitch container
20 -> 24   six cards
20 -> 16   EmptyState and ChainsEmptyState station variants
18 -> 16   VaultListRow
16 -> 24   ShareAppModal, the first sheet to converge
14 -> 16   FeatureTierGate balance row
10 -> 12   SearchField default theme, three Skeleton placeholders
```

## What the audit turned up beyond plain literals

The reason this is not a find-and-replace: a radius binds to a corner in more shapes than a `border-radius` declaration.

- **A named constant one hop from use.** `KeysignNotificationBanner` kept its radius in `const bottomCornerRadiusPx = 24`. This is precisely the shape a regex guard cannot see.
- **Radii spelled as dimensions.** `IconButton` set `border-radius: ${iconButtonSize[$size]}px` on a square element - a circle written as a size.
- **Capsules that did not look like capsules.** 20 on a 28px button, 25.5 on an icon badge, 2 on a 4px slider track, 1 on a 1.5px underline. All were already clamping to a full round; all are `pill` now, with no visual change.
- **Radii passed as values.** React `style` props and `Skeleton` string props, invisible to a CSS-text search.

## Dead code removed along the way

`Skeleton`s `variant` prop was passed nowhere, and its `circular` branch was dead twice over - the unconditional rule below it always won, so `variant="circular"` rendered a rectangle. `buttonSize` went with it, being a three-identical-values record whose only consumer was `ToggleSwitch`.

That last one is worth reading in #4625: `buttonSize.md` is 26, not the button height, so the first pass turned a container into a `pill` on a wrong assumption and would have shipped a visibly rounder control. It is a 26 -> 24 move instead.

## Deliberate survivors

Each carries a comment explaining itself, and each will need an exception when the lint guard lands:

- **The shared `Button`** (30px, 99px) - owned by #4548, just merged. Untouched.
- **Notched badge shapes** (`40px 0 25px 0`) in `SelectableItem`, `DefiPositionTile`, `DefiItem` - outlines, not surface radii.
- **Drawn phone hardware** (36px, 34px) in the keygen education overlay - the corners belong to an illustrated device.
- **Decorative glow blobs** (350px, 416px, 260px) - not surfaces.
- **The e2e mock dapp page fixture** - a third-party page, not our UI.

## Not in this PR

The lint guard from ask 3 of #4550 lands as a standalone PR against `main` after part 2 merges. Inside either part it would keep CI red for the whole life of the other.

Worth stating when it does: a regex enforces "use a token", it cannot enforce "use the right token" - whether a surface takes `xl` or a smaller step depends on whether it is a container or sits inside one, which is only visible at the call site. It prevents new literals; it does not prevent drift.

## Validation

`yarn check` clean, `yarn test` 942 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized corner rounding across cards, buttons, badges, icons, modals, inputs, banners, and other interface elements.
  * Improved visual consistency by applying shared small, medium, large, extra-large, and pill-shaped radius styles.
  * Updated skeleton, toggle, spinner, search, and tooltip styling to use consistent rounded treatments.
  * Refined circular icons and status indicators for more uniform presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
