### PR TITLE
fix(swap): show the signing vault and total fee to a swap co-signer

### DIFF
--- a/core/ui/mpc/keysign/join/tx/JoinKeysignSwapTotalFee.tsx
+++ b/core/ui/mpc/keysign/join/tx/JoinKeysignSwapTotalFee.tsx
@@ -20,9 +20,9 @@ type JoinKeysignSwapTotalFeeProps = {
  * uses so both devices arrive at one figure.
  *
  * Callers must only render this where the payload actually carries a swap fee.
- * A total summed over gas alone would understate the cost by the larger of the
- * two amounts, on the one screen whose job is to show a co-signer what they are
- * about to approve.
+ * A total summed over gas alone drops that fee entirely, understating the cost
+ * by its full amount on the one screen whose job is to show a co-signer what it
+ * is about to approve.
  */
 export const JoinKeysignSwapTotalFee = ({
   keysignPayload,

--- a/core/ui/mpc/keysign/join/tx/JoinKeysignSwapTotalFee.tsx
+++ b/core/ui/mpc/keysign/join/tx/JoinKeysignSwapTotalFee.tsx
@@ -1,0 +1,52 @@
+import { useKeysignFee } from '@core/ui/mpc/keysign/fee/useKeysignFee'
+import { SwapFeeFiatValue } from '@core/ui/vault/swap/form/info/SwapTotalFeeFiatValue'
+import { Spinner } from '@lib/ui/loaders/Spinner'
+import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
+import { Text } from '@lib/ui/text'
+import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
+import { SwapFee } from '@vultisig/core-chain/swap/SwapFee'
+import { getKeysignChain } from '@vultisig/core-mpc/keysign/utils/getKeysignChain'
+import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { useTranslation } from 'react-i18next'
+
+type JoinKeysignSwapTotalFeeProps = {
+  keysignPayload: KeysignPayload
+  swapFee: SwapFee
+}
+
+/**
+ * The whole cost of a swap to the signer: source-chain gas plus the swap fee the
+ * payload carries, valued through the same price lookup the initiator's total
+ * uses so both devices arrive at one figure.
+ *
+ * Callers must only render this where the payload actually carries a swap fee.
+ * A total summed over gas alone would understate the cost by the larger of the
+ * two amounts, on the one screen whose job is to show a co-signer what they are
+ * about to approve.
+ */
+export const JoinKeysignSwapTotalFee = ({
+  keysignPayload,
+  swapFee,
+}: JoinKeysignSwapTotalFeeProps) => {
+  const { t } = useTranslation()
+  const feeCoin = chainFeeCoin[getKeysignChain(keysignPayload)]
+  const feeQuery = useKeysignFee(keysignPayload)
+
+  return (
+    <MatchQuery
+      value={feeQuery}
+      pending={() => <Spinner />}
+      // A blank total reads as "nothing to pay" rather than "not known", so the
+      // failure has to say so in words.
+      error={() => <Text color="shy">{t('failed_to_load')}</Text>}
+      success={feeAmount => (
+        <SwapFeeFiatValue
+          value={[
+            { ...feeCoin, amount: feeAmount, decimals: feeCoin.decimals },
+            swapFee,
+          ]}
+        />
+      )}
+    />
+  )
+}

--- a/core/ui/mpc/keysign/join/tx/JoinKeysignSwapVerify.tsx
+++ b/core/ui/mpc/keysign/join/tx/JoinKeysignSwapVerify.tsx
@@ -3,6 +3,7 @@ import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { getSwapProviderLogoSrc } from '@core/ui/chain/metadata/getSwapProviderLogoSrc'
 import { KeysignFeeAmount } from '@core/ui/mpc/keysign/tx/FeeAmount'
 import { getSwapFeeFromPayload } from '@core/ui/mpc/keysign/tx/swap/getSwapFeeFromPayload'
+import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { SwapFeeFiatValue } from '@core/ui/vault/swap/form/info/SwapTotalFeeFiatValue'
 import { getSwapToAmountLimit } from '@core/ui/vault/swap/keysignPayload/getSwapToAmountLimit'
 import {
@@ -25,13 +26,26 @@ import { fromCommCoin } from '@vultisig/core-mpc/types/utils/commCoin'
 import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { formatAmount } from '@vultisig/lib-utils/formatAmount'
+import { formatWalletAddress } from '@vultisig/lib-utils/formatWalletAddress'
 import { getRecordUnionValue } from '@vultisig/lib-utils/record/union/getRecordUnionValue'
 import { useTranslation } from 'react-i18next'
 
+import { JoinKeysignSwapTotalFee } from './JoinKeysignSwapTotalFee'
 import { JoinSwapFiatAmount } from './JoinSwapFiatAmount'
 
+/**
+ * Joiner verify view for a swap. Carries the same cost breakdown and signing
+ * vault the initiator shows, so a co-signer approves the swap knowing what it
+ * pays and which vault pays it.
+ *
+ * The swap fee and the total that includes it render only when the payload
+ * carries a fee. An initiator that predates that field leaves it empty, and a
+ * co-signer holds no quote to recover it from — showing a total over gas alone
+ * would misstate the cost rather than admit it is unknown.
+ */
 export const JoinKeysignSwapVerify = ({ value }: ValueProp<KeysignPayload>) => {
   const { t } = useTranslation()
+  const vault = useCurrentVault()
 
   const swapPayload = shouldBePresent(
     getKeysignSwapPayload(value),
@@ -143,16 +157,42 @@ export const JoinKeysignSwapVerify = ({ value }: ValueProp<KeysignPayload>) => {
             extra={<KeysignFeeAmount keysignPayload={value} />}
           />
           {swapFee && (
-            <ListItem
-              hoverable={false}
-              title={t('swap_fee')}
-              extra={
-                <Text color="shy">
-                  <SwapFeeFiatValue value={[swapFee]} />
-                </Text>
-              }
-            />
+            <>
+              <ListItem
+                hoverable={false}
+                title={t('swap_fee')}
+                extra={
+                  <Text color="shy">
+                    <SwapFeeFiatValue value={[swapFee]} />
+                  </Text>
+                }
+              />
+              <ListItem
+                hoverable={false}
+                title={t('total_fee')}
+                extra={
+                  <Text color="supporting">
+                    <JoinKeysignSwapTotalFee
+                      keysignPayload={value}
+                      swapFee={swapFee}
+                    />
+                  </Text>
+                }
+              />
+            </>
           )}
+          <ListItem
+            hoverable={false}
+            title={t('vault')}
+            extra={
+              <Text color="contrast">
+                {vault.name}{' '}
+                <Text as="span" color="shy">
+                  ({formatWalletAddress(fromCoin.address)})
+                </Text>
+              </Text>
+            }
+          />
         </List>
       </VStack>
       <SwapVerifyRecipient keysignPayload={value} />


### PR DESCRIPTION
## Description

The joiner's swap Verify screen listed the provider, the network fee and the swap fee. A co-signer therefore approved a swap without seeing which vault pays for it or what the whole thing costs.

This adds the two rows a co-signer can be told truthfully, and documents why the third one in the issue title cannot follow them yet.

Refs #4378 — **does not close it**, see [Limitation](#limitation).

### What this PR adds

| Row | Status |
|---|---|
| **Vault** | Added. Name plus the truncated source address, as the sibling join screens (`JoinKeysignLimitOrderVerify`, `SwapKeysignTxOverview`) already name it. |
| **Max. Total Fee** | Added as **Total Fees**, matching the initiator's own wording rather than Android's, so our two screens agree. Sums source-chain gas and the payload's swap fee through the same price lookup the initiator's total uses. |

### What the issue asked for that already shipped

| Row | Where it landed |
|---|---|
| **Swap Fee** | #3984 |
| **Provider icon** | #4572 |

Both are visible on a current build; the issue screenshot predates the second and, for the first, the fee row is conditional (see below).

### One deliberate behaviour

The swap fee row — and therefore the new total — renders **only when the payload actually carries a fee**.

An initiator predating that proto field leaves it empty, and a co-signer holds no quote to recover it from. A total summed over gas alone drops that fee entirely, understating the cost by its full amount, on the one screen whose job is to show a co-signer what it is about to approve. Omitting the row says "unknown"; showing it would say "this is all you pay".

This is also the likeliest reason the issue's screenshot shows no Swap Fee row at all despite #3984 landing two months earlier — worth confirming with the Android initiator.

<a name="limitation"></a>
## Limitation — why Outbound Fee is not here

`THORChainSwapPayload` carries **one** composite fee:

```
THORChainSwapPayload.fee  // field 13 = quote.fees.total
```

That total is affiliate + outbound + liquidity, summed by the initiator. The quote that itemises it (`NativeSwapFees.outbound`) never travels to the co-signer, and a sum cannot be un-summed.

The co-signer *could* fetch `outbound_fee` itself via `getThorchainInboundAddress()`. That was rejected on three counts:

1. **Different units.** The network's `outbound_fee` is denominated in the destination chain's gas asset; the quote's `fees.outbound` is denominated in the destination asset. They diverge whenever the destination is a token.
2. **Different moment.** The fetched value is the fee *now*, not the fee the payload was built against. A verify screen exists to show the bytes being signed; a freshly-fetched number reads as part of that transaction while not being part of it.
3. **Broken arithmetic.** The payload's composite fee already contains the outbound share. A separate row beside it double-counts, and subtracting to avoid that would net two numbers from different sources and different moments.

**The real fix** is to carry the split in the payload — outbound and affiliate as their own fields alongside the composite. That is a `commondata` proto change first, then SDK, then here.

### A caveat for whoever picks that up

Android's own figures in the issue are exactly additive:

```
Swap Fee        $0.01
Outbound Fee    $0.25
Max. Total Fee  $0.26
```

That sum omits the liquidity fee, which THORChain's `fees.total` does include. Copying Android's three-row layout verbatim would make our total understate what the user actually pays. Our current itemisation derives the protocol share as `total - affiliate` precisely so liquidity stays inside it and the rows still sum to the headline figure — see `resolveSwapFees.ts`.

## Also missing, out of scope

Comparing a current initiator and joiner side by side surfaced three more gaps the issue does not list. All three share the Outbound Fee root cause — the data lives in the quote, not the payload:

- **Provider sub-name.** Initiator shows `SwapKit (ONEINCH)`, joiner shows `SwapKit`. `OneInchSwapPayload` has no `sub_provider` field. Note `SwapKitSwapPayload` *does* have one and we don't read it — a small, genuinely available win for deposit-channel routes.
- **Discount row.** `VULT (Gold -20 bps)` — the tier belongs to the initiator's account.
- **Price impact.** Quote-derived.

Separately, the network fee differs slightly between the two screens (`0.00097431` vs `0.00097206` ETH, both ≈$1.83). Nothing in this PR touches fee computation, and the likeliest explanation is benign — the initiator re-quotes on a timer, so its displayed fee can move on from the one the payload was built with. Flagging it rather than claiming a diagnosis.

## Which feature is affected?
- [x] Swap — display-only change on the co-signer verify screen; no keysign, signing-input, or broadcast path touched.

## Parity

- iOS: `n/a` for this change — display-only on our joiner screen. The initiator's row set already follows iOS's order (see `VerifySwapFees` JSDoc). The proto split described under Limitation will need an iOS sibling once filed.
- Android: `linked` — Android is the reference implementation in the issue; the triage comment on #4378 cites Android #5329 / #5313 as the fee-display parity siblings.
- SDK: `n/a` for this change. The Outbound Fee follow-up requires a `commondata` proto change plus an SDK regeneration; **not yet filed**.

> Sibling repos are not checked out in this environment, so the iOS/Android verdicts above are from the issue thread and existing in-repo references rather than a direct read. Worth a second pair of eyes.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

On tests: the change is two list rows and a fiat sum assembled from existing, already-tested helpers (`useKeysignFee`, `SwapFeeFiatValue`). There is no new branching logic worth pinning beyond the "render only when a fee is present" guard, which is a single conditional. Happy to add a component test if reviewers would rather have it pinned.

## Verification

- `yarn check` — typecheck, lint and i18n integrity clean
- `yarn test` — 973 tests across 144 files pass
- `yarn build:extension` — builds clean; rows confirmed on a loaded unpacked build

Note this screen needs a **Secure (multi-device) vault** to reach — a Fast Vault's second share is the server's and never joins. To reproduce the issue's exact fee conditions, the initiator must be Android; a Vultisig-initiated swap populates the fee field itself and would mask it.

## Additional context

The vault row shows name plus truncated address rather than the initiator's name-only, following the join-screen convention and matching what the issue's Android screenshot shows.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #4378
- **Confidence**: high on what landed; the Limitation section is the part worth arguing with
- **Needs human review for**: whether Total Fees should render at all when the payload carries no swap fee (this PR says no), and whether to pursue the proto split
