### PR TITLE
refactor(ui): vault chain surfaces adopt the corner-radius scale

### DIFF
--- a/core/ui/vault/chain/VaultChainCoinItem.tsx
+++ b/core/ui/vault/chain/VaultChainCoinItem.tsx
@@ -1,6 +1,7 @@
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { BalanceVisibilityAware } from '@core/ui/vault/balance/visibility/BalanceVisibilityAware'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ChevronRightIcon } from '@lib/ui/icons/ChevronRightIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -25,7 +26,7 @@ const PriceBadge = styled.div`
   align-items: center;
   align-self: flex-start;
   padding: 3px 8px;
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: ${getColor('foregroundExtra')};
 `
 

--- a/core/ui/vault/chain/VaultChainOverview.tsx
+++ b/core/ui/vault/chain/VaultChainOverview.tsx
@@ -8,6 +8,7 @@ import { VaultPrimaryActions } from '@core/ui/vault/components/VaultPrimaryActio
 import { useVaultChainTotalBalanceQuery } from '@core/ui/vault/queries/useVaultChainTotalBalanceQuery'
 import { useCurrentVaultAddress } from '@core/ui/vault/state/currentVaultCoins'
 import { Opener } from '@lib/ui/base/Opener'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Spinner } from '@lib/ui/loaders/Spinner'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
@@ -22,7 +23,7 @@ import { AddressQRModal } from './address/AddressQRModal'
 
 const AddressPill = styled(HStack)`
   padding: 4px 6px;
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: rgba(81, 128, 252, 0.12);
 
   & * {

--- a/core/ui/vault/chain/address/AddressQRCard.tsx
+++ b/core/ui/vault/chain/address/AddressQRCard.tsx
@@ -4,8 +4,8 @@ import { getChainLogoSrc } from '@core/ui/chain/metadata/getChainLogoSrc'
 import { useCore } from '@core/ui/state/core'
 import { useCurrentVaultAddress } from '@core/ui/vault/state/currentVaultCoins'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
-import { round } from '@lib/ui/css/round'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { toSizeUnit } from '@lib/ui/css/toSizeUnit'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -39,13 +39,13 @@ const QRContainer = styled.div`
   width: 100%;
   max-width: 232px;
   aspect-ratio: 232 / 272;
-  border-radius: 24px;
+  ${borderRadius.xl};
   background: ${getColor('foreground')};
   display: flex;
   flex-direction: column;
   align-items: center;
 
-  border-radius: 32px 32px 24px 24px;
+  ${borderRadius.xl};
   background: linear-gradient(180deg, #4879fd 0%, #0d39b1 100%);
   box-shadow:
     0 -3px 1px 0 rgba(0, 0, 0, 0.25) inset,
@@ -56,7 +56,7 @@ const QRContainer = styled.div`
 const QRWrapper = styled.div`
   width: 100%;
   aspect-ratio: 1;
-  border-radius: 32px 32px 24px 24px;
+  ${borderRadius.xl};
 
   overflow: hidden;
   background: white;
@@ -70,7 +70,7 @@ const ChainIconOverlay = styled.div`
   left: 50%;
   transform: translate(-50%, -50%);
   ${sameDimensions(toSizeUnit(76))};
-  ${round};
+  ${borderRadius.pill};
   ${centerContent};
   background: ${getColor('background')};
   border: 4px solid white;
@@ -84,7 +84,7 @@ const ReceiveLabel = styled.div`
   left: 0;
   right: 0;
   padding: 12px;
-  border-radius: 0 0 20px 20px;
+  border-radius: 0 0 ${borderRadiusPx.xl}px ${borderRadiusPx.xl}px;
   text-align: center;
 `
 

--- a/core/ui/vault/chain/coin/CoinDetailModal.tsx
+++ b/core/ui/vault/chain/coin/CoinDetailModal.tsx
@@ -13,6 +13,7 @@ import { VaultChainCoin } from '@core/ui/vault/queries/useVaultChainCoinsQuery'
 import { useCurrentVaultAddress } from '@core/ui/vault/state/currentVaultCoins'
 import { Opener } from '@lib/ui/base/Opener'
 import { IconButton } from '@lib/ui/buttons/IconButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ArCubeIcon } from '@lib/ui/icons/ArCubeIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -127,7 +128,7 @@ const ScrollContainer = styled.div`
     max-height: 82vh;
     overflow-y: auto;
     overflow-x: hidden;
-    border-radius: 12px;
+    ${borderRadius.md};
   }
 `
 
@@ -152,7 +153,7 @@ const ContentContainer = styled(VStack)`
       rgba(6, 27, 58, 0.5) 97%,
       rgba(6, 27, 58, 0) 100%
     );
-    border-radius: 12px;
+    ${borderRadius.md};
   }
 
   > * {

--- a/core/ui/vault/chain/coin/market/CoinChartRangePicker.tsx
+++ b/core/ui/vault/chain/coin/market/CoinChartRangePicker.tsx
@@ -3,6 +3,7 @@ import {
   marketChartRanges,
 } from '@core/ui/chain/coin/price/market/MarketChartRange'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { IsActiveProp } from '@lib/ui/props'
 import { Text } from '@lib/ui/text'
@@ -60,7 +61,7 @@ export const CoinChartRangePicker = ({
 const Segment = styled(UnstyledButton)<IsActiveProp>`
   flex: 1;
   padding: 10px 0;
-  border-radius: 999px;
+  ${borderRadius.pill};
   text-align: center;
   cursor: pointer;
 

--- a/core/ui/vault/chain/coin/market/CoinDetailSection.tsx
+++ b/core/ui/vault/chain/coin/market/CoinDetailSection.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { VStack } from '@lib/ui/layout/Stack'
 import { ChildrenProp, TitleProp } from '@lib/ui/props'
 import { Text } from '@lib/ui/text'
@@ -22,7 +23,7 @@ export const CoinDetailSection = ({
 
 const Card = styled(VStack)`
   width: 100%;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('background')};
   padding: 4px 0;
 `

--- a/core/ui/vault/chain/coin/market/CoinPriceChart.tsx
+++ b/core/ui/vault/chain/coin/market/CoinPriceChart.tsx
@@ -6,6 +6,7 @@ import { useCoinMarketStatsQuery } from '@core/ui/chain/coin/price/market/querie
 import { FiatAmountText } from '@core/ui/chain/components/FiatAmountText'
 import { VaultChainCoin } from '@core/ui/vault/queries/useVaultChainCoinsQuery'
 import { useCurrentVaultCoin } from '@core/ui/vault/state/currentVaultCoins'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -149,7 +150,7 @@ export const CoinPriceChart = ({ coin }: CoinPriceChartProps) => {
 
 const Card = styled(VStack)`
   width: 100%;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('background')};
   padding: 16px;
 `
@@ -160,7 +161,7 @@ const ScrubDateCaption = styled.div`
 
 const ChangeChip = styled.div`
   padding: 4px 10px;
-  border-radius: 999px;
+  ${borderRadius.pill};
 `
 
 const GraphContainer = styled.div`

--- a/core/ui/vault/chain/coin/market/CoinPriceChartGraph.tsx
+++ b/core/ui/vault/chain/coin/market/CoinPriceChartGraph.tsx
@@ -2,6 +2,7 @@ import {
   getMarketChartPriceDomain,
   MarketChartPoint,
 } from '@core/ui/chain/coin/price/market/marketChart'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { getColor } from '@lib/ui/theme/getters'
 import { motion } from 'framer-motion'
 import { useId } from 'react'
@@ -161,7 +162,7 @@ const ScrubDot = styled.div`
   position: absolute;
   width: 8px;
   height: 8px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   transform: translate(-50%, -50%);
   pointer-events: none;
 `

--- a/core/ui/vault/chain/coin/market/CoinPriceRangeBand.tsx
+++ b/core/ui/vault/chain/coin/market/CoinPriceRangeBand.tsx
@@ -1,4 +1,5 @@
 import { FiatAmountText } from '@core/ui/chain/components/FiatAmountText'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -57,7 +58,7 @@ const Track = styled.div`
   position: relative;
   width: 100%;
   height: 4px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   background: ${getColor('foregroundExtra')};
 `
 
@@ -66,7 +67,7 @@ const Dot = styled.div`
   top: 50%;
   width: 8px;
   height: 8px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   transform: translateY(-50%);
   background: ${getColor('primary')};
 `

--- a/core/ui/vault/chain/manage/ChainItem.tsx
+++ b/core/ui/vault/chain/manage/ChainItem.tsx
@@ -6,6 +6,7 @@ import {
 } from '@core/ui/storage/coins'
 import { useCurrentVaultNativeCoins } from '@core/ui/vault/state/currentVaultCoins'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CheckmarkIcon } from '@lib/ui/icons/CheckmarkIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { StationCheckmarkSmallIcon } from '@lib/ui/icons/StationFigmaIcons'
@@ -113,7 +114,7 @@ const ChainIconWrapper = styled.div<IsActiveProp>`
   })};
   position: relative;
   align-self: stretch;
-  border-radius: 24px;
+  ${borderRadius.xl};
   background: rgba(11, 26, 58, 0.5);
   height: 74px;
   padding: 17px;
@@ -146,6 +147,8 @@ const CheckBadge = styled(IconWrapper)`
   right: 0;
   height: 24px;
   padding: 8px;
+  /* A notched badge shape, not a surface radius: both values exceed half
+     the element and clamp, fully rounding two opposite corners. */
   border-radius: 40px 0 25px 0;
   background: ${getColor('foregroundSuper')};
   font-weight: 600;

--- a/core/ui/vault/chain/manage/coin/AddCustomTokenPrompt.tsx
+++ b/core/ui/vault/chain/manage/coin/AddCustomTokenPrompt.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { PlusIcon } from '@lib/ui/icons/PlusIcon'
 import { vStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
@@ -66,7 +67,7 @@ const CustomIconWrapper = styled.div`
   padding: 17px;
   font-size: 27.5px;
   color: ${getColor('buttonPrimary')};
-  border-radius: 24px;
+  ${borderRadius.xl};
   border: 1.5px dashed ${getColor('foregroundExtra')};
   opacity: 0.6;
   background: ${getColor('foreground')};

--- a/core/ui/vault/chain/manage/shared/DoneButton.tsx
+++ b/core/ui/vault/chain/manage/shared/DoneButton.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
 import { useTranslation } from 'react-i18next'
@@ -31,7 +32,7 @@ const StyledButton = styled(UnstyledButton)`
   align-items: center;
   gap: 6px;
 
-  border-radius: 99px;
+  ${borderRadius.pill};
   background: ${getColor('foreground')};
 
   transition: background 0.3s ease;

--- a/core/ui/vault/chain/manage/shared/SearchInput.tsx
+++ b/core/ui/vault/chain/manage/shared/SearchInput.tsx
@@ -1,6 +1,7 @@
 import { InputPasteAction } from '@core/ui/components/InputPasteAction'
 import { ActionInsideInteractiveElement } from '@lib/ui/base/ActionInsideInteractiveElement'
 import { IconButton } from '@lib/ui/buttons/IconButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CloseIcon } from '@lib/ui/icons/CloseIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { MagnifyingGlassIcon } from '@lib/ui/icons/MagnifyingGlassIcon'
@@ -90,7 +91,7 @@ export const SearchInput = ({
 }
 
 const InputWrapper = styled.div<{ hasBorder?: boolean }>`
-  border-radius: 99px;
+  ${borderRadius.pill};
   background: ${getColor('foreground')};
   background-clip: padding-box;
   overflow: hidden;
@@ -106,7 +107,7 @@ const InputWrapper = styled.div<{ hasBorder?: boolean }>`
 `
 
 const StyledTextInput = styled(TextInput)`
-  border-radius: 99px;
+  ${borderRadius.pill};
   background: ${getColor('foreground')};
   box-shadow: 0 0 8px 0 rgba(240, 244, 252, 0.03) inset;
   height: 44px;

--- a/core/ui/vault/chain/manage/shared/TokenItem.tsx
+++ b/core/ui/vault/chain/manage/shared/TokenItem.tsx
@@ -1,6 +1,7 @@
 import { ChainEntityIcon } from '@core/ui/chain/coin/icon/ChainEntityIcon'
 import { getCoinLogoSrc } from '@core/ui/chain/coin/icon/utils/getCoinLogoSrc'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CheckmarkIcon } from '@lib/ui/icons/CheckmarkIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { vStack } from '@lib/ui/layout/Stack'
@@ -85,7 +86,7 @@ const TokenIconWrapper = styled.div<IsActiveProp>`
   })};
   position: relative;
   align-self: stretch;
-  border-radius: 24px;
+  ${borderRadius.xl};
   background: rgba(11, 26, 58, 0.5);
   height: 74px;
   padding: 17px;
@@ -105,6 +106,8 @@ const CheckBadge = styled(IconWrapper)`
   right: 0;
   height: 24px;
   padding: 8px;
+  /* A notched badge shape, not a surface radius: both values exceed half
+     the element and clamp, fully rounding two opposite corners. */
   border-radius: 40px 0 25px 0;
   background: ${getColor('foregroundSuper')};
   font-weight: 600;

--- a/core/ui/vault/chain/tron/ResourcesCard.tsx
+++ b/core/ui/vault/chain/tron/ResourcesCard.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { InfoCircleIcon } from '@lib/ui/icons/InfoCircleIcon'
 import { TronBandwidthIcon } from '@lib/ui/icons/TronBandwidthIcon'
 import { TronEnergyIcon } from '@lib/ui/icons/TronEnergyIcon'
@@ -25,7 +26,7 @@ const energyAccent = '#FFC25C'
 const Card = styled(VStack)`
   flex: 1;
   padding: 12px;
-  border-radius: 8px;
+  ${borderRadius.sm};
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('background')};
   gap: 16px;
@@ -36,7 +37,7 @@ const BandwidthIconBox = styled.div`
   align-items: center;
   justify-content: center;
   padding: 8px;
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: rgba(19, 200, 157, 0.1);
   flex-shrink: 0;
 `
@@ -46,7 +47,7 @@ const EnergyIconBox = styled.div`
   align-items: center;
   justify-content: center;
   padding: 8px;
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: #1b2430;
   flex-shrink: 0;
 `

--- a/core/ui/vault/chain/tron/TronResourceBar.tsx
+++ b/core/ui/vault/chain/tron/TronResourceBar.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { toPercents } from '@vultisig/lib-utils/toPercents'
 import styled from 'styled-components'
 
@@ -9,14 +10,14 @@ type TronResourceBarProps = {
 const Track = styled.div`
   width: 100%;
   height: 8px;
-  border-radius: 12px;
+  ${borderRadius.pill};
   background: #11284a;
   overflow: hidden;
 `
 
 const Fill = styled.div<TronResourceBarProps>`
   height: 100%;
-  border-radius: 12px;
+  ${borderRadius.pill};
   background: ${({ $color }) => $color};
   width: ${({ $percentage }) =>
     toPercents(Math.max(Math.min($percentage, 1), 0))};

--- a/core/ui/vault/chain/tron/TronResourcesInfoModal.tsx
+++ b/core/ui/vault/chain/tron/TronResourcesInfoModal.tsx
@@ -2,6 +2,7 @@ import { ChainEntityIcon } from '@core/ui/chain/coin/icon/ChainEntityIcon'
 import { getChainLogoSrc } from '@core/ui/chain/metadata/getChainLogoSrc'
 import { useCore } from '@core/ui/state/core'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import CaretDownIcon from '@lib/ui/icons/CaretDownIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { TronBandwidthIcon } from '@lib/ui/icons/TronBandwidthIcon'
@@ -180,7 +181,7 @@ const ContentContainer = styled(VStack)`
   @media ${mediaQuery.tabletDeviceAndUp} {
     padding: 24px;
     background: ${getColor('background')};
-    border-radius: 12px;
+    ${borderRadius.md};
     border: 1px solid ${getColor('mistExtra')};
     max-width: 480px;
     width: 100%;
@@ -192,7 +193,7 @@ const BandwidthIconCircle = styled.div`
   align-items: center;
   justify-content: center;
   padding: 8px;
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: rgba(19, 200, 157, 0.1);
   flex-shrink: 0;
 `
@@ -202,7 +203,7 @@ const EnergyIconCircle = styled.div`
   align-items: center;
   justify-content: center;
   padding: 8px;
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: #1b2430;
   flex-shrink: 0;
 `
@@ -221,7 +222,7 @@ const RowWrapper = styled.div`
 `
 
 const AccordionWrapper = styled.div`
-  border-radius: 12px;
+  ${borderRadius.md};
   background-color: ${getColor('foreground')};
 
   & > ${RowWrapper}:first-of-type {


### PR DESCRIPTION
B.1 of #4623. 17 files in `core/ui/vault/chain`.

## Off-scale values that move

All in `AddressQRCard`, which is one surface described by four different radii:

| element | from | to |
|---|---|---|
| card | 24 | 24 |
| QR frame | 32 32 24 24 | 24 |
| QR wrapper | 32 32 24 24 | 24 |
| receive label | 0 0 20 20 | 0 0 24 24 |

The card, the frame stacked inside it and the label pinned to its bottom edge disagreed by up to 8px. They are now one radius, with the label keeping its bottom-only rounding because it sits flush against the card edge.

## A capsule in disguise

`TronResourceBar` sets `border-radius: 12px` on an 8px-tall track and its fill - already clamping to 4, so it was a capsule all along. Both become `pill`, no visual change.

## Everything else

Token-for-value at 8, 12 and 24, plus the usual `999px` / `99px` / `50%` / `round` collapse into `pill`.

`TokenItem` and `ChainItem` carry the same `40px 0 25px 0` notched badge as `SelectableItem` and the defi tiles - left as-is with the same comment.

## Validation

`yarn check` clean, `yarn test` 942 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
