### PR TITLE
build(lint): keep corner radii on the token scale

### DIFF
--- a/clients/desktop/src/versioning/CheckUpdatePage.tsx
+++ b/clients/desktop/src/versioning/CheckUpdatePage.tsx
@@ -105,6 +105,7 @@ const FixedWrapper = styled.div`
   gap: 34px;
 `
 
+// eslint-disable-next-line local/no-hardcoded-border-radius -- a decorative glow, not a surface
 const Overlay = styled(VStack)`
   position: fixed;
   inset: 0;

--- a/core/inpage-provider/popup/view/resolvers/grantVaultAccess/index.tsx
+++ b/core/inpage-provider/popup/view/resolvers/grantVaultAccess/index.tsx
@@ -15,7 +15,7 @@ import { useVaults } from '@core/ui/storage/vaults'
 import { VaultSigners } from '@core/ui/vault/signers'
 import { getVaultSecurityTone } from '@core/ui/vaultsOrganisation/utils/getVaultSecurityTone'
 import { Button } from '@lib/ui/buttons/Button'
-import { borderRadius } from '@lib/ui/css/borderRadius'
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { sameDimensions } from '@lib/ui/css/sameDimensions'
 import { ContainImage } from '@lib/ui/images/ContainImage'
 import { SafeImage } from '@lib/ui/images/SafeImage'
@@ -313,7 +313,7 @@ export const GrantVaultAccess: PopupResolver<'grantVaultAccess'> = ({
           )}
         </VStack>
         {selectedVault && (
-          <List radius={12}>
+          <List radius={borderRadiusPx.md}>
             <ListItem
               icon={<VaultRowIcon vault={selectedVault} />}
               title={selectedVault.name}

--- a/core/inpage-provider/popup/view/resolvers/sendTx/SendTxOverview.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/SendTxOverview.tsx
@@ -38,6 +38,7 @@ import {
   IconWrapper,
 } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerify.styled'
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { ErrorFallbackContent } from '@lib/ui/flow/ErrorFallbackContent'
 import { ArrowDownIcon } from '@lib/ui/icons/ArrowDownIcon'
 import { CircleInfoIcon } from '@lib/ui/icons/CircleInfoIcon'
@@ -408,7 +409,7 @@ export const SendTxOverview = ({
                     bgColor="foreground"
                     gap={16}
                     padding={24}
-                    radius={16}
+                    radius={borderRadiusPx.lg}
                   >
                     <DappRequestRow />
                     <DappRequestDivider />
@@ -546,7 +547,7 @@ export const SendTxOverview = ({
                         keysignPayload={keysignPayload}
                         signTon={keysignPayload.signData.value}
                       />
-                      <VStack bgColor="foreground" radius={16}>
+                      <VStack bgColor="foreground" radius={borderRadiusPx.lg}>
                         <NetworkFeeSection
                           keysignPayload={keysignPayload}
                           transactionPayload={transactionPayload}
@@ -584,7 +585,7 @@ export const SendTxOverview = ({
                       <SignRippleDisplay
                         rawJson={keysignPayload.signData.value.rawJson}
                       />
-                      <VStack bgColor="foreground" radius={16}>
+                      <VStack bgColor="foreground" radius={borderRadiusPx.lg}>
                         <NetworkFeeSection
                           keysignPayload={keysignPayload}
                           transactionPayload={transactionPayload}
@@ -620,7 +621,7 @@ export const SendTxOverview = ({
                         />
                       </List>
                       <MemoSection memo={keysignPayload.memo} chain={chain} />
-                      <VStack bgColor="foreground" radius={16}>
+                      <VStack bgColor="foreground" radius={borderRadiusPx.lg}>
                         <NetworkFeeSection
                           keysignPayload={keysignPayload}
                           transactionPayload={transactionPayload}

--- a/core/inpage-provider/popup/view/resolvers/sendTx/blockaid/BlockaidBalanceChanges.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/blockaid/BlockaidBalanceChanges.tsx
@@ -5,6 +5,7 @@ import {
 } from '@core/inpage-provider/popup/view/resolvers/sendTx/components/NetworkFeeSection'
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import type { BlockaidEvmBalanceChange } from '@core/ui/chain/security/blockaid/tx/blockaidEvmSimulationView'
+import { borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { ArrowUpRightIcon } from '@lib/ui/icons/ArrowUpRightIcon'
 import { TransactionReceiveIcon } from '@lib/ui/icons/TransactionReceiveIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -32,7 +33,12 @@ export const BlockaidBalanceChanges = ({
 
   return (
     <>
-      <VStack bgColor="foreground" gap={16} padding={24} radius={16}>
+      <VStack
+        bgColor="foreground"
+        gap={16}
+        padding={24}
+        radius={borderRadiusPx.lg}
+      >
         <Text color="supporting" size={15}>
           {t('balance_changes')}
         </Text>

--- a/core/inpage-provider/popup/view/resolvers/sendTx/blockaid/BlockaidSwapDisplay.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/blockaid/BlockaidSwapDisplay.tsx
@@ -9,6 +9,7 @@ import {
   HorizontalLine,
   IconWrapper,
 } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerify.styled'
+import { borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { ArrowDownIcon } from '@lib/ui/icons/ArrowDownIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
@@ -51,8 +52,13 @@ export const BlockaidSwapDisplay = ({
 
   return (
     <>
-      <ContainerWrapper radius={16}>
-        <VStack bgColor="foreground" gap={24} padding={24} radius={16}>
+      <ContainerWrapper radius={borderRadiusPx.lg}>
+        <VStack
+          bgColor="foreground"
+          gap={24}
+          padding={24}
+          radius={borderRadiusPx.lg}
+        >
           <Text color="supporting" size={15}>
             {t('youre_swapping')}
           </Text>

--- a/core/inpage-provider/popup/view/resolvers/sendTx/blockaid/BlockaidTransferDisplay.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/blockaid/BlockaidTransferDisplay.tsx
@@ -4,6 +4,7 @@ import {
   NetworkFeeSectionProps,
 } from '@core/inpage-provider/popup/view/resolvers/sendTx/components/NetworkFeeSection'
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
+import { borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { ListItem } from '@lib/ui/list/item'
 import { Text } from '@lib/ui/text'
@@ -43,7 +44,12 @@ export const BlockaidTransferDisplay = ({
 
   return (
     <>
-      <VStack bgColor="foreground" gap={24} padding={24} radius={16}>
+      <VStack
+        bgColor="foreground"
+        gap={24}
+        padding={24}
+        radius={borderRadiusPx.lg}
+      >
         <Text color="supporting" size={15}>
           {t('you_are_sending')}
         </Text>

--- a/core/inpage-provider/popup/view/resolvers/signMessage/components/SuiTxIntentDisplay.tsx
+++ b/core/inpage-provider/popup/view/resolvers/signMessage/components/SuiTxIntentDisplay.tsx
@@ -3,6 +3,7 @@ import {
   HorizontalLine,
   IconWrapper,
 } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerify.styled'
+import { borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { ArrowDownIcon } from '@lib/ui/icons/ArrowDownIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
@@ -62,7 +63,12 @@ export const SuiTxIntentDisplay: FC<SuiTxIntentDisplayProps> = ({ intent }) => {
   if ('swap' in intent) {
     const { from, to, fromAmount, toAmount } = intent.swap
     return (
-      <VStack bgColor="foreground" gap={16} padding={24} radius={16}>
+      <VStack
+        bgColor="foreground"
+        gap={16}
+        padding={24}
+        radius={borderRadiusPx.lg}
+      >
         <Text color="supporting" size={15}>
           {t('youre_swapping')}
         </Text>
@@ -85,7 +91,12 @@ export const SuiTxIntentDisplay: FC<SuiTxIntentDisplayProps> = ({ intent }) => {
   }
   const { from, fromAmount } = intent.transfer
   return (
-    <VStack bgColor="foreground" gap={16} padding={24} radius={16}>
+    <VStack
+      bgColor="foreground"
+      gap={16}
+      padding={24}
+      radius={borderRadiusPx.lg}
+    >
       <Text color="supporting" size={15}>
         {t('you_are_sending')}
       </Text>

--- a/core/ui/defi/chain/banners/shared.tsx
+++ b/core/ui/defi/chain/banners/shared.tsx
@@ -42,6 +42,7 @@ export const FallbackLogo = styled.div`
   font-weight: 600;
 `
 
+// eslint-disable-next-line local/no-hardcoded-border-radius -- a decorative glow, not a surface
 export const GradientBackground = styled.div`
   width: 260px;
   height: 260px;

