### PR TITLE
refactor(ui): vault settings and backup surfaces adopt the corner-radius scale

### DIFF
--- a/core/ui/vault/backup/VaultBackupWithoutPassword.tsx
+++ b/core/ui/vault/backup/VaultBackupWithoutPassword.tsx
@@ -1,6 +1,7 @@
 import { FlowPageHeader } from '@core/ui/flow/FlowPageHeader'
 import { useBackupVaultMutation } from '@core/ui/vault/mutations/useBackupVaultMutation'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { FileWarningIcon } from '@lib/ui/icons/FileWarningIcon'
@@ -21,7 +22,7 @@ const IconContainer = styled.div`
   ${sameDimensions(64)};
   ${centerContent};
   font-size: 32px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   align-self: center;
   background: ${getColor('foregroundExtra')};
 `

--- a/core/ui/vault/backup/fast/SaveBackupToCloudScreen.tsx
+++ b/core/ui/vault/backup/fast/SaveBackupToCloudScreen.tsx
@@ -1,6 +1,7 @@
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { backupSplashAnimationSource } from '@core/ui/vault/backup/getBackupAnimationSource'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CloudUploadIcon } from '@lib/ui/icons/CloudUploadIcon'
 import { Checkbox } from '@lib/ui/inputs/checkbox/Checkbox'
 import { VStack } from '@lib/ui/layout/Stack'
@@ -98,7 +99,7 @@ const IconWrapper = styled.div`
   position: relative;
   width: 40px;
   height: 40px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: #03132c;
   border: 1.5px solid rgba(255, 255, 255, 0.15);
   box-shadow: 0 2.051px 2.051px 0 rgba(0, 0, 0, 0.25) inset;
@@ -117,7 +118,7 @@ const IconWrapper = styled.div`
     width: 24px;
     height: 8px;
     background: #0c4eff;
-    border-radius: 50%;
+    ${borderRadius.pill};
     pointer-events: none;
     filter: blur(8px);
     opacity: 0.6;

--- a/core/ui/vault/backup/fast/VaultCreatedSuccessScreen.tsx
+++ b/core/ui/vault/backup/fast/VaultCreatedSuccessScreen.tsx
@@ -1,6 +1,7 @@
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { Animation } from '@lib/ui/animations/Animation'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ShieldCheckFilledIcon } from '@lib/ui/icons/ShieldCheckFilledIcon'
 import { VStack } from '@lib/ui/layout/Stack'
 import { PageContent } from '@lib/ui/page/PageContent'
@@ -59,7 +60,7 @@ const IconWrapper = styled.div`
   position: relative;
   width: 40px;
   height: 40px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: #03132c;
   border: 1.5px solid rgba(255, 255, 255, 0.15);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.25) inset;
@@ -79,7 +80,7 @@ const IconShadow = styled.div`
   opacity: 0.5;
   background: ${getColor('success')};
   filter: blur(9px);
-  border-radius: 50%;
+  ${borderRadius.pill};
   pointer-events: none;
 `
 

--- a/core/ui/vault/backup/fast/index.tsx
+++ b/core/ui/vault/backup/fast/index.tsx
@@ -1,6 +1,7 @@
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { EmailNotificationIcon } from '@lib/ui/icons/EmailNotificationIcon'
 import {
   MultiCharacterInput,
@@ -128,7 +129,7 @@ const IconWrapper = styled.div`
   position: relative;
   width: 40px;
   height: 40px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: #03132c;
   border: 1.5px solid rgba(255, 255, 255, 0.15);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.25) inset;
@@ -149,7 +150,7 @@ const IconWrapper = styled.div`
       rgba(37, 97, 255, 0.4) 0%,
       transparent 70%
     );
-    border-radius: 50%;
+    ${borderRadius.pill};
     pointer-events: none;
   }
 `

--- a/core/ui/vault/backup/secure/ReviewVaultDevicesScreen.tsx
+++ b/core/ui/vault/backup/secure/ReviewVaultDevicesScreen.tsx
@@ -1,5 +1,6 @@
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { BrowserExtensionIcon } from '@lib/ui/icons/BrowserExtensionIcon'
 import { DeviceIcon } from '@lib/ui/icons/DeviceIcon'
 import { LaptopIcon } from '@lib/ui/icons/LaptopIcon'
@@ -175,7 +176,7 @@ const DeviceCard = styled(HStack)`
   align-items: center;
   gap: 12px;
   padding: 12px 16px;
-  border-radius: 24px;
+  ${borderRadius.xl};
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
 `
