### PR TITLE
refactor(ui): vault page and shell surfaces adopt the corner-radius scale

### DIFF
--- a/core/ui/vault/balance/visibility/BalanceVisibilityAware.tsx
+++ b/core/ui/vault/balance/visibility/BalanceVisibilityAware.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ChildrenProp } from '@lib/ui/props'
 import { range } from '@vultisig/lib-utils/array/range'
 import styled from 'styled-components'
@@ -31,7 +32,7 @@ const Dot = styled.span`
   flex-shrink: 0;
   width: ${dotRatio}em;
   height: ${dotRatio}em;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background-color: currentColor;
 `
 

--- a/core/ui/vault/components/AgentBottomNavigationContent.tsx
+++ b/core/ui/vault/components/AgentBottomNavigationContent.tsx
@@ -5,8 +5,8 @@ import {
 import { autoUpdate, offset, shift, useFloating } from '@floating-ui/react'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
 import { Coachmark } from '@lib/ui/coachmark/Coachmark'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
-import { round } from '@lib/ui/css/round'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { AgentIcon } from '@lib/ui/icons/AgentIcon'
 import { Camera2Icon } from '@lib/ui/icons/Camera2Icon'
@@ -253,7 +253,7 @@ const FloatingCamera = styled(UnstyledButton)`
   right: 28px;
   bottom: 80px;
   z-index: 16;
-  ${round};
+  ${borderRadius.pill};
   ${centerContent};
   ${sameDimensions(cameraButtonSize)};
   background: ${({ theme }) =>
@@ -291,7 +291,7 @@ const TabButton = styled(UnstyledButton)<TabButtonProps>`
   height: 48px;
   padding: 3px 20px;
   font-size: 24px;
-  border-radius: 99px;
+  ${borderRadius.pill};
   transition: all 0.2s ease-in-out;
   background: transparent;
 

--- a/core/ui/vault/components/BottomNavigation.tsx
+++ b/core/ui/vault/components/BottomNavigation.tsx
@@ -1,8 +1,8 @@
 import { featureFlags } from '@core/ui/featureFlags'
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
-import { round } from '@lib/ui/css/round'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { Camera2Icon } from '@lib/ui/icons/Camera2Icon'
 import { NodesIcon } from '@lib/ui/icons/NodesIcon'
@@ -149,7 +149,7 @@ const ContainerOld = styled.div`
 `
 
 const CameraButton = styled(UnstyledButton)`
-  ${round};
+  ${borderRadius.pill};
   background: ${({ theme }) =>
     theme.iconStyle === 'station'
       ? theme.colors.buttonPrimary.toCssValue()
@@ -180,7 +180,7 @@ const TabButtonOld = styled(UnstyledButton)<TabButtonOldProps>`
   height: 48px;
   padding: 3px 20px;
   font-size: 24px;
-  border-radius: 99px;
+  ${borderRadius.pill};
   transition: all 0.2s ease-in-out;
   background: transparent;
 

--- a/core/ui/vault/components/PrimaryActions.styled.tsx
+++ b/core/ui/vault/components/PrimaryActions.styled.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
@@ -21,7 +22,7 @@ const ActionWrapper = styled(UnstyledButton)`
   justify-content: center;
   align-items: center;
   gap: 6px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   line-height: 0;
   font-size: 20px;
   transition: background 0.3s ease;
@@ -38,7 +39,7 @@ export const PrimaryActionWrapper = styled(ActionWrapper)`
 `
 
 export const SecondaryActionWrapper = styled(ActionWrapper)`
-  border-radius: 16px;
+  ${borderRadius.lg};
   border: 1px solid rgba(255, 255, 255, 0.03);
   background: ${getColor('foregroundExtra')};
 

--- a/core/ui/vault/components/action-form/ActionFormIconsWrapper.tsx
+++ b/core/ui/vault/components/action-form/ActionFormIconsWrapper.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
@@ -9,7 +10,7 @@ export const ActionFormIconsWrapper = styled(HStack)`
 export const ActionFormCheckBadge = styled.div`
   width: 16px;
   height: 16px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   border: 0.6667px solid ${getColor('success')};
   background: ${getColor('foreground')};
   color: ${getColor('success')};

--- a/core/ui/vault/components/action-form/ActionIconButton.tsx
+++ b/core/ui/vault/components/action-form/ActionIconButton.tsx
@@ -10,7 +10,7 @@ export const ActionIconButton = styled(IconButton)`
   font-size: 20px;
   padding: 12px 16px;
   width: 103px;
-  ${borderRadius.s};
+  ${borderRadius.sm};
 
   &:hover {
     background-color: ${getColor('foregroundExtra')};

--- a/core/ui/vault/components/action-form/ActionInputContainer.tsx
+++ b/core/ui/vault/components/action-form/ActionInputContainer.tsx
@@ -9,6 +9,6 @@ export const ActionInputContainer = styled(VStack)`
   gap: 16px;
   padding: 12px;
   flex: 1;
-  ${borderRadius.m};
+  ${borderRadius.md};
   border: 1px solid ${getColor('foregroundExtra')};
 `

--- a/core/ui/vault/create/setup-vault/DeviceCountPicker.tsx
+++ b/core/ui/vault/create/setup-vault/DeviceCountPicker.tsx
@@ -1,6 +1,7 @@
 import { DeviceSelectionTip } from '@core/ui/vault/create/setup-vault/DeviceSelectionTip'
 import { useDeviceSelectionAnimation } from '@core/ui/vault/create/setup-vault/hooks/useDeviceSelectionAnimation'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ScreenLayout } from '@lib/ui/layout/ScreenLayout/ScreenLayout'
 import { VStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
@@ -26,7 +27,7 @@ const TopGradient = styled.div`
   transform: translateX(-50%);
   width: 600px;
   height: 500px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: radial-gradient(
     50% 50% at 50% 50%,
     rgba(72, 121, 253, 0.5) 0%,

--- a/core/ui/vault/create/setup-vault/VaultExistsOnServerWarning.tsx
+++ b/core/ui/vault/create/setup-vault/VaultExistsOnServerWarning.tsx
@@ -54,7 +54,7 @@ export const VaultExistsOnServerWarning = ({
 }
 
 const WarningCard = styled(HStack)`
-  ${borderRadius.m};
+  ${borderRadius.md};
   background-color: ${getColor('idleDark')};
   border: 1px solid ${getColor('idle')};
   padding: 16px;

--- a/core/ui/vault/create/setup-vault/vault-setup-overview/VaultSetupBadge.tsx
+++ b/core/ui/vault/create/setup-vault/vault-setup-overview/VaultSetupBadge.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -31,7 +32,7 @@ export const VaultSetupBadge = ({
 const Container = styled(HStack)`
   background: #061b3a;
   border: 1px solid ${getColor('foreground')};
-  border-radius: 16px;
+  ${borderRadius.lg};
   padding: 8px 20px 8px 8px;
   align-self: flex-start;
 `
@@ -40,7 +41,7 @@ const IconWrapper = styled.div`
   flex-shrink: 0;
   width: 33px;
   height: 33px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   display: flex;
   align-items: center;
   justify-content: center;

--- a/core/ui/vault/import/seedphrase/EnterSeedphraseHeader.tsx
+++ b/core/ui/vault/import/seedphrase/EnterSeedphraseHeader.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { DownloadSeedphraseIcon } from '@lib/ui/icons/DownloadSeedphraseIcon'
@@ -9,7 +10,7 @@ import styled from 'styled-components'
 
 const IconContainer = styled.div`
   ${sameDimensions(48)}
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: ${getColor('foreground')};
   ${centerContent};
   font-size: 20px;

--- a/core/ui/vault/import/seedphrase/scanResult/ScanResultChainItem.tsx
+++ b/core/ui/vault/import/seedphrase/scanResult/ScanResultChainItem.tsx
@@ -1,5 +1,6 @@
 import { ChainEntityIcon } from '@core/ui/chain/coin/icon/ChainEntityIcon'
 import { getChainLogoSrc } from '@core/ui/chain/metadata/getChainLogoSrc'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { hStack } from '@lib/ui/layout/Stack'
 import { ValueProp } from '@lib/ui/props'
 import { getColor } from '@lib/ui/theme/getters'
@@ -8,7 +9,7 @@ import styled from 'styled-components'
 
 const Container = styled.div`
   height: 52px;
-  border-radius: 20px;
+  ${borderRadius.xl};
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
   ${hStack({

--- a/core/ui/vault/import/seedphrase/scanResult/ScanResultHeader.tsx
+++ b/core/ui/vault/import/seedphrase/scanResult/ScanResultHeader.tsx
@@ -1,5 +1,5 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
-import { round } from '@lib/ui/css/round'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { CubeWithCornersIcon } from '@lib/ui/icons/CubeWithCornersIcon'
 import { VStack } from '@lib/ui/layout/Stack'
@@ -15,7 +15,7 @@ type ScanResultHeaderProps = TitleProp &
   KindProp<ScanResultHeaderKind>
 
 const StyledIconWrapper = styled.div<KindProp<ScanResultHeaderKind>>`
-  ${round};
+  ${borderRadius.pill};
   color: ${matchColor('kind', {
     positive: 'primary',
     negative: 'danger',

--- a/core/ui/vault/new/ImportOption.tsx
+++ b/core/ui/vault/new/ImportOption.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack, vStack } from '@lib/ui/layout/Stack'
 import {
   DescriptionProp,
@@ -15,7 +16,7 @@ const Container = styled(UnstyledButton)`
   ${vStack({
     gap: 12,
   })}
-  border-radius: 24px;
+  ${borderRadius.xl};
   background: ${getColor('foreground')};
   padding: 24px;
   width: 100%;

--- a/core/ui/vault/new/index.tsx
+++ b/core/ui/vault/new/index.tsx
@@ -2,6 +2,7 @@ import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { useVaults } from '@core/ui/storage/vaults'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { UniformColumnGrid } from '@lib/ui/css/uniformColumnGrid'
 import { VStack } from '@lib/ui/layout/Stack'
 import { useNavigateBack } from '@lib/ui/navigation/hooks/useNavigateBack'
@@ -28,7 +29,7 @@ const TopGradient = styled.div`
   transform: translateX(-50%);
   width: 600px;
   height: 500px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: radial-gradient(
     50% 50% at 50% 50%,
     rgba(72, 121, 253, 0.5) 0%,
@@ -43,7 +44,7 @@ const LogoContainer = styled.div`
   justify-content: center;
   width: 60px;
   height: 60px;
-  border-radius: 19px;
+  ${borderRadius.lg};
   background: linear-gradient(180deg, #4879fd 0%, #0d39b1 100%);
   box-shadow: inset 0px 1.2px 1.2px 0px rgba(255, 255, 255, 0.35);
   color: white;

--- a/core/ui/vault/page/balance/visibility/ManageVaultBalanceVisibility.tsx
+++ b/core/ui/vault/page/balance/visibility/ManageVaultBalanceVisibility.tsx
@@ -2,6 +2,7 @@ import {
   useIsBalanceVisible,
   useSetIsBalanceVisibleMutation,
 } from '@core/ui/storage/balanceVisibility'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { EyeClosedIcon } from '@lib/ui/icons/EyeClosedIcon'
 import { EyeIcon } from '@lib/ui/icons/EyeIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
@@ -46,7 +47,7 @@ const Wrapper = styled.div`
   justify-content: center;
   align-items: center;
   gap: 4px;
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: rgba(81, 128, 252, 0.12);
   cursor: pointer;
 `

--- a/core/ui/vault/page/banners/BannerCarousel/BannerCarousel.styles.tsx
+++ b/core/ui/vault/page/banners/BannerCarousel/BannerCarousel.styles.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { getColor } from '@lib/ui/theme/getters'
 import { motion } from 'framer-motion'
 import styled from 'styled-components'
@@ -18,7 +19,7 @@ export const CarouselContainer = styled.div`
 export const CarouselViewport = styled.div`
   width: 100%;
   overflow: hidden;
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 export const CarouselTrack = styled(motion.div)`
@@ -57,7 +58,7 @@ export const PaginationDot = styled(UnstyledButton)<{ $isActive: boolean }>`
     display: block;
     width: ${({ $isActive }) => ($isActive ? 20 : 4)}px;
     height: 4px;
-    border-radius: 99px;
+    ${borderRadius.pill};
     background: ${({ $isActive, theme }) =>
       $isActive
         ? theme.colors.textShyExtra.toCssValue()

--- a/core/ui/vault/page/banners/BuyVultPromoBanner/BuyVultPromoBanner.styles.tsx
+++ b/core/ui/vault/page/banners/BuyVultPromoBanner/BuyVultPromoBanner.styles.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
 
@@ -23,7 +24,7 @@ export const IllustrationGlow = styled.div`
   right: -58px;
   width: 228px;
   height: 228px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: radial-gradient(
     50% 50% at 50% 50%,
     ${getColor('primaryAlt')} 0%,

--- a/core/ui/vault/page/banners/FollowOnXBanner/FollowOnXBanner.styles.tsx
+++ b/core/ui/vault/page/banners/FollowOnXBanner/FollowOnXBanner.styles.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import styled from 'styled-components'
 
 import { BannerPromoCtaButton } from '../shared/BannerPromoCtaButton.styles'
@@ -33,7 +34,7 @@ export const ButtonsRow = styled.div`
 `
 
 export const FollowButton = styled(BannerPromoCtaButton)`
-  border-radius: 24px;
+  ${borderRadius.xl};
   background: linear-gradient(135deg, #4ade80 0%, #22d3ee 100%);
   color: #0f172a;
   font-weight: 600;

--- a/core/ui/vault/page/banners/shared/HomePromoBanner.styles.tsx
+++ b/core/ui/vault/page/banners/shared/HomePromoBanner.styles.tsx
@@ -1,4 +1,5 @@
 import { IconButton } from '@lib/ui/buttons/IconButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { vStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
@@ -9,7 +10,7 @@ export const HomePromoBannerRoot = styled.div`
   height: 134px;
   box-sizing: border-box;
   padding: 24px;
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
   overflow: hidden;

--- a/core/ui/vault/page/components/ReceiveModal.tsx
+++ b/core/ui/vault/page/components/ReceiveModal.tsx
@@ -4,6 +4,7 @@ import { currentProductBrand } from '@core/ui/product/brand'
 import { AddressQRModal } from '@core/ui/vault/chain/address/AddressQRModal'
 import { useCurrentVaultChains } from '@core/ui/vault/state/currentVaultCoins'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ChevronLeftIcon } from '@lib/ui/icons/ChevronLeftIcon'
 import { StationChevronLeftIcon } from '@lib/ui/icons/StationFigmaIcons'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -67,7 +68,7 @@ const HeaderBackButton = styled(UnstyledButton)`
 const SearchFieldHalo = styled.div`
   width: 100%;
   padding: 0;
-  border-radius: 99px;
+  ${borderRadius.pill};
   background: transparent;
   box-shadow: none;
 `
@@ -75,7 +76,7 @@ const SearchFieldHalo = styled.div`
 const ReceiveSearchField = styled(SearchField)`
   color: ${getColor('contrast')};
 
-  border-radius: 99px;
+  ${borderRadius.pill};
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${({ theme }) =>
     theme.iconStyle === 'station'
@@ -93,7 +94,7 @@ const ReceiveSearchField = styled(SearchField)`
 `
 
 const ChainItemsWrapper = styled.div`
-  border-radius: 24px;
+  ${borderRadius.xl};
   border: none;
   overflow: hidden;
   box-shadow: none;
@@ -144,8 +145,7 @@ const ChainBadge = styled(Text)`
   display: inline-flex;
   align-items: center;
   padding: 8px 12px;
-  border-radius: 999px;
-  border-radius: 99px;
+  ${borderRadius.pill};
   border: 1.5px solid ${getColor('foregroundSuper')};
   background: ${getColor('foreground')};
 `

--- a/core/ui/vault/page/components/VaultOverview.tsx
+++ b/core/ui/vault/page/components/VaultOverview.tsx
@@ -1,6 +1,7 @@
 import { CollapsingBalance } from '@core/ui/page/CollapsingBalance'
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { Wrap } from '@lib/ui/base/Wrap'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { hideScrollbars } from '@lib/ui/css/hideScrollbars'
 import { VStack, vStack } from '@lib/ui/layout/Stack'
 import { PageContent } from '@lib/ui/page/PageContent'
@@ -123,7 +124,7 @@ const BlurEffect = styled.div`
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
-  border-radius: 16px;
+  ${borderRadius.lg};
   border-radius: 350px;
   height: 200px;
   top: -25px;

--- a/core/ui/vault/page/components/VaultTabs/VaultTabs.tsx
+++ b/core/ui/vault/page/components/VaultTabs/VaultTabs.tsx
@@ -1,4 +1,5 @@
 import { Tabs } from '@lib/ui/base/Tabs'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { hStack } from '@lib/ui/layout/Stack'
 import { IsActiveProp, IsDisabledProp } from '@lib/ui/props'
 import { Text } from '@lib/ui/text'
@@ -77,6 +78,6 @@ const ComingSoonWrapper = styled.div`
     justifyContent: 'center',
   })};
 
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: rgba(81, 128, 252, 0.12);
 `

--- a/core/ui/vault/page/keygen/migrate/MigrateVaultPrompt.tsx
+++ b/core/ui/vault/page/keygen/migrate/MigrateVaultPrompt.tsx
@@ -2,6 +2,7 @@ import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { Button } from '@lib/ui/buttons/Button'
 import { IconButton } from '@lib/ui/buttons/IconButton'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CrossIcon } from '@lib/ui/icons/CrossIcon'
 import { hStack, VStack } from '@lib/ui/layout/Stack'
 import { mediaQuery } from '@lib/ui/responsive/mediaQuery'
@@ -61,7 +62,7 @@ export const MigrateVaultPrompt = ({
 
 const Container = styled(UnstyledButton)`
   padding: 24px;
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
   width: 350px;

--- a/core/ui/vault/signers/index.tsx
+++ b/core/ui/vault/signers/index.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ZapIcon } from '@lib/ui/icons/ZapIcon'
 import { getColor } from '@lib/ui/theme/getters'
 import { hasServer, isServer } from '@vultisig/core-mpc/devices/localPartyId'
@@ -20,7 +21,7 @@ const StyledText = styled.span`
 
 const StyledVaultSigners = styled.div`
   align-items: center;
-  border-radius: 20px;
+  ${borderRadius.pill};
   background: ${({ theme }) =>
     theme.colors.foreground.withAlpha(0.35).toCssValue()};
   border: 1px solid ${getColor('foregroundExtra')};


### PR DESCRIPTION
B.4 of #4623. 25 files across `core/ui/vault/page`, `components`, and the small `new` / `import` / `create` / `signers` / `balance` directories.

## A duplicated declaration

`ReceiveModal`s chain badge carried two radii on consecutive lines:

```
border-radius: 999px;
border-radius: 99px;
```

Two spellings of the same capsule, the second silently winning. They collapse into one `pill`.

## Off-scale values that move

| | from | to | where |
|---|---|---|---|
| icon tile | 19 | 16 | `new/index` logo container, a 60px square |
| list row | 20 | 24 | `ScanResultChainItem`, a 52px bordered row |

`ScanResultChainItem` resolves upward for the same reason `BackupOption` did in B.2 - a bordered container row, not a compact list item.

## One more capsule spelled as a number

The signers chip in `signers/index` is `min-height: 30px` at `border-radius: 20px`, already clamping. It becomes `pill`, no visual change.

## Everything else

Token-for-value at 8, 12, 16 and 24, plus the usual `99px` / `999px` / `50%` / `round` collapse.

## Deliberate skips

Four decorative glow blobs, out of scope per #4623:

```
MigrateVaultPrompt.tsx       77px, 350px
HomePromoBanner.styles.tsx   77px
VaultOverview.tsx            350px
```

## Validation

`yarn check` clean, `yarn test` 942 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