--- a/core/ui/defi/chain/manage/DefiPositionTile.tsx
+++ b/core/ui/defi/chain/manage/DefiPositionTile.tsx
@@ -57,6 +57,7 @@ const PositionIconWrapper = styled.div<IsActiveProp>`
     `}
 `
 
+// eslint-disable-next-line local/no-hardcoded-border-radius -- a notched badge outline, not a surface radius
 const CheckBadge = styled(IconWrapper)`
   position: absolute;
   bottom: 0;

--- a/core/ui/defi/manage/DefiItem.tsx
+++ b/core/ui/defi/manage/DefiItem.tsx
@@ -113,6 +113,7 @@ const IconContainer = styled.div<IconContainerProps>`
     `}
 `
 
+// eslint-disable-next-line local/no-hardcoded-border-radius -- a notched badge outline, not a surface radius
 const CheckBadge = styled(IconWrapper)`
   position: absolute;
   bottom: 0;

--- a/core/ui/defi/page/components/DefiPortfolioBalance.tsx
+++ b/core/ui/defi/page/components/DefiPortfolioBalance.tsx
@@ -71,6 +71,7 @@ const Container = styled.div`
   }
 `
 
+// eslint-disable-next-line local/no-hardcoded-border-radius -- a decorative glow, not a surface
 const BlurEffect = styled.div`
   position: absolute;
   ${borderRadius.lg};

--- a/core/ui/mpc/keygen/education/devices/KeygenPeerDiscoveryEducationOverlay.tsx
+++ b/core/ui/mpc/keygen/education/devices/KeygenPeerDiscoveryEducationOverlay.tsx
@@ -83,6 +83,7 @@ const OverlayWrapper = styled(VStack)`
   background-color: rgba(0, 0, 0, 0.55);
 `
 
+// eslint-disable-next-line local/no-hardcoded-border-radius -- drawn phone hardware, not an app surface
 const PhonePreview = styled(VStack)`
   height: 320px;
   /* Drawn phone hardware, not an app surface: off the scale on purpose. */
@@ -102,6 +103,7 @@ const PhonePreview = styled(VStack)`
   }
 `
 
