### PR TITLE
fix(ui): keep modals and toasts from painting above the passcode lock

### DIFF
--- a/clients/extension/tests/e2e/playwright.config.ts
+++ b/clients/extension/tests/e2e/playwright.config.ts
@@ -102,6 +102,7 @@ export default defineConfig({
         '**/vault-import-export.spec.ts',
         '**/transaction-history.spec.ts',
         '**/address-book.spec.ts',
+        '**/passcode-lock-layering.spec.ts',
         '**/visual-regression.spec.ts',
         '**/station-migration.spec.ts',
         '**/search-field.spec.ts',

--- a/clients/extension/tests/e2e/specs/passcode-lock-layering.spec.ts
+++ b/clients/extension/tests/e2e/specs/passcode-lock-layering.spec.ts
@@ -1,0 +1,223 @@
+/**
+ * Passcode Lock Layering E2E
+ *
+ * Regression for #4596: the passcode gate rendered inside `#root`, which
+ * `isolation: isolate` confines, while modals, sheets and toasts portal out to
+ * `document.body`. A modal open when auto-lock fired stayed painted over the
+ * gate, still clickable, and its `FocusLock` held the keyboard so the passcode
+ * could not even be typed.
+ *
+ * Only a real browser can answer "which layer owns this pixel", which is why
+ * this is an e2e test. `topLayerTextAt` is the assertion that matters —
+ * asserting the gate is merely *visible* would have passed before the fix too,
+ * because the gate was always visible, just underneath.
+ *
+ * Requires a configured test vault (`tests/e2e/.env`); enabling the passcode
+ * encrypts real keyshares. Skips when unconfigured.
+ *
+ * Locator debt: the Security row, the enable switch, the interval option and
+ * every back button are matched by text or DOM position because none of them
+ * carry a `data-testid`, and `Switch`, `ListItem` and `PageHeaderBackButton`
+ * expose no ARIA role or accessible name. Adding `security-settings-link`,
+ * `passcode-enable-switch`, `back-button` and `passcode-gate` testids would
+ * make this file considerably less fragile.
+ */
+
+import type { Locator, Page } from '@playwright/test'
+
+import { expect, test } from '../fixtures/extension-loader'
+import {
+  ensureVaultExists,
+  getVaultConfigFromEnv,
+} from '../helpers/vault-import'
+import { VaultPage } from '../page-objects/VaultPage.po'
+
+const passcode = '13579'
+const autoLockMinutes = 1
+// Exact `en.ts` strings. `getByText` matches case-insensitively, but
+// `topLayerTextAt` compares raw textContent, so the casing has to be right.
+const modalMarker = 'Select chain'
+const gateMarker = 'App Locked'
+
+/**
+ * Returns the text of the top-level layer that owns the centre of the viewport.
+ *
+ * Everything portalled out of `#root` — modals, sheets, toasts and the gate —
+ * lands as a direct child of `<body>`, so `closest('body > *')` on the hit
+ * element names the layer that actually paints there. This is the browser's own
+ * hit test, the same one that decides where a click lands.
+ */
+const topLayerTextAt = (page: Page) =>
+  page.evaluate(() => {
+    const el = document.elementFromPoint(
+      Math.round(window.innerWidth / 2),
+      Math.round(window.innerHeight / 2)
+    )
+
+    return el?.closest('body > *')?.textContent ?? ''
+  })
+
+/**
+ * Reports whether a control can actually be clicked. A trial click runs every
+ * actionability check, hit-testing included, without dispatching the click — so
+ * a control buried under an overlay resolves to `covered`.
+ */
+const clickability = async (page: Page, text: string) =>
+  page
+    .getByText(text)
+    .first()
+    .click({ trial: true, timeout: 2_000 })
+    .then(() => 'clickable' as const)
+    .catch(() => 'covered' as const)
+
+/**
+ * Clicks the header back button and waits for the destination to prove itself.
+ *
+ * `PageHeaderBackButton` is an unlabelled icon button, so it can only be
+ * addressed by position: the page header renders before the content, making it
+ * the first button in the document. Waiting on `until` keeps a mis-click from
+ * being discovered several steps later.
+ */
+const goBack = async (page: Page, until: Locator) => {
+  await page.locator('button').first().click()
+  await expect(until).toBeVisible()
+}
+
+/**
+ * Turns the passcode on through the settings UI. The switch is an `Opener`, so
+ * flipping it reveals the two passcode fields and the submit button.
+ */
+const enablePasscode = async (page: Page) => {
+  const securityText = page.getByText('Security', { exact: true })
+
+  // One is the section heading, the other the row that navigates. Asserting the
+  // count keeps the nth() below from silently pointing at the wrong thing.
+  await expect(securityText).toHaveCount(2)
+  await securityText.nth(1).click()
+
+  await page.getByText('OFF', { exact: true }).first().click()
+
+  // Two PasscodeInputs, each a row of five single-character boxes that advance
+  // focus on input — so typing five characters fills one row.
+  const digitBoxes = page.locator('input[type="password"]')
+  await expect(digitBoxes).toHaveCount(10)
+
+  await digitBoxes.first().click()
+  await page.keyboard.type(passcode)
+  await digitBoxes.nth(5).click()
+  await page.keyboard.type(passcode)
+
+  await page.getByRole('button', { name: /set passcode/i }).click()
+
+  // Encrypting the keyshares takes a moment. The switch flipping to ON is what
+  // says it landed; ChangePasscode keeps its fields inside a closed modal.
+  await expect(page.getByText('ON', { exact: true })).toBeVisible({
+    timeout: 30_000,
+  })
+}
+
+/**
+ * Picks the shortest auto-lock interval. The Lock Time row only appears in
+ * settings once the passcode is on.
+ */
+const setAutoLock = async (page: Page) => {
+  await page.getByText('Lock Time', { exact: true }).first().click()
+
+  const option = page.getByText(`${autoLockMinutes} minute`, { exact: true })
+  await expect(option).toBeVisible()
+  await option.click()
+}
+
+/**
+ * Drives the inactivity timer instead of idling for a real minute — there is no
+ * manual lock action, the timer is the only way in.
+ *
+ * The clock is installed only once the app is up, so boot timers (splash,
+ * queries, animations) keep running on the real clock where they are far less
+ * brittle. Any interaction reschedules the auto-lock timeout, so the mouse move
+ * is what moves it onto the fake clock for `fastForward` to fire.
+ */
+const lockByInactivity = async (page: Page) => {
+  await page.clock.install()
+  await page.mouse.move(5, 5)
+  await page.clock.fastForward(`0${autoLockMinutes}:00`)
+}
+
+test.describe('Passcode lock layering', () => {
+  test.beforeEach(async ({ context, extensionId }) => {
+    const config = getVaultConfigFromEnv()
+
+    if (!config) {
+      test.skip(true, 'No test vault configured in tests/e2e/.env')
+      return
+    }
+
+    await ensureVaultExists(
+      context,
+      extensionId,
+      config.vaultPath,
+      config.password
+    )
+  })
+
+  test('the gate covers an open modal, takes the keyboard, and leaves it open', async ({
+    context,
+    extensionId,
+  }) => {
+    test.slow()
+
+    const page = await context.newPage()
+    const vaultPage = new VaultPage(page, extensionId)
+
+    try {
+      await vaultPage.goto()
+      await vaultPage.waitForView()
+      await vaultPage.dismissPromptSheets()
+
+      const settingsMarker = page.getByText('Security', { exact: true }).first()
+
+      // The page object's settingsButton falls back to "last button with an
+      // svg", which lands on the wrong control. The header carries a testid.
+      await page.locator('[data-testid="settings-button"]').click()
+      await expect(settingsMarker).toBeVisible()
+
+      await enablePasscode(page)
+      await goBack(page, settingsMarker)
+
+      await setAutoLock(page)
+      await goBack(page, settingsMarker)
+      await goBack(page, vaultPage.receiveButton)
+
+      await vaultPage.receiveButton.click()
+      await expect(page.getByText(modalMarker)).toBeVisible()
+
+      // Baseline: before locking, the modal is what the centre of the screen
+      // belongs to. Without this the later assertion could pass for the wrong
+      // reason — e.g. the modal never opened at all.
+      expect(await topLayerTextAt(page)).toContain(modalMarker)
+      expect(await clickability(page, modalMarker)).toBe('clickable')
+
+      await lockByInactivity(page)
+
+      await expect(page.getByText(gateMarker)).toBeVisible()
+
+      // The point of the bug: the modal is still mounted, but it must not own a
+      // single pixel or receive a single click.
+      const topLayer = await topLayerTextAt(page)
+      expect(topLayer).toContain(gateMarker)
+      expect(topLayer).not.toContain(modalMarker)
+
+      expect(await clickability(page, modalMarker)).toBe('covered')
+
+      // No click first: if a modal's FocusLock still held the keyboard these
+      // keystrokes would go nowhere and the gate would stay up.
+      await page.keyboard.type(passcode)
+      await expect(page.getByText(gateMarker)).toBeHidden({ timeout: 15_000 })
+
+      // Unlocking restores what the user was doing rather than discarding it.
+      await expect(page.getByText(modalMarker)).toBeVisible()
+    } finally {
+      await page.close()
+    }
+  })
+})

--- a/clients/extension/tests/e2e/specs/passcode-lock-layering.spec.ts
+++ b/clients/extension/tests/e2e/specs/passcode-lock-layering.spec.ts
@@ -140,7 +140,16 @@ const setAutoLock = async (page: Page) => {
 const lockByInactivity = async (page: Page) => {
   await page.clock.install()
   await page.mouse.move(5, 5)
-  await page.clock.fastForward(`0${autoLockMinutes}:00`)
+
+  // The reschedule lands in a React effect, a tick after the event. Jumping the
+  // clock before it commits would schedule the timeout past the jump, where it
+  // never fires. `waitForTimeout` runs driver-side, so the faked page clock does
+  // not govern it.
+  await page.waitForTimeout(250)
+
+  // Overshoot rather than landing on the interval exactly, so the test does not
+  // depend on the lock staying a `setTimeout` rather than a deadline check.
+  await page.clock.fastForward(`0${autoLockMinutes}:10`)
 }
 
 test.describe('Passcode lock layering', () => {
@@ -152,12 +161,16 @@ test.describe('Passcode lock layering', () => {
       return
     }
 
-    await ensureVaultExists(
+    // It reports failure by returning false rather than throwing, so without
+    // this the run dies later at a locator timeout that hides the real cause.
+    const imported = await ensureVaultExists(
       context,
       extensionId,
       config.vaultPath,
       config.password
     )
+
+    expect(imported, 'test vault could not be imported').toBe(true)
   })
 
   test('the gate covers an open modal, takes the keyboard, and leaves it open', async ({

--- a/core/ui/passcodeEncryption/guard/PasscodeGuard.tsx
+++ b/core/ui/passcodeEncryption/guard/PasscodeGuard.tsx
@@ -1,5 +1,5 @@
 import { ProductLogoBlock } from '@core/ui/product/ProductLogoBlock'
-import { TakeWholeSpaceAbsolutely } from '@lib/ui/css/takeWholeSpaceAbsolutely'
+import { BlockingOverlay } from '@lib/ui/overlay/BlockingOverlay'
 
 import { usePasscodeAutoLock } from '../../storage/passcodeAutoLock'
 import { useHasPasscodeEncryption } from '../../storage/passcodeEncryption'
@@ -27,16 +27,14 @@ export const PasscodeGuard = () => {
     <>
       {passcodeAutoLock && <PasscodeAutoLock />}
       {pendingPasscodeUnlockRestore && (
-        <TakeWholeSpaceAbsolutely>
+        <BlockingOverlay>
           <ProductLogoBlock />
-        </TakeWholeSpaceAbsolutely>
+        </BlockingOverlay>
       )}
       {isLocked && !pendingPasscodeUnlockRestore && (
-        <>
-          <TakeWholeSpaceAbsolutely>
-            <EnterPasscode />
-          </TakeWholeSpaceAbsolutely>
-        </>
+        <BlockingOverlay>
+          <EnterPasscode />
+        </BlockingOverlay>
       )}
       {hasPasscodeEnabled && !isLocked && !pendingPasscodeUnlockRestore && (
         <PasscodeEncryptionUpgrade />

--- a/lib/ui/css/takeWholeSpaceAbsolutely.tsx
+++ b/lib/ui/css/takeWholeSpaceAbsolutely.tsx
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components'
+import { css } from 'styled-components'
 
 import { takeWholeSpace } from './takeWholeSpace'
 
@@ -7,8 +7,4 @@ export const takeWholeSpaceAbsolutely = css`
   left: 0;
   top: 0;
   ${takeWholeSpace};
-`
-
-export const TakeWholeSpaceAbsolutely = styled.div`
-  ${takeWholeSpaceAbsolutely};
 `

--- a/lib/ui/overlay/BlockingOverlay.tsx
+++ b/lib/ui/overlay/BlockingOverlay.tsx
@@ -1,0 +1,31 @@
+import FocusLock from 'react-focus-lock'
+import styled from 'styled-components'
+
+import { BodyPortal } from '../dom/BodyPortal'
+import { ChildrenProp } from '../props'
+import { getColor } from '../theme/getters'
+
+// Above every other body-portalled surface — the highest currently in use is
+// the toast layer at 1100.
+const zIndex = 2000
+
+const Layer = styled(FocusLock)`
+  position: fixed;
+  inset: 0;
+  z-index: ${zIndex};
+  background: ${getColor('background')};
+`
+
+/**
+ * Full-screen gate that covers the whole app, modals, sheets and toasts
+ * included. They portal out of `#root`, whose `isolation: isolate` confines
+ * anything rendered inside it, so a gate has to share their layer to cover
+ * them. It also takes the focus trap from a modal that was already open —
+ * otherwise that modal keeps pulling focus back and the gate cannot be typed
+ * into — and returns focus to it once the gate unmounts.
+ */
+export const BlockingOverlay = ({ children }: ChildrenProp) => (
+  <BodyPortal>
+    <Layer returnFocus>{children}</Layer>
+  </BodyPortal>
+)


### PR DESCRIPTION
## Description

The passcode gate rendered inside `#root`. `GlobalStyle` gives `#root` an `isolation: isolate`, so nothing inside it can escape that stacking context — while every modal, sheet and toast portals out to `document.body` with a z-index of 1000–1100. The gate therefore covered in-app content but not any of those, which stayed **visible and clickable** over a locked app. Because auto-lock fires from an inactivity timer and nothing closes open modals, it needed no user action to hit.

Raising the gate's own z-index cannot fix this — it is confined by `#root` regardless of its value — so the gate has to share the layer the portals use.

This adds `BlockingOverlay` (`lib/ui/overlay/`) and renders the gate through it:

- **body-portalled**, at z-index 2000, above the highest layer in use (toasts, 1100). This covers every existing portal without enumerating call sites — `ResponsiveModal`, `PromptSheet`, `Backdrop`, `ToastItem`, `ScanQrModal`, `ReshareWarningSheet`, `BlockaidSiteScanMaliciousOverlay`.
- **holds the focus trap.** Noted by @realpaaao on the issue: `ModalContainer` wraps its content in `FocusLock`, so a modal painted over the gate also pulls focus off the passcode input and the code cannot be typed. `react-focus-lock` resolves competing traps as `traps.slice(-1)[0]` (`Trap.js:227`) — last mounted wins — and the gate always mounts after an already-open modal, so wrapping it in its own `FocusLock` deactivates the modal's. No modal call site changes.
- `returnFocus` hands focus back on unlock. The user's modal is left mounted underneath and is still there afterwards.

The `pendingPasscodeUnlockRestore` splash gets the same treatment. It turned out to be worse than mislayered — `ProductLogoBlock` paints no background, so app content showed through it even with no modal open. The overlay is opaque.

`TakeWholeSpaceAbsolutely` had no other consumer once the guard stopped using it, so it is removed; the `takeWholeSpaceAbsolutely` css helper it wrapped is still used by the address-book form and stays.

Fixes #4596

### Scope note

The issue is about a surface being **visible and interactive** over the lock. It does not cover DevTools inspection, and this PR does not change that: the app tree stays mounted while locked, so content remains in the DOM and decrypted data remains in memory. Worth its own issue if that is in the threat model — a route-based lock would not address it either, since the JS heap survives navigation.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

None of the above — passcode gate layering only. No keysign, broadcast or fee code touched.

## Parity

Not required by the template rules (no sending/swap/chain/keysign surface), included because the issue names sibling tickets:

- iOS: linked: vultisig/vultisig-ios#5082 — same bug, still open
- Android: linked: vultisig/vultisig-android#5551, fixed in vultisig/vultisig-android#5554
- SDK: n/a — client-side rendering layer, no SDK surface

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

`clients/extension/tests/e2e/specs/passcode-lock-layering.spec.ts` — an e2e test, because paint order and focus ownership across two stacking contexts are things only a real browser can answer. jsdom models neither, so a unit test here would prove nothing.

It opens the Receive modal, drives the inactivity timer with a fake clock (there is no manual lock action, and the shortest real interval is a minute), then asserts the gate owns the centre of the viewport, is the only thing clickable, takes the keyboard with no click first, and leaves the modal open after unlocking.

The load-bearing assertion is `document.elementFromPoint` walked up to its `body > *` layer — the browser's own hit test. Asserting the gate is merely *visible* would have passed against the bug too: the gate was always visible, just underneath.

**Verified both ways.** Against a build with the fix reverted it fails exactly where it should:

```
Expected substring: "App Locked"
Received string:    "Select chainBTCBitcoinETHEthereumRUNETHORChainSOLSolanaBNBBSC"
```

Validation run: `yarn check` clean (typecheck 0, lint 0, knip clean), `yarn test` 973/973 passing, `yarn build:extension` exit 0, and the new spec passing against the built artifact.

## Screenshots (if applicable):

None — Playwright's failure screenshots come out blank once `page.clock.install()` stubs `requestAnimationFrame`, so the page cannot repaint for the capture. The assertion text above is the evidence instead.

To watch it by hand, in the expanded extension view: enable the passcode, set auto-lock to 1 minute, open the Receive modal, and leave it. Only the lock screen should be visible, clicks should not reach the modal, the passcode should be typable without dismissing anything, and the modal should still be open afterwards.

## Additional context

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #4596
- **Confidence**: high — both the layering and the focus hand-off are covered by the e2e test, which was confirmed to fail against a build with the fix reverted
- **Needs human review for**: the desktop client, which the extension e2e suite does not cover, and the `pendingPasscodeUnlockRestore` splash, which no test reaches

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Passcode unlock and entry screens now use a consistent, full-screen blocking overlay.
  * The overlay prevents interaction with content underneath and keeps keyboard focus on passcode controls.
  * Its appearance follows the app theme and displays above open dialogs and other surfaces.
  * Focus is restored appropriately after unlocking, returning users to the content they were viewing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->