@@ -183,7 +184,7 @@ const DeviceCard = styled(HStack)`
 const DeviceIconCircle = styled.div`
   width: 32px;
   height: 32px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: #03132c;
   border: 1.5px solid rgba(255, 255, 255, 0.15);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.25) inset;

--- a/core/ui/vault/backup/select/OptionContainer.tsx
+++ b/core/ui/vault/backup/select/OptionContainer.tsx
@@ -21,7 +21,7 @@ const Header = styled.div`
 
 const Container = styled(UnstyledButton)`
   padding: 12px;
-  ${borderRadius.m};
+  ${borderRadius.md};
   font-size: 14px;
   border: 1px solid ${getColor('foregroundExtra')};
   ${vStack({

--- a/core/ui/vault/backup/select/VaultList.tsx
+++ b/core/ui/vault/backup/select/VaultList.tsx
@@ -9,7 +9,7 @@ import { VaultItem } from './VaultItem'
 
 const Container = styled(StackSeparatedBy)`
   background: ${getColor('foregroundExtra')};
-  ${borderRadius.m};
+  ${borderRadius.md};
   overflow: hidden;
   width: 100%;
 `

--- a/core/ui/vault/settings/advanced/customRpc/CustomRpcDetailPage.tsx
+++ b/core/ui/vault/settings/advanced/customRpc/CustomRpcDetailPage.tsx
@@ -8,6 +8,7 @@ import {
   useSetCustomRpcOverrideMutation,
 } from '@core/ui/storage/customRpcOverrides'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { VStack } from '@lib/ui/layout/Stack'
 import { PageContent as BasePageContent } from '@lib/ui/page/PageContent'
 import { PageFooter as BasePageFooter } from '@lib/ui/page/PageFooter'
@@ -226,7 +227,7 @@ const RpcTextAreaWrapper = styled.div<{ $invalid: boolean }>`
   border: 1px solid
     ${({ $invalid }) =>
       $invalid ? getColor('danger') : getColor('foregroundSuper')};
-  border-radius: 12px;
+  ${borderRadius.md};
   display: flex;
   gap: 4px;
   min-height: 120px;
@@ -259,7 +260,7 @@ const PasteAction = styled(InputPasteAction)`
 const DefaultEndpointCard = styled(VStack)`
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundSuper')};
-  border-radius: 12px;
+  ${borderRadius.md};
   gap: 20px;
   padding: 16px;
 `

--- a/core/ui/vault/settings/advanced/customRpc/index.tsx
+++ b/core/ui/vault/settings/advanced/customRpc/index.tsx
@@ -3,6 +3,7 @@ import { getChainLogoSrc } from '@core/ui/chain/metadata/getChainLogoSrc'
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { useCustomRpcOverrides } from '@core/ui/storage/customRpcOverrides'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { PencilIcon } from '@lib/ui/icons/PenciIcon'
 import { SearchIcon } from '@lib/ui/icons/SearchIcon'
 import { VStack } from '@lib/ui/layout/Stack'
@@ -142,7 +143,7 @@ const SearchInput = ({ value, onChange, placeholder }: SearchInputProps) => (
 const SearchWrapper = styled.div`
   align-items: center;
   background: ${getColor('foreground')};
-  border-radius: 99px;
+  ${borderRadius.pill};
   box-shadow: inset 0 0 8px rgba(240, 244, 252, 0.03);
   color: ${getColor('textShy')};
   display: flex;
@@ -203,7 +204,7 @@ const ChainIconFrame = styled.div<{ $isCustom: boolean }>`
   border: 1.5px solid
     ${({ $isCustom }) =>
       $isCustom ? getColor('foregroundExtra') : 'transparent'};
-  border-radius: 24px;
+  ${borderRadius.xl};
   display: flex;
   height: 74px;
   justify-content: center;

--- a/core/ui/vault/settings/backup/BackupModal.tsx
+++ b/core/ui/vault/settings/backup/BackupModal.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { CloseIcon } from '@lib/ui/icons/CloseIcon'
 import { CloudIcon } from '@lib/ui/icons/CloudIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
@@ -89,7 +90,7 @@ const Wrapper = styled.div`
   })};
 
   padding: 20px;
-  border-radius: 16px 16px 0 0;
+  border-radius: ${borderRadiusPx.xl}px ${borderRadiusPx.xl}px 0 0;
   background: ${getColor('background')};
 `
 
@@ -100,7 +101,7 @@ const DesktopModalWrapper = styled.div`
 const ActionButton = styled(UnstyledButton)`
   width: 44px;
   height: 44px;
-  border-radius: 50%;
+  ${borderRadius.pill};
 `
 
 const CancelButton = styled(ActionButton)`

--- a/core/ui/vault/settings/backup/BackupOption.tsx
+++ b/core/ui/vault/settings/backup/BackupOption.tsx
@@ -24,7 +24,7 @@ const Container = styled(UnstyledButton)`
     gap: 12,
     alignItems: 'center',
   })}
-  ${borderRadius.l};
+  ${borderRadius.xl};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   padding: 16px;

--- a/core/ui/vault/settings/delete/index.tsx
+++ b/core/ui/vault/settings/delete/index.tsx
@@ -5,6 +5,7 @@ import { useDeleteVaultMutation, useVaults } from '@core/ui/storage/vaults'
 import { useVaultTotalBalanceQuery } from '@core/ui/vault/queries/useVaultTotalBalanceQuery'
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { TriangleAlertIcon } from '@lib/ui/icons/TriangleAlertIcon'
 import { Checkbox } from '@lib/ui/inputs/checkbox/Checkbox'
@@ -170,7 +171,7 @@ const Item = styled.div`
     gap: 12,
   })};
 
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
   min-width: 0;

--- a/core/ui/vault/settings/details/VaultDetailsContent.tsx
+++ b/core/ui/vault/settings/details/VaultDetailsContent.tsx
@@ -1,5 +1,6 @@
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CopyIcon } from '@lib/ui/icons/CopyIcon'
 import { DeviceIcon } from '@lib/ui/icons/DeviceIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
