### PR TITLE
fix(extension): remove phantom page scroll in side panels shorter than 600px

### DIFF
--- a/clients/extension/src/pages/index.tsx
+++ b/clients/extension/src/pages/index.tsx
@@ -40,7 +40,9 @@ const ExtensionGlobalStyle = createGlobalStyle`
   }
 
   body {
-    min-height: ${isPopup ? `${popupHeight}px` : '600px'};
+    min-height: ${
+      isPopup ? `${popupHeight}px` : `min(${popupHeight}px, 100dvh)`
+    };
     min-width: ${isPopup ? `${popupWidth}px` : 'min(480px, 100vw)'};
     overflow: hidden;
 

--- a/clients/extension/tests/e2e/playwright.config.ts
+++ b/clients/extension/tests/e2e/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, devices } from '@playwright/test'
+import { defineConfig } from '@playwright/test'
 import { config } from 'dotenv'
 import path from 'path'
 import { fileURLToPath } from 'url'
@@ -36,9 +36,10 @@ config({ path: path.resolve(__dirname, '.env') })
 // PLAYWRIGHT_OFFSCREEN=1 pushes Chrome windows off-screen so local runs don't
 // steal focus while you work. Extension tests can't run headless, so this is
 // the closest equivalent. CI keeps default positioning.
-const offscreenArgs = process.env.PLAYWRIGHT_OFFSCREEN === '1'
-  ? ['--window-position=-3000,-3000', '--window-size=480,600']
-  : []
+const offscreenArgs =
+  process.env.PLAYWRIGHT_OFFSCREEN === '1'
+    ? ['--window-position=-3000,-3000', '--window-size=480,600']
+    : []
 
 const extensionLaunchArgs = [
   `--disable-extensions-except=${extensionPath}`,
@@ -104,6 +105,7 @@ export default defineConfig({
         '**/visual-regression.spec.ts',
         '**/station-migration.spec.ts',
         '**/search-field.spec.ts',
+        '**/viewport-fit.spec.ts',
       ],
       use: {
         launchOptions: {
@@ -168,7 +170,16 @@ export default defineConfig({
   // Reporter for CI
   reporter: [
     ['list'],
-    ['html', { open: 'never', outputFolder: path.resolve(__dirname, 'playwright-report') }],
-    ['json', { outputFile: path.resolve(__dirname, 'test-results/results.json') }],
+    [
+      'html',
+      {
+        open: 'never',
+        outputFolder: path.resolve(__dirname, 'playwright-report'),
+      },
+    ],
+    [
+      'json',
+      { outputFile: path.resolve(__dirname, 'test-results/results.json') },
+    ],
   ],
 })

--- a/clients/extension/tests/e2e/specs/viewport-fit.spec.ts
+++ b/clients/extension/tests/e2e/specs/viewport-fit.spec.ts
@@ -49,15 +49,15 @@ test.describe('Viewport fit', () => {
         horizontal: 0,
       })
 
-      const skipButton = page.getByRole('button', { name: /skip/i })
-      if (await skipButton.isVisible().catch(() => false)) {
-        await skipButton.click()
-        await page.waitForTimeout(500)
-        expect(await getPageOverflow(page)).toEqual({
-          vertical: 0,
-          horizontal: 0,
-        })
-      }
+      const createVaultButton = page.getByRole('button', {
+        name: /create new vault/i,
+      })
+      await expect(createVaultButton).toBeVisible()
+      await createVaultButton.click()
+      await expect(createVaultButton).toBeHidden()
+      await expect
+        .poll(() => getPageOverflow(page))
+        .toEqual({ vertical: 0, horizontal: 0 })
 
       await page.close()
     })

--- a/clients/extension/tests/e2e/specs/viewport-fit.spec.ts
+++ b/clients/extension/tests/e2e/specs/viewport-fit.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * Viewport Fit E2E Tests
+ *
+ * Guards against page-level scrolling on fixed extension screens (#4652).
+ * The extension body used to keep a hard 600px min-height in non-popup
+ * views, so any side panel shorter than 600px showed a phantom scrollbar
+ * even when every screen fit. These tests assert the page itself never
+ * scrolls at supported sizes; screens with unbounded content may still
+ * scroll inside their own bounded content region.
+ *
+ * Runs without a vault: covers the initial screen and the new-vault flow
+ * entry, which exercise the shared page chrome the floor used to break.
+ */
+
+import type { Page } from '@playwright/test'
+
+import { expect, test } from '../fixtures/extension-loader'
+
+const viewports = [
+  { width: 480, height: 600 }, // popup baseline
+  { width: 480, height: 500 }, // short side panel
+  { width: 360, height: 500 }, // minimal side panel
+]
+
+const getPageOverflow = (page: Page) =>
+  page.evaluate(() => {
+    const root = document.documentElement
+    return {
+      vertical: root.scrollHeight - root.clientHeight,
+      horizontal: root.scrollWidth - root.clientWidth,
+    }
+  })
+
+test.describe('Viewport fit', () => {
+  for (const viewport of viewports) {
+    test(`no page-level scroll at ${viewport.width}x${viewport.height}`, async ({
+      context,
+      extensionId,
+    }) => {
+      const page = await context.newPage()
+      await page.setViewportSize(viewport)
+      await page.goto(`chrome-extension://${extensionId}/index.html`)
+      await page.waitForFunction(
+        () => document.querySelectorAll('button').length > 0
+      )
+
+      expect(await getPageOverflow(page)).toEqual({
+        vertical: 0,
+        horizontal: 0,
+      })
+
+      const skipButton = page.getByRole('button', { name: /skip/i })
+      if (await skipButton.isVisible().catch(() => false)) {
+        await skipButton.click()
+        await page.waitForTimeout(500)
+        expect(await getPageOverflow(page)).toEqual({
+          vertical: 0,
+          horizontal: 0,
+        })
+      }
+
+      await page.close()
+    })
+  }
+})

--- a/core/ui/vault/swap/form/MarketSwapForm.tsx
+++ b/core/ui/vault/swap/form/MarketSwapForm.tsx
@@ -91,7 +91,7 @@ export const MarketSwapForm: FC<OnFinishProp<SwapQuote>> = ({ onFinish }) => {
   return (
     <PageContent
       as="form"
-      gap={40}
+      gap={12}
       data-testid="swap-form"
       {...getFormProps({
         onSubmit: handleSubmit,


### PR DESCRIPTION
Fixes #4652

The extension body kept a hard `min-height: 600px` in non-popup views, so any side panel shorter than 600px showed a page-level scrollbar even when the whole screen fit on screen. The scrollbar in the issue screenshot is that floor, not oversized content: at a 592px panel the page still measures 600px and scrolls over ~8px of empty background.

- cap the non-popup body min-height at `min(600px, 100dvh)` so the page never scrolls past real content
- align the market swap form gap with the limit form (40 -> 12) so a populated quote with a Price Impact row fits at 600px without internal scroll
- add a viewport-fit e2e spec (ui-isolated project) asserting zero page-level scroll at 480x600, 480x500 and 360x500

Measured on the built extension: page overflow at 480x500 was 100px before and 0 after; the populated form with a price impact row now fits at 480x600. At panels genuinely shorter than the content, only the form's bounded region scrolls and the header stays pinned. Existing visual-regression baselines are unaffected since they run at exactly 480x600.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extension layout behavior across popup and side-panel viewport sizes.
  * Prevented unwanted horizontal and vertical page scrolling during initial use and new-vault setup.
  * Reduced excess spacing in the market swap form for a more compact layout.

* **Tests**
  * Added automated coverage to verify the extension remains within viewport boundaries across supported layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->