### PR TITLE
fix(deps): bump the nanoid resolution to 3.3.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "linkify-it@^5.0.0": "5.0.2",
     "path-to-regexp": "8.4.2",
     "postcss": "8.5.18",
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
     "picomatch@^2.0.4": "2.3.2",
     "picomatch@^2.2.1": "2.3.2",
     "picomatch@^2.3.1": "2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13267,12 +13267,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:3.3.17":
-  version: 3.3.17
-  resolution: "nanoid@npm:3.3.17"
+"nanoid@npm:3.3.18":
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/06f7949c7cce5c92c6aea66022f29a1eae7f56e05acbfddf1e049e819b4bf234c44a765cc44da7163482b111677948514012e27acdfa56f95309295768bdae32
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #4648

## Problem

The `lint` job's "Run code health detectors" step fails on every PR. `yarn quality:audit` runs `yarn npm audit --recursive --all --severity high`, and nanoid 3.3.17 matches a new high advisory:

```
nanoid  <3.3.18  GHSA-2v37-7h3g-55p8  (high)
  "nanoid: custom generators can loop indefinitely when size is zero"
```

The version wasn't coming from the dependency tree on its own — `resolutions` already pinned `"nanoid": "3.3.17"`, which held it at the vulnerable version.

## Fix

Bump that existing pin to `3.3.18`. The only dependent is `postcss@8.5.18`, which asks for `^3.3.12`, so the new version is in range and no API changes are involved. No new `--ignore` entry, so the audit keeps its teeth.

## Checks

- `yarn quality:audit` → `No audit suggestions` (fails on `main`).
- `yarn why nanoid` → `nanoid@npm:3.3.18` as the only 3.x entry.
- `yarn typecheck`, `yarn test` (970 passing), `yarn build:extension` all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `nanoid` package to version 3.3.18.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->