### PR TITLE
refactor(ui): qbtc and agent surfaces adopt the corner-radius scale

### DIFF
--- a/core/ui/agent/components/AgentChatFooter.tsx
+++ b/core/ui/agent/components/AgentChatFooter.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { CrossIcon } from '@lib/ui/icons/CrossIcon'
 import { LockClosedIcon } from '@lib/ui/icons/LockClosedIcon'
 import { WalletIcon } from '@lib/ui/icons/WalletIcon'
@@ -64,7 +65,7 @@ export const AgentChatFooter: FC<AgentChatFooterProps> = props => {
                 placeholder={t('enter_vault_password')}
                 inputType="password"
                 containerHeight={70}
-                containerBorderRadius={24}
+                containerBorderRadius={borderRadiusPx.xl}
                 actionIcon={<LockClosedIcon style={{ fontSize: 20 }} />}
                 actionAriaLabel={label}
                 isLoading={props.isLoading}
@@ -136,7 +137,7 @@ const SideButton = styled(UnstyledButton)`
   justify-content: center;
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 40px;
+  ${borderRadius.pill};
   color: ${getColor('textShy')};
   cursor: pointer;
   transition: background-color 0.2s;

--- a/core/ui/agent/components/AgentChatInput.tsx
+++ b/core/ui/agent/components/AgentChatInput.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { SendIcon } from '@lib/ui/icons/SendIcon'
 import { StopCircleIcon } from '@lib/ui/icons/StopCircleIcon'
 import { getColor } from '@lib/ui/theme/getters'
@@ -18,7 +19,7 @@ type AgentChatInputProps = {
   inputType?: 'text' | 'password'
   /** Override the default container height (52px). */
   containerHeight?: number
-  /** Override the default container border-radius (40px). */
+  /** Override the container corner radius. Defaults to a capsule. */
   containerBorderRadius?: number
   /** Custom icon for the action button — replaces the default send/stop icons. */
   actionIcon?: ReactNode
@@ -36,7 +37,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
   isLoading = false,
   inputType = 'text',
   containerHeight = 52,
-  containerBorderRadius = 40,
+  containerBorderRadius = borderRadiusPx.pill,
   actionIcon,
   actionAriaLabel,
 }) => {
@@ -146,7 +147,7 @@ const ActionButton = styled(UnstyledButton)<{ $active: boolean }>`
   width: 36px;
   height: 36px;
   padding: 0;
-  border-radius: 77px;
+  ${borderRadius.pill};
   flex-shrink: 0;
   transition: background-color 0.2s;
 

--- a/core/ui/agent/components/AgentChatMenu.tsx
+++ b/core/ui/agent/components/AgentChatMenu.tsx
@@ -13,6 +13,7 @@ import {
   useTransitionStyles,
 } from '@floating-ui/react'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { CircleAlertIcon } from '@lib/ui/icons/CircleAlertIcon'
@@ -146,7 +147,7 @@ const MenuTrigger = styled(UnstyledButton)`
   flex-shrink: 0;
   font-size: 24px;
   color: ${getColor('contrast')};
-  border-radius: 4px;
+  ${borderRadius.xs};
 
   &:hover {
     opacity: 0.7;
@@ -158,7 +159,7 @@ const MenuContainer = styled.div``
 const MenuPanel = styled(VStack)`
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 16px;
+  ${borderRadius.lg};
   padding: 4px 0;
   min-width: 220px;
 `
@@ -171,7 +172,7 @@ const MenuItem = styled.button<{ $danger?: boolean }>`
   cursor: pointer;
   color: ${({ $danger }) =>
     $danger ? getColor('danger') : getColor('contrast')};
-  border-radius: 12px;
+  ${borderRadius.md};
 
   &:hover {
     background: ${getColor('foregroundExtra')};

--- a/core/ui/agent/components/AgentChatPage.tsx
+++ b/core/ui/agent/components/AgentChatPage.tsx
@@ -1,5 +1,6 @@
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { hideScrollbars } from '@lib/ui/css/hideScrollbars'
 import { ErrorBoundary } from '@lib/ui/errors/ErrorBoundary'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -602,7 +603,7 @@ const MessagesContainer = styled(PageContent)`
 const ErrorMessage = styled.div`
   padding: 12px 16px;
   background: ${getColor('danger')}20;
-  border-radius: 8px;
+  ${borderRadius.sm};
   cursor: pointer;
 `
 

--- a/core/ui/agent/components/AgentEmptyState.tsx
+++ b/core/ui/agent/components/AgentEmptyState.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -136,7 +137,7 @@ const PromptChip = styled(UnstyledButton)<{ $variant: PromptVariant }>`
   align-items: center;
   justify-content: center;
   padding: 12px;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${p => promptVariantBackground[p.$variant]};
   border: 1px solid rgba(255, 255, 255, 0.03);
   color: ${getColor('text')};

--- a/core/ui/agent/components/AgentHeaderButton.tsx
+++ b/core/ui/agent/components/AgentHeaderButton.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { getColor } from '@lib/ui/theme/getters'
@@ -23,7 +24,7 @@ const Container = styled(UnstyledButton)`
   flex-shrink: 0;
   font-size: 24px;
   color: ${getColor('contrast')};
-  border-radius: 4px;
+  ${borderRadius.xs};
 
   &:hover {
     opacity: 0.7;

--- a/core/ui/agent/components/AgentHistoryView.tsx
+++ b/core/ui/agent/components/AgentHistoryView.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@lib/ui/buttons/Button'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { CircleAlertIcon } from '@lib/ui/icons/CircleAlertIcon'
 import { VStack } from '@lib/ui/layout/Stack'
 import { Skeleton } from '@lib/ui/loaders/Skeleton'
@@ -49,7 +50,7 @@ export const AgentHistoryView: FC<AgentHistoryViewProps> = ({
               key={index}
               height="51px"
               width="100%"
-              borderRadius="14px"
+              borderRadius={`${borderRadiusPx.md}px`}
             />
           ))}
         </VStack>
@@ -143,7 +144,7 @@ const StatusCard = styled(VStack)`
   width: min(100%, 360px);
   padding: 28px 24px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 20px;
+  ${borderRadius.xl};
   background: ${getColor('foreground')};
 `
 
@@ -153,7 +154,7 @@ const StatusIcon = styled.div<{ $tone: 'accent' | 'danger' }>`
   justify-content: center;
   width: 52px;
   height: 52px;
-  border-radius: 18px;
+  ${borderRadius.lg};
   color: ${({ $tone }) =>
     $tone === 'danger' ? getColor('danger') : getColor('primary')};
   background: ${({ $tone }) =>
@@ -165,7 +166,7 @@ const StatusIcon = styled.div<{ $tone: 'accent' | 'danger' }>`
 const ConversationItem = styled(UnstyledButton)`
   width: 100%;
   padding: 14px;
-  border-radius: 14px;
+  ${borderRadius.md};
   text-align: left;
   cursor: pointer;
 

--- a/core/ui/agent/components/ChatMessage.tsx
+++ b/core/ui/agent/components/ChatMessage.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
 import { FC, memo } from 'react'
@@ -158,7 +159,7 @@ const UserRow = styled.div`
 
 const UserBubble = styled.div`
   padding: 10px 14px;
-  border-radius: 66px;
+  ${borderRadius.pill};
   background: ${getColor('foregroundExtra')};
   color: ${getColor('text')};
   max-width: min(

--- a/core/ui/agent/components/ConfirmationPrompt.tsx
+++ b/core/ui/agent/components/ConfirmationPrompt.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { VStack } from '@lib/ui/layout/Stack'
 import { Modal } from '@lib/ui/modal'
 import { Text } from '@lib/ui/text'
@@ -54,7 +55,7 @@ export const ConfirmationPrompt: FC<Props> = ({
 const DetailsBox = styled.div`
   padding: 12px;
   background: ${getColor('foreground')};
-  border-radius: 8px;
+  ${borderRadius.sm};
   max-height: 200px;
   overflow-y: auto;
 `

--- a/core/ui/agent/components/MarkdownContent.tsx
+++ b/core/ui/agent/components/MarkdownContent.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { getColor } from '@lib/ui/theme/getters'
 import { FC } from 'react'
 import Markdown from 'react-markdown'
@@ -44,14 +45,14 @@ const Container = styled.div`
     font-size: 12px;
     padding: 2px 6px;
     background: ${getColor('background')};
-    border-radius: 4px;
+    ${borderRadius.xs};
   }
 
   pre {
     margin: 8px 0;
     padding: 12px;
     background: ${getColor('background')};
-    border-radius: 6px;
+    ${borderRadius.sm};
     overflow-x: auto;
 
     code {

--- a/core/ui/qbtc/claim/components/ClaimUtxoSelection.styles.tsx
+++ b/core/ui/qbtc/claim/components/ClaimUtxoSelection.styles.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { vStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
@@ -12,7 +13,7 @@ export const HeaderCard = styled.div`
   min-height: 118px;
   box-sizing: border-box;
   padding: 16px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   background: linear-gradient(
     180deg,
     rgba(95, 191, 255, 0.18) 0%,

--- a/core/ui/qbtc/claim/components/QbtcClaimBanner.styles.tsx
+++ b/core/ui/qbtc/claim/components/QbtcClaimBanner.styles.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { vStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
@@ -14,7 +15,7 @@ export const BannerRoot = styled.div`
   margin-bottom: 32px;
   box-sizing: border-box;
   padding: 24px;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('foregroundExtra')};
   border: 1px solid ${getColor('foregroundExtra')};
   overflow: hidden;
@@ -27,7 +28,7 @@ export const BannerEllipseOuter = styled.div`
   width: 418px;
   height: 418px;
   margin-left: -209px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: rgba(255, 255, 255, 0.02);
   opacity: 0.7;
   pointer-events: none;
@@ -41,7 +42,7 @@ export const BannerEllipseGlass = styled.div`
   width: 294px;
   height: 294px;
   margin-left: -147px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: ${getColor('background')};
   border: 2px solid rgba(255, 255, 255, 0.1);
   backdrop-filter: blur(94px);
@@ -57,7 +58,7 @@ export const BannerEllipseGlow = styled.div`
   width: 350px;
   height: 350px;
   margin-left: -175px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: radial-gradient(
     circle at 50% 50%,
     rgba(4, 57, 199, 1) 0%,

--- a/core/ui/qbtc/governance/components/MessagesSection.tsx
+++ b/core/ui/qbtc/governance/components/MessagesSection.tsx
@@ -1,4 +1,5 @@
 import { deriveCosmosMessageLabel } from '@core/ui/transaction-history/cosmosMessageLabel'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -43,6 +44,6 @@ export const MessagesSection = ({
 const Card = styled(VStack).attrs({ gap: 12 })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('foreground')};
 `

--- a/core/ui/qbtc/governance/components/MyVoteBadge.tsx
+++ b/core/ui/qbtc/governance/components/MyVoteBadge.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { getColor } from '@lib/ui/theme/getters'
 import { QbtcGovVote } from '@vultisig/core-chain/chains/cosmos/qbtc/governance/proposal'
 import { useTranslation } from 'react-i18next'
@@ -26,7 +27,7 @@ export const MyVoteBadge = ({ vote }: { vote: QbtcGovVote }) => {
 const Badge = styled.span`
   align-self: flex-start;
   padding: 2px 8px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   font-size: 11px;
   font-weight: 600;
   line-height: 16px;

--- a/core/ui/qbtc/governance/components/ProposalListItem.tsx
+++ b/core/ui/qbtc/governance/components/ProposalListItem.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -61,7 +62,7 @@ const Card = styled(UnstyledButton)`
   padding: 16px;
   text-align: left;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('foreground')};
   cursor: pointer;
 `

--- a/core/ui/qbtc/governance/components/ProposalStatusBadge.tsx
+++ b/core/ui/qbtc/governance/components/ProposalStatusBadge.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { getColor } from '@lib/ui/theme/getters'
 import { QbtcProposalStatus } from '@vultisig/core-chain/chains/cosmos/qbtc/governance/proposal'
 import { useTranslation } from 'react-i18next'
@@ -26,7 +27,7 @@ export const ProposalStatusBadge = ({
 const Badge = styled.span<{ $token: GovColorToken }>`
   align-self: flex-start;
   padding: 2px 8px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   font-size: 11px;
   font-weight: 600;
   line-height: 16px;

--- a/core/ui/qbtc/governance/components/QbtcGovernanceProposalPage.tsx
+++ b/core/ui/qbtc/governance/components/QbtcGovernanceProposalPage.tsx
@@ -2,6 +2,7 @@ import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { useCoreViewState } from '@core/ui/navigation/hooks/useCoreViewState'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Spinner } from '@lib/ui/loaders/Spinner'
 import { PageContent } from '@lib/ui/page/PageContent'
@@ -227,7 +228,7 @@ const VoteOptionButton = ({
 const Card = styled(VStack).attrs({ gap: 12 })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('foreground')};
 `
 
@@ -244,7 +245,7 @@ const OptionButton = styled.button`
   gap: 10px;
   width: 100%;
   padding: 14px 16px;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   cursor: pointer;
@@ -253,6 +254,6 @@ const OptionButton = styled.button`
 const Dot = styled.span<{ $token: GovColorToken }>`
   width: 10px;
   height: 10px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   background: ${({ $token }) => getColor($token)};
 `

--- a/core/ui/qbtc/governance/components/TallyBar.tsx
+++ b/core/ui/qbtc/governance/components/TallyBar.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import {
@@ -35,7 +36,7 @@ export const TallyBar = ({ tally }: { tally: QbtcGovTally }) => {
 const Track = styled(HStack)`
   width: 100%;
   height: 6px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   overflow: hidden;
   background: ${getColor('foregroundExtra')};
 `

--- a/core/ui/qbtc/governance/components/TallyBreakdown.tsx
+++ b/core/ui/qbtc/governance/components/TallyBreakdown.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -54,6 +55,6 @@ export const TallyBreakdown = ({ tally }: { tally: QbtcGovTally }) => {
 const Dot = styled.span<{ $token: GovColorToken }>`
   width: 10px;
   height: 10px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   background: ${({ $token }) => getColor($token)};
 `

--- a/core/ui/qbtc/governance/components/VotingWindowSection.tsx
+++ b/core/ui/qbtc/governance/components/VotingWindowSection.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -62,6 +63,6 @@ const WindowRow = ({ label, value }: { label: string; value: string }) => (
 const Card = styled(VStack).attrs({ gap: 12 })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('foreground')};
 `

--- a/core/ui/qbtc/governance/components/WeightedVoteSheet.tsx
+++ b/core/ui/qbtc/governance/components/WeightedVoteSheet.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@lib/ui/buttons/Button'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Modal } from '@lib/ui/modal'
 import { Text } from '@lib/ui/text'
@@ -103,7 +104,7 @@ export const WeightedVoteSheet = ({
 const Dot = styled.span<{ $token: GovColorToken }>`
   width: 10px;
   height: 10px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   background: ${({ $token }) => getColor($token)};
 `
 
@@ -118,7 +119,7 @@ const PercentValue = styled.span`
 const StepperButton = styled(UnstyledButton)`
   width: 28px;
   height: 28px;
-  border-radius: 8px;
+  ${borderRadius.sm};
   font-size: 18px;
   line-height: 1;
   display: flex;

--- a/core/ui/qbtc/onboarding/QuantumSecurityOnboardingPage.styles.tsx
+++ b/core/ui/qbtc/onboarding/QuantumSecurityOnboardingPage.styles.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { vStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
@@ -18,7 +19,7 @@ export const HeroFrame = styled.div`
   max-width: 350px;
   aspect-ratio: 350 / 240;
   align-self: center;
-  border-radius: 8px;
+  ${borderRadius.sm};
   border: 1px dashed ${getColor('foregroundExtra')};
   background-image: url('${heroImageUrl}');
   background-repeat: no-repeat;


### PR DESCRIPTION
B.5 of #4623, the last sweep. 22 files across `core/ui/qbtc` and `core/ui/agent`.

`core/ui/agent` moved here from part 1 in the rebalance noted on #4622 - it is a product surface, and moving it kept both parts comfortably under the 150-file review limit.

## qbtc

Uniform and uneventful: `999px` badges and tally bars to `pill`, `50%` claim-banner icons to `pill`, and 8 / 12 / 16 swapping token-for-value.

## Three capsules spelled as large numbers

`66`, `77` and `40`, all already clamping, all now `pill` with no visual change:

- `AgentChatInput` action button, a 36px square
- `ChatMessage` user bubble, roughly 40px tall
- `AgentChatFooter` icon button, 40px

The `77` is worth calling out: part 1 skipped several 77px declarations as decorative glow blobs, and that was right for those. This one is a square button, so it is a circle rather than a blob. The value alone does not tell you which - only the element it sits on does.

## A radius passed as a prop

`AgentChatInput` takes `containerBorderRadius?: number`, defaulting to a bare `40`. The default is now `borderRadiusPx.pill` and its one caller passes `borderRadiusPx.xl` instead of `24`. The JSDoc said "defaults to 40px"; it now says "defaults to a capsule", which is what 40 on a 52px-tall input actually means.

## Off-scale values that move

| | from | to | where |
|---|---|---|---|
| card | 20 | 24 | `AgentHistoryView` status card |
| icon tile | 18 | 16 | `AgentHistoryView` status icon, a 52px square |
| list row | 14 | 12 | `AgentHistoryView` conversation item |
| skeleton | 14 | 12 | matching the row it stands in for |
| code block | 6 | 8 | `MarkdownContent` `pre`, one step above the inline code chip at 4 |

## Validation

`yarn check` clean, `yarn test` 942 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
