### PR TITLE
refactor(ui): vault, qbtc and agent surfaces onto the corner-radius scale (part 2/2)

### DIFF
--- a/core/ui/agent/components/AgentChatFooter.tsx
+++ b/core/ui/agent/components/AgentChatFooter.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { CrossIcon } from '@lib/ui/icons/CrossIcon'
 import { LockClosedIcon } from '@lib/ui/icons/LockClosedIcon'
 import { WalletIcon } from '@lib/ui/icons/WalletIcon'
@@ -64,7 +65,7 @@ export const AgentChatFooter: FC<AgentChatFooterProps> = props => {
                 placeholder={t('enter_vault_password')}
                 inputType="password"
                 containerHeight={70}
-                containerBorderRadius={24}
+                containerBorderRadius={borderRadiusPx.xl}
                 actionIcon={<LockClosedIcon style={{ fontSize: 20 }} />}
                 actionAriaLabel={label}
                 isLoading={props.isLoading}
@@ -136,7 +137,7 @@ const SideButton = styled(UnstyledButton)`
   justify-content: center;
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 40px;
+  ${borderRadius.pill};
   color: ${getColor('textShy')};
   cursor: pointer;
   transition: background-color 0.2s;

--- a/core/ui/agent/components/AgentChatInput.tsx
+++ b/core/ui/agent/components/AgentChatInput.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { SendIcon } from '@lib/ui/icons/SendIcon'
 import { StopCircleIcon } from '@lib/ui/icons/StopCircleIcon'
 import { getColor } from '@lib/ui/theme/getters'
@@ -18,7 +19,7 @@ type AgentChatInputProps = {
   inputType?: 'text' | 'password'
   /** Override the default container height (52px). */
   containerHeight?: number
-  /** Override the default container border-radius (40px). */
+  /** Override the container corner radius. Defaults to a capsule. */
   containerBorderRadius?: number
   /** Custom icon for the action button — replaces the default send/stop icons. */
   actionIcon?: ReactNode
@@ -36,7 +37,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
   isLoading = false,
   inputType = 'text',
   containerHeight = 52,
-  containerBorderRadius = 40,
+  containerBorderRadius = borderRadiusPx.pill,
   actionIcon,
   actionAriaLabel,
 }) => {
@@ -146,7 +147,7 @@ const ActionButton = styled(UnstyledButton)<{ $active: boolean }>`
   width: 36px;
   height: 36px;
   padding: 0;
-  border-radius: 77px;
+  ${borderRadius.pill};
   flex-shrink: 0;
   transition: background-color 0.2s;
 

--- a/core/ui/agent/components/AgentChatMenu.tsx
+++ b/core/ui/agent/components/AgentChatMenu.tsx
@@ -13,6 +13,7 @@ import {
   useTransitionStyles,
 } from '@floating-ui/react'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { CircleAlertIcon } from '@lib/ui/icons/CircleAlertIcon'
@@ -146,7 +147,7 @@ const MenuTrigger = styled(UnstyledButton)`
   flex-shrink: 0;
   font-size: 24px;
   color: ${getColor('contrast')};
-  border-radius: 4px;
+  ${borderRadius.xs};
 
   &:hover {
     opacity: 0.7;
@@ -158,7 +159,7 @@ const MenuContainer = styled.div``
 const MenuPanel = styled(VStack)`
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 16px;
+  ${borderRadius.lg};
   padding: 4px 0;
   min-width: 220px;
 `
@@ -171,7 +172,7 @@ const MenuItem = styled.button<{ $danger?: boolean }>`
   cursor: pointer;
   color: ${({ $danger }) =>
     $danger ? getColor('danger') : getColor('contrast')};
-  border-radius: 12px;
+  ${borderRadius.md};
 
   &:hover {
     background: ${getColor('foregroundExtra')};

--- a/core/ui/agent/components/AgentChatPage.tsx
+++ b/core/ui/agent/components/AgentChatPage.tsx
@@ -1,5 +1,6 @@
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { hideScrollbars } from '@lib/ui/css/hideScrollbars'
 import { ErrorBoundary } from '@lib/ui/errors/ErrorBoundary'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -602,7 +603,7 @@ const MessagesContainer = styled(PageContent)`
 const ErrorMessage = styled.div`
   padding: 12px 16px;
   background: ${getColor('danger')}20;
-  border-radius: 8px;
+  ${borderRadius.sm};
   cursor: pointer;
 `
 

--- a/core/ui/agent/components/AgentEmptyState.tsx
+++ b/core/ui/agent/components/AgentEmptyState.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -136,7 +137,7 @@ const PromptChip = styled(UnstyledButton)<{ $variant: PromptVariant }>`
   align-items: center;
   justify-content: center;
   padding: 12px;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${p => promptVariantBackground[p.$variant]};
   border: 1px solid rgba(255, 255, 255, 0.03);
   color: ${getColor('text')};

--- a/core/ui/agent/components/AgentHeaderButton.tsx
+++ b/core/ui/agent/components/AgentHeaderButton.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { getColor } from '@lib/ui/theme/getters'
@@ -23,7 +24,7 @@ const Container = styled(UnstyledButton)`
   flex-shrink: 0;
   font-size: 24px;
   color: ${getColor('contrast')};
-  border-radius: 4px;
+  ${borderRadius.xs};
 
   &:hover {
     opacity: 0.7;

--- a/core/ui/agent/components/AgentHistoryView.tsx
+++ b/core/ui/agent/components/AgentHistoryView.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@lib/ui/buttons/Button'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { CircleAlertIcon } from '@lib/ui/icons/CircleAlertIcon'
 import { VStack } from '@lib/ui/layout/Stack'
 import { Skeleton } from '@lib/ui/loaders/Skeleton'
@@ -49,7 +50,7 @@ export const AgentHistoryView: FC<AgentHistoryViewProps> = ({
               key={index}
               height="51px"
               width="100%"
-              borderRadius="14px"
+              borderRadius={`${borderRadiusPx.md}px`}
             />
           ))}
         </VStack>
@@ -143,7 +144,7 @@ const StatusCard = styled(VStack)`
   width: min(100%, 360px);
   padding: 28px 24px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 20px;
+  ${borderRadius.xl};
   background: ${getColor('foreground')};
 `
 
@@ -153,7 +154,7 @@ const StatusIcon = styled.div<{ $tone: 'accent' | 'danger' }>`
   justify-content: center;
   width: 52px;
   height: 52px;
-  border-radius: 18px;
+  ${borderRadius.lg};
   color: ${({ $tone }) =>
     $tone === 'danger' ? getColor('danger') : getColor('primary')};
   background: ${({ $tone }) =>
@@ -165,7 +166,7 @@ const StatusIcon = styled.div<{ $tone: 'accent' | 'danger' }>`
 const ConversationItem = styled(UnstyledButton)`
   width: 100%;
   padding: 14px;
-  border-radius: 14px;
+  ${borderRadius.md};
   text-align: left;
   cursor: pointer;
 

--- a/core/ui/agent/components/ChatMessage.tsx
+++ b/core/ui/agent/components/ChatMessage.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
 import { FC, memo } from 'react'
@@ -158,7 +159,7 @@ const UserRow = styled.div`
 
 const UserBubble = styled.div`
   padding: 10px 14px;
-  border-radius: 66px;
+  ${borderRadius.pill};
   background: ${getColor('foregroundExtra')};
   color: ${getColor('text')};
   max-width: min(

--- a/core/ui/agent/components/ConfirmationPrompt.tsx
+++ b/core/ui/agent/components/ConfirmationPrompt.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { VStack } from '@lib/ui/layout/Stack'
 import { Modal } from '@lib/ui/modal'
 import { Text } from '@lib/ui/text'
@@ -54,7 +55,7 @@ export const ConfirmationPrompt: FC<Props> = ({
 const DetailsBox = styled.div`
   padding: 12px;
   background: ${getColor('foreground')};
-  border-radius: 8px;
+  ${borderRadius.sm};
   max-height: 200px;
   overflow-y: auto;
 `

--- a/core/ui/agent/components/MarkdownContent.tsx
+++ b/core/ui/agent/components/MarkdownContent.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { getColor } from '@lib/ui/theme/getters'
 import { FC } from 'react'
 import Markdown from 'react-markdown'
@@ -44,14 +45,14 @@ const Container = styled.div`
     font-size: 12px;
     padding: 2px 6px;
     background: ${getColor('background')};
-    border-radius: 4px;
+    ${borderRadius.xs};
   }
 
   pre {
     margin: 8px 0;
     padding: 12px;
     background: ${getColor('background')};
-    border-radius: 6px;
+    ${borderRadius.sm};
     overflow-x: auto;
 
     code {

--- a/core/ui/qbtc/claim/components/ClaimUtxoSelection.styles.tsx
+++ b/core/ui/qbtc/claim/components/ClaimUtxoSelection.styles.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { vStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
@@ -12,7 +13,7 @@ export const HeaderCard = styled.div`
   min-height: 118px;
   box-sizing: border-box;
   padding: 16px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   background: linear-gradient(
     180deg,
     rgba(95, 191, 255, 0.18) 0%,

--- a/core/ui/qbtc/claim/components/QbtcClaimBanner.styles.tsx
+++ b/core/ui/qbtc/claim/components/QbtcClaimBanner.styles.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { vStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
@@ -14,7 +15,7 @@ export const BannerRoot = styled.div`
   margin-bottom: 32px;
   box-sizing: border-box;
   padding: 24px;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('foregroundExtra')};
   border: 1px solid ${getColor('foregroundExtra')};
   overflow: hidden;
@@ -27,7 +28,7 @@ export const BannerEllipseOuter = styled.div`
   width: 418px;
   height: 418px;
   margin-left: -209px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: rgba(255, 255, 255, 0.02);
   opacity: 0.7;
   pointer-events: none;
@@ -41,7 +42,7 @@ export const BannerEllipseGlass = styled.div`
   width: 294px;
   height: 294px;
   margin-left: -147px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: ${getColor('background')};
   border: 2px solid rgba(255, 255, 255, 0.1);
   backdrop-filter: blur(94px);
@@ -57,7 +58,7 @@ export const BannerEllipseGlow = styled.div`
   width: 350px;
   height: 350px;
   margin-left: -175px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: radial-gradient(
     circle at 50% 50%,
     rgba(4, 57, 199, 1) 0%,

--- a/core/ui/qbtc/governance/components/MessagesSection.tsx
+++ b/core/ui/qbtc/governance/components/MessagesSection.tsx
@@ -1,4 +1,5 @@
 import { deriveCosmosMessageLabel } from '@core/ui/transaction-history/cosmosMessageLabel'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -43,6 +44,6 @@ export const MessagesSection = ({
 const Card = styled(VStack).attrs({ gap: 12 })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('foreground')};
 `

--- a/core/ui/qbtc/governance/components/MyVoteBadge.tsx
+++ b/core/ui/qbtc/governance/components/MyVoteBadge.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { getColor } from '@lib/ui/theme/getters'
 import { QbtcGovVote } from '@vultisig/core-chain/chains/cosmos/qbtc/governance/proposal'
 import { useTranslation } from 'react-i18next'
@@ -26,7 +27,7 @@ export const MyVoteBadge = ({ vote }: { vote: QbtcGovVote }) => {
 const Badge = styled.span`
   align-self: flex-start;
   padding: 2px 8px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   font-size: 11px;
   font-weight: 600;
   line-height: 16px;

--- a/core/ui/qbtc/governance/components/ProposalListItem.tsx
+++ b/core/ui/qbtc/governance/components/ProposalListItem.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -61,7 +62,7 @@ const Card = styled(UnstyledButton)`
   padding: 16px;
   text-align: left;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('foreground')};
   cursor: pointer;
 `

--- a/core/ui/qbtc/governance/components/ProposalStatusBadge.tsx
+++ b/core/ui/qbtc/governance/components/ProposalStatusBadge.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { getColor } from '@lib/ui/theme/getters'
 import { QbtcProposalStatus } from '@vultisig/core-chain/chains/cosmos/qbtc/governance/proposal'
 import { useTranslation } from 'react-i18next'
@@ -26,7 +27,7 @@ export const ProposalStatusBadge = ({
 const Badge = styled.span<{ $token: GovColorToken }>`
   align-self: flex-start;
   padding: 2px 8px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   font-size: 11px;
   font-weight: 600;
   line-height: 16px;

--- a/core/ui/qbtc/governance/components/QbtcGovernanceProposalPage.tsx
+++ b/core/ui/qbtc/governance/components/QbtcGovernanceProposalPage.tsx
@@ -2,6 +2,7 @@ import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { useCoreViewState } from '@core/ui/navigation/hooks/useCoreViewState'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Spinner } from '@lib/ui/loaders/Spinner'
 import { PageContent } from '@lib/ui/page/PageContent'
@@ -227,7 +228,7 @@ const VoteOptionButton = ({
 const Card = styled(VStack).attrs({ gap: 12 })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('foreground')};
 `
 
@@ -244,7 +245,7 @@ const OptionButton = styled.button`
   gap: 10px;
   width: 100%;
   padding: 14px 16px;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   cursor: pointer;
@@ -253,6 +254,6 @@ const OptionButton = styled.button`
 const Dot = styled.span<{ $token: GovColorToken }>`
   width: 10px;
   height: 10px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   background: ${({ $token }) => getColor($token)};
 `

--- a/core/ui/qbtc/governance/components/TallyBar.tsx
+++ b/core/ui/qbtc/governance/components/TallyBar.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import {
@@ -35,7 +36,7 @@ export const TallyBar = ({ tally }: { tally: QbtcGovTally }) => {
 const Track = styled(HStack)`
   width: 100%;
   height: 6px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   overflow: hidden;
   background: ${getColor('foregroundExtra')};
 `

--- a/core/ui/qbtc/governance/components/TallyBreakdown.tsx
+++ b/core/ui/qbtc/governance/components/TallyBreakdown.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -54,6 +55,6 @@ export const TallyBreakdown = ({ tally }: { tally: QbtcGovTally }) => {
 const Dot = styled.span<{ $token: GovColorToken }>`
   width: 10px;
   height: 10px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   background: ${({ $token }) => getColor($token)};
 `

--- a/core/ui/qbtc/governance/components/VotingWindowSection.tsx
+++ b/core/ui/qbtc/governance/components/VotingWindowSection.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -62,6 +63,6 @@ const WindowRow = ({ label, value }: { label: string; value: string }) => (
 const Card = styled(VStack).attrs({ gap: 12 })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('foreground')};
 `

--- a/core/ui/qbtc/governance/components/WeightedVoteSheet.tsx
+++ b/core/ui/qbtc/governance/components/WeightedVoteSheet.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@lib/ui/buttons/Button'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Modal } from '@lib/ui/modal'
 import { Text } from '@lib/ui/text'
@@ -103,7 +104,7 @@ export const WeightedVoteSheet = ({
 const Dot = styled.span<{ $token: GovColorToken }>`
   width: 10px;
   height: 10px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   background: ${({ $token }) => getColor($token)};
 `
 
@@ -118,7 +119,7 @@ const PercentValue = styled.span`
 const StepperButton = styled(UnstyledButton)`
   width: 28px;
   height: 28px;
-  border-radius: 8px;
+  ${borderRadius.sm};
   font-size: 18px;
   line-height: 1;
   display: flex;

--- a/core/ui/qbtc/onboarding/QuantumSecurityOnboardingPage.styles.tsx
+++ b/core/ui/qbtc/onboarding/QuantumSecurityOnboardingPage.styles.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { vStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
@@ -18,7 +19,7 @@ export const HeroFrame = styled.div`
   max-width: 350px;
   aspect-ratio: 350 / 240;
   align-self: center;
-  border-radius: 8px;
+  ${borderRadius.sm};
   border: 1px dashed ${getColor('foregroundExtra')};
   background-image: url('${heroImageUrl}');
   background-repeat: no-repeat;

--- a/core/ui/vault/backup/VaultBackupWithoutPassword.tsx
+++ b/core/ui/vault/backup/VaultBackupWithoutPassword.tsx
@@ -1,6 +1,7 @@
 import { FlowPageHeader } from '@core/ui/flow/FlowPageHeader'
 import { useBackupVaultMutation } from '@core/ui/vault/mutations/useBackupVaultMutation'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { FileWarningIcon } from '@lib/ui/icons/FileWarningIcon'
@@ -21,7 +22,7 @@ const IconContainer = styled.div`
   ${sameDimensions(64)};
   ${centerContent};
   font-size: 32px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   align-self: center;
   background: ${getColor('foregroundExtra')};
 `

--- a/core/ui/vault/backup/fast/SaveBackupToCloudScreen.tsx
+++ b/core/ui/vault/backup/fast/SaveBackupToCloudScreen.tsx
@@ -1,6 +1,7 @@
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { backupSplashAnimationSource } from '@core/ui/vault/backup/getBackupAnimationSource'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CloudUploadIcon } from '@lib/ui/icons/CloudUploadIcon'
 import { Checkbox } from '@lib/ui/inputs/checkbox/Checkbox'
 import { VStack } from '@lib/ui/layout/Stack'
@@ -98,7 +99,7 @@ const IconWrapper = styled.div`
   position: relative;
   width: 40px;
   height: 40px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: #03132c;
   border: 1.5px solid rgba(255, 255, 255, 0.15);
   box-shadow: 0 2.051px 2.051px 0 rgba(0, 0, 0, 0.25) inset;
@@ -117,7 +118,7 @@ const IconWrapper = styled.div`
     width: 24px;
     height: 8px;
     background: #0c4eff;
-    border-radius: 50%;
+    ${borderRadius.pill};
     pointer-events: none;
     filter: blur(8px);
     opacity: 0.6;

--- a/core/ui/vault/backup/fast/VaultCreatedSuccessScreen.tsx
+++ b/core/ui/vault/backup/fast/VaultCreatedSuccessScreen.tsx
@@ -80,7 +80,9 @@ const IconShadow = styled.div`
   opacity: 0.5;
   background: ${getColor('success')};
   filter: blur(9px);
-  ${borderRadius.pill};
+  /* A blurred glow, not a surface: 16x8 means 50% is an ellipse and the
+     pill token would clamp it to a stadium. */
+  border-radius: 50%;
   pointer-events: none;
 `
 

--- a/core/ui/vault/backup/fast/VaultCreatedSuccessScreen.tsx
+++ b/core/ui/vault/backup/fast/VaultCreatedSuccessScreen.tsx
@@ -1,6 +1,7 @@
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { Animation } from '@lib/ui/animations/Animation'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ShieldCheckFilledIcon } from '@lib/ui/icons/ShieldCheckFilledIcon'
 import { VStack } from '@lib/ui/layout/Stack'
 import { PageContent } from '@lib/ui/page/PageContent'
@@ -59,7 +60,7 @@ const IconWrapper = styled.div`
   position: relative;
   width: 40px;
   height: 40px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: #03132c;
   border: 1.5px solid rgba(255, 255, 255, 0.15);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.25) inset;
@@ -79,7 +80,7 @@ const IconShadow = styled.div`
   opacity: 0.5;
   background: ${getColor('success')};
   filter: blur(9px);
-  border-radius: 50%;
+  ${borderRadius.pill};
   pointer-events: none;
 `
 

--- a/core/ui/vault/backup/fast/index.tsx
+++ b/core/ui/vault/backup/fast/index.tsx
@@ -1,6 +1,7 @@
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { EmailNotificationIcon } from '@lib/ui/icons/EmailNotificationIcon'
 import {
   MultiCharacterInput,
@@ -128,7 +129,7 @@ const IconWrapper = styled.div`
   position: relative;
   width: 40px;
   height: 40px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: #03132c;
   border: 1.5px solid rgba(255, 255, 255, 0.15);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.25) inset;
@@ -149,7 +150,7 @@ const IconWrapper = styled.div`
       rgba(37, 97, 255, 0.4) 0%,
       transparent 70%
     );
-    border-radius: 50%;
+    ${borderRadius.pill};
     pointer-events: none;
   }
 `

--- a/core/ui/vault/backup/secure/ReviewVaultDevicesScreen.tsx
+++ b/core/ui/vault/backup/secure/ReviewVaultDevicesScreen.tsx
@@ -1,5 +1,6 @@
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { BrowserExtensionIcon } from '@lib/ui/icons/BrowserExtensionIcon'
 import { DeviceIcon } from '@lib/ui/icons/DeviceIcon'
 import { LaptopIcon } from '@lib/ui/icons/LaptopIcon'
@@ -175,7 +176,7 @@ const DeviceCard = styled(HStack)`
   align-items: center;
   gap: 12px;
   padding: 12px 16px;
-  border-radius: 24px;
+  ${borderRadius.xl};
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
 `
@@ -183,7 +184,7 @@ const DeviceCard = styled(HStack)`
 const DeviceIconCircle = styled.div`
   width: 32px;
   height: 32px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: #03132c;
   border: 1.5px solid rgba(255, 255, 255, 0.15);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.25) inset;

--- a/core/ui/vault/backup/select/OptionContainer.tsx
+++ b/core/ui/vault/backup/select/OptionContainer.tsx
@@ -21,7 +21,7 @@ const Header = styled.div`
 
 const Container = styled(UnstyledButton)`
   padding: 12px;
-  ${borderRadius.m};
+  ${borderRadius.md};
   font-size: 14px;
   border: 1px solid ${getColor('foregroundExtra')};
   ${vStack({

--- a/core/ui/vault/backup/select/VaultList.tsx
+++ b/core/ui/vault/backup/select/VaultList.tsx
@@ -9,7 +9,7 @@ import { VaultItem } from './VaultItem'
 
 const Container = styled(StackSeparatedBy)`
   background: ${getColor('foregroundExtra')};
-  ${borderRadius.m};
+  ${borderRadius.md};
   overflow: hidden;
   width: 100%;
 `

--- a/core/ui/vault/balance/visibility/BalanceVisibilityAware.tsx
+++ b/core/ui/vault/balance/visibility/BalanceVisibilityAware.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ChildrenProp } from '@lib/ui/props'
 import { range } from '@vultisig/lib-utils/array/range'
 import styled from 'styled-components'
@@ -31,7 +32,7 @@ const Dot = styled.span`
   flex-shrink: 0;
   width: ${dotRatio}em;
   height: ${dotRatio}em;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background-color: currentColor;
 `
 

--- a/core/ui/vault/chain/VaultChainCoinItem.tsx
+++ b/core/ui/vault/chain/VaultChainCoinItem.tsx
@@ -1,6 +1,7 @@
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { BalanceVisibilityAware } from '@core/ui/vault/balance/visibility/BalanceVisibilityAware'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ChevronRightIcon } from '@lib/ui/icons/ChevronRightIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -25,7 +26,7 @@ const PriceBadge = styled.div`
   align-items: center;
   align-self: flex-start;
   padding: 3px 8px;
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: ${getColor('foregroundExtra')};
 `
 

--- a/core/ui/vault/chain/VaultChainOverview.tsx
+++ b/core/ui/vault/chain/VaultChainOverview.tsx
@@ -8,6 +8,7 @@ import { VaultPrimaryActions } from '@core/ui/vault/components/VaultPrimaryActio
 import { useVaultChainTotalBalanceQuery } from '@core/ui/vault/queries/useVaultChainTotalBalanceQuery'
 import { useCurrentVaultAddress } from '@core/ui/vault/state/currentVaultCoins'
 import { Opener } from '@lib/ui/base/Opener'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Spinner } from '@lib/ui/loaders/Spinner'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
@@ -22,7 +23,7 @@ import { AddressQRModal } from './address/AddressQRModal'
 
 const AddressPill = styled(HStack)`
   padding: 4px 6px;
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: rgba(81, 128, 252, 0.12);
 
   & * {

--- a/core/ui/vault/chain/address/AddressQRCard.tsx
+++ b/core/ui/vault/chain/address/AddressQRCard.tsx
@@ -4,8 +4,8 @@ import { getChainLogoSrc } from '@core/ui/chain/metadata/getChainLogoSrc'
 import { useCore } from '@core/ui/state/core'
 import { useCurrentVaultAddress } from '@core/ui/vault/state/currentVaultCoins'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
-import { round } from '@lib/ui/css/round'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { toSizeUnit } from '@lib/ui/css/toSizeUnit'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -39,13 +39,13 @@ const QRContainer = styled.div`
   width: 100%;
   max-width: 232px;
   aspect-ratio: 232 / 272;
-  border-radius: 24px;
+  ${borderRadius.xl};
   background: ${getColor('foreground')};
   display: flex;
   flex-direction: column;
   align-items: center;
 
-  border-radius: 32px 32px 24px 24px;
+  ${borderRadius.xl};
   background: linear-gradient(180deg, #4879fd 0%, #0d39b1 100%);
   box-shadow:
     0 -3px 1px 0 rgba(0, 0, 0, 0.25) inset,
@@ -56,7 +56,7 @@ const QRContainer = styled.div`
 const QRWrapper = styled.div`
   width: 100%;
   aspect-ratio: 1;
-  border-radius: 32px 32px 24px 24px;
+  ${borderRadius.xl};
 
   overflow: hidden;
   background: white;
@@ -70,7 +70,7 @@ const ChainIconOverlay = styled.div`
   left: 50%;
   transform: translate(-50%, -50%);
   ${sameDimensions(toSizeUnit(76))};
-  ${round};
+  ${borderRadius.pill};
   ${centerContent};
   background: ${getColor('background')};
   border: 4px solid white;
@@ -84,7 +84,7 @@ const ReceiveLabel = styled.div`
   left: 0;
   right: 0;
   padding: 12px;
-  border-radius: 0 0 20px 20px;
+  border-radius: 0 0 ${borderRadiusPx.xl}px ${borderRadiusPx.xl}px;
   text-align: center;
 `
 

--- a/core/ui/vault/chain/coin/CoinDetailModal.tsx
+++ b/core/ui/vault/chain/coin/CoinDetailModal.tsx
@@ -13,6 +13,7 @@ import { VaultChainCoin } from '@core/ui/vault/queries/useVaultChainCoinsQuery'
 import { useCurrentVaultAddress } from '@core/ui/vault/state/currentVaultCoins'
 import { Opener } from '@lib/ui/base/Opener'
 import { IconButton } from '@lib/ui/buttons/IconButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ArCubeIcon } from '@lib/ui/icons/ArCubeIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -127,7 +128,7 @@ const ScrollContainer = styled.div`
     max-height: 82vh;
     overflow-y: auto;
     overflow-x: hidden;
-    border-radius: 12px;
+    ${borderRadius.md};
   }
 `
 
@@ -152,7 +153,7 @@ const ContentContainer = styled(VStack)`
       rgba(6, 27, 58, 0.5) 97%,
       rgba(6, 27, 58, 0) 100%
     );
-    border-radius: 12px;
+    ${borderRadius.md};
   }
 
   > * {

--- a/core/ui/vault/chain/coin/market/CoinChartRangePicker.tsx
+++ b/core/ui/vault/chain/coin/market/CoinChartRangePicker.tsx
@@ -3,6 +3,7 @@ import {
   marketChartRanges,
 } from '@core/ui/chain/coin/price/market/MarketChartRange'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { IsActiveProp } from '@lib/ui/props'
 import { Text } from '@lib/ui/text'
@@ -60,7 +61,7 @@ export const CoinChartRangePicker = ({
 const Segment = styled(UnstyledButton)<IsActiveProp>`
   flex: 1;
   padding: 10px 0;
-  border-radius: 999px;
+  ${borderRadius.pill};
   text-align: center;
   cursor: pointer;
 

--- a/core/ui/vault/chain/coin/market/CoinDetailSection.tsx
+++ b/core/ui/vault/chain/coin/market/CoinDetailSection.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { VStack } from '@lib/ui/layout/Stack'
 import { ChildrenProp, TitleProp } from '@lib/ui/props'
 import { Text } from '@lib/ui/text'
@@ -22,7 +23,7 @@ export const CoinDetailSection = ({
 
 const Card = styled(VStack)`
   width: 100%;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('background')};
   padding: 4px 0;
 `

--- a/core/ui/vault/chain/coin/market/CoinPriceChart.tsx
+++ b/core/ui/vault/chain/coin/market/CoinPriceChart.tsx
@@ -6,6 +6,7 @@ import { useCoinMarketStatsQuery } from '@core/ui/chain/coin/price/market/querie
 import { FiatAmountText } from '@core/ui/chain/components/FiatAmountText'
 import { VaultChainCoin } from '@core/ui/vault/queries/useVaultChainCoinsQuery'
 import { useCurrentVaultCoin } from '@core/ui/vault/state/currentVaultCoins'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -149,7 +150,7 @@ export const CoinPriceChart = ({ coin }: CoinPriceChartProps) => {
 
 const Card = styled(VStack)`
   width: 100%;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('background')};
   padding: 16px;
 `
@@ -160,7 +161,7 @@ const ScrubDateCaption = styled.div`
 
 const ChangeChip = styled.div`
   padding: 4px 10px;
-  border-radius: 999px;
+  ${borderRadius.pill};
 `
 
 const GraphContainer = styled.div`

--- a/core/ui/vault/chain/coin/market/CoinPriceChartGraph.tsx
+++ b/core/ui/vault/chain/coin/market/CoinPriceChartGraph.tsx
@@ -2,6 +2,7 @@ import {
   getMarketChartPriceDomain,
   MarketChartPoint,
 } from '@core/ui/chain/coin/price/market/marketChart'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { getColor } from '@lib/ui/theme/getters'
 import { motion } from 'framer-motion'
 import { useId } from 'react'
@@ -161,7 +162,7 @@ const ScrubDot = styled.div`
   position: absolute;
   width: 8px;
   height: 8px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   transform: translate(-50%, -50%);
   pointer-events: none;
 `

--- a/core/ui/vault/chain/coin/market/CoinPriceRangeBand.tsx
+++ b/core/ui/vault/chain/coin/market/CoinPriceRangeBand.tsx
@@ -1,4 +1,5 @@
 import { FiatAmountText } from '@core/ui/chain/components/FiatAmountText'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -57,7 +58,7 @@ const Track = styled.div`
   position: relative;
   width: 100%;
   height: 4px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   background: ${getColor('foregroundExtra')};
 `
 
@@ -66,7 +67,7 @@ const Dot = styled.div`
   top: 50%;
   width: 8px;
   height: 8px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   transform: translateY(-50%);
   background: ${getColor('primary')};
 `

--- a/core/ui/vault/chain/manage/ChainItem.tsx
+++ b/core/ui/vault/chain/manage/ChainItem.tsx
@@ -6,6 +6,7 @@ import {
 } from '@core/ui/storage/coins'
 import { useCurrentVaultNativeCoins } from '@core/ui/vault/state/currentVaultCoins'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CheckmarkIcon } from '@lib/ui/icons/CheckmarkIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { StationCheckmarkSmallIcon } from '@lib/ui/icons/StationFigmaIcons'
@@ -113,7 +114,7 @@ const ChainIconWrapper = styled.div<IsActiveProp>`
   })};
   position: relative;
   align-self: stretch;
-  border-radius: 24px;
+  ${borderRadius.xl};
   background: rgba(11, 26, 58, 0.5);
   height: 74px;
   padding: 17px;
@@ -146,6 +147,8 @@ const CheckBadge = styled(IconWrapper)`
   right: 0;
   height: 24px;
   padding: 8px;
+  /* A notched badge shape, not a surface radius: both values exceed half
+     the element and clamp, fully rounding two opposite corners. */
   border-radius: 40px 0 25px 0;
   background: ${getColor('foregroundSuper')};
   font-weight: 600;

--- a/core/ui/vault/chain/manage/coin/AddCustomTokenPrompt.tsx
+++ b/core/ui/vault/chain/manage/coin/AddCustomTokenPrompt.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { PlusIcon } from '@lib/ui/icons/PlusIcon'
 import { vStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
@@ -66,7 +67,7 @@ const CustomIconWrapper = styled.div`
   padding: 17px;
   font-size: 27.5px;
   color: ${getColor('buttonPrimary')};
-  border-radius: 24px;
+  ${borderRadius.xl};
   border: 1.5px dashed ${getColor('foregroundExtra')};
   opacity: 0.6;
   background: ${getColor('foreground')};

--- a/core/ui/vault/chain/manage/shared/DoneButton.tsx
+++ b/core/ui/vault/chain/manage/shared/DoneButton.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
 import { useTranslation } from 'react-i18next'
@@ -31,7 +32,7 @@ const StyledButton = styled(UnstyledButton)`
   align-items: center;
   gap: 6px;
 
-  border-radius: 99px;
+  ${borderRadius.pill};
   background: ${getColor('foreground')};
 
   transition: background 0.3s ease;

--- a/core/ui/vault/chain/manage/shared/SearchInput.tsx
+++ b/core/ui/vault/chain/manage/shared/SearchInput.tsx
@@ -1,6 +1,7 @@
 import { InputPasteAction } from '@core/ui/components/InputPasteAction'
 import { ActionInsideInteractiveElement } from '@lib/ui/base/ActionInsideInteractiveElement'
 import { IconButton } from '@lib/ui/buttons/IconButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CloseIcon } from '@lib/ui/icons/CloseIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { MagnifyingGlassIcon } from '@lib/ui/icons/MagnifyingGlassIcon'
@@ -90,7 +91,7 @@ export const SearchInput = ({
 }
 
 const InputWrapper = styled.div<{ hasBorder?: boolean }>`
-  border-radius: 99px;
+  ${borderRadius.pill};
   background: ${getColor('foreground')};
   background-clip: padding-box;
   overflow: hidden;
@@ -106,7 +107,7 @@ const InputWrapper = styled.div<{ hasBorder?: boolean }>`
 `
 
 const StyledTextInput = styled(TextInput)`
-  border-radius: 99px;
+  ${borderRadius.pill};
   background: ${getColor('foreground')};
   box-shadow: 0 0 8px 0 rgba(240, 244, 252, 0.03) inset;
   height: 44px;

--- a/core/ui/vault/chain/manage/shared/TokenItem.tsx
+++ b/core/ui/vault/chain/manage/shared/TokenItem.tsx
@@ -1,6 +1,7 @@
 import { ChainEntityIcon } from '@core/ui/chain/coin/icon/ChainEntityIcon'
 import { getCoinLogoSrc } from '@core/ui/chain/coin/icon/utils/getCoinLogoSrc'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CheckmarkIcon } from '@lib/ui/icons/CheckmarkIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { vStack } from '@lib/ui/layout/Stack'
@@ -85,7 +86,7 @@ const TokenIconWrapper = styled.div<IsActiveProp>`
   })};
   position: relative;
   align-self: stretch;
-  border-radius: 24px;
+  ${borderRadius.xl};
   background: rgba(11, 26, 58, 0.5);
   height: 74px;
   padding: 17px;
@@ -105,6 +106,8 @@ const CheckBadge = styled(IconWrapper)`
   right: 0;
   height: 24px;
   padding: 8px;
+  /* A notched badge shape, not a surface radius: both values exceed half
+     the element and clamp, fully rounding two opposite corners. */
   border-radius: 40px 0 25px 0;
   background: ${getColor('foregroundSuper')};
   font-weight: 600;

--- a/core/ui/vault/chain/tron/ResourcesCard.tsx
+++ b/core/ui/vault/chain/tron/ResourcesCard.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { InfoCircleIcon } from '@lib/ui/icons/InfoCircleIcon'
 import { TronBandwidthIcon } from '@lib/ui/icons/TronBandwidthIcon'
 import { TronEnergyIcon } from '@lib/ui/icons/TronEnergyIcon'
@@ -25,7 +26,7 @@ const energyAccent = '#FFC25C'
 const Card = styled(VStack)`
   flex: 1;
   padding: 12px;
-  border-radius: 8px;
+  ${borderRadius.sm};
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('background')};
   gap: 16px;
@@ -36,7 +37,7 @@ const BandwidthIconBox = styled.div`
   align-items: center;
   justify-content: center;
   padding: 8px;
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: rgba(19, 200, 157, 0.1);
   flex-shrink: 0;
 `
@@ -46,7 +47,7 @@ const EnergyIconBox = styled.div`
   align-items: center;
   justify-content: center;
   padding: 8px;
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: #1b2430;
   flex-shrink: 0;
 `

--- a/core/ui/vault/chain/tron/TronResourceBar.tsx
+++ b/core/ui/vault/chain/tron/TronResourceBar.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { toPercents } from '@vultisig/lib-utils/toPercents'
 import styled from 'styled-components'
 
@@ -9,14 +10,14 @@ type TronResourceBarProps = {
 const Track = styled.div`
   width: 100%;
   height: 8px;
-  border-radius: 12px;
+  ${borderRadius.pill};
   background: #11284a;
   overflow: hidden;
 `
 
 const Fill = styled.div<TronResourceBarProps>`
   height: 100%;
-  border-radius: 12px;
+  ${borderRadius.pill};
   background: ${({ $color }) => $color};
   width: ${({ $percentage }) =>
     toPercents(Math.max(Math.min($percentage, 1), 0))};

--- a/core/ui/vault/chain/tron/TronResourcesInfoModal.tsx
+++ b/core/ui/vault/chain/tron/TronResourcesInfoModal.tsx
@@ -2,6 +2,7 @@ import { ChainEntityIcon } from '@core/ui/chain/coin/icon/ChainEntityIcon'
 import { getChainLogoSrc } from '@core/ui/chain/metadata/getChainLogoSrc'
 import { useCore } from '@core/ui/state/core'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import CaretDownIcon from '@lib/ui/icons/CaretDownIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { TronBandwidthIcon } from '@lib/ui/icons/TronBandwidthIcon'
@@ -180,7 +181,7 @@ const ContentContainer = styled(VStack)`
   @media ${mediaQuery.tabletDeviceAndUp} {
     padding: 24px;
     background: ${getColor('background')};
-    border-radius: 12px;
+    ${borderRadius.md};
     border: 1px solid ${getColor('mistExtra')};
     max-width: 480px;
     width: 100%;
@@ -192,7 +193,7 @@ const BandwidthIconCircle = styled.div`
   align-items: center;
   justify-content: center;
   padding: 8px;
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: rgba(19, 200, 157, 0.1);
   flex-shrink: 0;
 `
@@ -202,7 +203,7 @@ const EnergyIconCircle = styled.div`
   align-items: center;
   justify-content: center;
   padding: 8px;
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: #1b2430;
   flex-shrink: 0;
 `
@@ -221,7 +222,7 @@ const RowWrapper = styled.div`
 `
 
 const AccordionWrapper = styled.div`
-  border-radius: 12px;
+  ${borderRadius.md};
   background-color: ${getColor('foreground')};
 
   & > ${RowWrapper}:first-of-type {

--- a/core/ui/vault/components/AgentBottomNavigationContent.tsx
+++ b/core/ui/vault/components/AgentBottomNavigationContent.tsx
@@ -5,8 +5,8 @@ import {
 import { autoUpdate, offset, shift, useFloating } from '@floating-ui/react'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
 import { Coachmark } from '@lib/ui/coachmark/Coachmark'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
-import { round } from '@lib/ui/css/round'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { AgentIcon } from '@lib/ui/icons/AgentIcon'
 import { Camera2Icon } from '@lib/ui/icons/Camera2Icon'
@@ -253,7 +253,7 @@ const FloatingCamera = styled(UnstyledButton)`
   right: 28px;
   bottom: 80px;
   z-index: 16;
-  ${round};
+  ${borderRadius.pill};
   ${centerContent};
   ${sameDimensions(cameraButtonSize)};
   background: ${({ theme }) =>
@@ -291,7 +291,7 @@ const TabButton = styled(UnstyledButton)<TabButtonProps>`
   height: 48px;
   padding: 3px 20px;
   font-size: 24px;
-  border-radius: 99px;
+  ${borderRadius.pill};
   transition: all 0.2s ease-in-out;
   background: transparent;
 

--- a/core/ui/vault/components/BottomNavigation.tsx
+++ b/core/ui/vault/components/BottomNavigation.tsx
@@ -1,8 +1,8 @@
 import { featureFlags } from '@core/ui/featureFlags'
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
-import { round } from '@lib/ui/css/round'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { Camera2Icon } from '@lib/ui/icons/Camera2Icon'
 import { NodesIcon } from '@lib/ui/icons/NodesIcon'
@@ -149,7 +149,7 @@ const ContainerOld = styled.div`
 `
 
 const CameraButton = styled(UnstyledButton)`
-  ${round};
+  ${borderRadius.pill};
   background: ${({ theme }) =>
     theme.iconStyle === 'station'
       ? theme.colors.buttonPrimary.toCssValue()
@@ -180,7 +180,7 @@ const TabButtonOld = styled(UnstyledButton)<TabButtonOldProps>`
   height: 48px;
   padding: 3px 20px;
   font-size: 24px;
-  border-radius: 99px;
+  ${borderRadius.pill};
   transition: all 0.2s ease-in-out;
   background: transparent;
 

--- a/core/ui/vault/components/PrimaryActions.styled.tsx
+++ b/core/ui/vault/components/PrimaryActions.styled.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
@@ -21,7 +22,7 @@ const ActionWrapper = styled(UnstyledButton)`
   justify-content: center;
   align-items: center;
   gap: 6px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   line-height: 0;
   font-size: 20px;
   transition: background 0.3s ease;
@@ -38,7 +39,7 @@ export const PrimaryActionWrapper = styled(ActionWrapper)`
 `
 
 export const SecondaryActionWrapper = styled(ActionWrapper)`
-  border-radius: 16px;
+  ${borderRadius.lg};
   border: 1px solid rgba(255, 255, 255, 0.03);
   background: ${getColor('foregroundExtra')};
 

--- a/core/ui/vault/components/action-form/ActionFormIconsWrapper.tsx
+++ b/core/ui/vault/components/action-form/ActionFormIconsWrapper.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
@@ -9,7 +10,7 @@ export const ActionFormIconsWrapper = styled(HStack)`
 export const ActionFormCheckBadge = styled.div`
   width: 16px;
   height: 16px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   border: 0.6667px solid ${getColor('success')};
   background: ${getColor('foreground')};
   color: ${getColor('success')};

--- a/core/ui/vault/components/action-form/ActionIconButton.tsx
+++ b/core/ui/vault/components/action-form/ActionIconButton.tsx
@@ -10,7 +10,7 @@ export const ActionIconButton = styled(IconButton)`
   font-size: 20px;
   padding: 12px 16px;
   width: 103px;
-  ${borderRadius.s};
+  ${borderRadius.sm};
 
   &:hover {
     background-color: ${getColor('foregroundExtra')};

--- a/core/ui/vault/components/action-form/ActionInputContainer.tsx
+++ b/core/ui/vault/components/action-form/ActionInputContainer.tsx
@@ -9,6 +9,6 @@ export const ActionInputContainer = styled(VStack)`
   gap: 16px;
   padding: 12px;
   flex: 1;
-  ${borderRadius.m};
+  ${borderRadius.md};
   border: 1px solid ${getColor('foregroundExtra')};
 `

--- a/core/ui/vault/create/setup-vault/DeviceCountPicker.tsx
+++ b/core/ui/vault/create/setup-vault/DeviceCountPicker.tsx
@@ -1,7 +1,6 @@
 import { DeviceSelectionTip } from '@core/ui/vault/create/setup-vault/DeviceSelectionTip'
 import { useDeviceSelectionAnimation } from '@core/ui/vault/create/setup-vault/hooks/useDeviceSelectionAnimation'
 import { Button } from '@lib/ui/buttons/Button'
-import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ScreenLayout } from '@lib/ui/layout/ScreenLayout/ScreenLayout'
 import { VStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
@@ -27,7 +26,9 @@ const TopGradient = styled.div`
   transform: translateX(-50%);
   width: 600px;
   height: 500px;
-  ${borderRadius.pill};
+  /* A decorative radial glow, not a surface: 600x500 means 50% is an
+     ellipse and the pill token would clamp it to a stadium. */
+  border-radius: 50%;
   background: radial-gradient(
     50% 50% at 50% 50%,
     rgba(72, 121, 253, 0.5) 0%,

--- a/core/ui/vault/create/setup-vault/DeviceCountPicker.tsx
+++ b/core/ui/vault/create/setup-vault/DeviceCountPicker.tsx
@@ -1,6 +1,7 @@
 import { DeviceSelectionTip } from '@core/ui/vault/create/setup-vault/DeviceSelectionTip'
 import { useDeviceSelectionAnimation } from '@core/ui/vault/create/setup-vault/hooks/useDeviceSelectionAnimation'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ScreenLayout } from '@lib/ui/layout/ScreenLayout/ScreenLayout'
 import { VStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
@@ -26,7 +27,7 @@ const TopGradient = styled.div`
   transform: translateX(-50%);
   width: 600px;
   height: 500px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: radial-gradient(
     50% 50% at 50% 50%,
     rgba(72, 121, 253, 0.5) 0%,

--- a/core/ui/vault/create/setup-vault/VaultExistsOnServerWarning.tsx
+++ b/core/ui/vault/create/setup-vault/VaultExistsOnServerWarning.tsx
@@ -54,7 +54,7 @@ export const VaultExistsOnServerWarning = ({
 }
 
 const WarningCard = styled(HStack)`
-  ${borderRadius.m};
+  ${borderRadius.md};
   background-color: ${getColor('idleDark')};
   border: 1px solid ${getColor('idle')};
   padding: 16px;

--- a/core/ui/vault/create/setup-vault/vault-setup-overview/VaultSetupBadge.tsx
+++ b/core/ui/vault/create/setup-vault/vault-setup-overview/VaultSetupBadge.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -31,7 +32,7 @@ export const VaultSetupBadge = ({
 const Container = styled(HStack)`
   background: #061b3a;
   border: 1px solid ${getColor('foreground')};
-  border-radius: 16px;
+  ${borderRadius.lg};
   padding: 8px 20px 8px 8px;
   align-self: flex-start;
 `
@@ -40,7 +41,7 @@ const IconWrapper = styled.div`
   flex-shrink: 0;
   width: 33px;
   height: 33px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   display: flex;
   align-items: center;
   justify-content: center;

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/BondSpecific/BondForm.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/BondSpecific/BondForm.tsx
@@ -12,6 +12,7 @@ import { useDepositFormHandlers } from '@core/ui/vault/deposit/providers/Deposit
 import { stepFromDecimals } from '@core/ui/vault/deposit/utils/stepFromDecimals'
 import { AmountSuggestion } from '@core/ui/vault/send/amount/AmountSuggestion'
 import { ActionInsideInteractiveElement } from '@lib/ui/base/ActionInsideInteractiveElement'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CameraIcon } from '@lib/ui/icons/CameraIcon'
 import { CheckmarkIcon } from '@lib/ui/icons/CheckmarkIcon'
 import { ChevronDownIcon } from '@lib/ui/icons/ChevronDownIcon'
@@ -459,7 +460,7 @@ export const BondForm = ({
 const SuggestionOption = styled(AmountSuggestion)`
   flex: 1;
   padding: 6px 18px;
-  border-radius: 99px;
+  ${borderRadius.pill};
 `
 
 const FixedScanQRView = styled(ScanQrView)`
@@ -542,7 +543,7 @@ const FilledTextInput = styled(TextInput)`
   justify-content: space-between;
   align-items: center;
   align-self: stretch;
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid #11284a;
   background: #061b3a;
   font-size: 16px;

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/ClaimRewardsSpecific.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/ClaimRewardsSpecific.tsx
@@ -3,6 +3,7 @@ import { useCosmosRewardsQuery } from '@core/ui/chain/cosmos/staking/queries/use
 import { stakingDenomForChain } from '@core/ui/chain/cosmos/staking/stakingDenom'
 import { useDepositCoin } from '@core/ui/vault/deposit/providers/DepositCoinProvider'
 import { useDepositFormHandlers } from '@core/ui/vault/deposit/providers/DepositFormHandlersProvider'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { VStack } from '@lib/ui/layout/Stack'
 import { Spinner } from '@lib/ui/loaders/Spinner'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
@@ -115,5 +116,5 @@ export const ClaimRewardsSpecific = () => {
 const Card = styled(VStack).attrs({ gap: 8 })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/DelegateSpecific.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/DelegateSpecific.tsx
@@ -1,6 +1,7 @@
 import { useBalanceQuery } from '@core/ui/chain/coin/queries/useBalanceQuery'
 import { useDepositCoin } from '@core/ui/vault/deposit/providers/DepositCoinProvider'
 import { useDepositFormHandlers } from '@core/ui/vault/deposit/providers/DepositFormHandlersProvider'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { PercentageSelector } from '@lib/ui/inputs/PercentageSelector'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
@@ -118,7 +119,7 @@ const Layout = styled(VStack).attrs({ flexGrow: true, gap: 16 })``
 const Card = styled(VStack).attrs({ gap: 12, flexGrow: true })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 const CenteredAmount = styled.div`

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/RedelegateSpecific.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/RedelegateSpecific.tsx
@@ -2,6 +2,7 @@ import { ActiveDelegationPicker } from '@core/ui/chain/cosmos/staking/components
 import { useCosmosDelegationsQuery } from '@core/ui/chain/cosmos/staking/queries/useCosmosDelegationsQuery'
 import { useDepositCoin } from '@core/ui/vault/deposit/providers/DepositCoinProvider'
 import { useDepositFormHandlers } from '@core/ui/vault/deposit/providers/DepositFormHandlersProvider'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { Slider } from '@lib/ui/inputs/Slider'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
@@ -146,7 +147,7 @@ const Layout = styled(VStack).attrs({ flexGrow: true, gap: 16 })``
 const Card = styled(VStack).attrs({ gap: 12, flexGrow: true })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 const CenteredAmount = styled.div`

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/UndelegateSpecific.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/UndelegateSpecific.tsx
@@ -2,6 +2,7 @@ import { ActiveDelegationPicker } from '@core/ui/chain/cosmos/staking/components
 import { useCosmosDelegationsQuery } from '@core/ui/chain/cosmos/staking/queries/useCosmosDelegationsQuery'
 import { useDepositCoin } from '@core/ui/vault/deposit/providers/DepositCoinProvider'
 import { useDepositFormHandlers } from '@core/ui/vault/deposit/providers/DepositFormHandlersProvider'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { Slider } from '@lib/ui/inputs/Slider'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
@@ -148,7 +149,7 @@ export const UndelegateSpecific = () => {
 const Card = styled(VStack).attrs({ gap: 12 })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 const CenteredAmount = styled.div`

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/ValidatorPickerField.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/CosmosStakingSpecific/ValidatorPickerField.tsx
@@ -2,6 +2,7 @@ import { ValidatorAvatar } from '@core/ui/chain/cosmos/staking/components/Valida
 import { ValidatorPickerSheet } from '@core/ui/chain/cosmos/staking/components/ValidatorPickerSheet'
 import { useCosmosValidatorsQuery } from '@core/ui/chain/cosmos/staking/queries/useCosmosValidatorsQuery'
 import { Opener } from '@lib/ui/base/Opener'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CircleCheckIcon } from '@lib/ui/icons/CircleCheckIcon'
 import { IconFileEdit } from '@lib/ui/icons/IconFileEdit'
 import { HStack } from '@lib/ui/layout/Stack'
@@ -102,7 +103,7 @@ const FieldContainer = styled.button.attrs({ type: 'button' as const })`
   justify-content: space-between;
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
   cursor: pointer;
   background: transparent;
   color: inherit;

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/FreezeSpecific/TronResourceTypePicker.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/FreezeSpecific/TronResourceTypePicker.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -45,7 +46,7 @@ export const TronResourceTypePicker = ({
 }
 
 const Container = styled(HStack)`
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: ${getColor('foreground')};
   padding: 2px;
   gap: 2px;
@@ -55,7 +56,7 @@ const Option = styled.button<{ $active: boolean }>`
   flex: 1;
   padding: 8px 16px;
   border: none;
-  border-radius: 6px;
+  ${borderRadius.xs};
   cursor: pointer;
   background: ${({ $active, theme }) =>
     $active ? theme.colors.foregroundExtra.toCssValue() : 'transparent'};

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/SolanaStakingSpecific/SolanaDelegateSpecific.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/SolanaStakingSpecific/SolanaDelegateSpecific.tsx
@@ -3,6 +3,7 @@ import { useSolanaStakeableBalance } from '@core/ui/vault/deposit/hooks/useSolan
 import { useDepositCoin } from '@core/ui/vault/deposit/providers/DepositCoinProvider'
 import { useDepositFormHandlers } from '@core/ui/vault/deposit/providers/DepositFormHandlersProvider'
 import { getFieldErrorMessage } from '@core/ui/vault/deposit/utils/getFieldErrorMessage'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { PercentageSelector } from '@lib/ui/inputs/PercentageSelector'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
@@ -124,7 +125,7 @@ const Layout = styled(VStack).attrs({ flexGrow: true, gap: 16 })``
 const Card = styled(VStack).attrs({ gap: 12, flexGrow: true })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 const CenteredAmount = styled.div`

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/SolanaStakingSpecific/SolanaFinishMoveSpecific.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/SolanaStakingSpecific/SolanaFinishMoveSpecific.tsx
@@ -1,6 +1,7 @@
 import { SolanaValidatorPickerField } from '@core/ui/chain/solana/staking/components/SolanaValidatorPickerField'
 import { useDepositCoin } from '@core/ui/vault/deposit/providers/DepositCoinProvider'
 import { useDepositFormHandlers } from '@core/ui/vault/deposit/providers/DepositFormHandlersProvider'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -62,7 +63,7 @@ const Layout = styled(VStack).attrs({ gap: 16 })``
 const Card = styled(VStack).attrs({ gap: 12 })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 const Row = styled.div`
@@ -74,6 +75,6 @@ const Row = styled.div`
 
 const Notice = styled.div`
   padding: 12px 16px;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('foreground')};
 `

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/SolanaStakingSpecific/SolanaMoveStakeSpecific.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/SolanaStakingSpecific/SolanaMoveStakeSpecific.tsx
@@ -2,6 +2,7 @@ import { SolanaValidatorPickerField } from '@core/ui/chain/solana/staking/compon
 import { useSolanaValidatorsQuery } from '@core/ui/chain/solana/staking/queries/useSolanaValidatorsQuery'
 import { useDepositCoin } from '@core/ui/vault/deposit/providers/DepositCoinProvider'
 import { useDepositFormHandlers } from '@core/ui/vault/deposit/providers/DepositFormHandlersProvider'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -96,7 +97,7 @@ export const SolanaMoveStakeSpecific = () => {
 const Card = styled(VStack).attrs({ gap: 12 })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 const Row = styled.div`
@@ -108,6 +109,6 @@ const Row = styled.div`
 
 const Notice = styled.div`
   padding: 12px 16px;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('foreground')};
 `

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/SolanaStakingSpecific/SolanaStakingInfoCard.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/SolanaStakingSpecific/SolanaStakingInfoCard.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -44,7 +45,7 @@ export const SolanaStakingInfoCard = ({
 const Card = styled(VStack).attrs({ gap: 12 })`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 const Row = styled.div`
@@ -56,6 +57,6 @@ const Row = styled.div`
 
 const Notice = styled.div`
   padding: 12px 16px;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('foreground')};
 `

--- a/core/ui/vault/deposit/DepositForm/ActionSpecific/UnbondSpecific/UnbondForm.tsx
+++ b/core/ui/vault/deposit/DepositForm/ActionSpecific/UnbondSpecific/UnbondForm.tsx
@@ -7,6 +7,7 @@ import { useDepositCoin } from '@core/ui/vault/deposit/providers/DepositCoinProv
 import { useDepositFormHandlers } from '@core/ui/vault/deposit/providers/DepositFormHandlersProvider'
 import { stepFromDecimals } from '@core/ui/vault/deposit/utils/stepFromDecimals'
 import { ActionInsideInteractiveElement } from '@lib/ui/base/ActionInsideInteractiveElement'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CheckmarkIcon } from '@lib/ui/icons/CheckmarkIcon'
 import { PencilIcon } from '@lib/ui/icons/PenciIcon'
 import { InputLabel } from '@lib/ui/inputs/InputLabel'
@@ -293,7 +294,7 @@ const PencilIconWrapper = styled.div`
 
 const AddressDisplay = styled.div`
   padding: 16px;
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid #11284a;
   background: #061b3a;
   font-size: 16px;

--- a/core/ui/vault/import/seedphrase/EnterSeedphraseHeader.tsx
+++ b/core/ui/vault/import/seedphrase/EnterSeedphraseHeader.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { DownloadSeedphraseIcon } from '@lib/ui/icons/DownloadSeedphraseIcon'
@@ -9,7 +10,7 @@ import styled from 'styled-components'
 
 const IconContainer = styled.div`
   ${sameDimensions(48)}
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: ${getColor('foreground')};
   ${centerContent};
   font-size: 20px;

--- a/core/ui/vault/import/seedphrase/scanResult/ScanResultChainItem.tsx
+++ b/core/ui/vault/import/seedphrase/scanResult/ScanResultChainItem.tsx
@@ -1,5 +1,6 @@
 import { ChainEntityIcon } from '@core/ui/chain/coin/icon/ChainEntityIcon'
 import { getChainLogoSrc } from '@core/ui/chain/metadata/getChainLogoSrc'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { hStack } from '@lib/ui/layout/Stack'
 import { ValueProp } from '@lib/ui/props'
 import { getColor } from '@lib/ui/theme/getters'
@@ -8,7 +9,7 @@ import styled from 'styled-components'
 
 const Container = styled.div`
   height: 52px;
-  border-radius: 20px;
+  ${borderRadius.xl};
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
   ${hStack({

--- a/core/ui/vault/import/seedphrase/scanResult/ScanResultHeader.tsx
+++ b/core/ui/vault/import/seedphrase/scanResult/ScanResultHeader.tsx
@@ -1,5 +1,5 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
-import { round } from '@lib/ui/css/round'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { CubeWithCornersIcon } from '@lib/ui/icons/CubeWithCornersIcon'
 import { VStack } from '@lib/ui/layout/Stack'
@@ -15,7 +15,7 @@ type ScanResultHeaderProps = TitleProp &
   KindProp<ScanResultHeaderKind>
 
 const StyledIconWrapper = styled.div<KindProp<ScanResultHeaderKind>>`
-  ${round};
+  ${borderRadius.pill};
   color: ${matchColor('kind', {
     positive: 'primary',
     negative: 'danger',

--- a/core/ui/vault/new/ImportOption.tsx
+++ b/core/ui/vault/new/ImportOption.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack, vStack } from '@lib/ui/layout/Stack'
 import {
   DescriptionProp,
@@ -15,7 +16,7 @@ const Container = styled(UnstyledButton)`
   ${vStack({
     gap: 12,
   })}
-  border-radius: 24px;
+  ${borderRadius.xl};
   background: ${getColor('foreground')};
   padding: 24px;
   width: 100%;

--- a/core/ui/vault/new/index.tsx
+++ b/core/ui/vault/new/index.tsx
@@ -2,6 +2,7 @@ import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { useVaults } from '@core/ui/storage/vaults'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { UniformColumnGrid } from '@lib/ui/css/uniformColumnGrid'
 import { VStack } from '@lib/ui/layout/Stack'
 import { useNavigateBack } from '@lib/ui/navigation/hooks/useNavigateBack'
@@ -28,7 +29,7 @@ const TopGradient = styled.div`
   transform: translateX(-50%);
   width: 600px;
   height: 500px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: radial-gradient(
     50% 50% at 50% 50%,
     rgba(72, 121, 253, 0.5) 0%,
@@ -43,7 +44,7 @@ const LogoContainer = styled.div`
   justify-content: center;
   width: 60px;
   height: 60px;
-  border-radius: 19px;
+  ${borderRadius.lg};
   background: linear-gradient(180deg, #4879fd 0%, #0d39b1 100%);
   box-shadow: inset 0px 1.2px 1.2px 0px rgba(255, 255, 255, 0.35);
   color: white;

--- a/core/ui/vault/new/index.tsx
+++ b/core/ui/vault/new/index.tsx
@@ -29,7 +29,9 @@ const TopGradient = styled.div`
   transform: translateX(-50%);
   width: 600px;
   height: 500px;
-  ${borderRadius.pill};
+  /* A decorative radial glow, not a surface: 600x500 means 50% is an
+     ellipse and the pill token would clamp it to a stadium. */
+  border-radius: 50%;
   background: radial-gradient(
     50% 50% at 50% 50%,
     rgba(72, 121, 253, 0.5) 0%,

--- a/core/ui/vault/page/balance/visibility/ManageVaultBalanceVisibility.tsx
+++ b/core/ui/vault/page/balance/visibility/ManageVaultBalanceVisibility.tsx
@@ -2,6 +2,7 @@ import {
   useIsBalanceVisible,
   useSetIsBalanceVisibleMutation,
 } from '@core/ui/storage/balanceVisibility'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { EyeClosedIcon } from '@lib/ui/icons/EyeClosedIcon'
 import { EyeIcon } from '@lib/ui/icons/EyeIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
@@ -46,7 +47,7 @@ const Wrapper = styled.div`
   justify-content: center;
   align-items: center;
   gap: 4px;
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: rgba(81, 128, 252, 0.12);
   cursor: pointer;
 `

--- a/core/ui/vault/page/banners/BannerCarousel/BannerCarousel.styles.tsx
+++ b/core/ui/vault/page/banners/BannerCarousel/BannerCarousel.styles.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { getColor } from '@lib/ui/theme/getters'
 import { motion } from 'framer-motion'
 import styled from 'styled-components'
@@ -18,7 +19,7 @@ export const CarouselContainer = styled.div`
 export const CarouselViewport = styled.div`
   width: 100%;
   overflow: hidden;
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 export const CarouselTrack = styled(motion.div)`
@@ -57,7 +58,7 @@ export const PaginationDot = styled(UnstyledButton)<{ $isActive: boolean }>`
     display: block;
     width: ${({ $isActive }) => ($isActive ? 20 : 4)}px;
     height: 4px;
-    border-radius: 99px;
+    ${borderRadius.pill};
     background: ${({ $isActive, theme }) =>
       $isActive
         ? theme.colors.textShyExtra.toCssValue()

--- a/core/ui/vault/page/banners/BuyVultPromoBanner/BuyVultPromoBanner.styles.tsx
+++ b/core/ui/vault/page/banners/BuyVultPromoBanner/BuyVultPromoBanner.styles.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
 
@@ -23,7 +24,7 @@ export const IllustrationGlow = styled.div`
   right: -58px;
   width: 228px;
   height: 228px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   background: radial-gradient(
     50% 50% at 50% 50%,
     ${getColor('primaryAlt')} 0%,

--- a/core/ui/vault/page/banners/FollowOnXBanner/FollowOnXBanner.styles.tsx
+++ b/core/ui/vault/page/banners/FollowOnXBanner/FollowOnXBanner.styles.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import styled from 'styled-components'
 
 import { BannerPromoCtaButton } from '../shared/BannerPromoCtaButton.styles'
@@ -33,7 +34,7 @@ export const ButtonsRow = styled.div`
 `
 
 export const FollowButton = styled(BannerPromoCtaButton)`
-  border-radius: 24px;
+  ${borderRadius.xl};
   background: linear-gradient(135deg, #4ade80 0%, #22d3ee 100%);
   color: #0f172a;
   font-weight: 600;

--- a/core/ui/vault/page/banners/shared/HomePromoBanner.styles.tsx
+++ b/core/ui/vault/page/banners/shared/HomePromoBanner.styles.tsx
@@ -1,4 +1,5 @@
 import { IconButton } from '@lib/ui/buttons/IconButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { vStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
@@ -9,7 +10,7 @@ export const HomePromoBannerRoot = styled.div`
   height: 134px;
   box-sizing: border-box;
   padding: 24px;
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
   overflow: hidden;

--- a/core/ui/vault/page/components/ReceiveModal.tsx
+++ b/core/ui/vault/page/components/ReceiveModal.tsx
@@ -4,6 +4,7 @@ import { currentProductBrand } from '@core/ui/product/brand'
 import { AddressQRModal } from '@core/ui/vault/chain/address/AddressQRModal'
 import { useCurrentVaultChains } from '@core/ui/vault/state/currentVaultCoins'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ChevronLeftIcon } from '@lib/ui/icons/ChevronLeftIcon'
 import { StationChevronLeftIcon } from '@lib/ui/icons/StationFigmaIcons'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -67,7 +68,7 @@ const HeaderBackButton = styled(UnstyledButton)`
 const SearchFieldHalo = styled.div`
   width: 100%;
   padding: 0;
-  border-radius: 99px;
+  ${borderRadius.pill};
   background: transparent;
   box-shadow: none;
 `
@@ -75,7 +76,7 @@ const SearchFieldHalo = styled.div`
 const ReceiveSearchField = styled(SearchField)`
   color: ${getColor('contrast')};
 
-  border-radius: 99px;
+  ${borderRadius.pill};
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${({ theme }) =>
     theme.iconStyle === 'station'
@@ -93,7 +94,7 @@ const ReceiveSearchField = styled(SearchField)`
 `
 
 const ChainItemsWrapper = styled.div`
-  border-radius: 24px;
+  ${borderRadius.xl};
   border: none;
   overflow: hidden;
   box-shadow: none;
@@ -144,8 +145,7 @@ const ChainBadge = styled(Text)`
   display: inline-flex;
   align-items: center;
   padding: 8px 12px;
-  border-radius: 999px;
-  border-radius: 99px;
+  ${borderRadius.pill};
   border: 1.5px solid ${getColor('foregroundSuper')};
   background: ${getColor('foreground')};
 `

--- a/core/ui/vault/page/components/VaultOverview.tsx
+++ b/core/ui/vault/page/components/VaultOverview.tsx
@@ -1,6 +1,7 @@
 import { CollapsingBalance } from '@core/ui/page/CollapsingBalance'
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { Wrap } from '@lib/ui/base/Wrap'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { hideScrollbars } from '@lib/ui/css/hideScrollbars'
 import { VStack, vStack } from '@lib/ui/layout/Stack'
 import { PageContent } from '@lib/ui/page/PageContent'
@@ -123,7 +124,7 @@ const BlurEffect = styled.div`
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
-  border-radius: 16px;
+  ${borderRadius.lg};
   border-radius: 350px;
   height: 200px;
   top: -25px;

--- a/core/ui/vault/page/components/VaultTabs/VaultTabs.tsx
+++ b/core/ui/vault/page/components/VaultTabs/VaultTabs.tsx
@@ -1,4 +1,5 @@
 import { Tabs } from '@lib/ui/base/Tabs'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { hStack } from '@lib/ui/layout/Stack'
 import { IsActiveProp, IsDisabledProp } from '@lib/ui/props'
 import { Text } from '@lib/ui/text'
@@ -77,6 +78,6 @@ const ComingSoonWrapper = styled.div`
     justifyContent: 'center',
   })};
 
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: rgba(81, 128, 252, 0.12);
 `

--- a/core/ui/vault/page/keygen/migrate/MigrateVaultPrompt.tsx
+++ b/core/ui/vault/page/keygen/migrate/MigrateVaultPrompt.tsx
@@ -2,6 +2,7 @@ import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { Button } from '@lib/ui/buttons/Button'
 import { IconButton } from '@lib/ui/buttons/IconButton'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CrossIcon } from '@lib/ui/icons/CrossIcon'
 import { hStack, VStack } from '@lib/ui/layout/Stack'
 import { mediaQuery } from '@lib/ui/responsive/mediaQuery'
@@ -61,7 +62,7 @@ export const MigrateVaultPrompt = ({
 
 const Container = styled(UnstyledButton)`
   padding: 24px;
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
   width: 350px;

--- a/core/ui/vault/send/addresses/components/AddressBookModal/AddressBookItemAvatar.tsx
+++ b/core/ui/vault/send/addresses/components/AddressBookModal/AddressBookItemAvatar.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
 
@@ -18,7 +19,7 @@ export const AddressBookItemAvatar = ({ name, address }: VaultAvatarProps) => {
 const Circle = styled.div`
   width: 32px;
   height: 32px;
-  border-radius: 50%;
+  ${borderRadius.pill};
   color: ${getColor('text')};
   flex-shrink: 0;
   display: flex;

--- a/core/ui/vault/send/addresses/components/AddressBookModal/VaultAddressBookItem.tsx
+++ b/core/ui/vault/send/addresses/components/AddressBookModal/VaultAddressBookItem.tsx
@@ -44,7 +44,7 @@ export const VaultAddressBookItem = ({
 const AddressBookListItem = styled(ListItem)`
   background-color: transparent;
   border: 1px solid ${getColor('foregroundExtra')};
-  ${borderRadius.m};
+  ${borderRadius.md};
   padding: 16px 20px;
   max-height: 68px;
 `

--- a/core/ui/vault/send/addresses/components/AddressBookModal/index.tsx
+++ b/core/ui/vault/send/addresses/components/AddressBookModal/index.tsx
@@ -225,7 +225,7 @@ const ModalWrapper = styled(VStack)`
   height: 500px;
   width: 100%;
   background: ${getColor('foreground')};
-  ${borderRadius.m};
+  ${borderRadius.md};
   padding: 24px 20px;
 
   @media ${mediaQuery.tabletDeviceAndUp} {
@@ -235,7 +235,7 @@ const ModalWrapper = styled(VStack)`
 
 const OptionsContainer = styled(HStack)`
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 100%;
+  ${borderRadius.pill};
 `
 
 const StyledList = styled(List)`

--- a/core/ui/vault/send/addresses/components/ManageAddressesInputField.tsx
+++ b/core/ui/vault/send/addresses/components/ManageAddressesInputField.tsx
@@ -286,7 +286,7 @@ const AddressFieldWrapper = styled(VStack)`
   background-color: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   padding: 16px;
-  ${borderRadius.m}
+  ${borderRadius.md}
 `
 
 const Input = styled(TextInput)<{

--- a/core/ui/vault/send/amount/AmountSuggestion.tsx
+++ b/core/ui/vault/send/amount/AmountSuggestion.tsx
@@ -14,7 +14,7 @@ const Container = styled(UnstyledButton)<{
 }>`
   width: 56px;
   height: 30px;
-  ${borderRadius.s};
+  ${borderRadius.sm};
   ${centerContent};
   background-color: ${({ isActive }) =>
     isActive ? getColor('buttonPrimary') : getColor('foreground')};

--- a/core/ui/vault/send/amount/AmountSwitch.tsx
+++ b/core/ui/vault/send/amount/AmountSwitch.tsx
@@ -45,7 +45,7 @@ export const CurrencySwitch = ({ onClick, value }: Props) => {
 }
 
 const AnimatedIconButton = motion(styled(IconButton)<{ isActive: boolean }>`
-  border-radius: 50%;
+  ${borderRadius.pill};
   scale: ${({ isActive }) => (isActive ? 1.1 : 1)};
   opacity: ${({ isActive }) => (isActive ? 1 : 0.6)};
   transition:
@@ -58,9 +58,9 @@ const Wrapper = styled(VStack)`
   font-size: 16px;
   color: ${getColor('contrast')};
   background-color: ${getColor('foreground')};
-  ${borderRadius.l};
+  ${borderRadius.pill};
 
   > button {
-    border-radius: 50%;
+    ${borderRadius.pill};
   }
 `

--- a/core/ui/vault/send/amount/ManageAmountInputField.tsx
+++ b/core/ui/vault/send/amount/ManageAmountInputField.tsx
@@ -298,11 +298,11 @@ const StyledInputWrapper = styled(motion.div)`
 const TotalBalanceWrapper = styled(HStack)`
   background-color: ${getColor('foreground')};
   padding: 16px;
-  ${borderRadius.m}
+  ${borderRadius.md}
 `
 
 const SuggestionOption = styled(AmountSuggestion)`
   flex: 1;
   padding: 6px 18px;
-  border-radius: 99px;
+  ${borderRadius.pill};
 `

--- a/core/ui/vault/send/components/ChainOption.tsx
+++ b/core/ui/vault/send/components/ChainOption.tsx
@@ -56,7 +56,7 @@ export const ChainOption = ({
 const Container = styled('div')<{ isSelected?: boolean }>`
   ${panel()};
   padding: 12px 20px;
-  border-radius: 0px;
+  border-radius: 0;
   position: relative;
   cursor: pointer;
   background: ${({ isSelected }) =>

--- a/core/ui/vault/settings/advanced/customRpc/CustomRpcDetailPage.tsx
+++ b/core/ui/vault/settings/advanced/customRpc/CustomRpcDetailPage.tsx
@@ -8,6 +8,7 @@ import {
   useSetCustomRpcOverrideMutation,
 } from '@core/ui/storage/customRpcOverrides'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { VStack } from '@lib/ui/layout/Stack'
 import { PageContent as BasePageContent } from '@lib/ui/page/PageContent'
 import { PageFooter as BasePageFooter } from '@lib/ui/page/PageFooter'
@@ -226,7 +227,7 @@ const RpcTextAreaWrapper = styled.div<{ $invalid: boolean }>`
   border: 1px solid
     ${({ $invalid }) =>
       $invalid ? getColor('danger') : getColor('foregroundSuper')};
-  border-radius: 12px;
+  ${borderRadius.md};
   display: flex;
   gap: 4px;
   min-height: 120px;
@@ -259,7 +260,7 @@ const PasteAction = styled(InputPasteAction)`
 const DefaultEndpointCard = styled(VStack)`
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundSuper')};
-  border-radius: 12px;
+  ${borderRadius.md};
   gap: 20px;
   padding: 16px;
 `

--- a/core/ui/vault/settings/advanced/customRpc/index.tsx
+++ b/core/ui/vault/settings/advanced/customRpc/index.tsx
@@ -3,6 +3,7 @@ import { getChainLogoSrc } from '@core/ui/chain/metadata/getChainLogoSrc'
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { useCustomRpcOverrides } from '@core/ui/storage/customRpcOverrides'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { PencilIcon } from '@lib/ui/icons/PenciIcon'
 import { SearchIcon } from '@lib/ui/icons/SearchIcon'
 import { VStack } from '@lib/ui/layout/Stack'
@@ -142,7 +143,7 @@ const SearchInput = ({ value, onChange, placeholder }: SearchInputProps) => (
 const SearchWrapper = styled.div`
   align-items: center;
   background: ${getColor('foreground')};
-  border-radius: 99px;
+  ${borderRadius.pill};
   box-shadow: inset 0 0 8px rgba(240, 244, 252, 0.03);
   color: ${getColor('textShy')};
   display: flex;
@@ -203,7 +204,7 @@ const ChainIconFrame = styled.div<{ $isCustom: boolean }>`
   border: 1.5px solid
     ${({ $isCustom }) =>
       $isCustom ? getColor('foregroundExtra') : 'transparent'};
-  border-radius: 24px;
+  ${borderRadius.xl};
   display: flex;
   height: 74px;
   justify-content: center;

--- a/core/ui/vault/settings/backup/BackupModal.tsx
+++ b/core/ui/vault/settings/backup/BackupModal.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { CloseIcon } from '@lib/ui/icons/CloseIcon'
 import { CloudIcon } from '@lib/ui/icons/CloudIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
@@ -89,7 +90,7 @@ const Wrapper = styled.div`
   })};
 
   padding: 20px;
-  border-radius: 16px 16px 0 0;
+  border-radius: ${borderRadiusPx.xl}px ${borderRadiusPx.xl}px 0 0;
   background: ${getColor('background')};
 `
 
@@ -100,7 +101,7 @@ const DesktopModalWrapper = styled.div`
 const ActionButton = styled(UnstyledButton)`
   width: 44px;
   height: 44px;
-  border-radius: 50%;
+  ${borderRadius.pill};
 `
 
 const CancelButton = styled(ActionButton)`

--- a/core/ui/vault/settings/backup/BackupOption.tsx
+++ b/core/ui/vault/settings/backup/BackupOption.tsx
@@ -24,7 +24,7 @@ const Container = styled(UnstyledButton)`
     gap: 12,
     alignItems: 'center',
   })}
-  ${borderRadius.l};
+  ${borderRadius.xl};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   padding: 16px;

--- a/core/ui/vault/settings/delete/index.tsx
+++ b/core/ui/vault/settings/delete/index.tsx
@@ -5,6 +5,7 @@ import { useDeleteVaultMutation, useVaults } from '@core/ui/storage/vaults'
 import { useVaultTotalBalanceQuery } from '@core/ui/vault/queries/useVaultTotalBalanceQuery'
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { TriangleAlertIcon } from '@lib/ui/icons/TriangleAlertIcon'
 import { Checkbox } from '@lib/ui/inputs/checkbox/Checkbox'
@@ -170,7 +171,7 @@ const Item = styled.div`
     gap: 12,
   })};
 
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
   min-width: 0;

--- a/core/ui/vault/settings/details/VaultDetailsContent.tsx
+++ b/core/ui/vault/settings/details/VaultDetailsContent.tsx
@@ -1,5 +1,6 @@
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CopyIcon } from '@lib/ui/icons/CopyIcon'
 import { DeviceIcon } from '@lib/ui/icons/DeviceIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
@@ -19,7 +20,7 @@ const Item = styled.div`
     gap: 12,
   })};
 
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
 `

--- a/core/ui/vault/settings/index.tsx
+++ b/core/ui/vault/settings/index.tsx
@@ -1,5 +1,6 @@
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CircleInfoIcon } from '@lib/ui/icons/CircleInfoIcon'
 import { FolderKeyIcon } from '@lib/ui/icons/FolderKeyIcon'
 import { PenWritingFilledIcon } from '@lib/ui/icons/PenWritingFilledIcon'
@@ -113,7 +114,7 @@ const DeleteButtonIconWrapper = styled(ListItemIconWrapper)`
 `
 
 const DeleteItem = styled(ListItem)`
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 export { ListItemIconWrapper } from './vaultSettingsListStyles'

--- a/core/ui/vault/settings/referral/components/AddFriendsReferralPrompt.tsx
+++ b/core/ui/vault/settings/referral/components/AddFriendsReferralPrompt.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { Image } from '@lib/ui/image/Image'
 import { VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
@@ -49,7 +50,7 @@ const FriendsReferralPromptWrapper = styled(VStack)`
 
   cursor: pointer;
 
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
 `

--- a/core/ui/vault/settings/referral/components/CreateReferral/CreateReferralForm/Fields/ReferralCodeField.tsx
+++ b/core/ui/vault/settings/referral/components/CreateReferral/CreateReferralForm/Fields/ReferralCodeField.tsx
@@ -1,5 +1,6 @@
 import { Match } from '@lib/ui/base/Match'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { TextInput } from '@lib/ui/inputs/TextInput'
 import { CenterAbsolutely } from '@lib/ui/layout/CenterAbsolutely'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -144,7 +145,7 @@ const StatusPill = styled.div`
   padding: 8px 12px;
   align-items: center;
   gap: 4px;
-  border-radius: 99px;
+  ${borderRadius.pill};
   border: 1.5px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
 `

--- a/core/ui/vault/settings/referral/components/EditReferral/EditReferralForm/Fields/PayoutAssetField.tsx
+++ b/core/ui/vault/settings/referral/components/EditReferral/EditReferralForm/Fields/PayoutAssetField.tsx
@@ -118,5 +118,5 @@ const PayoutAssetTrigger = styled(HStack)`
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
   cursor: pointer;
-  ${borderRadius.m};
+  ${borderRadius.md};
 `

--- a/core/ui/vault/settings/referral/components/EditReferral/EditReferralForm/Fields/ReferralCodeField.tsx
+++ b/core/ui/vault/settings/referral/components/EditReferral/EditReferralForm/Fields/ReferralCodeField.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CopyIcon } from '@lib/ui/icons/CopyIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { VStack } from '@lib/ui/layout/Stack'
@@ -34,7 +35,7 @@ export const ReferralCodeField = () => {
 }
 
 const FieldWrapper = styled(VStack)`
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid ${getColor('foregroundExtra')};
   background: ${getColor('foreground')};
   padding: 14px;

--- a/core/ui/vault/settings/referral/components/ManageExistingReferral.tsx
+++ b/core/ui/vault/settings/referral/components/ManageExistingReferral.tsx
@@ -2,6 +2,7 @@ import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { Opener } from '@lib/ui/base/Opener'
 import { Button } from '@lib/ui/buttons/Button'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ArrowUndoIcon } from '@lib/ui/icons/ArrowUndoIcon'
 import { ChevronRightIcon } from '@lib/ui/icons/ChevronRightIcon'
 import { CopyIcon } from '@lib/ui/icons/CopyIcon'
@@ -232,7 +233,7 @@ const Wrapper = styled(VStack)`
 
   border: 1px solid ${getColor('foregroundExtra')};
   padding: 14px;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: rgba(2, 18, 43, 0.5);
 `
 
@@ -241,7 +242,7 @@ const RewardsCollectedWrapper = styled(VStack)`
   overflow: hidden;
 
   &::before {
-    border-radius: 12px;
+    ${borderRadius.md};
     content: '';
     position: absolute;
     inset: 0;
@@ -268,7 +269,7 @@ const FieldIconWrapper = styled(IconWrapper)`
 const FriendsReferralCode = styled(VStack)`
   padding: 16px;
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 const ReferralsThorchainLogoWrapper = styled.div`

--- a/core/ui/vault/settings/referral/components/ManageMissingReferral.tsx
+++ b/core/ui/vault/settings/referral/components/ManageMissingReferral.tsx
@@ -1,6 +1,7 @@
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { Opener } from '@lib/ui/base/Opener'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ChevronRightIcon } from '@lib/ui/icons/ChevronRightIcon'
 import { FileQuestionIcon } from '@lib/ui/icons/FileQuestionIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
@@ -132,7 +133,7 @@ const Wrapper = styled(VStack)`
 
   border: 1px solid ${getColor('foregroundExtra')};
   padding: 14px;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: rgba(2, 18, 43, 0.5);
 `
 
@@ -144,7 +145,7 @@ const NoReferralDescriptionWrapper = styled(VStack)`
 
   padding: 36px 12px 24px 12px;
   gap: 20px;
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid ${getColor('foregroundExtra')};
   background: rgba(2, 18, 43, 0.5);
 `

--- a/core/ui/vault/settings/referral/components/ManageReferrals.tsx
+++ b/core/ui/vault/settings/referral/components/ManageReferrals.tsx
@@ -3,6 +3,7 @@ import { useAssertCurrentVaultId } from '@core/ui/storage/currentVaultId'
 import { useFriendReferralQuery } from '@core/ui/storage/referrals'
 import { Match } from '@lib/ui/base/Match'
 import { StepTransition } from '@lib/ui/base/StepTransition'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ChevronRightIcon } from '@lib/ui/icons/ChevronRightIcon'
 import { MegaphoneIcon } from '@lib/ui/icons/MegaphoneIcon'
 import { UserSparkleIcon } from '@lib/ui/icons/UserSparkleIcon'
@@ -199,7 +200,7 @@ const ActionDescription = styled(Text)`
 const ActionItem = styled(HStack)`
   align-items: center;
   background-color: ${getColor('foreground')};
-  border-radius: 16px;
+  ${borderRadius.lg};
   cursor: pointer;
   gap: 24px;
   justify-content: space-between;

--- a/core/ui/vault/settings/referral/components/ReferralLanding.tsx
+++ b/core/ui/vault/settings/referral/components/ReferralLanding.tsx
@@ -37,7 +37,7 @@ export const ReferralLanding = ({ onFinish }: OnFinishProp) => {
 
 const Wrapper = styled(VStack)`
   background-color: ${getColor('foregroundExtra')};
-  ${borderRadius.m}
+  ${borderRadius.md}
   bottom: 0;
   height: 500px;
   left: 0;
@@ -67,11 +67,11 @@ const Overlay = styled.div`
 `
 
 const PositionedImage = styled.img`
-  border-radius: 12px;
+  ${borderRadius.md};
 `
 
 const ImageWrapper = styled(VStack)`
-  border-radius: 34px;
+  ${borderRadius.xl};
   box-shadow:
     0px -1px 4px 0px rgba(255, 255, 255, 0.2) inset,
     -2px 0px 5px -3px rgba(255, 255, 255, 0.4) inset;
@@ -85,7 +85,7 @@ const ImageWrapper = styled(VStack)`
 
   &::before {
     background-color: rgba(0, 0, 0, 0.1);
-    border-radius: 34px;
+    ${borderRadius.xl};
     content: '';
     height: 100%;
     left: 0;

--- a/core/ui/vault/settings/referral/components/ReferralSummary.tsx
+++ b/core/ui/vault/settings/referral/components/ReferralSummary.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { GroupOneIcon } from '@lib/ui/icons/GroupOneIcon'
 import { Keyboard3Icon } from '@lib/ui/icons/Keyboard3Icon'
 import { MegaphoneIcon } from '@lib/ui/icons/MegaphoneIcon'
@@ -90,7 +91,7 @@ const Item = styled(HStack)`
   align-items: center;
   background-color: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
-  border-radius: 16px;
+  ${borderRadius.lg};
   gap: 12px;
   padding: 16px;
   position: relative;
@@ -123,7 +124,7 @@ const Label = styled(HStack)`
   background-color: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   border-left: none;
-  border-radius: 0 16px 16px 0;
+  border-radius: 0 ${borderRadiusPx.lg}px ${borderRadiusPx.lg}px 0;
   color: ${getColor('textShy')};
   font-size: 12px;
   gap: 8px;

--- a/core/ui/vault/settings/referral/components/Referrals.styled.tsx
+++ b/core/ui/vault/settings/referral/components/Referrals.styled.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CenterAbsolutely } from '@lib/ui/layout/CenterAbsolutely'
 import { HStack, VStack, vStack } from '@lib/ui/layout/Stack'
 import { PageContent } from '@lib/ui/page/PageContent'
@@ -66,7 +67,7 @@ export const Overlay = styled.div`
 `
 
 export const fieldWrapperStyles = css`
-  border-radius: 12px;
+  ${borderRadius.md};
   border: 1px solid ${getColor('foregroundExtra')};
   padding: 14px;
 `
@@ -82,7 +83,7 @@ export const HorizontalFieldWrapper = styled(HStack)`
 `
 
 export const VaultFieldWrapper = styled(HorizontalFieldWrapper)`
-  border-radius: 99px;
+  ${borderRadius.pill};
   cursor: pointer;
   transition: background-color 0.2s ease-in-out;
 

--- a/core/ui/vault/settings/vaultFaq/FaqVaultPage.tsx
+++ b/core/ui/vault/settings/vaultFaq/FaqVaultPage.tsx
@@ -1,4 +1,5 @@
 import { FlowPageHeader } from '@core/ui/flow/FlowPageHeader'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import CaretDownIcon from '@lib/ui/icons/CaretDownIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -124,7 +125,7 @@ const FaqContent = styled.div`
 `
 
 const RowsWrapper = styled.div`
-  border-radius: 12px;
+  ${borderRadius.md};
   background-color: ${getColor('foreground')};
 
   & > ${RowWrapper}:first-of-type {

--- a/core/ui/vault/signers/index.tsx
+++ b/core/ui/vault/signers/index.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ZapIcon } from '@lib/ui/icons/ZapIcon'
 import { getColor } from '@lib/ui/theme/getters'
 import { hasServer, isServer } from '@vultisig/core-mpc/devices/localPartyId'
@@ -20,7 +21,7 @@ const StyledText = styled.span`
 
 const StyledVaultSigners = styled.div`
   align-items: center;
-  border-radius: 20px;
+  ${borderRadius.pill};
   background: ${({ theme }) =>
     theme.colors.foreground.withAlpha(0.35).toCssValue()};
   border: 1px solid ${getColor('foregroundExtra')};

--- a/core/ui/vault/swap/components/ChainOption.tsx
+++ b/core/ui/vault/swap/components/ChainOption.tsx
@@ -57,7 +57,7 @@ export const ChainOption = ({
 const Container = styled('div')<{ isSelected?: boolean }>`
   ${panel()};
   padding: 12px 20px;
-  border-radius: 0px;
+  border-radius: 0;
   position: relative;
   cursor: pointer;
   background: ${({ isSelected }) =>

--- a/core/ui/vault/swap/components/RefreshSwap.tsx
+++ b/core/ui/vault/swap/components/RefreshSwap.tsx
@@ -1,5 +1,6 @@
 import 'react-circular-progressbar/dist/styles.css'
 
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
@@ -37,7 +38,7 @@ export const RefreshSwap = () => {
 const Wrapper = styled(HStack)`
   padding: 8px;
   background-color: ${getColor('foreground')};
-  border-radius: 99px;
+  ${borderRadius.pill};
 `
 
 const Progress = styled(CircularProgressbar)`

--- a/core/ui/vault/swap/components/SwapCoinInputField/SwapCoinInputField.styled.tsx
+++ b/core/ui/vault/swap/components/SwapCoinInputField/SwapCoinInputField.styled.tsx
@@ -1,3 +1,4 @@
+import { borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { textInputBackground } from '@lib/ui/css/textInput'
 import { VStack } from '@lib/ui/layout/Stack'
 import { text } from '@lib/ui/text'
@@ -17,6 +18,8 @@ export const Container = styled(VStack)<{
   })}
   padding: clamp(12px, 3.33vw, 16px);
   border-radius: ${({ side }) =>
-    side === 'to' ? '12px 12px 24px 24px' : '24px 24px 12px 12px'};
+    side === 'to'
+      ? `${borderRadiusPx.md}px ${borderRadiusPx.md}px ${borderRadiusPx.xl}px ${borderRadiusPx.xl}px`
+      : `${borderRadiusPx.xl}px ${borderRadiusPx.xl}px ${borderRadiusPx.md}px ${borderRadiusPx.md}px`};
   border: 1px solid ${getColor('foregroundExtra')};
 `

--- a/core/ui/vault/swap/form/ReverseSwap.tsx
+++ b/core/ui/vault/swap/form/ReverseSwap.tsx
@@ -1,5 +1,6 @@
 import { useSwapToCoin } from '@core/ui/vault/swap/state/toCoin'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { ArrowsRotateCenterIcon } from '@lib/ui/icons/ArrowsRotateCenterIcon'
@@ -75,7 +76,7 @@ export const ReverseSwap = ({ errorMessage }: ReverseSwapProps) => {
 
 const Wrapper = styled(HStack)`
   background-color: ${getColor('background')};
-  border-radius: 25.5px;
+  ${borderRadius.pill};
   padding: 7px;
   position: absolute;
   top: 50%;
@@ -88,7 +89,7 @@ const Wrapper = styled(HStack)`
     width: 54px;
     top: 0;
     height: 19px;
-    border-radius: 50px;
+    ${borderRadius.pill};
     border: 1px solid ${getColor('foregroundExtra')};
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
@@ -101,7 +102,7 @@ const Wrapper = styled(HStack)`
     width: 54px;
     bottom: 0px;
     height: 19px;
-    border-radius: 50px;
+    ${borderRadius.pill};
     border: 1px solid ${getColor('foregroundExtra')};
     border-top-right-radius: 0;
     border-top-left-radius: 0;
@@ -113,7 +114,7 @@ const Button = styled(UnstyledButton)<{ $hasError: boolean }>`
   ${sameDimensions(40)};
   background: ${({ $hasError }) =>
     $hasError ? getColor('danger') : getColor('buttonPrimary')};
-  border-radius: ${({ $hasError }) => ($hasError ? '18px' : '1000px')};
+  ${({ $hasError }) => ($hasError ? borderRadius.lg : borderRadius.pill)};
   border: 2px solid ${getColor('background')};
   ${centerContent};
   font-size: ${({ $hasError }) => ($hasError ? '20px' : '16px')};

--- a/core/ui/vault/swap/form/SwapCoinsExplorer.tsx
+++ b/core/ui/vault/swap/form/SwapCoinsExplorer.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { hideScrollbars } from '@lib/ui/css/hideScrollbars'
 import { SelectItemModal } from '@lib/ui/inputs/SelectItemModal'
 import { hStack, VStack } from '@lib/ui/layout/Stack'
@@ -247,7 +248,7 @@ const FooterItem = styled.div<IsActiveProp>`
   scroll-snap-stop: always;
   cursor: pointer;
   padding: 8px 12px 8px 8px;
-  border-radius: 99px;
+  ${borderRadius.pill};
   outline: none;
 
   scroll-snap-align: center;
@@ -260,7 +261,7 @@ const FooterItem = styled.div<IsActiveProp>`
     content: '';
     position: absolute;
     inset: 0 -6px;
-    border-radius: 99px;
+    ${borderRadius.pill};
     z-index: -1;
     background: transparent;
     transition: background 0.2s ease;
@@ -288,7 +289,7 @@ const CenterStroke = styled.div`
   translate: -50%;
   pointer-events: none;
   border: 1px solid ${({ theme }) => theme.colors.buttonPrimary.toCssValue()};
-  border-radius: 99px;
+  ${borderRadius.pill};
   background: rgba(6, 27, 58, 0.02);
   box-shadow: 0 0 14px 0 rgba(33, 85, 223, 0.45);
   /* Width is written imperatively (setStrokeToKey) off the live chain, so snap

--- a/core/ui/vault/swap/form/SwapErrorTooltip.tsx
+++ b/core/ui/vault/swap/form/SwapErrorTooltip.tsx
@@ -14,6 +14,7 @@ import {
   useTransitionStyles,
 } from '@floating-ui/react'
 import { IconButton } from '@lib/ui/buttons/IconButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { NavigationXIcon } from '@lib/ui/icons/NavigationXIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
@@ -32,7 +33,7 @@ type SwapErrorTooltipProps = {
 }
 
 const Container = styled.div`
-  border-radius: 12px;
+  ${borderRadius.md};
   background: #ffffff;
   padding: 12px;
   min-width: 200px;

--- a/core/ui/vault/swap/form/advanced/AdvancedSheet.tsx
+++ b/core/ui/vault/swap/form/advanced/AdvancedSheet.tsx
@@ -76,7 +76,7 @@ export const AdvancedSheet = ({
 const Wrapper = styled(VStack)`
   width: 100%;
   background: ${getColor('background')};
-  ${borderRadius.m};
+  ${borderRadius.md};
   padding: 20px;
 
   @media ${mediaQuery.tabletDeviceAndUp} {

--- a/core/ui/vault/swap/form/advanced/ExternalRecipientSheet.tsx
+++ b/core/ui/vault/swap/form/advanced/ExternalRecipientSheet.tsx
@@ -2,6 +2,7 @@ import { ScanQrModal } from '@core/ui/qr/components/ScanQrModal'
 import { useCore } from '@core/ui/state/core'
 import { AddressBookModalContent } from '@core/ui/vault/send/addresses/components/AddressBookModal'
 import { useSwapToCoin } from '@core/ui/vault/swap/state/toCoin'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { OnCloseProp } from '@lib/ui/props'
@@ -128,7 +129,7 @@ const AddressInput = styled.input`
   width: 100%;
   height: 52px;
   padding: 0 16px;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('background')};
   border: 1px solid rgba(255, 255, 255, 0.03);
   color: ${getColor('text')};
@@ -151,7 +152,7 @@ const ActionButton = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   cursor: pointer;

--- a/core/ui/vault/swap/form/advanced/GasLimitSheet.tsx
+++ b/core/ui/vault/swap/form/advanced/GasLimitSheet.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { OnCloseProp } from '@lib/ui/props'
@@ -73,7 +74,7 @@ const GasInput = styled.input`
   width: 100%;
   height: 52px;
   padding: 0 16px;
-  border-radius: 12px;
+  ${borderRadius.md};
   background: ${getColor('foreground')};
   border: 1px solid rgba(255, 255, 255, 0.03);
   color: ${getColor('text')};

--- a/core/ui/vault/swap/limit/LimitAssetStep.tsx
+++ b/core/ui/vault/swap/limit/LimitAssetStep.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { RefreshCwIcon } from '@lib/ui/icons/RefreshCwIcon'
@@ -61,7 +62,7 @@ export const LimitAssetStep = () => {
 
 const Card = styled(VStack)`
   border: 1px solid ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};
-  border-radius: 12px;
+  ${borderRadius.md};
   padding: 16px;
 `
 
@@ -82,7 +83,7 @@ const Seam = styled.div`
 const ReverseWrapper = styled.div`
   ${centerContent};
   background-color: ${getColor('background')};
-  border-radius: 25.5px;
+  ${borderRadius.pill};
   padding: 7px;
   position: absolute;
   top: 50%;
@@ -95,7 +96,7 @@ const ReverseWrapper = styled.div`
     width: 54px;
     top: 0;
     height: 19px;
-    border-radius: 50px;
+    ${borderRadius.pill};
     border: 1px solid ${getColor('foregroundExtra')};
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
@@ -108,7 +109,7 @@ const ReverseWrapper = styled.div`
     width: 54px;
     bottom: 0;
     height: 19px;
-    border-radius: 50px;
+    ${borderRadius.pill};
     border: 1px solid ${getColor('foregroundExtra')};
     border-top-right-radius: 0;
     border-top-left-radius: 0;
@@ -119,7 +120,7 @@ const ReverseWrapper = styled.div`
 const ReverseButton = styled(UnstyledButton)`
   ${sameDimensions(40)};
   ${centerContent};
-  border-radius: 1000px;
+  ${borderRadius.pill};
   border: 2px solid ${getColor('background')};
   background: ${({ theme }) => theme.colors.buttonPrimary.toCssValue()};
   color: ${({ theme }) => theme.colors.contrast.toCssValue()};

--- a/core/ui/vault/swap/limit/LimitAssetSummary.tsx
+++ b/core/ui/vault/swap/limit/LimitAssetSummary.tsx
@@ -1,5 +1,6 @@
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CircleCheckIcon } from '@lib/ui/icons/CircleCheckIcon'
 import { PencilIcon } from '@lib/ui/icons/PenciIcon'
 import { HStack } from '@lib/ui/layout/Stack'
@@ -65,7 +66,7 @@ export const LimitAssetSummary: FC<LimitAssetSummaryProps> = ({
 
 const Card = styled(HStack)`
   border: 1px solid ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};
-  border-radius: 12px;
+  ${borderRadius.md};
   padding: 14px 16px;
 `
 

--- a/core/ui/vault/swap/limit/LimitExecuteWhen.tsx
+++ b/core/ui/vault/swap/limit/LimitExecuteWhen.tsx
@@ -1,5 +1,6 @@
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { centerContent } from '@lib/ui/css/centerContent'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { CircleDollarSignIcon } from '@lib/ui/icons/CircleDollarSignIcon'
@@ -186,7 +187,7 @@ export const LimitExecuteWhen: FC<LimitExecuteWhenProps> = ({
 
 const Card = styled(VStack)`
   border: 1px solid ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};
-  border-radius: 12px;
+  ${borderRadius.md};
   padding: 16px;
 `
 
@@ -238,14 +239,14 @@ const UnitToggleGroup = styled.div`
   flex-direction: column;
   gap: 2px;
   padding: 3px;
-  border-radius: 20px;
+  ${borderRadius.pill};
   background: ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};
 `
 
 const UnitToggle = styled(UnstyledButton)<IsActiveProp>`
   ${sameDimensions(32)};
   ${centerContent};
-  border-radius: 18px;
+  ${borderRadius.pill};
   cursor: pointer;
   color: ${({ theme }) => theme.colors.textShy.toCssValue()};
 
@@ -259,7 +260,7 @@ const UnitToggle = styled(UnstyledButton)<IsActiveProp>`
 
 const Pill = styled(UnstyledButton)<IsActiveProp>`
   padding: 8px 16px;
-  border-radius: 999px;
+  ${borderRadius.pill};
   border: 1px solid ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};
   cursor: pointer;
 
@@ -277,6 +278,6 @@ const Pill = styled(UnstyledButton)<IsActiveProp>`
 
 const ExpiryCard = styled(HStack)`
   border: 1px solid ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};
-  border-radius: 12px;
+  ${borderRadius.md};
   padding: 12px 16px;
 `

--- a/core/ui/vault/swap/limit/LimitExecuteWhenCollapsed.tsx
+++ b/core/ui/vault/swap/limit/LimitExecuteWhenCollapsed.tsx
@@ -1,4 +1,5 @@
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { Text } from '@lib/ui/text'
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -32,7 +33,7 @@ const Card = styled(UnstyledButton)`
   width: 100%;
   text-align: left;
   border: 1px solid ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};
-  border-radius: 12px;
+  ${borderRadius.md};
   padding: 16px;
   cursor: pointer;
 `

--- a/core/ui/vault/swap/limit/LimitOrderReview.tsx
+++ b/core/ui/vault/swap/limit/LimitOrderReview.tsx
@@ -2,6 +2,7 @@ import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { VerifyKeysignStart } from '@core/ui/mpc/keysign/start/VerifyKeysignStart'
 import { KeysignFeeAmount } from '@core/ui/mpc/keysign/tx/FeeAmount'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ArrowDownIcon } from '@lib/ui/icons/ArrowDownIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { PageHeader } from '@lib/ui/page/PageHeader'
@@ -168,7 +169,7 @@ const Row: FC<RowProps> = ({ label, value }) => (
 
 const Card = styled(VStack)`
   border: 1px solid ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};
-  border-radius: 12px;
+  ${borderRadius.md};
   padding: 16px;
 `
 

--- a/core/ui/vault/swap/limit/LimitSwapNotice.tsx
+++ b/core/ui/vault/swap/limit/LimitSwapNotice.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { FC } from 'react'
@@ -28,6 +29,6 @@ export const LimitSwapNotice: FC<LimitSwapNoticeProps> = ({
 
 const Notice = styled(HStack)`
   padding: 10px 12px;
-  border-radius: 8px;
+  ${borderRadius.sm};
   background: ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};
 `

--- a/core/ui/vault/swap/limit/cancel/CancelLimitOrderPage.tsx
+++ b/core/ui/vault/swap/limit/cancel/CancelLimitOrderPage.tsx
@@ -3,6 +3,7 @@ import { VerifyKeysignStart } from '@core/ui/mpc/keysign/start/VerifyKeysignStar
 import { KeysignFeeAmount } from '@core/ui/mpc/keysign/tx/FeeAmount'
 import { useCoreViewState } from '@core/ui/navigation/hooks/useCoreViewState'
 import { useTransactionRecordsQuery } from '@core/ui/storage/transactionHistory'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { useNavigateBack } from '@lib/ui/navigation/hooks/useNavigateBack'
 import { PageHeader } from '@lib/ui/page/PageHeader'
@@ -251,7 +252,7 @@ const Body = styled(VStack)`
 
 const Card = styled(VStack)`
   border: 1px solid ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};
-  border-radius: 12px;
+  ${borderRadius.md};
   padding: 16px;
 `
 

--- a/core/ui/vault/swap/limit/orders/LimitOrderRecordRow.tsx
+++ b/core/ui/vault/swap/limit/orders/LimitOrderRecordRow.tsx
@@ -5,6 +5,7 @@ import {
   useFormatLimitOrderExpiry,
   useLimitOrderStatusLabels,
 } from '@core/ui/vault/swap/limit/tracking/presentation'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { ValueProp } from '@lib/ui/props'
 import { Text } from '@lib/ui/text'
@@ -20,7 +21,7 @@ const Row = styled.button`
   all: unset;
   cursor: pointer;
   padding: 16px;
-  border-radius: 16px;
+  ${borderRadius.lg};
   background: ${getColor('foreground')};
   border: 1px solid ${getColor('foregroundExtra')};
   display: flex;

--- a/core/ui/vault/swap/verify/SwapVerify/SwapExternalRecipientWarning.tsx
+++ b/core/ui/vault/swap/verify/SwapVerify/SwapExternalRecipientWarning.tsx
@@ -46,7 +46,7 @@ export const SwapExternalRecipientWarning = ({
 type KindProp = { kind: SwapExternalRecipientWarningKind }
 
 const Container = styled(HStack)<KindProp>`
-  ${borderRadius.m};
+  ${borderRadius.md};
   padding: 16px;
   background: ${({ kind, theme: { colors } }) =>
     (kind === 'danger'

--- a/core/ui/vault/swap/verify/SwapVerify/SwapVerify.styled.tsx
+++ b/core/ui/vault/swap/verify/SwapVerify/SwapVerify.styled.tsx
@@ -1,3 +1,4 @@
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { VStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import styled from 'styled-components'
@@ -19,7 +20,7 @@ export const IconWrapper = styled.div`
   height: 24px;
   font-size: 14px;
   background-color: ${getColor('foregroundExtra')};
-  border-radius: 99px;
+  ${borderRadius.pill};
   position: relative;
 
   &:before {


### PR DESCRIPTION
Part 2 of 2 of #4550, tracked in #4623. 128 files.

Migrates the vault product surfaces, plus `qbtc` and `agent`, onto the corner-radius scale established in part 1 (#4630).

> **Base branch:** this targets `4550-radius-scale-and-shared-surfaces` because it needs the token from part 1. GitHub retargets it to `main` automatically once part 1 merges, at which point the diff is the 128 files listed here. The two parts touch disjoint directories, so they cannot conflict.

## The five PRs

| | | files |
|---|---|---|
| #4631 | `core/ui/vault/chain` | 17 |
| #4632 | `core/ui/vault/settings` and `backup` | 25 |
| #4633 | swap, deposit, send | 39 |
| #4634 | vault page, shell, and the new/import/create flows | 25 |
| #4635 | `core/ui/qbtc` and `core/ui/agent` | 22 |

`core/ui/agent` moved here from part 1 partway through, once the true file count came in above the original audit - see the correction on #4622. Both parts sit around 20 files below the 150-file review limit.

## Governing rule, same as part 1

**A radius already on a scale step keeps its pixels.** Only off-scale values move, and every one is listed in its own PR. This is why the diff is large but the visual surface area is small.

## `borderRadius.l` is now empty

The three 20px orphans #4622 flagged are all resolved, each by looking at the surface rather than by a rename:

```
InfoItem          -> xl     (part 1)
BackupOption      -> xl     (B.2)
AmountSwitch      -> pill   (B.3)
```

`AmountSwitch` is the one that did not resolve to a number: it is a vertical stack of circular buttons in a 42px-wide container, so 20 already put it within a pixel of a stadium. Worth a look in review.

The token now has no `l` call sites anywhere in the tree.

## The recurring finding: capsules that were not spelled as capsules

Across both parts, a large share of "arbitrary" radii turned out to be full rounds that had already clamped. Part 2 alone:

```
25.5  ReverseSwap and LimitAssetStep icon badges
50    the notch outlines around them, on 19px pseudo-elements
20    LimitExecuteWhen toggle group, 38px tall
18    its unit toggle, a 32px square
20    the signers chip, 30px min-height
12    TronResourceBar track, 8px tall
66    ChatMessage user bubble
77    AgentChatInput action button, a 36px square
40    AgentChatFooter icon button
```

None of these change visually. All of them would have read as deliberate design values to anyone auditing by number - the element they sit on is the only thing that says otherwise. That is also the honest limit of the lint guard: it can require a token, it cannot tell you which one is right.

The `77` is the sharpest example. Part 1 skipped several 77px declarations as decorative glow blobs, correctly. This one is a square button, so it is a circle. Same number, opposite answer.

## Other things worth a reviewer's eye

- **A duplicated declaration.** `ReceiveModal`s chain badge carried `border-radius: 999px` and `border-radius: 99px` on consecutive lines, two spellings of the same capsule with the second silently winning. Collapsed to one `pill`.
- **A surface described by four radii.** `AddressQRCard` had a 24 card, a 32/24 frame and wrapper stacked inside it, and a 20 label pinned to its bottom edge - disagreeing by up to 8px. They are one radius now, with the label keeping its bottom-only rounding.
- **A radius passed as a prop.** `AgentChatInput` defaulted `containerBorderRadius` to a bare `40`, documented as "defaults to 40px". On a 52px-tall input that means "capsule", and it now says so.
- **An inner-radius calculation.** `TronResourceTypePicker` used 6 inside an 8-radius container with 2px padding. It resolves to `xs` (4) rather than `sm` (8), which would have matched the container and read wrong.

## Sheets

Every sheet in the tree now rounds at 24. The outliers that converged: 34 (`PromptSheet`), 16 (`ShareAppModal`, `BackupModal`), and the mixed 32/24 and 24/20 pairs.

## Out of scope, unchanged

Decorative glow blobs, the shared `Button` (owned by #4548), the notched badge shapes, the drawn phone hardware in the keygen overlay, and the e2e mock dapp page. Each carries a comment where it lives.

## Still to come

The lint guard from ask 3 of #4550, as a standalone PR against `main` once both parts land. It prevents new literals; it does not prevent drift, and the PR should say so.

## Validation

`yarn check` clean, `yarn test` 942 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized rounded corners across chat, governance, vault, swap, onboarding, and settings interfaces.
  * Updated cards, buttons, inputs, badges, modals, icons, charts, banners, and status indicators for more consistent shapes.
  * Improved visual consistency for pill-shaped and circular elements throughout the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->