@@ -19,7 +20,7 @@ const Item = styled.div`
     gap: 12,
   })};
 
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
 `

--- a/core/ui/vault/settings/index.tsx
+++ b/core/ui/vault/settings/index.tsx
@@ -1,5 +1,6 @@
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CircleInfoIcon } from '@lib/ui/icons/CircleInfoIcon'
 import { FolderKeyIcon } from '@lib/ui/icons/FolderKeyIcon'
 import { PenWritingFilledIcon } from '@lib/ui/icons/PenWritingFilledIcon'
@@ -113,7 +114,7 @@ const DeleteButtonIconWrapper = styled(ListItemIconWrapper)`
 `
 
 const DeleteItem = styled(ListItem)`
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 export { ListItemIconWrapper } from './vaultSettingsListStyles'

--- a/core/ui/vault/settings/referral/components/AddFriendsReferralPrompt.tsx
+++ b/core/ui/vault/settings/referral/components/AddFriendsReferralPrompt.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { Image } from '@lib/ui/image/Image'
 import { VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
@@ -49,7 +50,7 @@ const FriendsReferralPromptWrapper = styled(VStack)`
 
   cursor: pointer;
 
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
 `

--- a/core/ui/vault/settings/referral/components/CreateReferral/CreateReferralForm/Fields/ReferralCodeField.tsx
+++ b/core/ui/vault/settings/referral/components/CreateReferral/CreateReferralForm/Fields/ReferralCodeField.tsx
@@ -1,5 +1,6 @@
 import { Match } from '@lib/ui/base/Match'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { TextInput } from '@lib/ui/inputs/TextInput'
 import { CenterAbsolutely } from '@lib/ui/layout/CenterAbsolutely'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -144,7 +145,7 @@ const StatusPill = styled.div`
   padding: 8px 12px;
   align-items: center;
   gap: 4px;
-  border-radius: 99px;
+  ${borderRadius.pill};
   border: 1.5px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
 `

--- a/core/ui/vault/settings/referral/components/EditReferral/EditReferralForm/Fields/PayoutAssetField.tsx
+++ b/core/ui/vault/settings/referral/components/EditReferral/EditReferralForm/Fields/PayoutAssetField.tsx
@@ -118,5 +118,5 @@ const PayoutAssetTrigger = styled(HStack)`
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
   cursor: pointer;