+// eslint-disable-next-line local/no-hardcoded-border-radius -- drawn phone hardware, not an app surface
 const PhoneMock = styled(VStack)`
   position: relative;
   width: min(100%, 430px);

--- a/core/ui/mpc/keygen/reshare/plugin/PreviewInfo.tsx
+++ b/core/ui/mpc/keygen/reshare/plugin/PreviewInfo.tsx
@@ -5,7 +5,7 @@ import {
 } from '@core/ui/mpc/fast/FastVaultPasswordModal'
 import { Plugin } from '@core/ui/plugins/core/get'
 import { Button } from '@lib/ui/buttons/Button'
-import { borderRadius } from '@lib/ui/css/borderRadius'
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { CircleInfoIcon } from '@lib/ui/icons/CircleInfoIcon'
 import { LogoBoxIcon } from '@lib/ui/icons/LogoBoxIcon'
 import { PlusIcon } from '@lib/ui/icons/PlusIcon'
@@ -131,7 +131,7 @@ export const PreviewInfo: FC<
                         height={100}
                         width={100}
                         {...props}
-                        style={{ borderRadius: 24 }}
+                        style={{ borderRadius: borderRadiusPx.xl }}
                       />
                     )}
                   />

--- a/core/ui/mpc/keysign/join/tx/JoinKeysignLimitOrderCancelVerify.tsx
+++ b/core/ui/mpc/keysign/join/tx/JoinKeysignLimitOrderCancelVerify.tsx
@@ -3,6 +3,7 @@ import {
   ContainerWrapper,
   HorizontalLine,
 } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerify.styled'
+import { borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { ValueProp } from '@lib/ui/props'
 import { Text } from '@lib/ui/text'
@@ -51,8 +52,13 @@ export const JoinKeysignLimitOrderCancelVerify = ({ value, cancel }: Props) => {
   )
 
   return (
-    <ContainerWrapper radius={16}>
-      <VStack bgColor="foreground" gap={20} padding={24} radius={16}>
+    <ContainerWrapper radius={borderRadiusPx.lg}>
+      <VStack
+        bgColor="foreground"
+        gap={20}
+        padding={24}
+        radius={borderRadiusPx.lg}
+      >
         <VStack gap={4}>
           <Text color="contrast" size={17} weight="500">
             {t('swap_limit_cancel_verify_title')}

--- a/core/ui/mpc/keysign/join/tx/JoinKeysignLimitOrderVerify.tsx
+++ b/core/ui/mpc/keysign/join/tx/JoinKeysignLimitOrderVerify.tsx
@@ -7,6 +7,7 @@ import {
   HorizontalLine,
   IconWrapper,
 } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerify.styled'
+import { borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { ArrowDownIcon } from '@lib/ui/icons/ArrowDownIcon'
 import { ClockIcon } from '@lib/ui/icons/ClockIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
@@ -112,8 +113,13 @@ export const JoinKeysignLimitOrderVerify = ({ value, order }: Props) => {
   })
 
   return (
-    <ContainerWrapper radius={16}>
-      <VStack bgColor="foreground" gap={20} padding={24} radius={16}>
+    <ContainerWrapper radius={borderRadiusPx.lg}>
+      <VStack
+        bgColor="foreground"
+        gap={20}
+        padding={24}
+        radius={borderRadiusPx.lg}
+      >
         <Text color="contrast" size={17} weight="500">
           {t('swap_limit_review_heading')}
         </Text>

--- a/core/ui/mpc/keysign/join/tx/JoinKeysignSwapVerify.tsx
+++ b/core/ui/mpc/keysign/join/tx/JoinKeysignSwapVerify.tsx
@@ -11,6 +11,7 @@ import {
   IconWrapper,
 } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerify.styled'
 import { SwapVerifyRecipient } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerifyRecipient'
+import { borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { ArrowDownIcon } from '@lib/ui/icons/ArrowDownIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { List } from '@lib/ui/list'
@@ -62,8 +63,13 @@ export const JoinKeysignSwapVerify = ({ value }: ValueProp<KeysignPayload>) => {
 
   return (
     <>
-      <ContainerWrapper radius={16}>
-        <VStack bgColor="foreground" gap={24} padding={24} radius={16}>
+      <ContainerWrapper radius={borderRadiusPx.lg}>
+        <VStack
+          bgColor="foreground"
+          gap={24}
+          padding={24}
+          radius={borderRadiusPx.lg}
+        >
           <Text color="supporting" size={15}>
             {t('youre_swapping')}
           </Text>
@@ -109,7 +115,12 @@ export const JoinKeysignSwapVerify = ({ value }: ValueProp<KeysignPayload>) => {
           </VStack>
         </VStack>
       </ContainerWrapper>
-      <VStack bgColor="foreground" gap={12} padding={12} radius={16}>
+      <VStack
+        bgColor="foreground"
+        gap={12}
+        padding={12}
+        radius={borderRadiusPx.lg}
+      >
         <List>
           <ListItem
             hoverable={false}

--- a/core/ui/mpc/keysign/tx/components/SignTonDisplay.tsx
+++ b/core/ui/mpc/keysign/tx/components/SignTonDisplay.tsx
@@ -12,7 +12,7 @@ import {
   HorizontalLine,
   IconWrapper,
 } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerify.styled'
-import { borderRadius } from '@lib/ui/css/borderRadius'
+import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { toSizeUnit } from '@lib/ui/css/toSizeUnit'
 import { ArrowDownIcon } from '@lib/ui/icons/ArrowDownIcon'
 import { Collapse } from '@lib/ui/layout/Collapse'
@@ -158,8 +158,13 @@ const TonSwapItem = ({ decoded }: { decoded: DecodedTonMessage }) => {
     swapIntent.offerAsset === 'ton' ? chainFeeCoin[Chain.Ton] : jettonCoin
 
   return (
-    <ContainerWrapper radius={16}>
-      <VStack bgColor="foreground" gap={24} padding={24} radius={16}>
+    <ContainerWrapper radius={borderRadiusPx.lg}>
+      <VStack
+        bgColor="foreground"
+        gap={24}
+        padding={24}
+        radius={borderRadiusPx.lg}
+      >
         <Text color="supporting" size={15}>
           {t('youre_swapping')}
         </Text>
@@ -189,8 +194,13 @@ const TonSimulationSwapItem = ({
   const { t } = useTranslation()
 
   return (
-    <ContainerWrapper radius={16}>
-      <VStack bgColor="foreground" gap={24} padding={24} radius={16}>
+    <ContainerWrapper radius={borderRadiusPx.lg}>
+      <VStack
+        bgColor="foreground"
+        gap={24}
+        padding={24}
+        radius={borderRadiusPx.lg}
+      >
         <Text color="supporting" size={15}>
           {t('youre_swapping')}
         </Text>

--- a/core/ui/mpc/keysign/verify/VerifyTransactionOverview.tsx
+++ b/core/ui/mpc/keysign/verify/VerifyTransactionOverview.tsx
@@ -5,6 +5,7 @@ import {
   TransactionOverviewAmount,
   TransactionOverviewItem,
 } from '@core/ui/mpc/keysign/verify/components'
+import { borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { HStack } from '@lib/ui/layout/Stack'
 import { List } from '@lib/ui/list'
 import { Spinner } from '@lib/ui/loaders/Spinner'
@@ -107,7 +108,7 @@ export const VerifyTransactionOverview = ({
   })()
 
   return (
-    <List border="gradient" radius={16}>
+    <List border="gradient" radius={borderRadiusPx.lg}>
       <TransactionOverviewAmount
         label={amountLabel ?? t('you_are_sending')}
         coin={coin}

--- a/core/ui/qbtc/governance/components/VoteOverview.tsx
+++ b/core/ui/qbtc/governance/components/VoteOverview.tsx
@@ -1,3 +1,4 @@
+import { borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { List } from '@lib/ui/list'
 import { ListItem } from '@lib/ui/list/item'
@@ -22,7 +23,7 @@ export const VoteOverview = ({
   const { t } = useTranslation()
 
   return (
-    <List border="gradient" radius={16}>
+    <List border="gradient" radius={borderRadiusPx.lg}>
       <ListItem
         title={t('qbtc_gov.proposal_number', { id: proposalId })}
         description={proposalTitle || t('qbtc_gov.untitled_proposal')}

--- a/core/ui/vault/backup/fast/VaultCreatedSuccessScreen.tsx
+++ b/core/ui/vault/backup/fast/VaultCreatedSuccessScreen.tsx
@@ -70,6 +70,7 @@ const IconWrapper = styled.div`
   color: ${getColor('success')};
 `
 
+// eslint-disable-next-line local/no-hardcoded-border-radius -- a non-square decorative element: 50% is an ellipse, the pill token would clamp it to a stadium
 const IconShadow = styled.div`
   position: absolute;
   bottom: -6px;

