### PR TITLE
ci: auto-open bump PRs for @vultisig/* npm releases

### DIFF
--- a/.github/workflows/bump-vultisig-packages.yml
+++ b/.github/workflows/bump-vultisig-packages.yml
@@ -24,8 +24,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.repository.default_branch }}
           submodules: recursive
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -50,14 +52,22 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Require CI-capable token
+        if: steps.bump.outputs.changed == 'true'
+        env:
+          BUMP_PR_TOKEN: ${{ secrets.BUMP_PR_TOKEN }}
+        run: |
+          if [ -z "$BUMP_PR_TOKEN" ]; then
+            echo "::error::BUMP_PR_TOKEN secret is missing. A PR created with GITHUB_TOKEN gets no CI (build.yml is the merge gate), so refusing to open a checkless bump PR. Add a fine-grained PAT with contents + pull-requests write."
+            exit 1
+          fi
+
       - name: Create or update bump PR
         if: steps.bump.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
-          # BUMP_PR_TOKEN: fine-grained PAT (contents + pull-requests write).
-          # Falls back to GITHUB_TOKEN, which creates the PR but does NOT
-          # trigger build.yml on it — set the secret to get CI on bump PRs.
-          token: ${{ secrets.BUMP_PR_TOKEN || github.token }}
+          token: ${{ secrets.BUMP_PR_TOKEN }}
+          base: ${{ github.event.repository.default_branch }}
           branch: chore/bump-vultisig-packages
           delete-branch: true
           commit-message: 'chore(deps): bump @vultisig/* packages to latest'

--- a/.github/workflows/bump-vultisig-packages.yml
+++ b/.github/workflows/bump-vultisig-packages.yml
@@ -1,0 +1,72 @@
+name: Bump Vultisig packages
+
+on:
+  schedule:
+    - cron: '30 6,12,18 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: bump-vultisig-packages
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  NODE_OPTIONS: '--max-old-space-size=8192'
+  NODE_VERSION: '23.7.0'
+
+jobs:
+  bump:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Bump @vultisig/* packages to latest
+        id: bump
+        run: |
+          yarn up -E '@vultisig/core-chain' '@vultisig/core-config' '@vultisig/core-mpc' '@vultisig/lib-utils' '@vultisig/sdk'
+          if git diff --quiet -- '**/package.json' yarn.lock; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            {
+              echo 'versions<<EOF'
+              git diff -- '**/package.json' | grep '^+.*"@vultisig/' | sed 's/^+ *//' | sort -u
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create or update bump PR
+        if: steps.bump.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          # BUMP_PR_TOKEN: fine-grained PAT (contents + pull-requests write).
+          # Falls back to GITHUB_TOKEN, which creates the PR but does NOT
+          # trigger build.yml on it — set the secret to get CI on bump PRs.
+          token: ${{ secrets.BUMP_PR_TOKEN || github.token }}
+          branch: chore/bump-vultisig-packages
+          delete-branch: true
+          commit-message: 'chore(deps): bump @vultisig/* packages to latest'
+          title: 'chore(deps): bump @vultisig/* packages to latest'
+          body: |
+            Automated bump of first-party `@vultisig/*` packages to the latest npm release.
+
+            ```
+            ${{ steps.bump.outputs.versions }}
+            ```
+
+            Opened by the `bump-vultisig-packages` workflow (runs 06:30/12:30/18:30 UTC; re-runs update this PR in place). CI on this PR is the merge gate.


### PR DESCRIPTION
## Summary
- Adds a scheduled workflow (06:30 / 12:30 / 18:30 UTC + manual dispatch) that runs `yarn up -E` on the five first-party packages (`@vultisig/core-chain`, `core-config`, `core-mpc`, `lib-utils`, `sdk`) and opens a bump PR when npm has newer versions.
- Re-runs update the same PR branch (`chore/bump-vultisig-packages`) in place — one standing PR, not a stream of them.
- `build.yml` on the bump PR is the merge gate; merge stays human.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/bump-vultisig-packages.yml` | New scheduled workflow: bump first-party deps, open/update PR via `peter-evans/create-pull-request` |

## Context
The SDK repo publishes to npm near-daily (changesets `release.yml`), but pins here only move by hand. That lag is how the extension shipped without Robinhood Chain (4663) support: core-chain 2.31.0 had it on Aug 2, this repo caught up piecemeal, and dApp connections on Robinhood failed with error 4902 in the meantime. First-party `@vultisig/*` packages are exempt from the dependency-cooldown policy (we publish them ourselves), so same-day bumps are compliant.

**Setup requirement (one-time, blocking):** add a `BUMP_PR_TOKEN` repo secret — fine-grained PAT with contents + pull-requests write. The workflow fails loudly when a bump is available and the secret is missing, rather than opening a PR that `build.yml` won't run on (GitHub suppresses workflows on `GITHUB_TOKEN`-created PRs).

## Test plan
- [x] Workflow YAML parses (`js-yaml`)
- [x] `yarn up -E '@vultisig/core-chain' ...` dry-run locally on yarn 4.16.0 — clean no-op with pins already at latest
- [x] Confirmed `build.yml` triggers on `pull_request` against `main` (the merge gate for bump PRs)
- [ ] Add `BUMP_PR_TOKEN` secret, then trigger via `workflow_dispatch` to verify end-to-end
- [ ] First scheduled run opens a PR on the next SDK release

## receipts
no runtime changes

CI/config-only diff. Local validation:
```
$ npx js-yaml .github/workflows/bump-vultisig-packages.yml  # → parses clean
$ yarn up -E '@vultisig/core-chain' '@vultisig/core-config' '@vultisig/core-mpc' '@vultisig/lib-utils' '@vultisig/sdk'
➤ YN0000: · Done with warnings in 4s 844ms   # no-op, pins already at latest
```