### PR TITLE
fix(security): stop signing credentials from outliving the passcode lock

### DIFF
--- a/clients/extension/public/manifest.json
+++ b/clients/extension/public/manifest.json
@@ -51,7 +51,7 @@
     "64": "icon64.png",
     "128": "icon128.png"
   },
-  "permissions": ["activeTab", "clipboardRead", "clipboardWrite", "notifications", "sidePanel", "storage", "windows", "tabs"],
+  "permissions": ["activeTab", "alarms", "clipboardRead", "clipboardWrite", "notifications", "sidePanel", "storage", "windows", "tabs"],
   "side_panel": {
     "default_path": "index.html"
   },

--- a/clients/extension/src/background/common.ts
+++ b/clients/extension/src/background/common.ts
@@ -2,9 +2,11 @@ import { runBackgroundEventsAgent } from '@core/inpage-provider/background/event
 import { runInpageProviderBridgeBackgroundAgent } from '@core/inpage-provider/bridge/background'
 
 import { getIsSidePanelEnabled } from '../storage/isSidePanelEnabled'
+import { registerFastVaultPasswordCacheExpiry } from './registerFastVaultPasswordCacheExpiry'
 import { registerFreshInstallStorageClear } from './registerFreshInstallStorageClear'
 
 registerFreshInstallStorageClear()
+registerFastVaultPasswordCacheExpiry()
 
 /**
  * Bootstraps the extension background: locks down built-in prototypes (non-Firefox),

--- a/clients/extension/src/background/registerFastVaultPasswordCacheExpiry.ts
+++ b/clients/extension/src/background/registerFastVaultPasswordCacheExpiry.ts
@@ -1,0 +1,19 @@
+import {
+  fastVaultPasswordCacheAlarmName,
+  pruneExpiredVaultPasswords,
+} from '@core/ui/mpc/fast/passwordCache'
+
+/**
+ * Expires the fast-vault password cache when its TTL elapses with no extension
+ * UI open to run the in-context timer. The alarm is scheduled only while
+ * something is cached, so nothing wakes the worker on an idle browser.
+ */
+export const registerFastVaultPasswordCacheExpiry = (): void => {
+  chrome.alarms.onAlarm.addListener(alarm => {
+    if (alarm.name !== fastVaultPasswordCacheAlarmName) {
+      return
+    }
+
+    pruneExpiredVaultPasswords().catch(console.error)
+  })
+}

--- a/clients/extension/tests/unit/passcodeUnlockSessionStorage.test.ts
+++ b/clients/extension/tests/unit/passcodeUnlockSessionStorage.test.ts
@@ -1,11 +1,36 @@
-import { computePasscodeUnlockSessionExpiresAt } from '@core/ui/storage/passcodeUnlockSession'
 import {
   passcodeUnlockSessionChromeStorageKey,
   passcodeUnlockSessionStorage,
 } from '@core/extension/storage/passcodeUnlockSession'