-  ${borderRadius.m};
+  ${borderRadius.md};
 `

--- a/core/ui/vault/settings/referral/components/EditReferral/EditReferralForm/Fields/ReferralCodeField.tsx
+++ b/core/ui/vault/settings/referral/components/EditReferral/EditReferralForm/Fields/ReferralCodeField.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CopyIcon } from '@lib/ui/icons/CopyIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { VStack } from '@lib/ui/layout/Stack'
@@ -34,7 +35,7 @@ export const ReferralCodeField = () => {
 }
 
 const FieldWrapper = styled(VStack)`
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
   padding: 14px;

--- a/core/ui/vault/settings/referral/components/ManageExistingReferral.tsx
+++ b/core/ui/vault/settings/referral/components/ManageExistingReferral.tsx
@@ -2,6 +2,7 @@ import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { Opener } from '@lib/ui/base/Opener'
 import { Button } from '@lib/ui/buttons/Button'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ArrowUndoIcon } from '@lib/ui/icons/ArrowUndoIcon'
 import { ChevronRightIcon } from '@lib/ui/icons/ChevronRightIcon'
 import { CopyIcon } from '@lib/ui/icons/CopyIcon'
@@ -232,7 +233,7 @@ const Wrapper = styled(VStack)`
 
   border: 1px solid ${getColor('foregroundExtra')};
   padding: 14px;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: rgba(2, 18, 43, 0.5);
 `
 
@@ -241,7 +242,7 @@ const RewardsCollectedWrapper = styled(VStack)`
   overflow: hidden;
 
   &::before {
-    border-radius: 12px;
+    ${borderRadius.md};
     content: '';
     position: absolute;
     inset: 0;
@@ -268,7 +269,7 @@ const FieldIconWrapper = styled(IconWrapper)`
 const FriendsReferralCode = styled(VStack)`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 const ReferralsThorchainLogoWrapper = styled.div`

--- a/core/ui/vault/settings/referral/components/ManageMissingReferral.tsx
+++ b/core/ui/vault/settings/referral/components/ManageMissingReferral.tsx
@@ -1,6 +1,7 @@
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { Opener } from '@lib/ui/base/Opener'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ChevronRightIcon } from '@lib/ui/icons/ChevronRightIcon'
 import { FileQuestionIcon } from '@lib/ui/icons/FileQuestionIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
@@ -132,7 +133,7 @@ const Wrapper = styled(VStack)`
 
   border: 1px solid ${getColor('foregroundExtra')};
   padding: 14px;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: rgba(2, 18, 43, 0.5);
 `
 
@@ -144,7 +145,7 @@ const NoReferralDescriptionWrapper = styled(VStack)`
 
   padding: 36px 12px 24px 12px;
   gap: 20px;
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid ${getColor('foregroundExtra')};
   background: rgba(2, 18, 43, 0.5);
 `

--- a/core/ui/vault/settings/referral/components/ManageReferrals.tsx
+++ b/core/ui/vault/settings/referral/components/ManageReferrals.tsx
@@ -3,6 +3,7 @@ import { useAssertCurrentVaultId } from '@core/ui/storage/currentVaultId'
 import { useFriendReferralQuery } from '@core/ui/storage/referrals'
 import { Match } from '@lib/ui/base/Match'
 import { StepTransition } from '@lib/ui/base/StepTransition'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ChevronRightIcon } from '@lib/ui/icons/ChevronRightIcon'
 import { MegaphoneIcon } from '@lib/ui/icons/MegaphoneIcon'
 import { UserSparkleIcon } from '@lib/ui/icons/UserSparkleIcon'
@@ -199,7 +200,7 @@ const ActionDescription = styled(Text)`
 const ActionItem = styled(HStack)`
   align-items: center;
   background-color: ${getColor('foreground')};
-  border-radius: 16px;
+  ${borderRadius.lg};
   cursor: pointer;
   gap: 24px;
   justify-content: space-between;