--- a/core/ui/vault/chain/manage/ChainItem.tsx
+++ b/core/ui/vault/chain/manage/ChainItem.tsx
@@ -141,6 +141,7 @@ const ChainIconWrapper = styled.div<IsActiveProp>`
     `}
 `
 
+// eslint-disable-next-line local/no-hardcoded-border-radius -- a notched badge outline, not a surface radius
 const CheckBadge = styled(IconWrapper)`
   position: absolute;
   bottom: 0;

--- a/core/ui/vault/chain/manage/shared/TokenItem.tsx
+++ b/core/ui/vault/chain/manage/shared/TokenItem.tsx
@@ -100,6 +100,7 @@ const TokenIconWrapper = styled.div<IsActiveProp>`
     `}
 `
 
+// eslint-disable-next-line local/no-hardcoded-border-radius -- a notched badge outline, not a surface radius
 const CheckBadge = styled(IconWrapper)`
   position: absolute;
   bottom: 0;

--- a/core/ui/vault/create/setup-vault/DeviceCountPicker.tsx
+++ b/core/ui/vault/create/setup-vault/DeviceCountPicker.tsx
@@ -18,6 +18,7 @@ const GradientWrapper = styled.div`
   overflow: hidden;
 `
 
+// eslint-disable-next-line local/no-hardcoded-border-radius -- a non-square decorative element: 50% is an ellipse, the pill token would clamp it to a stadium
 const TopGradient = styled.div`
   position: absolute;
   z-index: 0;

--- a/core/ui/vault/deposit/DepositVerify/BondOverview.tsx
+++ b/core/ui/vault/deposit/DepositVerify/BondOverview.tsx
@@ -14,6 +14,7 @@ import { useDepositCoin } from '@core/ui/vault/deposit/providers/DepositCoinProv
 import { useDepositData } from '@core/ui/vault/deposit/state/data'
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { useCurrentVaultAddress } from '@core/ui/vault/state/currentVaultCoins'
+import { borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { CheckmarkIcon } from '@lib/ui/icons/CheckmarkIcon'
 import { HStack } from '@lib/ui/layout/Stack'
 import { List } from '@lib/ui/list'
@@ -75,7 +76,7 @@ export const BondOverview = ({ onBack }: OnBackProp) => {
           </BlockaidStatus>
         )}
 
-        <List border="gradient" radius={16}>
+        <List border="gradient" radius={borderRadiusPx.lg}>
           <TransactionOverviewAmount
             label={actionLabel}
             coin={coin}

--- a/core/ui/vault/deposit/DepositVerify/StakeOverview.tsx
+++ b/core/ui/vault/deposit/DepositVerify/StakeOverview.tsx
@@ -16,6 +16,7 @@ import { useDepositCoin } from '@core/ui/vault/deposit/providers/DepositCoinProv
 import { useDepositData } from '@core/ui/vault/deposit/state/data'
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { useCurrentVaultAddress } from '@core/ui/vault/state/currentVaultCoins'
+import { borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { CheckmarkIcon } from '@lib/ui/icons/CheckmarkIcon'
 import { HStack } from '@lib/ui/layout/Stack'
 import { List } from '@lib/ui/list'
@@ -156,7 +157,7 @@ export const StakeOverview = ({ onBack }: OnBackProp) => {
           </BlockaidStatus>
         )}
 
-        <List border="gradient" radius={16}>
+        <List border="gradient" radius={borderRadiusPx.lg}>
           {/* Hide amount row for native TCY unstake when fallback is 0, as the actual
               amount is determined by THORChain based on the percentage in the memo */}
           {!(isNativeTcyUnstake && fallbackAmount === 0) && (

--- a/core/ui/vault/new/index.tsx
+++ b/core/ui/vault/new/index.tsx
@@ -22,6 +22,7 @@ const PageWrapper = styled(VStack)`
   overflow: hidden;
 `
 
+// eslint-disable-next-line local/no-hardcoded-border-radius -- a non-square decorative element: 50% is an ellipse, the pill token would clamp it to a stadium
 const TopGradient = styled.div`
   position: absolute;
   top: -200px;

