### PR TITLE
fix: build Linux against WebKitGTK 4.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,6 +167,12 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      - name: Install WebKitGTK 4.1 build dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libwebkit2gtk-4.1-dev
+
       - name: Build wails
         uses: dAppServer/wails-build-action@main
         id: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
         build:
           - name: 'App'
             platform: 'linux/amd64'
-            os: 'ubuntu-22.04'
+            os: 'ubuntu-24.04'
           - name: 'App'
             platform: 'windows/amd64'
             os: 'windows-latest'
@@ -167,12 +167,6 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Install WebKitGTK 4.1 build dependencies
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes libwebkit2gtk-4.1-dev
-
       - name: Build wails
         uses: dAppServer/wails-build-action@main
         id: build
@@ -180,6 +174,10 @@ jobs:
           build-name: ${{ matrix.build.name }}
           build-platform: ${{ matrix.build.platform }}
           package: false
+
+      - name: Verify Linux WebKitGTK 4.1 linkage
+        if: runner.os == 'Linux'
+        run: bash scripts/verify-linux-webkit.sh "build/bin/${{ matrix.build.name }}"
 
       - name: Run Go storage tests
         run: go test ./storage

--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ This project uses Wails. Please refer to https://wails.io/docs/gettingstarted/in
 
 ### For Linux Users
 
-Vultisig under Linux requires `libwebkit2gtk-4.0-dev`. Install it with:
+Vultisig under Linux requires the WebKitGTK 4.1 runtime. On Debian 12+ and
+Ubuntu 22.04+, install it with:
 
 ```bash
 sudo apt update
-sudo apt install libwebkit2gtk-4.0-dev
+sudo apt install libwebkit2gtk-4.1-0
 ```
 
 ### Development
@@ -36,16 +37,12 @@ database automatically.
 
 ### Building
 
-To build the desktop app dist:
+Install the Linux build dependencies and build against the WebKitGTK 4.1 ABI:
 
 ```bash
-yarn build:desktop
+sudo apt install libgtk-3-dev libwebkit2gtk-4.1-dev
+wails build
 ```
-
-For Ubuntu 24.4 users who can't find `libwebkit2gtk-4.0-dev`:
-
-1. Add `deb http://gb.archive.ubuntu.com/ubuntu jammy main` to `/etc/apt/sources.list`
-2. Run `sudo apt update && sudo apt install libwebkit2gtk-4.0-dev`
 
 ## Vultisig Extension Extension
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,16 @@ This project uses Wails. Please refer to https://wails.io/docs/gettingstarted/in
 
 ### For Linux Users
 
-Vultisig under Linux requires the WebKitGTK 4.1 runtime. On Debian 12+ and
-Ubuntu 22.04+, install it with:
+Released Linux builds link WebKitGTK 4.1. On Debian 13 and Ubuntu 24.04:
 
 ```bash
 sudo apt update
 sudo apt install libwebkit2gtk-4.1-0
 ```
+
+Ubuntu 22.04 local development still uses WebKitGTK 4.0 (`libwebkit2gtk-4.0-dev`).
+Do not add `webkit2_41` to `wails.json` — Wails v2.11 applies those tags on every
+`wails build` / `wails dev`, which fails on 22.04.
 
 ### Development
 
@@ -37,11 +40,22 @@ database automatically.
 
 ### Building
 
-Install the Linux build dependencies and build against the WebKitGTK 4.1 ABI:
+To build the desktop frontend:
 
 ```bash
-sudo apt install libgtk-3-dev libwebkit2gtk-4.1-dev
+yarn build:desktop
+```
+
+To build the native desktop binary:
+
+```bash
+# Ubuntu 22.04 (WebKitGTK 4.0)
+sudo apt install libgtk-3-dev libwebkit2gtk-4.0-dev
 wails build
+
+# Ubuntu 24.04 / Debian 13 (WebKitGTK 4.1)
+sudo apt install libgtk-3-dev libwebkit2gtk-4.1-dev
+wails build -tags webkit2_41
 ```
 
 ## Vultisig Extension Extension

--- a/ci/deb/nfpm.yaml
+++ b/ci/deb/nfpm.yaml
@@ -10,6 +10,8 @@ description: |
 vendor: "Vultisig"
 homepage: "https://vultisig.com"
 license: "MIT"
