### PR TITLE
refactor(ui): vault transaction flows adopt the corner-radius scale

### DIFF
--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/BondSpecific/BondForm.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/BondSpecific/BondForm.tsx
@@ -12,6 +12,7 @@ import { useDepositFormHandlers } from '@core/ui/vault/deposit/providers/Deposit
 import { stepFromDecimals } from '@core/ui/vault/deposit/utils/stepFromDecimals'
 import { AmountSuggestion } from '@core/ui/vault/send/amount/AmountSuggestion'
 import { ActionInsideInteractiveElement } from '@lib/ui/base/ActionInsideInteractiveElement'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CameraIcon } from '@lib/ui/icons/CameraIcon'
 import { CheckmarkIcon } from '@lib/ui/icons/CheckmarkIcon'
 import { ChevronDownIcon } from '@lib/ui/icons/ChevronDownIcon'
@@ -459,7 +460,7 @@ export const BondForm = ({
 const SuggestionOption = styled(AmountSuggestion)`
   flex: 1;
   padding: 6px 18px;
-  border-radius: 99px;
+  ${borderRadius.pill};
 `
 
 const FixedScanQRView = styled(ScanQrView)`
@@ -542,7 +543,7 @@ const FilledTextInput = styled(TextInput)`
   justify-content: space-between;
   align-items: center;
   align-self: stretch;
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid #11284a;
   background: #061b3a;
   font-size: 16px;

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/ClaimRewardsSpecific.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/ClaimRewardsSpecific.tsx
@@ -3,6 +3,7 @@ import { useCosmosRewardsQuery } from '@core/ui/chain/cosmos/staking/queries/use
 import { stakingDenomForChain } from '@core/ui/chain/cosmos/staking/stakingDenom'
 import { useDepositCoin } from '@core/ui/vault/deposit/providers/DepositCoinProvider'
 import { useDepositFormHandlers } from '@core/ui/vault/deposit/providers/DepositFormHandlersProvider'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { VStack } from '@lib/ui/layout/Stack'
 import { Spinner } from '@lib/ui/loaders/Spinner'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
@@ -115,5 +116,5 @@ export const ClaimRewardsSpecific = () => {
 const Card = styled(VStack).attrs({ gap: 8 })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/DelegateSpecific.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/DelegateSpecific.tsx
@@ -1,6 +1,7 @@
 import { useBalanceQuery } from '@core/ui/chain/coin/queries/useBalanceQuery'
 import { useDepositCoin } from '@core/ui/vault/deposit/providers/DepositCoinProvider'
 import { useDepositFormHandlers } from '@core/ui/vault/deposit/providers/DepositFormHandlersProvider'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { PercentageSelector } from '@lib/ui/inputs/PercentageSelector'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
@@ -118,7 +119,7 @@ const Layout = styled(VStack).attrs({ flexGrow: true, gap: 16 })``
 const Card = styled(VStack).attrs({ gap: 12, flexGrow: true })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 const CenteredAmount = styled.div`

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/RedelegateSpecific.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/RedelegateSpecific.tsx
@@ -2,6 +2,7 @@ import { ActiveDelegationPicker } from '@core/ui/chain/cosmos/staking/components
 import { useCosmosDelegationsQuery } from '@core/ui/chain/cosmos/staking/queries/useCosmosDelegationsQuery'
 import { useDepositCoin } from '@core/ui/vault/deposit/providers/DepositCoinProvider'
 import { useDepositFormHandlers } from '@core/ui/vault/deposit/providers/DepositFormHandlersProvider'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { Slider } from '@lib/ui/inputs/Slider'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
@@ -146,7 +147,7 @@ const Layout = styled(VStack).attrs({ flexGrow: true, gap: 16 })``
 const Card = styled(VStack).attrs({ gap: 12, flexGrow: true })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 const CenteredAmount = styled.div`

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/UndelegateSpecific.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/UndelegateSpecific.tsx
@@ -2,6 +2,7 @@ import { ActiveDelegationPicker } from '@core/ui/chain/cosmos/staking/components
 import { useCosmosDelegationsQuery } from '@core/ui/chain/cosmos/staking/queries/useCosmosDelegationsQuery'
 import { useDepositCoin } from '@core/ui/vault/deposit/providers/DepositCoinProvider'
 import { useDepositFormHandlers } from '@core/ui/vault/deposit/providers/DepositFormHandlersProvider'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { Slider } from '@lib/ui/inputs/Slider'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
@@ -148,7 +149,7 @@ export const UndelegateSpecific = () => {
 const Card = styled(VStack).attrs({ gap: 12 })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 const CenteredAmount = styled.div`

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/ValidatorPickerField.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/ValidatorPickerField.tsx
@@ -2,6 +2,7 @@ import { ValidatorAvatar } from '@core/ui/chain/cosmos/staking/components/Valida
 import { ValidatorPickerSheet } from '@core/ui/chain/cosmos/staking/components/ValidatorPickerSheet'
 import { useCosmosValidatorsQuery } from '@core/ui/chain/cosmos/staking/queries/useCosmosValidatorsQuery'
 import { Opener } from '@lib/ui/base/Opener'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CircleCheckIcon } from '@lib/ui/icons/CircleCheckIcon'
 import { IconFileEdit } from '@lib/ui/icons/IconFileEdit'
 import { HStack } from '@lib/ui/layout/Stack'
@@ -102,7 +103,7 @@ const FieldContainer = styled.button.attrs({ type: 'button' as const })`
   justify-content: space-between;
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
   cursor: pointer;
   background: transparent;
   color: inherit;

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/FreezeSpecific/TronResourceTypePicker.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/FreezeSpecific/TronResourceTypePicker.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -45,7 +46,7 @@ export const TronResourceTypePicker = ({
 }
 
 const Container = styled(HStack)`
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: ${getColor('foreground')};
   padding: 2px;
   gap: 2px;
@@ -55,7 +56,7 @@ const Option = styled.button<{ $active: boolean }>`
   flex: 1;
   padding: 8px 16px;
   border: none;
-  border-radius: 6px;
+  ${borderRadius.xs};
   cursor: pointer;
   background: ${({ $active, theme }) =>
     $active ? theme.colors.foregroundExtra.toCssValue() : 'transparent'};

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/SolanaStakingSpecific/SolanaDelegateSpecific.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/SolanaStakingSpecific/SolanaDelegateSpecific.tsx
@@ -3,6 +3,7 @@ import { useSolanaStakeableBalance } from '@core/ui/vault/deposit/hooks/useSolan
 import { useDepositCoin } from '@core/ui/vault/deposit/providers/DepositCoinProvider'
 import { useDepositFormHandlers } from '@core/ui/vault/deposit/providers/DepositFormHandlersProvider'
 import { getFieldErrorMessage } from '@core/ui/vault/deposit/utils/getFieldErrorMessage'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { PercentageSelector } from '@lib/ui/inputs/PercentageSelector'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
@@ -124,7 +125,7 @@ const Layout = styled(VStack).attrs({ flexGrow: true, gap: 16 })``
 const Card = styled(VStack).attrs({ gap: 12, flexGrow: true })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 const CenteredAmount = styled.div`

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/SolanaStakingSpecific/SolanaFinishMoveSpecific.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/SolanaStakingSpecific/SolanaFinishMoveSpecific.tsx
@@ -1,6 +1,7 @@
 import { SolanaValidatorPickerField } from '@core/ui/chain/solana/staking/components/SolanaValidatorPickerField'
 import { useDepositCoin } from '@core/ui/vault/deposit/providers/DepositCoinProvider'
 import { useDepositFormHandlers } from '@core/ui/vault/deposit/providers/DepositFormHandlersProvider'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -62,7 +63,7 @@ const Layout = styled(VStack).attrs({ gap: 16 })``
 const Card = styled(VStack).attrs({ gap: 12 })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 const Row = styled.div`
@@ -74,6 +75,6 @@ const Row = styled.div`
 
 const Notice = styled.div`
   padding: 12px 16px;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('foreground')};
 `

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/SolanaStakingSpecific/SolanaMoveStakeSpecific.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/SolanaStakingSpecific/SolanaMoveStakeSpecific.tsx
@@ -2,6 +2,7 @@ import { SolanaValidatorPickerField } from '@core/ui/chain/solana/staking/compon
 import { useSolanaValidatorsQuery } from '@core/ui/chain/solana/staking/queries/useSolanaValidatorsQuery'
 import { useDepositCoin } from '@core/ui/vault/deposit/providers/DepositCoinProvider'
 import { useDepositFormHandlers } from '@core/ui/vault/deposit/providers/DepositFormHandlersProvider'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -96,7 +97,7 @@ export const SolanaMoveStakeSpecific = () => {
 const Card = styled(VStack).attrs({ gap: 12 })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 const Row = styled.div`
@@ -108,6 +109,6 @@ const Row = styled.div`
 
 const Notice = styled.div`
   padding: 12px 16px;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('foreground')};
 `

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/SolanaStakingSpecific/SolanaStakingInfoCard.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/SolanaStakingSpecific/SolanaStakingInfoCard.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -44,7 +45,7 @@ export const SolanaStakingInfoCard = ({
 const Card = styled(VStack).attrs({ gap: 12 })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 const Row = styled.div`
@@ -56,6 +57,6 @@ const Row = styled.div`
 
 const Notice = styled.div`
   padding: 12px 16px;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('foreground')};
 `

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/UnbondSpecific/UnbondForm.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/UnbondSpecific/UnbondForm.tsx
@@ -7,6 +7,7 @@ import { useDepositCoin } from '@core/ui/vault/deposit/providers/DepositCoinProv
 import { useDepositFormHandlers } from '@core/ui/vault/deposit/providers/DepositFormHandlersProvider'
 import { stepFromDecimals } from '@core/ui/vault/deposit/utils/stepFromDecimals'
 import { ActionInsideInteractiveElement } from '@lib/ui/base/ActionInsideInteractiveElement'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CheckmarkIcon } from '@lib/ui/icons/CheckmarkIcon'
 import { PencilIcon } from '@lib/ui/icons/PenciIcon'
 import { InputLabel } from '@lib/ui/inputs/InputLabel'
@@ -293,7 +294,7 @@ const PencilIconWrapper = styled.div`
 
 const AddressDisplay = styled.div`
   padding: 16px;
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid #11284a;
   background: #061b3a;
   font-size: 16px;

--- a/core/ui/vault/send/addresses/components/AddressBookModal/AddressBookItemAvatar.tsx
+++ b/core/ui/vault/send/addresses/components/AddressBookModal/AddressBookItemAvatar.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
 
@@ -18,7 +19,7 @@ export const AddressBookItemAvatar = ({ name, address }: VaultAvatarProps) => {
 const Circle = styled.div`
   width: 32px;
   height: 32px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   color: ${getColor('text')};
   flex-shrink: 0;
   display: flex;

--- a/core/ui/vault/send/addresses/components/AddressBookModal/VaultAddressBookItem.tsx
+++ b/core/ui/vault/send/addresses/components/AddressBookModal/VaultAddressBookItem.tsx
@@ -44,7 +44,7 @@ export const VaultAddressBookItem = ({
 const AddressBookListItem = styled(ListItem)`
   background-color: transparent;
   border: 1px solid ${getColor('foregroundExtra')};
-  ${borderRadius.m};
+  ${borderRadius.md};
   padding: 16px 20px;
   max-height: 68px;
 `

--- a/core/ui/vault/send/addresses/components/AddressBookModal/index.tsx
+++ b/core/ui/vault/send/addresses/components/AddressBookModal/index.tsx
@@ -225,7 +225,7 @@ const ModalWrapper = styled(VStack)`
   height: 500px;
   width: 100%;
   background: ${getColor('foreground')};
-  ${borderRadius.m};
+  ${borderRadius.md};
   padding: 24px 20px;
 
   @media ${mediaQuery.tabletDeviceAndUp} {
@@ -235,7 +235,7 @@ const ModalWrapper = styled(VStack)`
 
 const OptionsContainer = styled(HStack)`
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 100%;
+  ${borderRadius.pill};
 `
 
 const StyledList = styled(List)`

--- a/core/ui/vault/send/addresses/components/ManageAddressesInputField.tsx
+++ b/core/ui/vault/send/addresses/components/ManageAddressesInputField.tsx
@@ -286,7 +286,7 @@ const AddressFieldWrapper = styled(VStack)`
   background-color: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   padding: 16px;
-  ${borderRadius.m}
+  ${borderRadius.md}
 `
 
 const Input = styled(TextInput)<{

--- a/core/ui/vault/send/amount/AmountSuggestion.tsx
+++ b/core/ui/vault/send/amount/AmountSuggestion.tsx
@@ -14,7 +14,7 @@ const Container = styled(UnstyledButton)<{
 }>`
   width: 56px;
   height: 30px;
-  ${borderRadius.s};
+  ${borderRadius.sm};
   ${centerContent};
   background-color: ${({ isActive }) =>
     isActive ? getColor('buttonPrimary') : getColor('foreground')};

--- a/core/ui/vault/send/amount/AmountSwitch.tsx
+++ b/core/ui/vault/send/amount/AmountSwitch.tsx
@@ -45,7 +45,7 @@ export const CurrencySwitch = ({ onClick, value }: Props) => {
 }
 
 const AnimatedIconButton = motion(styled(IconButton)<{ isActive: boolean }>`
-  border-radius: 50%;
+  ${borderRadius.pill};
   scale: ${({ isActive }) => (isActive ? 1.1 : 1)};
   opacity: ${({ isActive }) => (isActive ? 1 : 0.6)};
   transition:
@@ -58,9 +58,9 @@ const Wrapper = styled(VStack)`
   font-size: 16px;
   color: ${getColor('contrast')};
   background-color: ${getColor('foreground')};
-  ${borderRadius.l};
+  ${borderRadius.pill};
 
   > button {
-    border-radius: 50%;
+    ${borderRadius.pill};
   }
 `

--- a/core/ui/vault/send/amount/ManageAmountInputField.tsx
+++ b/core/ui/vault/send/amount/ManageAmountInputField.tsx
@@ -298,11 +298,11 @@ const StyledInputWrapper = styled(motion.div)`
 const TotalBalanceWrapper = styled(HStack)`
   background-color: ${getColor('foreground')};
   padding: 16px;
-  ${borderRadius.m}
+  ${borderRadius.md}
 `
 
 const SuggestionOption = styled(AmountSuggestion)`
   flex: 1;
   padding: 6px 18px;
-  border-radius: 99px;
+  ${borderRadius.pill};
 `

--- a/core/ui/vault/send/components/ChainOption.tsx
+++ b/core/ui/vault/send/components/ChainOption.tsx
@@ -56,7 +56,7 @@ export const ChainOption = ({
 const Container = styled('div')<{ isSelected?: boolean }>`
   ${panel()};
   padding: 12px 20px;
-  border-radius: 0px;
+  border-radius: 0;
   position: relative;
   cursor: pointer;
   background: ${({ isSelected }) =>

--- a/core/ui/vault/swap/components/ChainOption.tsx
+++ b/core/ui/vault/swap/components/ChainOption.tsx
@@ -57,7 +57,7 @@ export const ChainOption = ({
 const Container = styled('div')<{ isSelected?: boolean }>`
   ${panel()};
   padding: 12px 20px;
-  border-radius: 0px;
+  border-radius: 0;
   position: relative;
   cursor: pointer;
   background: ${({ isSelected }) =>

--- a/core/ui/vault/swap/components/RefreshSwap.tsx
+++ b/core/ui/vault/swap/components/RefreshSwap.tsx
@@ -1,5 +1,6 @@
 import 'react-circular-progressbar/dist/styles.css'
 
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -37,7 +38,7 @@ export const RefreshSwap = () => {
 const Wrapper = styled(HStack)`
   padding: 8px;
   background-color: ${getColor('foreground')};
-  border-radius: 99px;
+  ${borderRadius.pill};
 `
 
 const Progress = styled(CircularProgressbar)`

--- a/core/ui/vault/swap/components/SwapCoinInputField/SwapCoinInputField.styled.tsx
+++ b/core/ui/vault/swap/components/SwapCoinInputField/SwapCoinInputField.styled.tsx
@@ -1,3 +1,4 @@
+import { borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { textInputBackground } from '@lib/ui/css/textInput'
 import { VStack } from '@lib/ui/layout/Stack'
 import { text } from '@lib/ui/text'
@@ -17,6 +18,8 @@ export const Container = styled(VStack)<{
   })}
   padding: clamp(12px, 3.33vw, 16px);
   border-radius: ${({ side }) =>
-    side === 'to' ? '12px 12px 24px 24px' : '24px 24px 12px 12px'};
+    side === 'to'
+      ? `${borderRadiusPx.md}px ${borderRadiusPx.md}px ${borderRadiusPx.xl}px ${borderRadiusPx.xl}px`
+      : `${borderRadiusPx.xl}px ${borderRadiusPx.xl}px ${borderRadiusPx.md}px ${borderRadiusPx.md}px`};
   border: 1px solid ${getColor('foregroundExtra')};
 `

--- a/core/ui/vault/swap/form/ReverseSwap.tsx
+++ b/core/ui/vault/swap/form/ReverseSwap.tsx
@@ -1,5 +1,6 @@
 import { useSwapToCoin } from '@core/ui/vault/swap/state/toCoin'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { ArrowsRotateCenterIcon } from '@lib/ui/icons/ArrowsRotateCenterIcon'
@@ -75,7 +76,7 @@ export const ReverseSwap = ({ errorMessage }: ReverseSwapProps) => {
 
 const Wrapper = styled(HStack)`
   background-color: ${getColor('background')};
-  border-radius: 25.5px;
+  ${borderRadius.pill};
   padding: 7px;
   position: absolute;
   top: 50%;
@@ -88,7 +89,7 @@ const Wrapper = styled(HStack)`
     width: 54px;
     top: 0;
     height: 19px;
-    border-radius: 50px;
+    ${borderRadius.pill};
     border: 1px solid ${getColor('foregroundExtra')};
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
@@ -101,7 +102,7 @@ const Wrapper = styled(HStack)`
     width: 54px;
     bottom: 0px;
     height: 19px;
-    border-radius: 50px;
+    ${borderRadius.pill};
     border: 1px solid ${getColor('foregroundExtra')};
     border-top-right-radius: 0;
     border-top-left-radius: 0;
@@ -113,7 +114,7 @@ const Button = styled(UnstyledButton)<{ $hasError: boolean }>`
   ${sameDimensions(40)};
   background: ${({ $hasError }) =>
     $hasError ? getColor('danger') : getColor('buttonPrimary')};
-  border-radius: ${({ $hasError }) => ($hasError ? '18px' : '1000px')};
+  ${({ $hasError }) => ($hasError ? borderRadius.lg : borderRadius.pill)};
   border: 2px solid ${getColor('background')};
   ${centerContent};
   font-size: ${({ $hasError }) => ($hasError ? '20px' : '16px')};

--- a/core/ui/vault/swap/form/SwapCoinsExplorer.tsx
+++ b/core/ui/vault/swap/form/SwapCoinsExplorer.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { hideScrollbars } from '@lib/ui/css/hideScrollbars'
 import { SelectItemModal } from '@lib/ui/inputs/SelectItemModal'
 import { hStack, VStack } from '@lib/ui/layout/Stack'
@@ -247,7 +248,7 @@ const FooterItem = styled.div<IsActiveProp>`
   scroll-snap-stop: always;
   cursor: pointer;
   padding: 8px 12px 8px 8px;
-  border-radius: 99px;
+  ${borderRadius.pill};
   outline: none;
 
   scroll-snap-align: center;
@@ -260,7 +261,7 @@ const FooterItem = styled.div<IsActiveProp>`
     content: '';
     position: absolute;
     inset: 0 -6px;
-    border-radius: 99px;
+    ${borderRadius.pill};
     z-index: -1;
     background: transparent;
     transition: background 0.2s ease;
@@ -288,7 +289,7 @@ const CenterStroke = styled.div`
   translate: -50%;
   pointer-events: none;
   border: 1px solid ${({ theme }) => theme.colors.buttonPrimary.toCssValue()};
-  border-radius: 99px;
+  ${borderRadius.pill};
   background: rgba(6, 27, 58, 0.02);
   box-shadow: 0 0 14px 0 rgba(33, 85, 223, 0.45);
   /* Width is written imperatively (setStrokeToKey) off the live chain, so snap

--- a/core/ui/vault/swap/form/SwapErrorTooltip.tsx
+++ b/core/ui/vault/swap/form/SwapErrorTooltip.tsx
@@ -14,6 +14,7 @@ import {
   useTransitionStyles,
 } from '@floating-ui/react'
 import { IconButton } from '@lib/ui/buttons/IconButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { NavigationXIcon } from '@lib/ui/icons/NavigationXIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
@@ -32,7 +33,7 @@ type SwapErrorTooltipProps = {
 }
 
 const Container = styled.div`
-  border-radius: 12px;
+  ${borderRadius.md};
   background: #ffffff;
   padding: 12px;
   min-width: 200px;

--- a/core/ui/vault/swap/form/advanced/AdvancedSheet.tsx
+++ b/core/ui/vault/swap/form/advanced/AdvancedSheet.tsx
@@ -76,7 +76,7 @@ export const AdvancedSheet = ({
 const Wrapper = styled(VStack)`
   width: 100%;
   background: ${getColor('background')};
-  ${borderRadius.m};
+  ${borderRadius.md};
   padding: 20px;
 
   @media ${mediaQuery.tabletDeviceAndUp} {

--- a/core/ui/vault/swap/form/advanced/ExternalRecipientSheet.tsx
+++ b/core/ui/vault/swap/form/advanced/ExternalRecipientSheet.tsx
@@ -2,6 +2,7 @@ import { ScanQrModal } from '@core/ui/qr/components/ScanQrModal'
 import { useCore } from '@core/ui/state/core'
 import { AddressBookModalContent } from '@core/ui/vault/send/addresses/components/AddressBookModal'
 import { useSwapToCoin } from '@core/ui/vault/swap/state/toCoin'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { OnCloseProp } from '@lib/ui/props'
@@ -128,7 +129,7 @@ const AddressInput = styled.input`
   width: 100%;
   height: 52px;
   padding: 0 16px;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('background')};
   border: 1px solid rgba(255, 255, 255, 0.03);
   color: ${getColor('text')};
@@ -151,7 +152,7 @@ const ActionButton = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   cursor: pointer;

--- a/core/ui/vault/swap/form/advanced/GasLimitSheet.tsx
+++ b/core/ui/vault/swap/form/advanced/GasLimitSheet.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { OnCloseProp } from '@lib/ui/props'
@@ -73,7 +74,7 @@ const GasInput = styled.input`
   width: 100%;
   height: 52px;
   padding: 0 16px;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('foreground')};
   border: 1px solid rgba(255, 255, 255, 0.03);
   color: ${getColor('text')};

--- a/core/ui/vault/swap/limit/LimitAssetStep.tsx
+++ b/core/ui/vault/swap/limit/LimitAssetStep.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { RefreshCwIcon } from '@lib/ui/icons/RefreshCwIcon'
@@ -61,7 +62,7 @@ export const LimitAssetStep = () => {
 
 const Card = styled(VStack)`
   border: 1px solid ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};
-  border-radius: 12px;
+  ${borderRadius.md};
   padding: 16px;
 `
 
@@ -82,7 +83,7 @@ const Seam = styled.div`
 const ReverseWrapper = styled.div`
   ${centerContent};
   background-color: ${getColor('background')};
-  border-radius: 25.5px;
+  ${borderRadius.pill};
   padding: 7px;
   position: absolute;
   top: 50%;
@@ -95,7 +96,7 @@ const ReverseWrapper = styled.div`
     width: 54px;
     top: 0;
     height: 19px;
-    border-radius: 50px;
+    ${borderRadius.pill};
     border: 1px solid ${getColor('foregroundExtra')};
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
@@ -108,7 +109,7 @@ const ReverseWrapper = styled.div`
     width: 54px;
     bottom: 0;
     height: 19px;
-    border-radius: 50px;
+    ${borderRadius.pill};
     border: 1px solid ${getColor('foregroundExtra')};
     border-top-right-radius: 0;
     border-top-left-radius: 0;
@@ -119,7 +120,7 @@ const ReverseWrapper = styled.div`
 const ReverseButton = styled(UnstyledButton)`
   ${sameDimensions(40)};
   ${centerContent};
-  border-radius: 1000px;
+  ${borderRadius.pill};
   border: 2px solid ${getColor('background')};
   background: ${({ theme }) => theme.colors.buttonPrimary.toCssValue()};
   color: ${({ theme }) => theme.colors.contrast.toCssValue()};

--- a/core/ui/vault/swap/limit/LimitAssetSummary.tsx
+++ b/core/ui/vault/swap/limit/LimitAssetSummary.tsx
@@ -1,5 +1,6 @@
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CircleCheckIcon } from '@lib/ui/icons/CircleCheckIcon'
 import { PencilIcon } from '@lib/ui/icons/PenciIcon'
 import { HStack } from '@lib/ui/layout/Stack'
@@ -65,7 +66,7 @@ export const LimitAssetSummary: FC<LimitAssetSummaryProps> = ({
 
 const Card = styled(HStack)`
   border: 1px solid ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};
-  border-radius: 12px;
+  ${borderRadius.md};
   padding: 14px 16px;
 `
 

--- a/core/ui/vault/swap/limit/LimitExecuteWhen.tsx
+++ b/core/ui/vault/swap/limit/LimitExecuteWhen.tsx
@@ -1,5 +1,6 @@
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { CircleDollarSignIcon } from '@lib/ui/icons/CircleDollarSignIcon'
@@ -186,7 +187,7 @@ export const LimitExecuteWhen: FC<LimitExecuteWhenProps> = ({
 
 const Card = styled(VStack)`
   border: 1px solid ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};
-  border-radius: 12px;
+  ${borderRadius.md};
   padding: 16px;
 `
 
@@ -238,14 +239,14 @@ const UnitToggleGroup = styled.div`
   flex-direction: column;
   gap: 2px;
   padding: 3px;
-  border-radius: 20px;
+  ${borderRadius.pill};
   background: ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};
 `
 
 const UnitToggle = styled(UnstyledButton)<IsActiveProp>`
   ${sameDimensions(32)};
   ${centerContent};
-  border-radius: 18px;
+  ${borderRadius.pill};
   cursor: pointer;
   color: ${({ theme }) => theme.colors.textShy.toCssValue()};
 
@@ -259,7 +260,7 @@ const UnitToggle = styled(UnstyledButton)<IsActiveProp>`
 
 const Pill = styled(UnstyledButton)<IsActiveProp>`
   padding: 8px 16px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   border: 1px solid ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};
   cursor: pointer;
 
@@ -277,6 +278,6 @@ const Pill = styled(UnstyledButton)<IsActiveProp>`
 
 const ExpiryCard = styled(HStack)`
   border: 1px solid ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};
-  border-radius: 12px;
+  ${borderRadius.md};
   padding: 12px 16px;
 `

--- a/core/ui/vault/swap/limit/LimitExecuteWhenCollapsed.tsx
+++ b/core/ui/vault/swap/limit/LimitExecuteWhenCollapsed.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { Text } from '@lib/ui/text'
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -32,7 +33,7 @@ const Card = styled(UnstyledButton)`
   width: 100%;
   text-align: left;
   border: 1px solid ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};
-  border-radius: 12px;
+  ${borderRadius.md};
   padding: 16px;
   cursor: pointer;
 `

--- a/core/ui/vault/swap/limit/LimitOrderReview.tsx
+++ b/core/ui/vault/swap/limit/LimitOrderReview.tsx
@@ -2,6 +2,7 @@ import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { VerifyKeysignStart } from '@core/ui/mpc/keysign/start/VerifyKeysignStart'
 import { KeysignFeeAmount } from '@core/ui/mpc/keysign/tx/FeeAmount'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ArrowDownIcon } from '@lib/ui/icons/ArrowDownIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { PageHeader } from '@lib/ui/page/PageHeader'
@@ -168,7 +169,7 @@ const Row: FC<RowProps> = ({ label, value }) => (
 
 const Card = styled(VStack)`
   border: 1px solid ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};
-  border-radius: 12px;
+  ${borderRadius.md};
   padding: 16px;
 `
 

--- a/core/ui/vault/swap/limit/LimitSwapNotice.tsx
+++ b/core/ui/vault/swap/limit/LimitSwapNotice.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { FC } from 'react'
@@ -28,6 +29,6 @@ export const LimitSwapNotice: FC<LimitSwapNoticeProps> = ({
 
 const Notice = styled(HStack)`
   padding: 10px 12px;
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};
 `

--- a/core/ui/vault/swap/limit/cancel/CancelLimitOrderPage.tsx
+++ b/core/ui/vault/swap/limit/cancel/CancelLimitOrderPage.tsx
@@ -3,6 +3,7 @@ import { VerifyKeysignStart } from '@core/ui/mpc/keysign/start/VerifyKeysignStar
 import { KeysignFeeAmount } from '@core/ui/mpc/keysign/tx/FeeAmount'
 import { useCoreViewState } from '@core/ui/navigation/hooks/useCoreViewState'
 import { useTransactionRecordsQuery } from '@core/ui/storage/transactionHistory'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { useNavigateBack } from '@lib/ui/navigation/hooks/useNavigateBack'
 import { PageHeader } from '@lib/ui/page/PageHeader'
@@ -251,7 +252,7 @@ const Body = styled(VStack)`
 
 const Card = styled(VStack)`
   border: 1px solid ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};
-  border-radius: 12px;
+  ${borderRadius.md};
   padding: 16px;
 `
 

--- a/core/ui/vault/swap/limit/orders/LimitOrderRecordRow.tsx
+++ b/core/ui/vault/swap/limit/orders/LimitOrderRecordRow.tsx
@@ -5,6 +5,7 @@ import {
   useFormatLimitOrderExpiry,
   useLimitOrderStatusLabels,
 } from '@core/ui/vault/swap/limit/tracking/presentation'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { ValueProp } from '@lib/ui/props'
 import { Text } from '@lib/ui/text'
@@ -20,7 +21,7 @@ const Row = styled.button`
   all: unset;
   cursor: pointer;
   padding: 16px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   display: flex;

--- a/core/ui/vault/swap/verify/SwapVerify/SwapExternalRecipientWarning.tsx
+++ b/core/ui/vault/swap/verify/SwapVerify/SwapExternalRecipientWarning.tsx
@@ -46,7 +46,7 @@ export const SwapExternalRecipientWarning = ({
 type KindProp = { kind: SwapExternalRecipientWarningKind }
 
 const Container = styled(HStack)<KindProp>`
-  ${borderRadius.m};
+  ${borderRadius.md};
   padding: 16px;
   background: ${({ kind, theme: { colors } }) =>
     (kind === 'danger'

--- a/core/ui/vault/swap/verify/SwapVerify/SwapVerify.styled.tsx
+++ b/core/ui/vault/swap/verify/SwapVerify/SwapVerify.styled.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { VStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
@@ -19,7 +20,7 @@ export const IconWrapper = styled.div`
   height: 24px;
   font-size: 14px;
   background-color: ${getColor('foregroundExtra')};
-  border-radius: 99px;
+  ${borderRadius.pill};
   position: relative;
 
   &:before {


### PR DESCRIPTION
B.3 of #4623. 39 files across `core/ui/vault/swap`, `deposit` and `send` - the transaction flows.

The largest PR of part 2, but also the most repetitive: the staking and deposit forms are near-identical `12px` cards, which swap token-for-value with no visual change.

## The last `borderRadius.l` orphan

`AmountSwitch` is the **third and final** of the three 20px orphans called out in #4622. It is a vertical stack of circular icon buttons in a 42px-wide container, so 20 already put it within a pixel of a stadium. It resolves to `pill` rather than to a numeric step - worth a look in review, since it is the one orphan that did not resolve to a number.

The other two landed in part 1 (`InfoItem` -> `xl`) and B.2 (`BackupOption` -> `xl`). `borderRadius.l` now has no call sites left.

## Six capsules that were spelled as numbers

None of these change visually - every one was already clamping to a full round:

| | radius | on |
|---|---|---|
| `ReverseSwap` wrapper | 25.5 | 7px padding around an icon |
| `ReverseSwap` notch outline | 50 | a 19px-tall pseudo-element, x2 |
| `LimitAssetStep` | 25.5, 50 | the same pattern again |
| `LimitExecuteWhen` toggle group | 20 | a 38px-tall container |
| `LimitExecuteWhen` unit toggle | 18 | a 32px square |

## Off-scale values that do move

- **`ReverseSwap` button** - `$hasError ? '18px' : '1000px'` on a 40px square. The default was a capsule; the error state at 18 was a genuine rounded square, just off the scale. It becomes `$hasError ? lg : pill`.
- **`TronResourceTypePicker` option** - 6 inside an 8-radius container with 2px padding. That is the classic inner-radius calculation, and 6 is not a step; it resolves to `xs` (4) rather than `sm` (8), which would have matched the container and read wrong.

## Two stacked cards that form one control

`SwapCoinInputField` rounds its outer corners at 24 and its inner seam at 12, flipping the pair depending on which side it renders. Both values are on the scale, so the shape is preserved and only the numbers are replaced.

## Validation

`yarn check` clean, `yarn test` 942 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