--- a/core/ui/vault/page/banners/shared/HomePromoBanner.styles.tsx
+++ b/core/ui/vault/page/banners/shared/HomePromoBanner.styles.tsx
@@ -29,6 +29,7 @@ export const HomePromoBannerTextStack = styled.div`
   max-width: 214px;
 `
 
+// eslint-disable-next-line local/no-hardcoded-border-radius -- a decorative glow, not a surface
 export const HomePromoBannerCloseButton = styled(IconButton)`
   position: absolute;
   z-index: 3;

--- a/core/ui/vault/page/components/VaultOverview.tsx
+++ b/core/ui/vault/page/components/VaultOverview.tsx
@@ -120,6 +120,7 @@ const BalanceWrapper = styled.div`
     `}
 `
 
+// eslint-disable-next-line local/no-hardcoded-border-radius -- a decorative glow, not a surface
 const BlurEffect = styled.div`
   position: absolute;
   left: 50%;

--- a/core/ui/vault/page/keygen/migrate/MigrateVaultPrompt.tsx
+++ b/core/ui/vault/page/keygen/migrate/MigrateVaultPrompt.tsx
@@ -78,6 +78,7 @@ const Container = styled(UnstyledButton)`
   }
 `
 
+// eslint-disable-next-line local/no-hardcoded-border-radius -- a decorative glow, not a surface
 const CloseButton = styled(IconButton)`
   display: flex;
   width: 44px;
@@ -107,6 +108,7 @@ const AnimationWrapper = styled.div`
   mix-blend-mode: screen;
 `
 
+// eslint-disable-next-line local/no-hardcoded-border-radius -- a decorative glow, not a surface
 const LightingBackground = styled.div`
   width: 350px;
   height: 350px;

--- a/core/ui/vault/settings/delete/index.tsx
+++ b/core/ui/vault/settings/delete/index.tsx
@@ -182,6 +182,7 @@ const VItem = styled(Item)`
   flex: 1;
 `
 
+// eslint-disable-next-line local/no-hardcoded-border-radius -- a decorative glow, not a surface
 const GradientBackground = styled.div`
   position: absolute;
   top: 50%;

--- a/core/ui/vault/settings/referral/components/AddFriendsReferralPrompt.tsx
+++ b/core/ui/vault/settings/referral/components/AddFriendsReferralPrompt.tsx
@@ -55,6 +55,7 @@ const FriendsReferralPromptWrapper = styled(VStack)`
   background: ${getColor('foreground')};
 `
 
+// eslint-disable-next-line local/no-hardcoded-border-radius -- a decorative glow, not a surface
 const FriendsReferralPromptOverlay = styled.div`
   position: absolute;
   width: 350px;

--- a/core/ui/vault/settings/referral/components/Referrals.styled.tsx
+++ b/core/ui/vault/settings/referral/components/Referrals.styled.tsx
@@ -48,6 +48,7 @@ export const FixedWrapper = styled(CenterAbsolutely)`
   background-color: ${getColor('background')};
 `
 
+// eslint-disable-next-line local/no-hardcoded-border-radius -- a decorative glow, not a surface
 export const Overlay = styled.div`
   position: absolute;
   width: 374px;

--- a/core/ui/vault/swap/verify/SwapVerify/index.tsx
+++ b/core/ui/vault/swap/verify/SwapVerify/index.tsx
@@ -15,6 +15,7 @@ import {
   IconWrapper,
 } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerify.styled'
 import { SwapVerifyRecipient } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerifyRecipient'