+depends:
+  - libwebkit2gtk-4.1-0
 contents:
   - src: ../../build/bin/vultisig
     dst: /usr/bin/vultisig

--- a/scripts/verify-linux-webkit-test.sh
+++ b/scripts/verify-linux-webkit-test.sh
@@ -5,34 +5,44 @@ set -euo pipefail
 script_dir=$(cd "$(dirname "$0")" && pwd)
 verify_script="$script_dir/verify-linux-webkit.sh"
 failed=0
+cleanup_paths=()
+
+cleanup() {
+  if [[ ${#cleanup_paths[@]} -gt 0 ]]; then
+    rm -rf "${cleanup_paths[@]}"
+  fi
+}
+trap cleanup EXIT
 
 assert_exit() {
   local name="$1"
   local expected="$2"
   local fixture="$3"
-  local mock_dir
+  local mock_dir fixture_file stdout_file stderr_file fake_elf
+
   mock_dir=$(mktemp -d)
+  fixture_file=$(mktemp)
+  stdout_file=$(mktemp)
+  stderr_file=$(mktemp)
+  fake_elf=$(mktemp)
+  cleanup_paths+=("$mock_dir" "$fixture_file" "$stdout_file" "$stderr_file" "$fake_elf")
+
   cat >"$mock_dir/readelf" <<'EOF'
 #!/usr/bin/env bash
 cat "$MOCK_READELF_OUTPUT"
 EOF
   chmod +x "$mock_dir/readelf"
-
-  local fixture_file
-  fixture_file=$(mktemp)
   printf '%s\n' "$fixture" >"$fixture_file"
 
   set +e
   MOCK_READELF_OUTPUT="$fixture_file" PATH="$mock_dir:$PATH" \
-    bash "$verify_script" /tmp/fake-linux-elf >/tmp/verify-linux-webkit.out 2>/tmp/verify-linux-webkit.err
+    bash "$verify_script" "$fake_elf" >"$stdout_file" 2>"$stderr_file"
   local actual=$?
   set -e
 
-  rm -rf "$mock_dir" "$fixture_file"
-
   if [[ "$actual" -ne "$expected" ]]; then
     echo "FAIL $name: expected exit $expected, got $actual" >&2
-    cat /tmp/verify-linux-webkit.err >&2
+    cat "$stderr_file" >&2
     failed=1
     return
   fi
@@ -42,17 +52,24 @@ EOF
 
 needed_41=' 0x0000000000000001 (NEEDED)             Shared library: [libwebkit2gtk-4.1.so.0]'
 needed_40=' 0x0000000000000001 (NEEDED)             Shared library: [libwebkit2gtk-4.0.so.37]'
+needed_lookalike=' 0x0000000000000001 (NEEDED)             Shared library: [libwebkit2gtk-4.1.so.0-next]'
+needed_regex=' 0x0000000000000001 (NEEDED)             Shared library: [libwebkit2gtk-4X1YsoZ0]'
 runpath_41=' 0x000000000000001d (RUNPATH)            Library runpath: [/opt/libwebkit2gtk-4.1.so.0]'
 soname_41=' 0x000000000000000e (SONAME)             Library soname: [libwebkit2gtk-4.1.so.0]'
 
 assert_exit 'accepts DT_NEEDED 4.1' 0 "$needed_41"
 assert_exit 'rejects DT_NEEDED 4.0' 1 "$needed_40"
+assert_exit 'rejects lookalike SONAME' 1 "$needed_lookalike"
+assert_exit 'rejects regex-wildcard SONAME' 1 "$needed_regex"
 assert_exit 'rejects RUNPATH-only 4.1' 1 "$needed_40
 $runpath_41"
 assert_exit 'rejects SONAME-only 4.1' 1 "$soname_41"
 
+usage_stdout=$(mktemp)
+usage_stderr=$(mktemp)
+cleanup_paths+=("$usage_stdout" "$usage_stderr")
 set +e
-bash "$verify_script" >/tmp/verify-linux-webkit.out 2>/tmp/verify-linux-webkit.err
+bash "$verify_script" >"$usage_stdout" 2>"$usage_stderr"
 usage_exit=$?
 set -e
 if [[ "$usage_exit" -ne 2 ]]; then

--- a/scripts/verify-linux-webkit-test.sh
+++ b/scripts/verify-linux-webkit-test.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+verify_script="$script_dir/verify-linux-webkit.sh"
+failed=0
+
+assert_exit() {
+  local name="$1"
+  local expected="$2"
+  local fixture="$3"
+  local mock_dir
+  mock_dir=$(mktemp -d)
+  cat >"$mock_dir/readelf" <<'EOF'
+#!/usr/bin/env bash
+cat "$MOCK_READELF_OUTPUT"
+EOF
+  chmod +x "$mock_dir/readelf"
+
+  local fixture_file
+  fixture_file=$(mktemp)
+  printf '%s\n' "$fixture" >"$fixture_file"
+
+  set +e
+  MOCK_READELF_OUTPUT="$fixture_file" PATH="$mock_dir:$PATH" \
+    bash "$verify_script" /tmp/fake-linux-elf >/tmp/verify-linux-webkit.out 2>/tmp/verify-linux-webkit.err
+  local actual=$?
+  set -e
+
+  rm -rf "$mock_dir" "$fixture_file"
+
+  if [[ "$actual" -ne "$expected" ]]; then
+    echo "FAIL $name: expected exit $expected, got $actual" >&2
+    cat /tmp/verify-linux-webkit.err >&2
+    failed=1
+    return
+  fi
+
+  echo "PASS $name"
+}
+
+needed_41=' 0x0000000000000001 (NEEDED)             Shared library: [libwebkit2gtk-4.1.so.0]'
+needed_40=' 0x0000000000000001 (NEEDED)             Shared library: [libwebkit2gtk-4.0.so.37]'
+runpath_41=' 0x000000000000001d (RUNPATH)            Library runpath: [/opt/libwebkit2gtk-4.1.so.0]'
+soname_41=' 0x000000000000000e (SONAME)             Library soname: [libwebkit2gtk-4.1.so.0]'
+
+assert_exit 'accepts DT_NEEDED 4.1' 0 "$needed_41"
+assert_exit 'rejects DT_NEEDED 4.0' 1 "$needed_40"
+assert_exit 'rejects RUNPATH-only 4.1' 1 "$needed_40
+$runpath_41"
+assert_exit 'rejects SONAME-only 4.1' 1 "$soname_41"
+
+set +e
+bash "$verify_script" >/tmp/verify-linux-webkit.out 2>/tmp/verify-linux-webkit.err
+usage_exit=$?
+set -e
+if [[ "$usage_exit" -ne 2 ]]; then
+  echo "FAIL missing-arg: expected exit 2, got $usage_exit" >&2
+  failed=1
+else
+  echo 'PASS missing-arg'
+fi
+
+if [[ "$failed" -ne 0 ]]; then
+  exit 1
+fi

--- a/scripts/verify-linux-webkit.sh
+++ b/scripts/verify-linux-webkit.sh
@@ -2,12 +2,19 @@
 
 set -euo pipefail
 
-binary_path="$1"
-dependencies=$(readelf --dynamic "$binary_path")
+WEBKIT_SONAME='libwebkit2gtk-4.1.so.0'
 
-if grep --fixed-strings --quiet 'libwebkit2gtk-4.1.so.0' <<<"$dependencies"; then
+if [[ $# -lt 1 || -z "${1:-}" ]]; then
+  echo "usage: $0 <linux-elf>" >&2
+  exit 2
+fi
+
+binary_path="$1"
+needed=$(readelf --dynamic "$binary_path" | grep -E '\(NEEDED\)' || true)
+
+if grep -E --quiet "Shared library:[[:space:]]*\[${WEBKIT_SONAME}\]" <<<"$needed"; then
   exit 0
 fi
 
-echo 'Linux build must use WebKitGTK 4.1. Check build:tags in wails.json.' >&2
+echo "Linux build must link ${WEBKIT_SONAME}. Pass -tags webkit2_41 on Ubuntu 24.04 / Debian 13." >&2
 exit 1

--- a/scripts/verify-linux-webkit.sh
+++ b/scripts/verify-linux-webkit.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+binary_path="$1"
+dependencies=$(readelf --dynamic "$binary_path")
+
+if grep --fixed-strings --quiet 'libwebkit2gtk-4.1.so.0' <<<"$dependencies"; then
+  exit 0
+fi
+
+echo 'Linux build must use WebKitGTK 4.1. Check build:tags in wails.json.' >&2
+exit 1

--- a/scripts/verify-linux-webkit.sh
+++ b/scripts/verify-linux-webkit.sh
@@ -12,7 +12,7 @@ fi
 binary_path="$1"
 needed=$(readelf --dynamic "$binary_path" | grep -E '\(NEEDED\)' || true)
 
-if grep -E --quiet "Shared library:[[:space:]]*\[${WEBKIT_SONAME}\]" <<<"$needed"; then
+if grep --fixed-strings --quiet "[${WEBKIT_SONAME}]" <<<"$needed"; then
   exit 0
 fi
 

--- a/wails.json
+++ b/wails.json
@@ -2,7 +2,6 @@
   "$schema": "https://wails.io/schemas/config.v2.json",
   "name": "Vultisig",
   "outputfilename": "vultisig",
-  "build:tags": "webkit2_41",
   "packageManager": "yarn@4.9.4",
   "workspaces": ["clients/desktop"],
   "devServer": "localhost:34115",
@@ -11,9 +10,6 @@
   "frontend:build": "yarn build",
   "frontend:dev:watcher": "yarn dev",
   "frontend:dev:serverUrl": "auto",
-  "postBuildHooks": {
-    "linux/*": "bash ../../scripts/verify-linux-webkit.sh \"${bin}\""
-  },
   "description": "Vultisig for Windows",
   "info": {
     "companyName": "Vultisig",

--- a/wails.json
+++ b/wails.json
@@ -2,6 +2,7 @@
   "$schema": "https://wails.io/schemas/config.v2.json",
   "name": "Vultisig",
   "outputfilename": "vultisig",
+  "build:tags": "webkit2_41",
   "packageManager": "yarn@4.9.4",
   "workspaces": ["clients/desktop"],
   "devServer": "localhost:34115",
@@ -10,6 +11,9 @@
   "frontend:build": "yarn build",
   "frontend:dev:watcher": "yarn dev",
   "frontend:dev:serverUrl": "auto",
+  "postBuildHooks": {
+    "linux/*": "bash ../../scripts/verify-linux-webkit.sh \"${bin}\""
+  },
   "description": "Vultisig for Windows",
   "info": {
     "companyName": "Vultisig",


### PR DESCRIPTION
## Summary

- keep local Ubuntu 22.04 `wails build` / `wails dev` on WebKitGTK 4.0
- build the Linux CI binary on `ubuntu-24.04` so it links WebKitGTK 4.1
- fail the Linux CI job if the binary does not declare `DT_NEEDED` `libwebkit2gtk-4.1.so.0`
- declare the WebKitGTK 4.1 runtime in Debian package metadata
- document both ABIs and restore `yarn build:desktop`

## Issue

The current Linux release links `libwebkit2gtk-4.0.so.37`, which is unavailable on Debian 13. Launching Vultisig therefore fails before startup even when Debian's WebKitGTK 4.1 runtime is installed.

The first version of this PR put `webkit2_41` in `wails.json`. Wails v2.11 applies that tag on every local Linux build, so a 22.04 box with only 4.0-dev fails. That is now CI-only.

## Test Plan

- `bash -n scripts/verify-linux-webkit.sh scripts/verify-linux-webkit-test.sh`
- `bash scripts/verify-linux-webkit-test.sh` (accepts 4.1 `DT_NEEDED`, rejects 4.0 / RUNPATH / SONAME / missing arg)
- parse `wails.json`, `.github/workflows/build.yml`, `ci/deb/nfpm.yaml`
- `git diff --check`
- CI: `build (App, linux/amd64, ubuntu-24.04)` plus the WebKitGTK 4.1 linkage step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Builds**
  - Updated Linux build environments for improved compatibility with current Ubuntu releases.
  - Added validation to ensure generated applications use the supported WebKitGTK version.

- **Packaging**
  - Debian packages now declare the required WebKitGTK runtime dependency.

- **Documentation**
  - Clarified Linux development and release build requirements.
  - Added platform-specific desktop build guidance.

- **Quality**
  - Added automated checks covering WebKitGTK linking and common configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->