+import { sealPasscode } from '@core/extension/storage/passcodeUnlockSessionCipher'
+import { computePasscodeUnlockSessionExpiresAt } from '@core/ui/storage/passcodeUnlockSession'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { chromeMock } from './mocks/chrome'
+
+const storeSealedSession = async (
+  passcode: string,
+  expiresAt: number | null
+) => {
+  const { iv, sealedPasscode } = await sealPasscode(passcode)
+
+  await chrome.storage.session.set({
+    [passcodeUnlockSessionChromeStorageKey]: {
+      v: 2,
+      iv,
+      sealedPasscode,
+      expiresAt,
+    },
+  })
+}
+
+const readStoredPayload = async () => {
+  const stored = await chrome.storage.session.get(
+    passcodeUnlockSessionChromeStorageKey
+  )
+
+  return stored[passcodeUnlockSessionChromeStorageKey]
+}
 
 describe('passcodeUnlockSessionStorage (extension)', () => {
   afterEach(() => {
@@ -32,22 +57,13 @@ describe('passcodeUnlockSessionStorage (extension)', () => {
   })
 
   it('returns null and clears storage when session is expired', async () => {
-    await chrome.storage.session.set({
-      [passcodeUnlockSessionChromeStorageKey]: {
-        v: 1,
-        passcode: 'stale',
-        expiresAt: Date.now() - 60_000,
-      },
-    })
+    await storeSealedSession('stale', Date.now() - 60_000)
 
     await expect(
       passcodeUnlockSessionStorage.getPasscodeUnlockSession()
     ).resolves.toBeNull()
 
-    const after = await chrome.storage.session.get(
-      passcodeUnlockSessionChromeStorageKey
-    )
-    expect(after[passcodeUnlockSessionChromeStorageKey]).toBeUndefined()
+    await expect(readStoredPayload()).resolves.toBeUndefined()
   })
 
   it('refreshes TTL on subsequent writes', async () => {
@@ -103,6 +119,34 @@ describe('passcodeUnlockSessionStorage (extension)', () => {
     ).resolves.toEqual({ passcode: 'session-only', expiresAt: null })
   })
 
+  it('never writes the passcode in the clear', async () => {
+    await passcodeUnlockSessionStorage.setPasscodeUnlockSession({
+      passcode: 'plaintext-passcode',
+      expiresAt: computePasscodeUnlockSessionExpiresAt(null),
+    })
+
+    const payload = await readStoredPayload()
+
+    expect(JSON.stringify(payload)).not.toContain('plaintext-passcode')
+    expect(payload).not.toHaveProperty('passcode')
+  })
+
+  it('seals repeated writes of one passcode under different nonces', async () => {
+    await passcodeUnlockSessionStorage.setPasscodeUnlockSession({
+      passcode: 'same',
+      expiresAt: null,
+    })
+    const first = await readStoredPayload()
+
+    await passcodeUnlockSessionStorage.setPasscodeUnlockSession({
+      passcode: 'same',
+      expiresAt: null,
+    })
+    const second = await readStoredPayload()
+
+    expect(first).not.toEqual(second)
+  })
+
   it('falls back to locked state when session storage read fails', async () => {
     chromeMock.storage.session.get.mockRejectedValueOnce(new Error('boom'))
 
@@ -111,15 +155,55 @@ describe('passcodeUnlockSessionStorage (extension)', () => {
     ).resolves.toBeNull()
   })
 
+  it('rejects and discards a plaintext v1 record', async () => {
+    await chrome.storage.session.set({
+      [passcodeUnlockSessionChromeStorageKey]: {
+        v: 1,
+        passcode: 'legacy-plaintext',
+        expiresAt: null,
+      },
+    })
+
+    await expect(
+      passcodeUnlockSessionStorage.getPasscodeUnlockSession()
+    ).resolves.toBeNull()
+
+    await expect(readStoredPayload()).resolves.toBeUndefined()
+  })
+
   it.each([
-    ['wrong schema version', { v: 2, passcode: 'x', expiresAt: null }],
-    ['missing passcode', { v: 1, expiresAt: null }],
-    ['missing expiresAt key', { v: 1, passcode: 'x' }],
-    ['expiresAt is NaN', { v: 1, passcode: 'x', expiresAt: Number.NaN }],
-    ['expiresAt is non-number', { v: 1, passcode: 'x', expiresAt: 'nope' }],
+    ['unknown schema version', { v: 3, iv: 'a', sealedPasscode: 'b', expiresAt: null }],
+    ['missing iv', { v: 2, sealedPasscode: 'b', expiresAt: null }],
+    ['missing sealedPasscode', { v: 2, iv: 'a', expiresAt: null }],
+    ['missing expiresAt key', { v: 2, iv: 'a', sealedPasscode: 'b' }],
+    [
+      'expiresAt is NaN',
+      { v: 2, iv: 'a', sealedPasscode: 'b', expiresAt: Number.NaN },
+    ],
+    [
+      'expiresAt is non-number',
+      { v: 2, iv: 'a', sealedPasscode: 'b', expiresAt: 'nope' },
+    ],
   ])('returns null for corrupt payload: %s', async (_label, payload) => {
     await chrome.storage.session.set({
       [passcodeUnlockSessionChromeStorageKey]: payload,
+    })
+
+    await expect(
+      passcodeUnlockSessionStorage.getPasscodeUnlockSession()
+    ).resolves.toBeNull()
+  })
+
+  it('returns null when the sealed passcode cannot be opened', async () => {
+    const { iv } = await sealPasscode('x')
+
+    await chrome.storage.session.set({
+      [passcodeUnlockSessionChromeStorageKey]: {
+        v: 2,
+        iv,
+        sealedPasscode: 'dGFtcGVyZWQtY2lwaGVydGV4dA==',
+        expiresAt: null,
+      },
     })
 
     await expect(
@@ -166,13 +250,7 @@ describe('passcodeUnlockSessionStorage (extension)', () => {
     const now = new Date('2026-03-01T12:00:00.000Z')
     vi.setSystemTime(now)
 
-    await chrome.storage.session.set({
-      [passcodeUnlockSessionChromeStorageKey]: {
-        v: 1,
-        passcode: 'edge',
-        expiresAt: now.getTime(),
-      },
-    })
+    await storeSealedSession('edge', now.getTime())
 
     await expect(
       passcodeUnlockSessionStorage.getPasscodeUnlockSession()

--- a/core/extension/storage/passcodeUnlockSession.ts
+++ b/core/extension/storage/passcodeUnlockSession.ts
@@ -119,8 +119,15 @@ export const passcodeUnlockSessionStorage: PasscodeUnlockSessionStorage = {
         [passcodeUnlockSessionChromeStorageKey]: payload,
       })
     } catch {
-      // ignore — session persistence is best-effort, and a sealing failure must
-      // never fall back to writing the passcode in the clear
+      // Session persistence is best-effort, and a sealing failure must never
+      // fall back to writing the passcode in the clear. Drop any earlier record
+      // too — it still opens to an earlier passcode under the same key, and
+      // leaving it would hand that stale passcode back on the next read.
+      try {
+        await area.remove(passcodeUnlockSessionChromeStorageKey)
+      } catch {
+        // ignore
+      }
     }
   },
   clearPasscodeUnlockSession: async () => {

--- a/core/extension/storage/passcodeUnlockSession.ts
+++ b/core/extension/storage/passcodeUnlockSession.ts
@@ -3,13 +3,21 @@ import type {
   PasscodeUnlockSessionStorage,
 } from '@core/ui/storage/passcodeUnlockSession'
 
+import { openPasscode, sealPasscode } from './passcodeUnlockSessionCipher'
+
 /** Key in `chrome.storage.session` only; value is never mirrored to local/sync storage. */
 export const passcodeUnlockSessionChromeStorageKey =
   'extensionPasscodeUnlockSession'
 
-type StoredPayloadV1 = {
-  v: 1
-  passcode: string
+/**
+ * Version 2 seals the passcode under a non-extractable key. Version 1 records
+ * held it in the clear and are rejected rather than migrated, so an upgrade
+ * costs one passcode entry and leaves no plaintext behind.
+ */
+type StoredPayloadV2 = {
+  v: 2
+  iv: string
+  sealedPasscode: string
   expiresAt: number | null
 }
 
@@ -18,16 +26,20 @@ const isNumber = (value: unknown): value is number =>
 
 const isString = (value: unknown): value is string => typeof value === 'string'
 
-const parsePayload = (raw: unknown): StoredPayloadV1 | null => {
+const parsePayload = (raw: unknown): StoredPayloadV2 | null => {
   if (typeof raw !== 'object' || raw === null) {
     return null
   }
 
-  if (!('v' in raw) || raw.v !== 1) {
+  if (!('v' in raw) || raw.v !== 2) {
     return null
   }
 
-  if (!('passcode' in raw) || !isString(raw.passcode)) {
+  if (!('iv' in raw) || !isString(raw.iv)) {
+    return null
+  }
+
+  if (!('sealedPasscode' in raw) || !isString(raw.sealedPasscode)) {
     return null
   }
 
@@ -41,7 +53,12 @@ const parsePayload = (raw: unknown): StoredPayloadV1 | null => {
     return null
   }
 
-  return { v: 1, passcode: raw.passcode, expiresAt }
+  return {
+    v: 2,
+    iv: raw.iv,
+    sealedPasscode: raw.sealedPasscode,
+    expiresAt,
+  }
 }
 
 const getSessionStorageArea = (): chrome.storage.StorageArea | undefined =>
@@ -63,6 +80,9 @@ export const passcodeUnlockSessionStorage: PasscodeUnlockSessionStorage = {
       const parsed = parsePayload(raw)
 
       if (!parsed) {
+        if (raw !== undefined) {
+          await area.remove(passcodeUnlockSessionChromeStorageKey)
+        }
         return null
       }
 
@@ -72,7 +92,7 @@ export const passcodeUnlockSessionStorage: PasscodeUnlockSessionStorage = {
       }
 
       return {
-        passcode: parsed.passcode,
+        passcode: await openPasscode(parsed),
         expiresAt: parsed.expiresAt,
       }
     } catch {
@@ -85,18 +105,22 @@ export const passcodeUnlockSessionStorage: PasscodeUnlockSessionStorage = {
       return
     }
 
-    const payload: StoredPayloadV1 = {
-      v: 1,
-      passcode: value.passcode,
-      expiresAt: value.expiresAt,
-    }
-
     try {
+      const { iv, sealedPasscode } = await sealPasscode(value.passcode)
+
+      const payload: StoredPayloadV2 = {
+        v: 2,
+        iv,
+        sealedPasscode,
+        expiresAt: value.expiresAt,
+      }
+
       await area.set({
         [passcodeUnlockSessionChromeStorageKey]: payload,
       })
     } catch {
-      // ignore — session persistence is best-effort
+      // ignore — session persistence is best-effort, and a sealing failure must
+      // never fall back to writing the passcode in the clear
     }
   },
   clearPasscodeUnlockSession: async () => {

--- a/core/extension/storage/passcodeUnlockSessionCipher.ts
+++ b/core/extension/storage/passcodeUnlockSessionCipher.ts
@@ -1,0 +1,63 @@
+import { base64Encode } from '@vultisig/lib-utils/base64Encode'
+import { fromBase64 } from '@vultisig/lib-utils/fromBase64'
+
+import { getPasscodeUnlockSessionKey } from './passcodeUnlockSessionKey'
+
+const ivLength = 12
+
+/** A passcode at rest: AES-GCM ciphertext plus the nonce it was sealed under. */
+type SealedPasscode = {
+  iv: string
+  sealedPasscode: string
+}
+
+// WebCrypto wants a DOM `BufferSource`; `@types/node`'s `Buffer` isn't
+// assignable (it may be SharedArrayBuffer backed), so copy into a plain
+// `ArrayBuffer`-backed `Uint8Array`.
+const toBytes = (value: Buffer): Uint8Array<ArrayBuffer> => {
+  const bytes = new Uint8Array(value.length)
+  bytes.set(value)
+  return bytes
+}
+
+/**
+ * Seals a passcode under the non-extractable session key so the unlock session
+ * never holds it in the clear. A fresh nonce per write keeps repeated unlocks
+ * from producing identical records.
+ */
+export const sealPasscode = async (
+  passcode: string
+): Promise<SealedPasscode> => {
+  const key = await getPasscodeUnlockSessionKey()
+  const iv = crypto.getRandomValues(new Uint8Array(ivLength))
+
+  const sealed = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    new TextEncoder().encode(passcode)
+  )
+
+  return {
+    iv: base64Encode(iv),
+    sealedPasscode: base64Encode(new Uint8Array(sealed)),
+  }
+}
+
+/**
+ * Recovers a sealed passcode. Rejects when the record was sealed under a key
+ * this context no longer has, which the caller treats as "no session".
+ */
+export const openPasscode = async ({
+  iv,
+  sealedPasscode,
+}: SealedPasscode): Promise<string> => {
+  const key = await getPasscodeUnlockSessionKey()
+
+  const opened = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: toBytes(fromBase64(iv)) },
+    key,
+    toBytes(fromBase64(sealedPasscode))
+  )
+
+  return new TextDecoder().decode(opened)
+}

--- a/core/extension/storage/passcodeUnlockSessionKey.ts
+++ b/core/extension/storage/passcodeUnlockSessionKey.ts
@@ -1,0 +1,82 @@
+const databaseName = 'vultisig-passcode-unlock-session'
+const storeName = 'keys'
+const recordKey = 'unlockSessionKey'
+const databaseVersion = 1
+
+const keyAlgorithm = { name: 'AES-GCM', length: 256 } as const
+const keyUsages: KeyUsage[] = ['encrypt', 'decrypt']
+
+const openDatabase = (): Promise<IDBDatabase> =>
+  new Promise((resolve, reject) => {
+    const request = indexedDB.open(databaseName, databaseVersion)
+
+    request.onupgradeneeded = () => {
+      if (!request.result.objectStoreNames.contains(storeName)) {
+        request.result.createObjectStore(storeName)
+      }
+    }
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error)
+    request.onblocked = () => reject(new Error('indexedDB open blocked'))
+  })
+
+const readRequest = <T>(request: IDBRequest<T>): Promise<T> =>
+  new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error)
+  })
+
+const loadPersistedKey = async (): Promise<CryptoKey> => {
+  const db = await openDatabase()
+
+  try {
+    const stored = await readRequest(
+      db
+        .transaction(storeName, 'readonly')
+        .objectStore(storeName)
+        .get(recordKey)
+    )
+
+    if (stored instanceof CryptoKey) {
+      return stored
+    }
+
+    const key = await crypto.subtle.generateKey(keyAlgorithm, false, keyUsages)
+
+    await readRequest(
+      db
+        .transaction(storeName, 'readwrite')
+        .objectStore(storeName)
+        .put(key, recordKey)
+    )
+
+    return key
+  } finally {
+    db.close()
+  }
+}
+
+let keyPromise: Promise<CryptoKey> | null = null
+
+/**
+ * The non-extractable AES-GCM key that seals the persisted unlock session.
+ *
+ * Kept in IndexedDB so it survives a popup teardown while staying unreadable:
+ * `extractable: false` means no code in the extension — nor anything reading the
+ * stored record — can recover the raw key bytes. Where IndexedDB is unavailable
+ * the key is generated per context instead, which degrades the feature to "the
+ * user re-enters the passcode after the popup closes" rather than falling back
+ * to storing the passcode in the clear.
+ */
+export const getPasscodeUnlockSessionKey = (): Promise<CryptoKey> => {
+  if (!keyPromise) {
+    keyPromise =
+      typeof indexedDB === 'undefined'
+        ? crypto.subtle.generateKey(keyAlgorithm, false, keyUsages)
+        : loadPersistedKey().catch(() =>
+            crypto.subtle.generateKey(keyAlgorithm, false, keyUsages)
+          )
+  }
+
+  return keyPromise
+}

--- a/core/ui/mpc/fast/passwordCache.test.ts
+++ b/core/ui/mpc/fast/passwordCache.test.ts
@@ -1,0 +1,130 @@
+import { convertDuration } from '@vultisig/lib-utils/time/convertDuration'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const storageKey = 'fastVaultPasswordCache'
+const ttlMs = convertDuration(5, 'min', 'ms')
+
+type CacheEntry = { password: string; expiresAt: number }
+type StoredCache = Record<string, CacheEntry>
+
+const sessionStore = new Map<string, unknown>()
+
+const alarms = {
+  create: vi.fn(),
+  clear: vi.fn(async () => true),
+}
+
+const readStoredCache = (): StoredCache | undefined =>
+  sessionStore.get(storageKey) as StoredCache | undefined
+
+const loadPasswordCache = async () => {
+  vi.resetModules()
+
+  return import('./passwordCache')
+}
+
+beforeEach(() => {
+  sessionStore.clear()
+  alarms.create.mockClear()
+  alarms.clear.mockClear()
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+  ;(globalThis as any).chrome = {
+    storage: {
+      session: {
+        get: async (key: string) => ({ [key]: sessionStore.get(key) }),
+        set: async (items: Record<string, unknown>) => {
+          for (const [key, value] of Object.entries(items)) {
+            sessionStore.set(key, value)
+          }
+        },
+      },
+    },
+    alarms,
+  }
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  delete (globalThis as any).chrome
+})
+
+describe('fast vault password cache', () => {
+  it('clears every cached password on demand', async () => {
+    const { cacheVaultPassword, clearVaultPasswordCache } =
+      await loadPasswordCache()
+
+    await cacheVaultPassword({ vaultId: 'vault-a', password: 'secret-a' })
+    await cacheVaultPassword({ vaultId: 'vault-b', password: 'secret-b' })
+
+    await clearVaultPasswordCache()
+
+    expect(readStoredCache()).toEqual({})
+  })
+
+  it('expires the cache on a timer with no further reads', async () => {
+    const { cacheVaultPassword } = await loadPasswordCache()
+
+    await cacheVaultPassword({ vaultId: 'vault-a', password: 'secret-a' })
+    expect(readStoredCache()).toHaveProperty('vault-a')
+
+    await vi.advanceTimersByTimeAsync(ttlMs + 1)
+
+    expect(readStoredCache()).toEqual({})
+  })
+
+  it('keeps an entry that has not reached its TTL', async () => {
+    const { cacheVaultPassword } = await loadPasswordCache()
+
+    await cacheVaultPassword({ vaultId: 'vault-a', password: 'secret-a' })
+
+    await vi.advanceTimersByTimeAsync(ttlMs - 1_000)
+
+    expect(readStoredCache()).toHaveProperty('vault-a')
+  })
+
+  it('refuses a stale entry even when the timer never ran', async () => {
+    const { getCachedVaultPassword } = await loadPasswordCache()
+
+    sessionStore.set(storageKey, {
+      'vault-a': { password: 'secret-a', expiresAt: Date.now() - 1 },
+    })
+
+    await expect(
+      getCachedVaultPassword({ vaultId: 'vault-a' })
+    ).resolves.toBeNull()
+    expect(readStoredCache()).toEqual({})
+  })
+
+  it('returns a cached password before it expires', async () => {
+    const { cacheVaultPassword, getCachedVaultPassword } =
+      await loadPasswordCache()
+
+    await cacheVaultPassword({ vaultId: 'vault-a', password: 'secret-a' })
+
+    await expect(getCachedVaultPassword({ vaultId: 'vault-a' })).resolves.toBe(
+      'secret-a'
+    )
+  })
+
+  it('wakes the background only while something is cached', async () => {
+    const {
+      cacheVaultPassword,
+      clearVaultPasswordCache,
+      fastVaultPasswordCacheAlarmName,
+    } = await loadPasswordCache()
+
+    await cacheVaultPassword({ vaultId: 'vault-a', password: 'secret-a' })
+
+    expect(alarms.create).toHaveBeenCalledWith(
+      fastVaultPasswordCacheAlarmName,
+      {
+        when: Date.now() + ttlMs,
+      }
+    )
+
+    await clearVaultPasswordCache()
+
+    expect(alarms.clear).toHaveBeenCalledWith(fastVaultPasswordCacheAlarmName)
+  })
+})

--- a/core/ui/mpc/fast/passwordCache.test.ts
+++ b/core/ui/mpc/fast/passwordCache.test.ts
@@ -29,24 +29,27 @@ beforeEach(() => {
   alarms.clear.mockClear()
   vi.useFakeTimers()
   vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
-  ;(globalThis as any).chrome = {
-    storage: {
-      session: {
-        get: async (key: string) => ({ [key]: sessionStore.get(key) }),
-        set: async (items: Record<string, unknown>) => {
-          for (const [key, value] of Object.entries(items)) {
-            sessionStore.set(key, value)
-          }
+
+  Object.assign(globalThis, {
+    chrome: {
+      storage: {
+        session: {
+          get: async (key: string) => ({ [key]: sessionStore.get(key) }),
+          set: async (items: Record<string, unknown>) => {
+            for (const [key, value] of Object.entries(items)) {
+              sessionStore.set(key, value)
+            }
+          },
         },
       },
+      alarms,
     },
-    alarms,
-  }
+  })
 })
 
 afterEach(() => {
   vi.useRealTimers()
-  delete (globalThis as any).chrome
+  Reflect.deleteProperty(globalThis, 'chrome')
 })
 
 describe('fast vault password cache', () => {
@@ -81,6 +84,38 @@ describe('fast vault password cache', () => {
     await vi.advanceTimersByTimeAsync(ttlMs - 1_000)
 
     expect(readStoredCache()).toHaveProperty('vault-a')
+  })
+
+  it('drops an in-flight write when a lock clears the cache mid-write', async () => {
+    const { cacheVaultPassword, clearVaultPasswordCache } =
+      await loadPasswordCache()
+
+    const pendingWrite = cacheVaultPassword({
+      vaultId: 'vault-a',
+      password: 'secret-a',
+    })
+
+    await clearVaultPasswordCache()
+    await pendingWrite
+
+    expect(readStoredCache()).toEqual({})
+  })
+
+  it('drops an in-flight prune when a lock clears the cache mid-prune', async () => {
+    const { clearVaultPasswordCache, pruneExpiredVaultPasswords } =
+      await loadPasswordCache()
+
+    sessionStore.set(storageKey, {
+      'vault-a': { password: 'secret-a', expiresAt: Date.now() - 1 },
+      'vault-b': { password: 'secret-b', expiresAt: Date.now() + ttlMs },
+    })
+
+    const pendingPrune = pruneExpiredVaultPasswords()
+
+    await clearVaultPasswordCache()
+    await pendingPrune
+
+    expect(readStoredCache()).toEqual({})
   })
 
   it('refuses a stale entry even when the timer never ran', async () => {

--- a/core/ui/mpc/fast/passwordCache.ts
+++ b/core/ui/mpc/fast/passwordCache.ts
@@ -3,6 +3,13 @@ import { convertDuration } from '@vultisig/lib-utils/time/convertDuration'
 const cacheDurationMs = convertDuration(5, 'min', 'ms')
 const storageKey = 'fastVaultPasswordCache'
 
+/**
+ * Alarm the extension background listens on to prune the cache when it expires
+ * while no UI context is alive to run the in-context timer. Only ever scheduled
+ * while something is cached, so an idle browser is never woken for nothing.
+ */
+export const fastVaultPasswordCacheAlarmName = 'fastVaultPasswordCacheExpiry'
+
 type CacheEntry = {
   password: string
   expiresAt: number
@@ -12,6 +19,8 @@ type CacheData = Record<string, CacheEntry>
 
 const hasSessionStorage =
   typeof chrome !== 'undefined' && !!chrome.storage?.session
+
+const hasAlarms = typeof chrome !== 'undefined' && !!chrome.alarms
 
 const memoryCache = new Map<string, CacheEntry>()
 
@@ -36,16 +45,87 @@ const setCache = async (data: CacheData): Promise<void> => {
   await chrome.storage.session.set({ [storageKey]: data })
 }
 
+const withoutExpiredEntries = (cache: CacheData): CacheData =>
+  Object.fromEntries(
+    Object.entries(cache).filter(([, entry]) => Date.now() <= entry.expiresAt)
+  )
+
+const earliestExpiryAt = (cache: CacheData): number | null => {
+  const expiries = Object.values(cache).map(entry => entry.expiresAt)
+
+  return expiries.length > 0 ? Math.min(...expiries) : null
+}
+
+let expiryTimeout: ReturnType<typeof setTimeout> | null = null
+
+const scheduleExpiry = (cache: CacheData): void => {
+  if (expiryTimeout !== null) {
+    clearTimeout(expiryTimeout)
+    expiryTimeout = null
+  }
+
+  const expiresAt = earliestExpiryAt(cache)
+
+  if (hasAlarms) {
+    if (expiresAt === null) {
+      void chrome.alarms.clear(fastVaultPasswordCacheAlarmName)
+    } else {
+      chrome.alarms.create(fastVaultPasswordCacheAlarmName, { when: expiresAt })
+    }
+  }
+
+  if (expiresAt === null) {
+    return
+  }
+
+  expiryTimeout = setTimeout(
+    () => {
+      expiryTimeout = null
+      void pruneExpiredVaultPasswords()
+    },
+    Math.max(0, expiresAt - Date.now())
+  )
+}
+
+/**
+ * Drops every entry whose TTL has elapsed and re-arms the timer for the next
+ * one. Runs on a timer rather than only when the cache is next read, so an
+ * unused password does not sit in session storage for the whole browser session.
+ */
+export const pruneExpiredVaultPasswords = async (): Promise<void> => {
+  const cache = await getCache()
+  const remaining = withoutExpiredEntries(cache)
+
+  if (Object.keys(remaining).length !== Object.keys(cache).length) {
+    await setCache(remaining)
+  }
+
+  scheduleExpiry(remaining)
+}
+
+/**
+ * Wipes every cached password. Called when the app locks — the passcode gate is
+ * meant to withhold all signing credentials, and this cache has its own store
+ * that would otherwise outlive the lock.
+ */
+export const clearVaultPasswordCache = async (): Promise<void> => {
+  await setCache({})
+  scheduleExpiry({})
+}
+
 type CacheVaultPasswordInput = {
   vaultId: string
   password: string
 }
 
+/**
+ * Caches a fast-vault password for its TTL and arms the expiry timer.
+ */
 export const cacheVaultPassword = async ({
   vaultId,
   password,
 }: CacheVaultPasswordInput) => {
-  const cache = await getCache()
+  const cache = withoutExpiredEntries(await getCache())
 
   cache[vaultId] = {
     password,
@@ -53,12 +133,18 @@ export const cacheVaultPassword = async ({
   }
 
   await setCache(cache)
+  scheduleExpiry(cache)
 }
 
 type GetCachedVaultPasswordInput = {
   vaultId: string
 }
 
+/**
+ * Returns the cached password for a vault, or `null` when nothing valid is
+ * cached. The expiry is re-checked here as well as on the timer, so a stale
+ * entry can never be handed out even if the timer never got to run.
+ */
 export const getCachedVaultPassword = async ({
   vaultId,
 }: GetCachedVaultPasswordInput): Promise<string | null> => {
@@ -69,6 +155,7 @@ export const getCachedVaultPassword = async ({
   if (Date.now() > entry.expiresAt) {
     delete cache[vaultId]
     await setCache(cache)
+    scheduleExpiry(cache)
     return null
   }
 

--- a/core/ui/mpc/fast/passwordCache.ts
+++ b/core/ui/mpc/fast/passwordCache.ts
@@ -56,6 +56,11 @@ const earliestExpiryAt = (cache: CacheData): number | null => {
   return expiries.length > 0 ? Math.min(...expiries) : null
 }
 
+// Every mutation is a read-modify-write across an await, so a lock landing
+// mid-write would otherwise be undone by the pending writer. Clearing bumps this
+// synchronously; a writer that sees a different value drops its write.
+let clearGeneration = 0
+
 let expiryTimeout: ReturnType<typeof setTimeout> | null = null
 
 const scheduleExpiry = (cache: CacheData): void => {
@@ -93,8 +98,13 @@ const scheduleExpiry = (cache: CacheData): void => {
  * unused password does not sit in session storage for the whole browser session.
  */
 export const pruneExpiredVaultPasswords = async (): Promise<void> => {
+  const generation = clearGeneration
   const cache = await getCache()
   const remaining = withoutExpiredEntries(cache)
+
+  if (generation !== clearGeneration) {
+    return
+  }
 
   if (Object.keys(remaining).length !== Object.keys(cache).length) {
     await setCache(remaining)
@@ -109,6 +119,8 @@ export const pruneExpiredVaultPasswords = async (): Promise<void> => {
  * that would otherwise outlive the lock.
  */
 export const clearVaultPasswordCache = async (): Promise<void> => {
+  clearGeneration += 1
+
   await setCache({})
   scheduleExpiry({})
 }
@@ -119,17 +131,24 @@ type CacheVaultPasswordInput = {
 }
 
 /**
- * Caches a fast-vault password for its TTL and arms the expiry timer.
+ * Caches a fast-vault password for its TTL and arms the expiry timer. A lock
+ * that lands while this is in flight wins: the write is dropped rather than
+ * restoring the password behind the gate.
  */
 export const cacheVaultPassword = async ({
   vaultId,
   password,
 }: CacheVaultPasswordInput) => {
+  const generation = clearGeneration
   const cache = withoutExpiredEntries(await getCache())
 
   cache[vaultId] = {
     password,
     expiresAt: Date.now() + cacheDurationMs,
+  }
+
+  if (generation !== clearGeneration) {
+    return
   }
 
   await setCache(cache)

--- a/core/ui/passcodeEncryption/guard/PasscodeGuard.tsx
+++ b/core/ui/passcodeEncryption/guard/PasscodeGuard.tsx
@@ -8,6 +8,7 @@ import { usePasscodeUnlockSession } from '../autoLock/usePasscodeUnlockSession'
 import { usePasscode } from '../state/passcode'
 import { EnterPasscode } from './EnterPasscode'
 import { PasscodeEncryptionUpgrade } from './PasscodeEncryptionUpgrade'
+import { useClearSigningCredentialsOnLock } from './useClearSigningCredentialsOnLock'
 
 export const PasscodeGuard = () => {
   const [passcode] = usePasscode()
@@ -22,6 +23,8 @@ export const PasscodeGuard = () => {
   })
 
   const isLocked = hasPasscodeEnabled && !passcode
+
+  useClearSigningCredentialsOnLock(isLocked)
 
   return (
     <>

--- a/core/ui/passcodeEncryption/guard/useClearSigningCredentialsOnLock.ts
+++ b/core/ui/passcodeEncryption/guard/useClearSigningCredentialsOnLock.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+
+import { clearVaultPasswordCache } from '../../mpc/fast/passwordCache'
+
+/**
+ * Wipes cached signing credentials for as long as the app is locked. Runs on
+ * every lock transition and on mount while already locked, so a password cached
+ * before the lock cannot survive it — the passcode gate is meant to withhold
+ * every credential, not just the passcode itself.
+ */
+export const useClearSigningCredentialsOnLock = (isLocked: boolean) => {
+  useEffect(() => {
+    if (!isLocked) {
+      return
+    }
+
+    void clearVaultPasswordCache()
+  }, [isLocked])
+}


### PR DESCRIPTION
## Description

Two findings from the 2026-08 passcode audit: credentials outlive the lock. Locking cleared the passcode session and nothing else, so a locked wallet still held everything needed to sign.

Fixes #4602

**1. The fast-vault password cache is cleared on lock.** `usePasscodeUnlockSession` cleared the passcode session but never touched `fastVaultPasswordCache`, so an opt-in cached password stayed live behind the lock screen. A new `useClearSigningCredentialsOnLock` hook, wired into `PasscodeGuard`, wipes it on every lock transition *and* on mount while already locked — the second case matters, since a popup reopening into a locked state was the exact way a stale password got carried past the gate. Being in the guard, it covers desktop, the extension, and the dApp popup alike.

**2. The cache expires on a timer, not only when it is next read.** The TTL was enforced lazily in `getCachedVaultPassword`, so a password that was never read again sat in `chrome.storage.session` for the whole browser session. Note this was a *residency* bug, not a bypass — the read-time check did prevent use after 5 minutes, and it is kept as defence in depth. Expiry is now driven by an in-context `setTimeout` plus a one-shot `chrome.alarms` wake-up for when no UI context is alive to run it. The alarm is scheduled only while something is cached and cleared when nothing is, so an idle browser is never woken. This adds the `alarms` permission, which carries no user-facing warning and is supported on Firefox.

**3. The raw passcode is no longer persisted.** The unlock session stored the passcode in the clear, with `expiresAt: null` under the default configuration. It is now sealed under a non-extractable AES-GCM key kept in IndexedDB: `extractable: false` means nothing in the extension — nor anything reading the stored record — can recover the key bytes. Plaintext v1 records are rejected and discarded rather than migrated, so an upgrade costs one passcode entry and leaves no plaintext behind. Where IndexedDB is unavailable the key is generated per context, degrading to "re-enter the passcode after the popup closes" rather than ever falling back to writing plaintext.

### Deviations from the issue, both deliberate

- The issue proposed persisting *a derived verifier* instead of the passcode. That is not achievable as written: the passcode is the key material itself (PBKDF2 → AES-GCM over the key shares), so a verifier cannot decrypt anything and the unlock-across-popup-reopens behaviour would be lost. Sealing under a non-extractable key reaches the same acceptance criterion — no raw passcode at rest — without dropping the feature.
- The auto-lock default is untouched. Per @realpaaao's comment, `Never` is a deliberate requirement from @johnnyluo shared with Android (vultisig-android#5561, closed), not an oversight. It is a product question and needs its own issue; the fourth acceptance-criteria box is intentionally left unchecked here.

### Acceptance criteria

- [x] Locking clears every cached signing credential
- [x] The fast-vault cache expires on time even with no further reads
- [x] No raw passcode is persisted anywhere
- [ ] Auto-lock has a non-null default — deliberately out of scope, see above

## Which feature is affected?

- [ ] Create vault ( Secure / Fast)
- [ ] Sending
- [ ] Swap
- [ ] New Chain / Chain related feature

None of the above. No keysign, broadcast, or fee-computation path is touched — the change is confined to credential lifetime behind the passcode gate.

## Parity

- iOS: **unverified** — the sibling checkout is not available in this environment, so no verdict is claimed. The lock-clears-credentials question is inherently cross-platform and someone with the repo to hand should confirm.
- Android: partially settled — the auto-lock default half is vultisig-android#5561 (closed, `Never` is intentional). The credential-clearing half is **unverified** for the same reason.
- SDK: vultisig/vultisig-sdk#1838, the audit this finding came from.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

New tests encode exactly what the issue described. In `core/ui/mpc/fast/passwordCache.test.ts`: the cache empties on a timer with no intervening read, a stale entry is still refused when the timer never ran, and the background alarm exists only while something is cached. In `passcodeUnlockSessionStorage.test.ts`: the stored record never contains the passcode as a string or as a field, repeated writes of one passcode produce different records, a plaintext v1 record is rejected and discarded, and a tampered ciphertext reads as no session.

Validation: `yarn check` clean (typecheck, lint, knip, i18n). Tests green — 979 core, 565 extension, 26 desktop. `yarn build:extension` succeeds; the built manifest carries the `alarms` permission and the alarm listener is present in the background bundle.

## Additional context

Companion to #4656, which fixed the other half of the same audit (modals painting above the lock). That one closed the visual bypass; this one closes the credential lifetime behind it.

## Agent Metadata

- **Agent**: Claude Code
- **Issue**: #4602
- **Confidence**: high on items 1 and 2, medium on item 3
- **Needs human review for**: the item-3 design call — swapping the issue's "derived verifier" for a non-extractable IndexedDB key, and accepting that v1 sessions are dropped rather than migrated (one extra passcode entry after the update). Also worth a second opinion on adding the `alarms` permission versus accepting a longer residency window.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Passcode unlock sessions are now encrypted, protecting stored session data and rejecting invalid or tampered records.
  * Signing credentials and cached vault passwords are cleared when the app locks.

* **Bug Fixes**
  * Cached vault passwords now expire reliably, including when the extension is inactive, reducing stale credential availability.
  * Improved handling of expired, malformed, or unavailable session data without storing passcodes in plaintext.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->