--- a/core/ui/vault/settings/referral/components/ReferralLanding.tsx
+++ b/core/ui/vault/settings/referral/components/ReferralLanding.tsx
@@ -37,7 +37,7 @@ export const ReferralLanding = ({ onFinish }: OnFinishProp) => {
 
 const Wrapper = styled(VStack)`
   background-color: ${getColor('foregroundExtra')};
-  ${borderRadius.m}
+  ${borderRadius.md}
   bottom: 0;
   height: 500px;
   left: 0;
@@ -67,11 +67,11 @@ const Overlay = styled.div`
 `
 
 const PositionedImage = styled.img`
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 const ImageWrapper = styled(VStack)`
-  border-radius: 34px;
+  ${borderRadius.xl};
   box-shadow:
     0px -1px 4px 0px rgba(255, 255, 255, 0.2) inset,
     -2px 0px 5px -3px rgba(255, 255, 255, 0.4) inset;
@@ -85,7 +85,7 @@ const ImageWrapper = styled(VStack)`
 
   &::before {
     background-color: rgba(0, 0, 0, 0.1);
-    border-radius: 34px;
+    ${borderRadius.xl};
     content: '';
     height: 100%;
     left: 0;

--- a/core/ui/vault/settings/referral/components/ReferralSummary.tsx
+++ b/core/ui/vault/settings/referral/components/ReferralSummary.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { GroupOneIcon } from '@lib/ui/icons/GroupOneIcon'
 import { Keyboard3Icon } from '@lib/ui/icons/Keyboard3Icon'
 import { MegaphoneIcon } from '@lib/ui/icons/MegaphoneIcon'
@@ -90,7 +91,7 @@ const Item = styled(HStack)`
   align-items: center;
   background-color: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 16px;
+  ${borderRadius.lg};
   gap: 12px;
   padding: 16px;
   position: relative;
@@ -123,7 +124,7 @@ const Label = styled(HStack)`
   background-color: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   border-left: none;
-  border-radius: 0 16px 16px 0;
+  border-radius: 0 ${borderRadiusPx.lg}px ${borderRadiusPx.lg}px 0;
   color: ${getColor('textShy')};
   font-size: 12px;
   gap: 8px;

--- a/core/ui/vault/settings/referral/components/Referrals.styled.tsx
+++ b/core/ui/vault/settings/referral/components/Referrals.styled.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CenterAbsolutely } from '@lib/ui/layout/CenterAbsolutely'
 import { HStack, VStack, vStack } from '@lib/ui/layout/Stack'
 import { PageContent } from '@lib/ui/page/PageContent'
@@ -66,7 +67,7 @@ export const Overlay = styled.div`
 `
 
 export const fieldWrapperStyles = css`
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid ${getColor('foregroundExtra')};
   padding: 14px;
 `
@@ -82,7 +83,7 @@ export const HorizontalFieldWrapper = styled(HStack)`
 `
 
 export const VaultFieldWrapper = styled(HorizontalFieldWrapper)`
-  border-radius: 99px;
+  ${borderRadius.pill};
   cursor: pointer;
   transition: background-color 0.2s ease-in-out;
 

--- a/core/ui/vault/settings/vaultFaq/FaqVaultPage.tsx
+++ b/core/ui/vault/settings/vaultFaq/FaqVaultPage.tsx
@@ -1,4 +1,5 @@
 import { FlowPageHeader } from '@core/ui/flow/FlowPageHeader'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import CaretDownIcon from '@lib/ui/icons/CaretDownIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -124,7 +125,7 @@ const FaqContent = styled.div`
 `
 
 const RowsWrapper = styled.div`
-  border-radius: 12px;
+  ${borderRadius.md};
   background-color: ${getColor('foreground')};
 
   & > ${RowWrapper}:first-of-type {


### PR DESCRIPTION
B.2 of #4623. 25 files across `core/ui/vault/settings` and `core/ui/vault/backup`.

Referral-heavy, and mostly token-for-value at 12 and 16 with no visual change.

## Off-scale values that move

| | from | to | where |
|---|---|---|---|
| promo card | 34 | 24 | `ReferralLanding` image wrapper and its `::before` |
| card | 20 | 24 | `BackupOption` |
| sheet | 16 | 24 | `BackupModal` |

`BackupOption` is the **second of the three `borderRadius.l` (20) orphans** called out in #4622. 20 is not on the scale, and the token carries a note saying so rather than being renamed - renaming it to `lg` would have shrunk this card by 4px with nothing visible in review. It is a bordered card with 16px padding, so it resolves upward to `xl`. One orphan left, in `AmountSwitch` (B.3).

`BackupModal` is the second sheet to converge on 24, after `ShareAppModal` in part 1.

## Surfaces that round individual corners

`ReferralSummary`s label sits flush against the panel to its left - `border-left: none` and rounding only on the right. It keeps that shape, composed from `borderRadiusPx.lg`.

## Deliberate skips

Three decorative glow blobs, out of scope per #4623:

```
Referrals.styled.tsx            416px
AddFriendsReferralPrompt.tsx    350px
settings/delete/index.tsx       512px
```

## Validation

`yarn check` clean, `yarn test` 942 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