+import { borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { ArrowDownIcon } from '@lib/ui/icons/ArrowDownIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { PageHeader } from '@lib/ui/page/PageHeader'
@@ -58,8 +59,13 @@ export const SwapVerify = ({ swapQuote, onBack }: SwapVerifyProps) => {
         terms={translatedTerms}
         swapQuote={swapQuote}
       >
-        <ContainerWrapper radius={16}>
-          <VStack bgColor="foreground" gap={24} padding={24} radius={16}>
+        <ContainerWrapper radius={borderRadiusPx.lg}>
+          <VStack
+            bgColor="foreground"
+            gap={24}
+            padding={24}
+            radius={borderRadiusPx.lg}
+          >
             <Text color="supporting" size={15}>
               {t('youre_swapping')}
             </Text>
@@ -138,7 +144,12 @@ export const SwapVerify = ({ swapQuote, onBack }: SwapVerifyProps) => {
             </VStack>
           </VStack>
         </ContainerWrapper>
-        <VStack bgColor="foreground" gap={24} padding={12} radius={16}>
+        <VStack
+          bgColor="foreground"
+          gap={24}
+          padding={12}
+          radius={borderRadiusPx.lg}
+        >
           <VerifySwapFees swapQuote={swapQuote} />
         </VStack>
         <MatchQuery

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -73,22 +73,49 @@ const noUnicodeDashLiterals = {
 // site. It stops new literals; it does not stop drift. See vultisig/
 // vultisig-windows#4639.
 const radiusValuePattern = /border-radius\s*:\s*([^;}]*)/g
-const hardcodedLengthPattern = /(?<![\w.$])\d*\.?\d+\s*(px|%|r?em|pt|vh|vw)/i
+const lengthPattern = /(?<![\w.$])(\d*\.?\d+)\s*(px|%|r?em|pt|vh|vw)/gi
 const radiusConstantPattern = /(border)?radius(px)?$/i
 // Exact names only: `tipRadius` on floating-ui's Arrow is an arrowhead, not a
 // surface corner, and has no business on the scale.
 const radiusPropNames = new Set(['radius', 'borderRadius'])
+
+// Zero is the absence of a radius, not a step, in every spelling it has: `0`,
+// `0px`, and the zero corners of `0 0 24px 24px`. Only a non-zero length is a
+// value the scale should have an opinion about.
+const hasNonZeroLength = text =>
+  [...String(text).matchAll(lengthPattern)].some(
+    ([, number]) => parseFloat(number) !== 0
+  )
+
+// The one thing the rule cannot check, repeated on every diagnostic so it is
+// never inferred from silence.
+const cannotVerifyStep =
+  'This rule checks that a token is used, not that the right step was picked - that depends on whether the surface is a container or sits inside one, which only the call site knows.'
+
+// Resolve a value node to the constant it always evaluates to, so
+// ``borderRadius={`16px`}`` is caught alongside `borderRadius="16px"`. A
+// template carrying expressions is composed at runtime - almost always from
+// `borderRadiusPx` - and is left to the reader.
+const staticValueOf = node => {
+  if (!node) return undefined
+  if (node.type === 'JSXExpressionContainer') return staticValueOf(node.expression)
+  if (node.type === 'Literal') return node.value
+  if (node.type === 'TemplateLiteral') {
+    if (node.expressions.length > 0) return undefined
+    const [quasi] = node.quasis
+    return quasi?.value.cooked ?? quasi?.value.raw
+  }
+  return undefined
+}
 
 const noHardcodedBorderRadius = {
   meta: {
     type: 'problem',
     schema: [],
     messages: {
-      literal:
-        'Hardcoded corner radius `{{value}}`. Use a step from `borderRadius` in @lib/ui/css/borderRadius, or `borderRadiusPx` when a surface rounds its corners individually. If this is deliberately off the scale, disable the rule on the line above with a reason.',
-      constant:
-        'Corner radius `{{value}}` held in a constant. Read it from `borderRadiusPx` instead, so the scale stays the single source.',
-      prop: 'Corner radius `{{value}}` passed as a value. Use `borderRadiusPx` so the call site names a step rather than a number.',
+      literal: `Hardcoded corner radius \`{{value}}\`. Use a step from \`borderRadius\` in @lib/ui/css/borderRadius, or \`borderRadiusPx\` when a surface rounds its corners individually. If this is deliberately off the scale, disable the rule on the line above with a reason. ${cannotVerifyStep}`,
+      constant: `Corner radius \`{{value}}\` held in a constant. Read it from \`borderRadiusPx\` instead, so the scale stays the single source. ${cannotVerifyStep}`,
+      prop: `Corner radius \`{{value}}\` passed as a value. Use \`borderRadiusPx\` so the call site names a step rather than a number. ${cannotVerifyStep}`,
     },
   },
   create(context) {
@@ -110,7 +137,7 @@ const noHardcodedBorderRadius = {
         const text = node.value.cooked ?? node.value.raw
         for (const match of text.matchAll(radiusValuePattern)) {
           const value = match[1].trim()
-          if (!value || !hardcodedLengthPattern.test(value)) continue
+          if (!value || !hasNonZeroLength(value)) continue
           context.report({
             node: enclosingStatement(node),
             messageId: 'literal',
@@ -123,7 +150,8 @@ const noHardcodedBorderRadius = {
           node.id.type !== 'Identifier' ||
           !radiusConstantPattern.test(node.id.name) ||
           node.init?.type !== 'Literal' ||
-          typeof node.init.value !== 'number'
+          typeof node.init.value !== 'number' ||
+          node.init.value === 0
         ) {
           return
         }
@@ -141,18 +169,9 @@ const noHardcodedBorderRadius = {
               ? node.key.name
               : node.key.value
         if (typeof name !== 'string' || !radiusPropNames.has(name)) return
-        const value =
-          node.type === 'JSXAttribute'
-            ? node.value?.type === 'Literal'
-              ? node.value.value
-              : node.value?.expression?.value
-            : node.value?.value
+        const value = staticValueOf(node.value)
         if (value === undefined || value === null) return
-        if (
-          typeof value === 'number'
-            ? value === 0
-            : !hardcodedLengthPattern.test(String(value))
-        ) {
+        if (typeof value === 'number' ? value === 0 : !hasNonZeroLength(value)) {
           return
         }
         context.report({

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -61,6 +61,110 @@ const noUnicodeDashLiterals = {
   },
 }
 
+// A corner radius binds to a surface in more shapes than a `border-radius`
+// declaration, and the #4550 migration found all four of them in the tree:
+// the plain literal, a named constant one hop from use, a radius spelled as a
+// dimension, and a radius handed to a component as a prop. A regex over
+// `border-radius:` alone would have missed three.
+//
+// What this rule cannot do is check that the *right* step was picked. Whether a
+// surface takes `xl` or something smaller depends on whether it is a container,
+// sits inside one, or is not a surface at all - only ever visible at the call
+// site. It stops new literals; it does not stop drift. See vultisig/
+// vultisig-windows#4639.
+const radiusValuePattern = /border-radius\s*:\s*([^;}]*)/g
+const hardcodedLengthPattern = /(?<![\w.$])\d*\.?\d+\s*(px|%|r?em|pt|vh|vw)/i
+const radiusConstantPattern = /(border)?radius(px)?$/i
+// Exact names only: `tipRadius` on floating-ui's Arrow is an arrowhead, not a
+// surface corner, and has no business on the scale.
+const radiusPropNames = new Set(['radius', 'borderRadius'])
+
+const noHardcodedBorderRadius = {
+  meta: {
+    type: 'problem',
+    schema: [],
+    messages: {
+      literal:
+        'Hardcoded corner radius `{{value}}`. Use a step from `borderRadius` in @lib/ui/css/borderRadius, or `borderRadiusPx` when a surface rounds its corners individually. If this is deliberately off the scale, disable the rule on the line above with a reason.',
+      constant:
+        'Corner radius `{{value}}` held in a constant. Read it from `borderRadiusPx` instead, so the scale stays the single source.',
+      prop: 'Corner radius `{{value}}` passed as a value. Use `borderRadiusPx` so the call site names a step rather than a number.',
+    },
+  },
+  create(context) {
+    // Report against the enclosing statement: a disable comment cannot live
+    // inside a template literal, so it has to attach above the declaration.
+    const enclosingStatement = node => {
+      let current = node
+      while (
+        current.parent &&
+        !/Statement|Declaration/.test(current.parent.type)
+      ) {
+        current = current.parent
+      }
+      return current.parent ?? node
+    }
+
+    return {
+      TemplateElement(node) {
+        const text = node.value.cooked ?? node.value.raw
+        for (const match of text.matchAll(radiusValuePattern)) {
+          const value = match[1].trim()
+          if (!value || !hardcodedLengthPattern.test(value)) continue
+          context.report({
+            node: enclosingStatement(node),
+            messageId: 'literal',
+            data: { value },
+          })
+        }
+      },
+      VariableDeclarator(node) {
+        if (
+          node.id.type !== 'Identifier' ||
+          !radiusConstantPattern.test(node.id.name) ||
+          node.init?.type !== 'Literal' ||
+          typeof node.init.value !== 'number'
+        ) {
+          return
+        }
+        context.report({
+          node,
+          messageId: 'constant',
+          data: { value: String(node.init.value) },
+        })
+      },
+      'Property, JSXAttribute'(node) {
+        const name =
+          node.type === 'JSXAttribute'
+            ? node.name.name
+            : node.key.type === 'Identifier'
+              ? node.key.name
+              : node.key.value
+        if (typeof name !== 'string' || !radiusPropNames.has(name)) return
+        const value =
+          node.type === 'JSXAttribute'
+            ? node.value?.type === 'Literal'
+              ? node.value.value
+              : node.value?.expression?.value
+            : node.value?.value
+        if (value === undefined || value === null) return
+        if (
+          typeof value === 'number'
+            ? value === 0
+            : !hardcodedLengthPattern.test(String(value))
+        ) {
+          return
+        }
+        context.report({
+          node,
+          messageId: 'prop',
+          data: { value: String(value) },
+        })
+      },
+    }
+  },
+}
+
 export default [
   {
     ignores: [
@@ -93,7 +197,12 @@ export default [
       'unused-imports': fixupPluginRules(unusedImportsPlugin),
       storybook,
       'react-compiler': reactCompiler,
-      local: noUnicodeDashLiterals,
+      local: {
+        rules: {
+          ...noUnicodeDashLiterals.rules,
+          'no-hardcoded-border-radius': noHardcodedBorderRadius,
+        },
+      },
     },
 
     languageOptions: {
@@ -157,12 +266,34 @@ export default [
       ],
       '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
       'local/no-unicode-dash-literals': 'error',
+      'local/no-hardcoded-border-radius': 'error',
     },
   }, // Override for declaration files where interfaces are required for module augmentation
   {
     files: ['core/ui/i18n/locales/**/*.{ts,tsx}'],
     rules: {
       'local/no-unicode-dash-literals': 'off',
+    },
+  },
+  // The token module defines the scale, so it is the one place a raw radius
+  // belongs. `round` is the deprecated spelling it replaces.
+  {
+    files: ['lib/ui/css/borderRadius.tsx', 'lib/ui/css/round.tsx'],
+    rules: {
+      'local/no-hardcoded-border-radius': 'off',
+    },
+  },
+  // Stories and specs illustrate or assert values rather than ship surfaces,
+  // and the e2e fixture builds a mock third-party dapp page whose radii are not
+  // ours to standardise.
+  {
+    files: [
+      '**/*.stories.{ts,tsx}',
+      '**/*.spec.{ts,tsx}',
+      'clients/extension/tests/**/*.{ts,tsx}',
+    ],
+    rules: {
+      'local/no-hardcoded-border-radius': 'off',
     },
   },
   {

--- a/lib/ui/buttons/Button/index.tsx
+++ b/lib/ui/buttons/Button/index.tsx
@@ -63,6 +63,7 @@ const mediumHeight: Record<PrimaryButtonStatus, number> = {
   success: 42,
 }
 
+// eslint-disable-next-line local/no-hardcoded-border-radius -- the shared button's own design language, owned by #4548
 const pillMetrics = (size: ButtonSize, status: PrimaryButtonStatus) =>
   match(size, {
     xs: () => css`
@@ -102,6 +103,7 @@ const linkMetrics = css`
   ${horizontalPadding(4)}
 `
 
+// eslint-disable-next-line local/no-hardcoded-border-radius -- the shared button's own design language, owned by #4548
 const StyledButton = styled(UnstyledButton)<{
   $disabled: boolean
   $kind: NonNullable<ButtonProps['kind']>

--- a/lib/ui/selection/SelectableItem.tsx
+++ b/lib/ui/selection/SelectableItem.tsx
@@ -32,6 +32,7 @@ const IconWrapper = styled.div<IsActiveProp>`
     `}
 `
 
+// eslint-disable-next-line local/no-hardcoded-border-radius -- a notched badge outline, not a surface radius
 const CheckBadge = styled(BaseIconWrapper)`
   position: absolute;
   bottom: 0;


### PR DESCRIPTION
Closes #4639, the last ask of #4550. Standalone against `main` now that #4630 and #4636 have landed — inside either of them it would have kept CI red for the whole life of the other.

## The rule

One ESLint rule, `local/no-hardcoded-border-radius`, following the shape of the inline `local` plugin already in `eslint.config.mjs`. No new dependency.

It covers three binder shapes, because a radius reaches a surface in more ways than a `border-radius` declaration:

```
border-radius: 24px                        the literal inside a styled template
const bottomCornerRadiusPx = 24            a named constant one hop from use
<VStack radius={16} />                     a radius handed over as a prop
style={{ borderRadius: 24 }}               or as a style value
```

## The third shape earned its place immediately

Turned on against `main`, the rule found **30 call sites the migration never saw**. All of them pass `radius={16}` to `VStack`, `List` or `ContainerWrapper` — the generic primitives whose `radius` prop #4625 deliberately left alone, on the understanding that the sweeps owning those directories would fix the call sites. They never did, because every sweep searched for `border-radius:` text and token usage, and these are neither.

```
core/inpage-provider/popup/view/resolvers/     11 sites
core/ui/mpc/keysign/                           11 sites
core/ui/vault/{swap,deposit}/                   5 sites
core/ui/qbtc/, core/ui/mpc/keygen/              3 sites
```

**They are migrated here, not suppressed.** A guard that opens with 30 inline disables for real violations certifies the drift it was written to stop.

## The 22 deliberate survivors

Each silenced with an inline disable carrying its reason, placed next to the comment that already justified it:

| | | |
|---|---|---|
| decorative glows | 9 | `350px`, `416px`, `512px`, `260px`, `77px` |
| notched badge outlines | 5 | `40px 0 25px 0` |
| drawn phone hardware | 2 | `36px`, `34px` in the keygen education overlay |
| non-square decoratives | 3 | `50%` — an ellipse, not a stadium |
| the shared `Button` | 2 | `30px`, `99px` — owned by #4548 |

Stories, specs and the e2e mock-dapp fixture are excluded by file pattern rather than inline: they illustrate or assert values instead of shipping surfaces.

## One false positive, fixed in the rule rather than suppressed

The first pass matched any identifier ending in `radius`, which caught `tipRadius={2}` on floating-ui's `Arrow`. That is an arrowhead, not a surface corner, and has no business on the scale. The prop check now matches the exact names `radius` and `borderRadius`.

## ⚠️ What this does not do

**It enforces "use a token". It cannot enforce "use the right token."**

Whether a surface takes `xl` or a smaller step depends on whether it is a container, sits inside one, or is not a surface at all — only ever visible at the call site, never at the declaration.

This is not hypothetical. Review on #4636 caught three decorative glows converted from `border-radius: 50%` to the `pill` token: two 600x500 radial gradients and a 16x8 blurred shadow. All three used a token correctly by this rule's standard. All three were wrong — on a non-square element `pill` clamps an ellipse into a stadium.

So the rule prevents *new literals*. It does not prevent *drift*. The rule's own message says so, and **#4550's "drift can't re-accumulate" should be read as half-delivered.**

## Also

`.claude/rules/border-radius.md` — the scale, how to compose individual corners, why there is no circle step, and how to go off the scale on purpose. So the convention is discoverable before someone hits the lint error, not after.

## Validation

`yarn lint` clean on the whole tree, `yarn typecheck` clean, `yarn test` 942 passing, `knip` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized corner rounding across transaction, vault, DeFi, governance, and verification screens for a more consistent interface.
  * Preserved intentional custom rounding for decorative elements and distinctive badge designs.

* **Chores**
  * Added automated checks to prevent unintended hardcoded corner-radius values while allowing approved visual exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->