### PR TITLE
fix(security): recover a vault when the passcode proof and shares disagree

### DIFF
--- a/clients/extension/tests/unit/passcodeCrashRecovery.test.tsx
+++ b/clients/extension/tests/unit/passcodeCrashRecovery.test.tsx
@@ -20,7 +20,10 @@ import {
   isPasscodeRequired,
   verifyPasscode,
 } from '@core/ui/passcodeEncryption/core/passcodeLock'
-import { encryptSample } from '@core/ui/passcodeEncryption/core/sample'
+import {
+  decryptSample,
+  encryptSample,
+} from '@core/ui/passcodeEncryption/core/sample'
 import { decryptVaultAllKeyShares } from '@core/ui/passcodeEncryption/core/vaultKeyShares'
 import { useChangePasscodeMutation } from '@core/ui/passcodeEncryption/manage/change/mutations/changePasscode'
 import { useDisablePasscodeMutation } from '@core/ui/passcodeEncryption/mutations/useDisablePasscodeMutation'
@@ -266,6 +269,34 @@ const seedLegacyEncryptedVault = async () => {
 
 const healthyVault = { ecdsaShare, servedCiphertext: false }
 
+/** Which passcodes the stored proof answers to, in isolation from the shares. */
+const proofOpensWith = async (candidates: string[]) => {
+  const proof = await passcodeEncryptionStorage.getPasscodeEncryption()
+
+  if (proof === null) {
+    return null
+  }
+
+  const opens = await Promise.all(
+    candidates.map(candidate =>
+      decryptSample({ key: candidate, value: proof.encryptedSample }).then(
+        () => true,
+        () => false
+      )
+    )
+  )
+
+  return candidates.filter((_, index) => opens[index])
+}
+
+/** Runs the post-unlock reconcile the way `PasscodeEncryptionUpgrade` does. */
+const reconcileAfterUnlock = (passcodeInMemory: string) =>
+  runMutation({
+    useMutationHook: useUpgradePasscodeEncryptionMutation,
+    input: undefined,
+    passcodeInMemory,
+  })
+
 let restorePopup = () => {}
 
 /**
@@ -402,5 +433,92 @@ describe('passcode set/change survives a popup teardown', () => {
     await changePasscodeOverLegacyVault({ interleaveUpgrade: true })
 
     expect(await openVaultOnNextLaunch([newPasscode])).toEqual(healthyVault)
+  })
+
+  describe('the reconcile repairs a proof left disagreeing with the shares', () => {
+    // An interrupted change-passcode leaves a proof that is present and on the
+    // current format, but sealed under the old passcode. Unlock survives it —
+    // the shares are the authority — but the disagreement itself has to go, or
+    // it outlives every later unlock and strands the vault the moment no sealed
+    // share is left to outvote the proof.
+    const interruptChangePasscode = async () => {
+      await runMutation({
+        useMutationHook: useSetPasscodeMutation,
+        input: passcode,
+        passcodeInMemory: null,
+      })
+
+      restorePopup = killPopupAfterWrite(1)
+
+      await runMutation({
+        useMutationHook: useChangePasscodeMutation,
+        input: newPasscode,
+        passcodeInMemory: passcode,
+      })
+
+      restorePopup()
+      restorePopup = () => {}
+    }
+
+    it('rewrites the stale proof under the passcode the shares answer to', async () => {
+      await interruptChangePasscode()
+
+      expect(await proofOpensWith([passcode, newPasscode])).toEqual([passcode])
+
+      await reconcileAfterUnlock(newPasscode)
+
+      expect(await proofOpensWith([passcode, newPasscode])).toEqual([
+        newPasscode,
+      ])
+    })
+
+    it('leaves the lock accepting the new passcode once no sealed share is left', async () => {
+      await interruptChangePasscode()
+      await reconcileAfterUnlock(newPasscode)
+
+      // Deleting the vault removes the shares the lock screen was leaning on,
+      // so the proof alone decides. Before the repair this accepted only the
+      // old passcode.
+      await chrome.storage.local.set({ [StorageKey.vaults]: [] })
+
+      const encryptedSample = shouldBePresent(
+        await passcodeEncryptionStorage.getPasscodeEncryption()
+      ).encryptedSample
+
+      expect({
+        old: await verifyPasscode({
+          vaults: [],
+          encryptedSample,
+          passcode,
+        }),
+        new: await verifyPasscode({
+          vaults: [],
+          encryptedSample,
+          passcode: newPasscode,
+        }),
+      }).toEqual({ old: false, new: true })
+    })
+
+    it('writes nothing when the stored state already agrees', async () => {
+      await runMutation({
+        useMutationHook: useSetPasscodeMutation,
+        input: passcode,
+        passcodeInMemory: null,
+      })
+
+      const writesBefore = vi.mocked(chrome.storage.local.set).mock.calls.length
+
+      await reconcileAfterUnlock(passcode)
+
+      expect(
+        vi.mocked(chrome.storage.local.set).mock.calls.length - writesBefore
+      ).toBe(0)
+    })
+
+    it('never writes a proof when no passcode is in play', async () => {
+      await reconcileAfterUnlock(passcode)
+
+      expect(await passcodeEncryptionStorage.getPasscodeEncryption()).toBeNull()
+    })
   })
 })

--- a/clients/extension/tests/unit/passcodeCrashRecovery.test.tsx
+++ b/clients/extension/tests/unit/passcodeCrashRecovery.test.tsx
@@ -1,0 +1,406 @@
+// @vitest-environment happy-dom
+/**
+ * Crash-injection tests for the passcode set / change / disable flows.
+ *
+ * Reproduces https://github.com/vultisig/vultisig-windows/issues/4599: the key
+ * shares and the `encryptedSample` that proves a passcode are two independent
+ * durable writes with no transaction spanning them, so a teardown between them
+ * (closing the extension popup is enough) leaves storage in a state where no
+ * passcode can open the vault again.
+ *
+ * Everything below the injection point is production code: the real mutation
+ * hooks, the real PBKDF2 cipher, and the real extension storage adapters
+ * writing through `chrome.storage.local`. The only thing the test controls is
+ * *when* the popup dies — expressed as "die right after the Nth storage write
+ * lands", which is deterministic instead of racing a ~1s mutation.
+ */
+import { passcodeEncryptionStorage } from '@core/extension/storage/passcodeEncryption'
+import { vaultsStorage } from '@core/extension/storage/vaults'
+import {
+  isPasscodeRequired,
+  verifyPasscode,
+} from '@core/ui/passcodeEncryption/core/passcodeLock'
+import { encryptSample } from '@core/ui/passcodeEncryption/core/sample'
+import { decryptVaultAllKeyShares } from '@core/ui/passcodeEncryption/core/vaultKeyShares'
+import { useChangePasscodeMutation } from '@core/ui/passcodeEncryption/manage/change/mutations/changePasscode'
+import { useDisablePasscodeMutation } from '@core/ui/passcodeEncryption/mutations/useDisablePasscodeMutation'
+import { useSetPasscodeMutation } from '@core/ui/passcodeEncryption/mutations/useSetPasscodeMutation'
+import { useUpgradePasscodeEncryptionMutation } from '@core/ui/passcodeEncryption/mutations/useUpgradePasscodeEncryptionMutation'
+import { PasscodeProvider } from '@core/ui/passcodeEncryption/state/passcode'
+import { PasscodeEncryptionStorage } from '@core/ui/storage/passcodeEncryption'
+import { StorageKey } from '@core/ui/storage/StorageKey'
+import { VaultsProvider, VaultsStorage } from '@core/ui/storage/vaults'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook } from '@testing-library/react'
+import type { Vault } from '@vultisig/core-mpc/vault/Vault'
+import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
+import { encryptWithAesGcm } from '@vultisig/lib-utils/encryption/aesGcm/encryptWithAesGcm'
+import {
+  encryptedEncoding,
+  plainTextEncoding,
+} from '@vultisig/lib-utils/encryption/config'
+import {
+  VAULT_BACKUP_BLOB_MAGIC,
+  VAULT_BACKUP_MAGIC_LEN,
+} from '@vultisig/lib-utils/encryption/vaultBackup/vaultBackupConstants'
+import { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// The storage barrel reaches a UI module that pulls in the Lottie player, which
+// needs a real canvas. Nothing under test animates.
+vi.mock('lottie-react', () => ({ default: () => null }))
+
+// The extension builds its CoreState by spreading these same two adapters
+// (core/extension/storage/index.tsx:36,45), so the mutations under test talk to
+// exactly the storage they talk to in production. The adapters are imported
+// normally and handed over through this holder — importing them inside the
+// factory would deadlock, since their own module graph reaches this mock.
+type CoreStub = PasscodeEncryptionStorage &
+  Pick<VaultsStorage, 'getVaults' | 'updateVaultsKeyShares'>
+
+const coreHolder: { value: CoreStub | undefined } = vi.hoisted(() => ({
+  value: undefined,
+}))
+
+vi.mock('@core/ui/state/core', () => ({
+  useCore: () => shouldBePresent(coreHolder.value),
+}))
+
+coreHolder.value = { ...vaultsStorage, ...passcodeEncryptionStorage }
+
+const passcode = '123456'
+const newPasscode = '654321'
+
+const ecdsaShare = 'ecdsa-key-share-plaintext'
+const eddsaShare = 'eddsa-key-share-plaintext'
+
+const vault: Vault = {
+  name: 'Test Vault',
+  publicKeys: { ecdsa: 'ecdsa-public-key', eddsa: 'eddsa-public-key' },
+  signers: ['device-1'],
+  hexChainCode: 'chain-code',
+  keyShares: { ecdsa: ecdsaShare, eddsa: eddsaShare },
+  localPartyId: 'device-1',
+  libType: 'DKLS',
+  isBackedUp: true,
+  order: 0,
+}
+
+const isEncryptedBlob = (value: string) =>
+  Buffer.from(value, encryptedEncoding)
+    .subarray(0, VAULT_BACKUP_MAGIC_LEN)
+    .equals(VAULT_BACKUP_BLOB_MAGIC)
+
+/**
+ * Runs `action` the moment the `writeIndex`-th `chrome.storage.local.set`
+ * lands, before the caller reaches its next statement. Throwing from `action`
+ * models the popup being torn down right there; awaiting other work models a
+ * second flow interleaving at that exact point. Returns the restore function.
+ */
+const afterStorageWrite = (writeIndex: number, action: () => Promise<void>) => {
+  const original = chrome.storage.local.set
+  let writes = 0
+
+  chrome.storage.local.set = async (items: Record<string, unknown>) => {
+    await original(items)
+    writes += 1
+    if (writes === writeIndex) {
+      await action()
+    }
+  }
+
+  return () => {
+    chrome.storage.local.set = original
+  }
+}
+
+const killPopupAfterWrite = (writeIndex: number) =>
+  afterStorageWrite(writeIndex, async () => {
+    throw new Error('popup destroyed')
+  })
+
+/**
+ * Mounts hooks with the providers the popup gives them: the passcode held in
+ * memory, the vault snapshot read at render time, and the passcode proof
+ * already in the query cache, the way it is once the app has unlocked.
+ */
+const renderInPopup = async <T,>(
+  useHooks: () => T,
+  passcodeInMemory: string | null
+) => {
+  const vaults = (await vaultsStorage.getVaults()).map(v => ({
+    ...v,
+    coins: [],
+  }))
+
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+
+  queryClient.setQueryData(
+    [StorageKey.passcodeEncryption],
+    await passcodeEncryptionStorage.getPasscodeEncryption()
+  )
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <PasscodeProvider initialValue={passcodeInMemory}>
+        <VaultsProvider value={vaults}>{children}</VaultsProvider>
+      </PasscodeProvider>
+    </QueryClientProvider>
+  )
+
+  return renderHook(useHooks, { wrapper })
+}
+
+// The popup is gone once a mutation settles; leaving it mounted lets React
+// Query settle state after the act block and warns about it.
+const closePopup = async (unmount: () => void) => {
+  await act(async () => {
+    unmount()
+  })
+}
+
+type RunMutationInput<T> = {
+  useMutationHook: () => { mutateAsync: (input: T) => Promise<unknown> }
+  input: T
+  passcodeInMemory: string | null
+}
+
+/**
+ * Renders one passcode mutation and runs it to completion. Rejections are the
+ * point of these tests, so they are swallowed here and asserted on storage
+ * afterwards.
+ */
+const runMutation = async <T,>({
+  useMutationHook,
+  input,
+  passcodeInMemory,
+}: RunMutationInput<T>) => {
+  const { result, unmount } = await renderInPopup(
+    useMutationHook,
+    passcodeInMemory
+  )
+
+  await act(async () => {
+    await result.current.mutateAsync(input).catch(() => {})
+  })
+
+  await closePopup(unmount)
+}
+
+/**
+ * What the app serves for the vault's ECDSA key share on the next launch. Both
+ * decisions come from the production entry points rather than being restated
+ * here, so this cannot drift from what the app does:
+ *
+ * - whether a lock screen appears at all (`useIsPasscodeRequired`)
+ * - which passcode that lock screen accepts (`verifyPasscode`)
+ *
+ * The last step is the app's own leniency: `currentVault` swallows a failed
+ * share decryption and serves the stored record untouched
+ * (currentVault.tsx:82-88), which is how ciphertext reaches signing.
+ */
+const openVaultOnNextLaunch = async (knownPasscodes: string[]) => {
+  const [storedVault] = await vaultsStorage.getVaults()
+  const proof = await passcodeEncryptionStorage.getPasscodeEncryption()
+  const encryptedSample = proof?.encryptedSample ?? null
+
+  const served = async (share: string) => ({
+    ecdsaShare: share,
+    servedCiphertext: isEncryptedBlob(share),
+  })
+
+  const lockState = { vaults: [storedVault], encryptedSample }
+
+  if (!isPasscodeRequired(lockState)) {
+    return served(storedVault.keyShares.ecdsa)
+  }
+
+  for (const candidate of knownPasscodes) {
+    const opensLockScreen = await verifyPasscode({
+      ...lockState,
+      passcode: candidate,
+    })
+
+    if (!opensLockScreen) continue
+
+    const shares = await decryptVaultAllKeyShares({
+      key: candidate,
+      keyShares: storedVault.keyShares,
+      chainKeyShares: storedVault.chainKeyShares,
+      keyShareMldsa: storedVault.keyShareMldsa,
+    }).catch(() => null)
+
+    return served(shares?.keyShares.ecdsa ?? storedVault.keyShares.ecdsa)
+  }
+
+  return { ecdsaShare: null, servedCiphertext: false }
+}
+
+/**
+ * Puts the vault in the state the legacy re-wrap exists for: shares sealed with
+ * the old `SHA-256(passcode)` KDF, alongside a proof already on the current
+ * PBKDF2 format so only the share branch of the upgrade has work to do.
+ */
+const seedLegacyEncryptedVault = async () => {
+  const seal = (value: string) =>
+    encryptWithAesGcm({
+      key: passcode,
+      value: Buffer.from(value, plainTextEncoding),
+    }).toString(encryptedEncoding)
+
+  await chrome.storage.local.set({
+    [StorageKey.vaults]: [
+      {
+        ...vault,
+        keyShares: { ecdsa: seal(ecdsaShare), eddsa: seal(eddsaShare) },
+      },
+    ],
+  })
+
+  await passcodeEncryptionStorage.setPasscodeEncryption({
+    encryptedSample: await encryptSample({ key: passcode, value: 'sample' }),
+  })
+}
+
+const healthyVault = { ecdsaShare, servedCiphertext: false }
+
+let restorePopup = () => {}
+
+/**
+ * Changes the passcode on a legacy-encrypted vault, optionally letting the
+ * legacy re-wrap run in change-passcode's window between the vault write
+ * (changePasscode.ts:48) and `setPasscode` (changePasscode.ts:51). The re-wrap
+ * auto-fires on unlock (PasscodeGuard.tsx:42), and its staleness guard reads a
+ * ref that only moves at :51 — so inside that window it still sees the old
+ * passcode as live and re-writes old-key blobs over the new-key ones.
+ */
+const changePasscodeOverLegacyVault = async ({
+  interleaveUpgrade,
+}: {
+  interleaveUpgrade: boolean
+}) => {
+  await seedLegacyEncryptedVault()
+
+  const { result, unmount } = await renderInPopup(
+    () => ({
+      change: useChangePasscodeMutation(),
+      upgrade: useUpgradePasscodeEncryptionMutation(),
+    }),
+    passcode
+  )
+
+  if (interleaveUpgrade) {
+    restorePopup = afterStorageWrite(1, async () => {
+      await result.current.upgrade.mutateAsync().catch(() => {})
+    })
+  }
+
+  await act(async () => {
+    await result.current.change.mutateAsync(newPasscode).catch(() => {})
+  })
+
+  await closePopup(unmount)
+}
+
+describe('passcode set/change survives a popup teardown', () => {
+  beforeEach(async () => {
+    await chrome.storage.local.set({ [StorageKey.vaults]: [vault] })
+  })
+
+  afterEach(() => {
+    restorePopup()
+    restorePopup = () => {}
+  })
+
+  it('opens with the passcode when nothing interrupts set-passcode', async () => {
+    await runMutation({
+      useMutationHook: useSetPasscodeMutation,
+      input: passcode,
+      passcodeInMemory: null,
+    })
+
+    expect(await openVaultOnNextLaunch([passcode])).toEqual(healthyVault)
+  })
+
+  it('survives the popup dying between the two set-passcode writes', async () => {
+    restorePopup = killPopupAfterWrite(1)
+
+    await runMutation({
+      useMutationHook: useSetPasscodeMutation,
+      input: passcode,
+      passcodeInMemory: null,
+    })
+
+    expect(await openVaultOnNextLaunch([passcode])).toEqual(healthyVault)
+  })
+
+  it('survives the popup dying between the two change-passcode writes', async () => {
+    await runMutation({
+      useMutationHook: useSetPasscodeMutation,
+      input: passcode,
+      passcodeInMemory: null,
+    })
+
+    restorePopup = killPopupAfterWrite(1)
+
+    await runMutation({
+      useMutationHook: useChangePasscodeMutation,
+      input: newPasscode,
+      passcodeInMemory: passcode,
+    })
+
+    expect(await openVaultOnNextLaunch([passcode, newPasscode])).toEqual(
+      healthyVault
+    )
+  })
+
+  it('survives the popup dying midway through disable-passcode', async () => {
+    await runMutation({
+      useMutationHook: useSetPasscodeMutation,
+      input: passcode,
+      passcodeInMemory: null,
+    })
+
+    restorePopup = killPopupAfterWrite(1)
+
+    await runMutation({
+      useMutationHook: useDisablePasscodeMutation,
+      input: undefined,
+      passcodeInMemory: passcode,
+    })
+
+    expect(await openVaultOnNextLaunch([passcode])).toEqual(healthyVault)
+  })
+
+  it('opens after the desktop WebView profile drops the proof but keeps the shares', async () => {
+    await runMutation({
+      useMutationHook: useSetPasscodeMutation,
+      input: passcode,
+      passcodeInMemory: null,
+    })
+
+    // Desktop keeps the shares in SQLite and the proof in the WebView's
+    // localStorage (clients/desktop/src/storage/passcodeEncryption.ts:22-24), so
+    // a WebView2 profile reset wipes one and leaves the other.
+    await chrome.storage.local.remove(StorageKey.passcodeEncryption)
+
+    expect(await openVaultOnNextLaunch([passcode])).toEqual(healthyVault)
+  })
+
+  // Change-passcode runs to completion in both of these, so the new passcode is
+  // the only one the user is left holding — offering the old one as a candidate
+  // would hide a re-wrap that put the shares back under it.
+  it('opens with the new passcode when the legacy re-wrap stays out of the way', async () => {
+    await changePasscodeOverLegacyVault({ interleaveUpgrade: false })
+
+    expect(await openVaultOnNextLaunch([newPasscode])).toEqual(healthyVault)
+  })
+
+  it('survives the legacy re-wrap landing in the middle of change-passcode', async () => {
+    await changePasscodeOverLegacyVault({ interleaveUpgrade: true })
+
+    expect(await openVaultOnNextLaunch([newPasscode])).toEqual(healthyVault)
+  })
+})

--- a/clients/extension/tests/unit/vitest.config.ts
+++ b/clients/extension/tests/unit/vitest.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     environment: 'node',
     pool: 'forks',
     setupFiles: [path.resolve(__dirname, 'setup.ts')],
-    include: [path.resolve(__dirname, '**/*.test.ts')],
+    include: [path.resolve(__dirname, '**/*.test.{ts,tsx}')],
     testTimeout: 30000,
   },
 })

--- a/core/ui/passcodeEncryption/core/passcodeCipher.ts
+++ b/core/ui/passcodeEncryption/core/passcodeCipher.ts
@@ -42,6 +42,15 @@ const hasPbkdf2Magic = (value: Buffer): boolean =>
   value.length >= VAULT_BACKUP_PBKDF2_HEADER_LEN + gcmTagLength &&
   value.subarray(0, VAULT_BACKUP_MAGIC_LEN).equals(VAULT_BACKUP_BLOB_MAGIC)
 
+/**
+ * Whether a blob is recognizably sealed with this cipher. Only the PBKDF2
+ * format carries a header; legacy `SHA-256(passcode)` blobs are headerless and
+ * so indistinguishable from plaintext. A `false` therefore means "no proof it
+ * is sealed", never "proven plain".
+ */
+export const isPasscodeEncryptedBlob = (value: Buffer): boolean =>
+  hasPbkdf2Magic(value)
+
 /** A blob is legacy when it lacks the PBKDF2 magic header (still SHA-256 KDF). */
 export const isLegacyPasscodeBlob = (value: Buffer): boolean =>
   !hasPbkdf2Magic(value)

--- a/core/ui/passcodeEncryption/core/passcodeLock.test.ts
+++ b/core/ui/passcodeEncryption/core/passcodeLock.test.ts
@@ -1,0 +1,237 @@
+import { VaultAllKeyShares } from '@vultisig/core-mpc/vault/Vault'
+import { encryptWithAesGcm } from '@vultisig/lib-utils/encryption/aesGcm/encryptWithAesGcm'
+import {
+  encryptedEncoding,
+  plainTextEncoding,
+} from '@vultisig/lib-utils/encryption/config'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import {
+  isPasscodeRequired,
+  mayNeedPasscodeSampleRewrite,
+  needsPasscodeSampleRewrite,
+  verifyPasscode,
+} from './passcodeLock'
+import { encryptSample } from './sample'
+import { encryptVaultAllKeyShares } from './vaultKeyShares'
+
+const passcode = '123456'
+const otherPasscode = '654321'
+
+const plainShares: VaultAllKeyShares = {
+  keyShares: { ecdsa: 'ecdsa-share', eddsa: 'eddsa-share' },
+}
+
+/** Headerless `SHA-256(passcode)` blob, the format predating the PBKDF2 one. */
+const legacyBlob = (value: string, key: string) =>
+  encryptWithAesGcm({
+    key,
+    value: Buffer.from(value, plainTextEncoding),
+  }).toString(encryptedEncoding)
+
+const legacyShares: VaultAllKeyShares = {
+  keyShares: {
+    ecdsa: legacyBlob('ecdsa-share', passcode),
+    eddsa: legacyBlob('eddsa-share', passcode),
+  },
+}
+
+let sealedShares: VaultAllKeyShares
+let sealedSharesUnderOther: VaultAllKeyShares
+let sample: string
+let sampleUnderOther: string
+let legacySample: string
+
+beforeAll(async () => {
+  sealedShares = await encryptVaultAllKeyShares({
+    ...plainShares,
+    key: passcode,
+  })
+  sealedSharesUnderOther = await encryptVaultAllKeyShares({
+    ...plainShares,
+    key: otherPasscode,
+  })
+  sample = await encryptSample({ key: passcode, value: 'sample' })
+  sampleUnderOther = await encryptSample({
+    key: otherPasscode,
+    value: 'sample',
+  })
+  legacySample = legacyBlob('sample', passcode)
+})
+
+describe('isPasscodeRequired', () => {
+  it('is false with no passcode in play', () => {
+    expect(
+      isPasscodeRequired({ vaults: [plainShares], encryptedSample: null })
+    ).toBe(false)
+  })
+
+  it('is true on the stored proof alone', () => {
+    expect(
+      isPasscodeRequired({ vaults: [plainShares], encryptedSample: sample })
+    ).toBe(true)
+  })
+
+  it('is true on sealed shares alone, which is what a half-landed write leaves', () => {
+    expect(
+      isPasscodeRequired({ vaults: [sealedShares], encryptedSample: null })
+    ).toBe(true)
+  })
+
+  it('cannot see legacy headerless shares, so falls back to the proof', () => {
+    expect(
+      isPasscodeRequired({ vaults: [legacyShares], encryptedSample: null })
+    ).toBe(false)
+  })
+})
+
+describe('verifyPasscode', () => {
+  it('accepts the passcode that opens the sealed shares', async () => {
+    await expect(
+      verifyPasscode({
+        vaults: [sealedShares],
+        encryptedSample: sample,
+        passcode,
+      })
+    ).resolves.toBe(true)
+  })
+
+  it('rejects a passcode the shares do not answer to, even when the sample says yes', async () => {
+    await expect(
+      verifyPasscode({
+        vaults: [sealedShares],
+        encryptedSample: sampleUnderOther,
+        passcode: otherPasscode,
+      })
+    ).resolves.toBe(false)
+  })
+
+  it('accepts the shares passcode when the sample disagrees', async () => {
+    await expect(
+      verifyPasscode({
+        vaults: [sealedShares],
+        encryptedSample: sampleUnderOther,
+        passcode,
+      })
+    ).resolves.toBe(true)
+  })
+
+  it('falls back to the sample when nothing is recognizably sealed', async () => {
+    const lockState = { vaults: [plainShares], encryptedSample: sample }
+
+    await expect(verifyPasscode({ ...lockState, passcode })).resolves.toBe(true)
+    await expect(
+      verifyPasscode({ ...lockState, passcode: otherPasscode })
+    ).resolves.toBe(false)
+  })
+
+  it('rejects everything when there is nothing to check against', async () => {
+    await expect(
+      verifyPasscode({
+        vaults: [plainShares],
+        encryptedSample: null,
+        passcode,
+      })
+    ).resolves.toBe(false)
+  })
+})
+
+describe('mayNeedPasscodeSampleRewrite', () => {
+  it('is false with no passcode in play', () => {
+    expect(
+      mayNeedPasscodeSampleRewrite({
+        vaults: [plainShares],
+        encryptedSample: null,
+      })
+    ).toBe(false)
+  })
+
+  it('is true for a missing proof beside sealed shares', () => {
+    expect(
+      mayNeedPasscodeSampleRewrite({
+        vaults: [sealedShares],
+        encryptedSample: null,
+      })
+    ).toBe(true)
+  })
+
+  it('is true for a legacy sample even with nothing sealed', () => {
+    expect(
+      mayNeedPasscodeSampleRewrite({
+        vaults: [legacyShares],
+        encryptedSample: legacySample,
+      })
+    ).toBe(true)
+  })
+
+  it('defers to the async check whenever sealed shares could contradict the sample', () => {
+    expect(
+      mayNeedPasscodeSampleRewrite({
+        vaults: [sealedShares],
+        encryptedSample: sample,
+      })
+    ).toBe(true)
+  })
+})
+
+describe('needsPasscodeSampleRewrite', () => {
+  it('is false for a sample that already answers to the passcode', async () => {
+    await expect(
+      needsPasscodeSampleRewrite({
+        vaults: [sealedShares],
+        encryptedSample: sample,
+        passcode,
+      })
+    ).resolves.toBe(false)
+  })
+
+  it('is true for a stale sample the sealed shares contradict', async () => {
+    await expect(
+      needsPasscodeSampleRewrite({
+        vaults: [sealedShares],
+        encryptedSample: sampleUnderOther,
+        passcode,
+      })
+    ).resolves.toBe(true)
+  })
+
+  it('is true for a missing sample beside sealed shares', async () => {
+    await expect(
+      needsPasscodeSampleRewrite({
+        vaults: [sealedShares],
+        encryptedSample: null,
+        passcode,
+      })
+    ).resolves.toBe(true)
+  })
+
+  it('is true for a legacy sample', async () => {
+    await expect(
+      needsPasscodeSampleRewrite({
+        vaults: [legacyShares],
+        encryptedSample: legacySample,
+        passcode,
+      })
+    ).resolves.toBe(true)
+  })
+
+  it('is false with no passcode in play, so the lock can never be turned on', async () => {
+    await expect(
+      needsPasscodeSampleRewrite({
+        vaults: [plainShares],
+        encryptedSample: null,
+        passcode,
+      })
+    ).resolves.toBe(false)
+  })
+
+  it('refuses to replace a sample on the word of a passcode that opens nothing', async () => {
+    await expect(
+      needsPasscodeSampleRewrite({
+        vaults: [sealedSharesUnderOther],
+        encryptedSample: sample,
+        passcode: 'wrong-guess',
+      })
+    ).resolves.toBe(false)
+  })
+})

--- a/core/ui/passcodeEncryption/core/passcodeLock.ts
+++ b/core/ui/passcodeEncryption/core/passcodeLock.ts
@@ -1,0 +1,90 @@
+import { VaultAllKeyShares } from '@vultisig/core-mpc/vault/Vault'
+import { attempt } from '@vultisig/lib-utils/attempt'
+
+import { decryptSample } from './sample'
+import {
+  decryptVaultAllKeyShares,
+  isLegacyEncryptedPasscodeBlob,
+  vaultKeySharesArePasscodeEncrypted,
+} from './vaultKeyShares'
+
+type PasscodeLockState = {
+  vaults: VaultAllKeyShares[]
+  encryptedSample: string | null
+}
+
+/**
+ * Whether the app has to ask for a passcode before it can serve key shares.
+ *
+ * The stored proof normally answers this on its own, but it and the sealed
+ * shares are separate durable writes: an interrupted set-passcode, or a wiped
+ * WebView profile on desktop, can leave sealed shares with no proof beside
+ * them. Without counting the shares the app would show no lock screen and hand
+ * ciphertext downstream as if it were the share.
+ */
+export const isPasscodeRequired = ({
+  vaults,
+  encryptedSample,
+}: PasscodeLockState): boolean =>
+  encryptedSample !== null || vaults.some(vaultKeySharesArePasscodeEncrypted)
+
+/**
+ * Whether the stored state is missing a passcode sample the active passcode
+ * should fill in — either none is stored beside sealed shares, or the stored
+ * one still uses the legacy KDF. Answers `false` when no passcode is in play,
+ * so it can never turn the lock on for someone who has not set one.
+ */
+export const needsPasscodeSample = ({
+  vaults,
+  encryptedSample,
+}: PasscodeLockState): boolean =>
+  encryptedSample === null
+    ? vaults.some(vaultKeySharesArePasscodeEncrypted)
+    : isLegacyEncryptedPasscodeBlob(encryptedSample)
+
+type VerifyPasscodeInput = PasscodeLockState & {
+  passcode: string
+}
+
+/**
+ * Whether a passcode opens what is actually stored.
+ *
+ * The sealed key shares are the authority, not the passcode sample: they are
+ * the thing the passcode has to unseal, and the two are written separately, so
+ * an interrupted write can leave a sample that validates a passcode the shares
+ * no longer answer to. The sample is consulted only when no vault is
+ * recognizably sealed — with encryption off, or on legacy headerless shares,
+ * it is the sole thing left to check against.
+ */
+export const verifyPasscode = async ({
+  vaults,
+  encryptedSample,
+  passcode,
+}: VerifyPasscodeInput): Promise<boolean> => {
+  const sealedVault = vaults.find(vaultKeySharesArePasscodeEncrypted)
+
+  if (sealedVault) {
+    const { keyShares, chainKeyShares, keyShareMldsa } = sealedVault
+
+    const result = await attempt(() =>
+      decryptVaultAllKeyShares({
+        key: passcode,
+        keyShares,
+        chainKeyShares,
+        keyShareMldsa,
+      })
+    )
+
+    return 'data' in result
+  }
+
+  if (encryptedSample === null) {
+    return false
+  }
+
+  const result = await attempt(() =>
+    decryptSample({ key: passcode, value: encryptedSample })
+  )
+
+  return 'data' in result
+}

--- a/core/ui/passcodeEncryption/core/passcodeLock.ts
+++ b/core/ui/passcodeEncryption/core/passcodeLock.ts
@@ -29,18 +29,23 @@ export const isPasscodeRequired = ({
   encryptedSample !== null || vaults.some(vaultKeySharesArePasscodeEncrypted)
 
 /**
- * Whether the stored state is missing a passcode sample the active passcode
- * should fill in — either none is stored beside sealed shares, or the stored
- * one still uses the legacy KDF. Answers `false` when no passcode is in play,
- * so it can never turn the lock on for someone who has not set one.
+ * Synchronous gate for the post-unlock reconcile: whether the stored state
+ * could need its passcode sample rewritten.
+ *
+ * A sample can also be *stale* — current-format but sealed under a passcode the
+ * shares no longer answer to — and that only shows up under decryption. So this
+ * answers `true` whenever sealed shares exist to contradict the sample and
+ * leaves the real decision to {@link needsPasscodeSampleRewrite}. Answers
+ * `false` when no passcode is in play, so it can never turn the lock on for
+ * someone who has not set one.
  */
-export const needsPasscodeSample = ({
+export const mayNeedPasscodeSampleRewrite = ({
   vaults,
   encryptedSample,
 }: PasscodeLockState): boolean =>
-  encryptedSample === null
-    ? vaults.some(vaultKeySharesArePasscodeEncrypted)
-    : isLegacyEncryptedPasscodeBlob(encryptedSample)
+  (encryptedSample !== null &&
+    isLegacyEncryptedPasscodeBlob(encryptedSample)) ||
+  vaults.some(vaultKeySharesArePasscodeEncrypted)
 
 type VerifyPasscodeInput = PasscodeLockState & {
   passcode: string
@@ -87,4 +92,46 @@ export const verifyPasscode = async ({
   )
 
   return 'data' in result
+}
+
+type NeedsPasscodeSampleRewriteInput = PasscodeLockState & {
+  passcode: string
+}
+
+/**
+ * Whether the stored passcode sample has to be rewritten for the passcode the
+ * app is unlocked with.
+ *
+ * Three states qualify: no sample beside sealed shares, a sample still on the
+ * legacy KDF, and — the one only decryption can see — a current-format sample
+ * sealed under a passcode the shares no longer answer to, which is what a
+ * change-passcode interrupted between its two writes leaves behind.
+ *
+ * A healthy unlock costs one key derivation, spent opening the sample. The
+ * repair path spends a second one re-proving the passcode against the sealed
+ * shares: a sample is never replaced on the word of a passcode that cannot open
+ * the vault, and with nothing sealed to prove it against, nothing is written.
+ */
+export const needsPasscodeSampleRewrite = async ({
+  vaults,
+  encryptedSample,
+  passcode,
+}: NeedsPasscodeSampleRewriteInput): Promise<boolean> => {
+  if (encryptedSample === null) {
+    return vaults.some(vaultKeySharesArePasscodeEncrypted)
+  }
+
+  if (isLegacyEncryptedPasscodeBlob(encryptedSample)) {
+    return true
+  }
+
+  const opened = await attempt(() =>
+    decryptSample({ key: passcode, value: encryptedSample })
+  )
+
+  if ('data' in opened) {
+    return false
+  }
+
+  return verifyPasscode({ vaults, encryptedSample, passcode })
 }

--- a/core/ui/passcodeEncryption/core/vaultKeyShares.ts
+++ b/core/ui/passcodeEncryption/core/vaultKeyShares.ts
@@ -15,6 +15,7 @@ import {
   decryptWithPasscode,
   encryptWithPasscode,
   isLegacyPasscodeBlob,
+  isPasscodeEncryptedBlob,
 } from './passcodeCipher'
 
 type EncryptInput = VaultAllKeyShares & { key: string }
@@ -130,21 +131,36 @@ export const mapVaultsKeyShares = async ({
 export const isLegacyEncryptedPasscodeBlob = (value: string): boolean =>
   isLegacyPasscodeBlob(Buffer.from(value, encryptedEncoding))
 
-/**
- * Whether any of a vault's encrypted shares still use the legacy
- * `SHA-256(passcode)` KDF and should be re-encrypted with PBKDF2 on unlock.
- * Only meaningful while passcode encryption is enabled.
- */
-export const vaultKeySharesNeedPasscodeUpgrade = ({
+const storedKeyShareValues = ({
   keyShares,
   chainKeyShares,
   keyShareMldsa,
-}: VaultAllKeyShares): boolean => {
-  const values = [
+}: VaultAllKeyShares): string[] =>
+  [
     ...Object.values(keyShares),
     ...Object.values(chainKeyShares ?? {}),
     ...(keyShareMldsa ? [keyShareMldsa] : []),
   ].filter((value): value is string => Boolean(value))
 
-  return values.some(isLegacyEncryptedPasscodeBlob)
-}
+/**
+ * Whether any of a vault's encrypted shares still use the legacy
+ * `SHA-256(passcode)` KDF and should be re-encrypted with PBKDF2 on unlock.
+ * Only meaningful while passcode encryption is enabled.
+ */
+export const vaultKeySharesNeedPasscodeUpgrade = (
+  allKeyShares: VaultAllKeyShares
+): boolean =>
+  storedKeyShareValues(allKeyShares).some(isLegacyEncryptedPasscodeBlob)
+
+/**
+ * Whether a vault's stored shares are recognizably sealed with the passcode
+ * cipher. This is what makes sealed shares self-describing: the app can tell a
+ * passcode is in play from the shares alone, without the separate proof that a
+ * half-landed write may have left behind.
+ */
+export const vaultKeySharesArePasscodeEncrypted = (
+  allKeyShares: VaultAllKeyShares
+): boolean =>
+  storedKeyShareValues(allKeyShares).some(value =>
+    isPasscodeEncryptedBlob(Buffer.from(value, encryptedEncoding))
+  )

--- a/core/ui/passcodeEncryption/guard/EnterPasscode.tsx
+++ b/core/ui/passcodeEncryption/guard/EnterPasscode.tsx
@@ -1,14 +1,14 @@
 import { passcodeEncryptionConfig } from '@core/ui/passcodeEncryption/core/config'
-import { decryptSample } from '@core/ui/passcodeEncryption/core/sample'
+import { verifyPasscode } from '@core/ui/passcodeEncryption/core/passcodeLock'
 import { PasscodeInput } from '@core/ui/passcodeEncryption/manage/PasscodeInput'
 import { usePasscode } from '@core/ui/passcodeEncryption/state/passcode'
 import { usePasscodeEncryption } from '@core/ui/storage/passcodeEncryption'
+import { useVaults } from '@core/ui/storage/vaults'
 import { takeWholeSpace } from '@lib/ui/css/takeWholeSpace'
 import { VStack, vStack } from '@lib/ui/layout/Stack'
 import { panel } from '@lib/ui/panel/Panel'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
-import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -49,6 +49,7 @@ export const EnterPasscode = () => {
   const { t } = useTranslation()
 
   const passcodeEncryption = usePasscodeEncryption()
+  const vaults = useVaults()
 
   const [inputValue, setInputValue] = useState<string | null>(null)
   const [, setPasscode] = usePasscode()
@@ -59,34 +60,35 @@ export const EnterPasscode = () => {
     inputValue.length === passcodeEncryptionConfig.passcodeLength
 
   // Validate only once the full passcode is entered, and asynchronously:
-  // decryptSample runs the PBKDF2 key derivation, so validating synchronously on
-  // every keystroke would block the UI. On success the passcode unlocks the app.
+  // verifyPasscode runs the PBKDF2 key derivation, so validating synchronously
+  // on every keystroke would block the UI. On success the passcode unlocks the
+  // app.
   useEffect(() => {
     if (!isComplete) {
       setIsInvalid(false)
       return
     }
 
-    const { encryptedSample } = shouldBePresent(passcodeEncryption)
     let cancelled = false
 
-    decryptSample({ key: inputValue, value: encryptedSample })
-      .then(() => {
-        if (!cancelled) {
-          setIsInvalid(false)
-          setPasscode(inputValue)
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setIsInvalid(true)
-        }
-      })
+    verifyPasscode({
+      vaults,
+      encryptedSample: passcodeEncryption?.encryptedSample ?? null,
+      passcode: inputValue,
+    }).then(isValid => {
+      if (cancelled) return
+
+      setIsInvalid(!isValid)
+
+      if (isValid) {
+        setPasscode(inputValue)
+      }
+    })
 
     return () => {
       cancelled = true
     }
-  }, [isComplete, inputValue, passcodeEncryption, setPasscode])
+  }, [isComplete, inputValue, passcodeEncryption, vaults, setPasscode])
 
   return (
     <Wrapper>

--- a/core/ui/passcodeEncryption/guard/PasscodeEncryptionUpgrade.tsx
+++ b/core/ui/passcodeEncryption/guard/PasscodeEncryptionUpgrade.tsx
@@ -2,16 +2,16 @@ import { usePasscodeEncryption } from '@core/ui/storage/passcodeEncryption'
 import { useVaults } from '@core/ui/storage/vaults'
 import { useEffect, useRef } from 'react'
 
-import {
-  isLegacyEncryptedPasscodeBlob,
-  vaultKeySharesNeedPasscodeUpgrade,
-} from '../core/vaultKeyShares'
+import { isPasscodeRequired, needsPasscodeSample } from '../core/passcodeLock'
+import { vaultKeySharesNeedPasscodeUpgrade } from '../core/vaultKeyShares'
 import { useUpgradePasscodeEncryptionMutation } from '../mutations/useUpgradePasscodeEncryptionMutation'
 import { usePasscode } from '../state/passcode'
 
 /**
- * Transparently re-encrypts legacy `SHA-256(passcode)` shares and sample with
- * the strong PBKDF2 cipher once the vault is unlocked. Renders nothing.
+ * Reconciles passcode encryption once the vault is unlocked: re-encrypts legacy
+ * `SHA-256(passcode)` shares and sample with the strong PBKDF2 cipher, and
+ * writes back a proof an interrupted passcode write left missing. Renders
+ * nothing.
  */
 export const PasscodeEncryptionUpgrade = () => {
   const [passcode] = usePasscode()
@@ -24,11 +24,16 @@ export const PasscodeEncryptionUpgrade = () => {
   // false — without this guard the effect would re-fire in a tight loop.
   const attempted = useRef(false)
 
+  const lockState = {
+    vaults,
+    encryptedSample: passcodeEncryption?.encryptedSample ?? null,
+  }
+
   const shouldUpgrade =
     !!passcode &&
-    passcodeEncryption !== null &&
+    isPasscodeRequired(lockState) &&
     (vaults.some(vaultKeySharesNeedPasscodeUpgrade) ||
-      isLegacyEncryptedPasscodeBlob(passcodeEncryption.encryptedSample))
+      needsPasscodeSample(lockState))
 
   useEffect(() => {
     if (!shouldUpgrade) {

--- a/core/ui/passcodeEncryption/guard/PasscodeEncryptionUpgrade.tsx
+++ b/core/ui/passcodeEncryption/guard/PasscodeEncryptionUpgrade.tsx
@@ -2,7 +2,10 @@ import { usePasscodeEncryption } from '@core/ui/storage/passcodeEncryption'
 import { useVaults } from '@core/ui/storage/vaults'
 import { useEffect, useRef } from 'react'
 
-import { isPasscodeRequired, needsPasscodeSample } from '../core/passcodeLock'
+import {
+  isPasscodeRequired,
+  mayNeedPasscodeSampleRewrite,
+} from '../core/passcodeLock'
 import { vaultKeySharesNeedPasscodeUpgrade } from '../core/vaultKeyShares'
 import { useUpgradePasscodeEncryptionMutation } from '../mutations/useUpgradePasscodeEncryptionMutation'
 import { usePasscode } from '../state/passcode'
@@ -33,7 +36,7 @@ export const PasscodeEncryptionUpgrade = () => {
     !!passcode &&
     isPasscodeRequired(lockState) &&
     (vaults.some(vaultKeySharesNeedPasscodeUpgrade) ||
-      needsPasscodeSample(lockState))
+      mayNeedPasscodeSampleRewrite(lockState))
 
   useEffect(() => {
     if (!shouldUpgrade) {

--- a/core/ui/passcodeEncryption/guard/PasscodeGuard.tsx
+++ b/core/ui/passcodeEncryption/guard/PasscodeGuard.tsx
@@ -2,10 +2,10 @@ import { ProductLogoBlock } from '@core/ui/product/ProductLogoBlock'
 import { BlockingOverlay } from '@lib/ui/overlay/BlockingOverlay'
 
 import { usePasscodeAutoLock } from '../../storage/passcodeAutoLock'
-import { useHasPasscodeEncryption } from '../../storage/passcodeEncryption'
 import { PasscodeAutoLock } from '../autoLock/PasscodeAutoLock'
 import { usePasscodeUnlockSession } from '../autoLock/usePasscodeUnlockSession'
 import { usePasscode } from '../state/passcode'
+import { useIsPasscodeRequired } from '../state/useIsPasscodeRequired'
 import { EnterPasscode } from './EnterPasscode'
 import { PasscodeEncryptionUpgrade } from './PasscodeEncryptionUpgrade'
 import { useClearSigningCredentialsOnLock } from './useClearSigningCredentialsOnLock'
@@ -15,7 +15,7 @@ export const PasscodeGuard = () => {
 
   const passcodeAutoLock = usePasscodeAutoLock()
 
-  const hasPasscodeEnabled = useHasPasscodeEncryption()
+  const hasPasscodeEnabled = useIsPasscodeRequired()
 
   const { pendingPasscodeUnlockRestore } = usePasscodeUnlockSession({
     hasPasscodeEncryption: hasPasscodeEnabled,

--- a/core/ui/passcodeEncryption/manage/ManagePasscodeEncryptionPage.tsx
+++ b/core/ui/passcodeEncryption/manage/ManagePasscodeEncryptionPage.tsx
@@ -1,14 +1,14 @@
 import { FlowPageHeader } from '@core/ui/flow/FlowPageHeader'
 import { ManagePasscode } from '@core/ui/passcodeEncryption/manage/ManagePasscode'
 import { SetPasscode } from '@core/ui/passcodeEncryption/manage/SetPasscode'
-import { useHasPasscodeEncryption } from '@core/ui/storage/passcodeEncryption'
+import { useIsPasscodeRequired } from '@core/ui/passcodeEncryption/state/useIsPasscodeRequired'
 import { VStack } from '@lib/ui/layout/Stack'
 import { PageContent } from '@lib/ui/page/PageContent'
 import { useTranslation } from 'react-i18next'
 
 export const ManagePasscodeEncryptionPage = () => {
   const { t } = useTranslation()
-  const hasPasscodeEnabled = useHasPasscodeEncryption()
+  const hasPasscodeEnabled = useIsPasscodeRequired()
 
   return (
     <VStack fullHeight>

--- a/core/ui/passcodeEncryption/mutations/useUpgradePasscodeEncryptionMutation.ts
+++ b/core/ui/passcodeEncryption/mutations/useUpgradePasscodeEncryptionMutation.ts
@@ -4,28 +4,35 @@ import { StorageKey } from '@core/ui/storage/StorageKey'
 import { useVaults } from '@core/ui/storage/vaults'
 import { useRefetchQueries } from '@lib/ui/query/hooks/useRefetchQueries'
 import { useMutation } from '@tanstack/react-query'
+import { getVaultId } from '@vultisig/core-mpc/vault/Vault'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { useRef } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
+import { needsPasscodeSample } from '../core/passcodeLock'
 import { encryptSample } from '../core/sample'
 import {
   decryptVaultAllKeyShares,
   encryptVaultAllKeyShares,
-  isLegacyEncryptedPasscodeBlob,
   mapVaultsKeyShares,
   vaultKeySharesNeedPasscodeUpgrade,
 } from '../core/vaultKeyShares'
 import { usePasscode } from '../state/passcode'
 
 /**
- * Re-encrypts passcode-protected data still using the legacy `SHA-256(passcode)`
- * KDF (key shares and the passcode sample) with the strong PBKDF2 cipher. Runs
- * once after unlock; vaults/sample already on the new format are skipped, so it
- * is a no-op once everything is upgraded.
+ * Reconciles passcode-protected data with the passcode currently in hand:
+ * re-encrypts anything still using the legacy `SHA-256(passcode)` KDF with the
+ * strong PBKDF2 cipher, and writes a passcode sample when none is stored beside
+ * sealed shares. Runs once after unlock; records already in order are skipped,
+ * so it is a no-op when there is nothing to reconcile.
  */
 export const useUpgradePasscodeEncryptionMutation = () => {
-  const { updateVaultsKeyShares, setPasscodeEncryption } = useCore()
+  const {
+    updateVaultsKeyShares,
+    setPasscodeEncryption,
+    getPasscodeEncryption,
+    getVaults,
+  } = useCore()
   const refetchQueries = useRefetchQueries()
   const [passcode] = usePasscode()
   const passcodeEncryption = usePasscodeEncryption()
@@ -40,7 +47,6 @@ export const useUpgradePasscodeEncryptionMutation = () => {
   return useMutation({
     mutationFn: async () => {
       const key = shouldBePresent(passcode, 'passcode')
-      const { encryptedSample } = shouldBePresent(passcodeEncryption)
 
       const isPasscodeStale = () => livePasscodeRef.current !== key
 
@@ -62,14 +68,51 @@ export const useUpgradePasscodeEncryptionMutation = () => {
 
         if (isPasscodeStale()) return
 
-        await updateVaultsKeyShares(vaultsKeyShares)
-        await refetchQueries([StorageKey.vaults])
+        // The ref above only moves once a concurrent change-passcode reaches
+        // its own `setPasscode`, which is after it has already rewritten every
+        // vault — so it is not enough on its own. Re-read what is stored and
+        // keep only the records that still want this re-wrap; anything another
+        // flow has since rewritten is left alone.
+        const storedVaults = await getVaults()
+        const stillLegacy = Object.fromEntries(
+          Object.entries(vaultsKeyShares).filter(([vaultId]) => {
+            const stored = storedVaults.find(v => getVaultId(v) === vaultId)
+
+            return (
+              stored !== undefined && vaultKeySharesNeedPasscodeUpgrade(stored)
+            )
+          })
+        )
+
+        if (Object.keys(stillLegacy).length > 0) {
+          await updateVaultsKeyShares(stillLegacy)
+          await refetchQueries([StorageKey.vaults])
+        }
       }
 
-      if (isLegacyEncryptedPasscodeBlob(encryptedSample)) {
+      const wantsSample = needsPasscodeSample({
+        vaults,
+        encryptedSample: passcodeEncryption?.encryptedSample ?? null,
+      })
+
+      if (wantsSample) {
         const encrypted = await encryptSample({ key, value: uuidv4() })
 
         if (isPasscodeStale()) return
+
+        // Same reasoning as the vault re-write above: decide off what is stored
+        // now, not off the snapshot this render captured.
+        const [storedPasscodeEncryption, storedVaults] = await Promise.all([
+          getPasscodeEncryption(),
+          getVaults(),
+        ])
+
+        const stillWantsSample = needsPasscodeSample({
+          vaults: storedVaults,
+          encryptedSample: storedPasscodeEncryption?.encryptedSample ?? null,
+        })
+
+        if (!stillWantsSample) return
 
         await setPasscodeEncryption({ encryptedSample: encrypted })
         await refetchQueries([StorageKey.passcodeEncryption])

--- a/core/ui/passcodeEncryption/mutations/useUpgradePasscodeEncryptionMutation.ts
+++ b/core/ui/passcodeEncryption/mutations/useUpgradePasscodeEncryptionMutation.ts
@@ -1,5 +1,4 @@
 import { useCore } from '@core/ui/state/core'
-import { usePasscodeEncryption } from '@core/ui/storage/passcodeEncryption'
 import { StorageKey } from '@core/ui/storage/StorageKey'
 import { useVaults } from '@core/ui/storage/vaults'
 import { useRefetchQueries } from '@lib/ui/query/hooks/useRefetchQueries'
@@ -9,7 +8,7 @@ import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { useRef } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
-import { needsPasscodeSample } from '../core/passcodeLock'
+import { needsPasscodeSampleRewrite } from '../core/passcodeLock'
 import { encryptSample } from '../core/sample'
 import {
   decryptVaultAllKeyShares,
@@ -35,7 +34,6 @@ export const useUpgradePasscodeEncryptionMutation = () => {
   } = useCore()
   const refetchQueries = useRefetchQueries()
   const [passcode] = usePasscode()
-  const passcodeEncryption = usePasscodeEncryption()
   const vaults = useVaults()
 
   // Latest active passcode, so a concurrent change/disable (which captures and
@@ -43,6 +41,19 @@ export const useUpgradePasscodeEncryptionMutation = () => {
   // it overwrites records with stale-key blobs.
   const livePasscodeRef = useRef(passcode)
   livePasscodeRef.current = passcode
+
+  const readSampleRewriteNeed = async (key: string) => {
+    const [storedPasscodeEncryption, storedVaults] = await Promise.all([
+      getPasscodeEncryption(),
+      getVaults(),
+    ])
+
+    return needsPasscodeSampleRewrite({
+      vaults: storedVaults,
+      encryptedSample: storedPasscodeEncryption?.encryptedSample ?? null,
+      passcode: key,
+    })
+  }
 
   return useMutation({
     mutationFn: async () => {
@@ -90,29 +101,20 @@ export const useUpgradePasscodeEncryptionMutation = () => {
         }
       }
 
-      const wantsSample = needsPasscodeSample({
-        vaults,
-        encryptedSample: passcodeEncryption?.encryptedSample ?? null,
-      })
+      // Whether the sample is stale needs a decryption attempt, so unlike the
+      // re-wrap above this decides off stored state from the start rather than
+      // off the snapshot this render captured.
+      const wantsSample = await readSampleRewriteNeed(key)
 
       if (wantsSample) {
         const encrypted = await encryptSample({ key, value: uuidv4() })
 
         if (isPasscodeStale()) return
 
-        // Same reasoning as the vault re-write above: decide off what is stored
-        // now, not off the snapshot this render captured.
-        const [storedPasscodeEncryption, storedVaults] = await Promise.all([
-          getPasscodeEncryption(),
-          getVaults(),
-        ])
-
-        const stillWantsSample = needsPasscodeSample({
-          vaults: storedVaults,
-          encryptedSample: storedPasscodeEncryption?.encryptedSample ?? null,
-        })
-
-        if (!stillWantsSample) return
+        // Re-read for the same reason as the vault re-write: a concurrent
+        // change-passcode may have written its own sample while this one was
+        // being derived.
+        if (!(await readSampleRewriteNeed(key))) return
 
         await setPasscodeEncryption({ encryptedSample: encrypted })
         await refetchQueries([StorageKey.passcodeEncryption])

--- a/core/ui/passcodeEncryption/state/useIsPasscodeRequired.ts
+++ b/core/ui/passcodeEncryption/state/useIsPasscodeRequired.ts
@@ -1,0 +1,15 @@
+import { usePasscodeEncryption } from '@core/ui/storage/passcodeEncryption'
+import { useVaults } from '@core/ui/storage/vaults'
+
+import { isPasscodeRequired } from '../core/passcodeLock'
+
+/** Reads {@link isPasscodeRequired} off the stored vaults and passcode proof. */
+export const useIsPasscodeRequired = () => {
+  const passcodeEncryption = usePasscodeEncryption()
+  const vaults = useVaults()
+
+  return isPasscodeRequired({
+    vaults,
+    encryptedSample: passcodeEncryption?.encryptedSample ?? null,
+  })
+}

--- a/core/ui/settings/index.tsx
+++ b/core/ui/settings/index.tsx
@@ -2,11 +2,11 @@ import { ManageBlockaid } from '@core/ui/chain/security/blockaid/ManageBlockaid'
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { languageName } from '@core/ui/i18n/Language'
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
+import { useIsPasscodeRequired } from '@core/ui/passcodeEncryption/state/useIsPasscodeRequired'
 import { SettingsSection } from '@core/ui/settings/SettingsSection'
 import { useCore } from '@core/ui/state/core'
 import { useFiatCurrency } from '@core/ui/storage/fiatCurrency'
 import { useLanguage } from '@core/ui/storage/language'
-import { useHasPasscodeEncryption } from '@core/ui/storage/passcodeEncryption'
 import { useCurrentVaultAddresses } from '@core/ui/vault/state/currentVaultCoins'
 import { Opener } from '@lib/ui/base/Opener'
 import { BellIcon } from '@lib/ui/icons/BellIcon'
@@ -68,7 +68,7 @@ export const SettingsPage: FC<Props> = props => {
   const currency = useFiatCurrency()
   const language = useLanguage()
 
-  const hasPasscodeEncryption = useHasPasscodeEncryption()
+  const hasPasscodeEncryption = useIsPasscodeRequired()
   const addresses = useCurrentVaultAddresses()
   const areReferralEnabled = Boolean(addresses[Chain.THORChain])
   const shouldShowVultDiscounts = currentProductBrand === 'vultisig'

--- a/core/ui/storage/passcodeEncryption.tsx
+++ b/core/ui/storage/passcodeEncryption.tsx
@@ -33,9 +33,3 @@ export const usePasscodeEncryption = () => {
 
   return shouldBeDefined(data)
 }
-
-export const useHasPasscodeEncryption = () => {
-  const data = usePasscodeEncryption()
-
-  return data !== null
-}

--- a/core/ui/vault/mutations/useCreateVaultMutation.ts
+++ b/core/ui/vault/mutations/useCreateVaultMutation.ts
@@ -14,10 +14,10 @@ import { getRecordKeys } from '@vultisig/lib-utils/record/getRecordKeys'
 import { useAssertWalletCore } from '../../chain/providers/WalletCoreProvider'
 import { encryptVaultAllKeyShares } from '../../passcodeEncryption/core/vaultKeyShares'
 import { usePasscode } from '../../passcodeEncryption/state/passcode'
+import { useIsPasscodeRequired } from '../../passcodeEncryption/state/useIsPasscodeRequired'
 import { currentProductBrand } from '../../product/brand'
 import { useCreateCoinsMutation } from '../../storage/coins'
 import { useSetCurrentVaultIdMutation } from '../../storage/currentVaultId'
-import { useHasPasscodeEncryption } from '../../storage/passcodeEncryption'
 import { StorageKey } from '../../storage/StorageKey'
 import { getDefaultVaultChains } from '../chains/defaultVaultChains'
 
@@ -25,7 +25,7 @@ export const useCreateVaultMutation = (
   options?: UseMutationOptions<any, any, Vault, unknown>
 ) => {
   const refetchQueries = useRefetchQueries()
-  const hasPasscodeEncryption = useHasPasscodeEncryption()
+  const hasPasscodeEncryption = useIsPasscodeRequired()
   const [passcode] = usePasscode()
 
   const { createVault } = useCore()


### PR DESCRIPTION
## Description

The sealed key shares and the `encryptedSample` that proves a passcode are two independent durable writes with no transaction spanning them. Anything landing between them left storage in a state where **no passcode could open the vault again** — because the proof alone decided both whether to show the lock screen and which passcode to accept:

- closing the extension popup mid-set-passcode → sealed shares, no proof → no lock screen, ciphertext handed downstream as if it were the share
- the same interruption mid-change-passcode → shares under the new passcode, proof still validating the old
- a WebView2 profile reset on desktop → the proof lives in the WebView's localStorage while the shares live in SQLite, so one vanishes and the other survives
- the legacy re-wrap interleaving with change-passcode → its `livePasscodeRef` guard only moves *after* change-passcode has already written every vault, so it cannot catch that window

This lands in two steps: make every disagreement **survivable**, then **eliminate** it.

### 1. Make the shares the authority

They carry the cipher's header, so they are self-describing:

- `isPasscodeRequired` counts sealed shares as "a passcode is in play", even with no proof beside them
- `verifyPasscode` accepts the passcode that actually unseals the shares, rather than the one the sample validates

Supporting changes: the legacy re-wrap re-reads stored state before writing and drops records another flow has since rewritten; and the remaining proof-only consumers move to the same source of truth. The manage-passcode page was the dangerous one — during recovery it offered "set a passcode", which would encrypt already-sealed shares a second time.

### 2. Repair the disagreement instead of only tolerating it

Survivable was not enough for acceptance criterion 1. The reconcile recognized two states worth repairing — no sample beside sealed shares, and a sample still on the legacy KDF — but never enumerated a third: **a sample that is present and on the current format, but sealed under a passcode the shares no longer answer to.** That is exactly what change-passcode leaves when it dies between its two writes, so the reconcile saw nothing to do and the disagreement outlived every later unlock.

Unlock still worked, because the shares are the authority. But once no recognizably sealed vault was left — the user deletes it, or a profile comes back without it — `verifyPasscode` fell back to the sample and the lock screen accepted only the **old** passcode.

Staleness is only visible under decryption, so the render-time gate cannot answer it. The question is split in two:

- `mayNeedPasscodeSampleRewrite` stays synchronous and gates the render, answering true whenever sealed shares exist to contradict the sample
- `needsPasscodeSampleRewrite` makes the real decision inside the mutation, under decryption

A sample is never replaced on the word of a passcode that opens nothing, and with nothing sealed to prove it against, nothing is written — so this cannot turn the lock on for someone who never set a passcode.

Ordering is deliberately unchanged. Writing the proof first fixes set-passcode but **not** change-passcode, where either order leaves a broken pair — verified by experiment. This does not remove the two-write window; it makes every outcome of that window both survivable and self-repairing.

Fixes #4599

## Acceptance criteria

| criterion | status |
|---|---|
| No interleaving of set/change/upgrade leaves shares and proof disagreeing | met — the reconcile now repairs the stale-proof case that survived step 1 |
| Killing the extension popup mid-set-passcode leaves a recoverable state | met, with an injected-crash test |
| Desktop proof and ciphertext live in the same storage domain | **not addressed** — see below |
| Tests inject a crash at each await point in set/change | met for the extension; desktop's storage split is simulated, not exercised against a real profile reset |

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

Passcode encryption / app lock. No keysign, broadcast, or fee path is touched.

## Parity

- iOS: n/a — the failure is specific to this repo's split between the passcode proof and the key shares, and to the extension popup / WebView2 storage domains
- Android: n/a — same
- SDK: n/a — same

## Tests

**`clients/extension/tests/unit/passcodeCrashRecovery.test.tsx`** injects a crash at each durable write in set/change/disable and drives the **real** mutation hooks, the real PBKDF2 cipher, and the real extension storage adapters over `chrome.storage.local`. The only thing the test controls is *when* the popup dies, expressed as "die right after the Nth storage write lands" — deterministic rather than racing a ~1s mutation.

```
survives a popup teardown
  ✓ opens with the passcode when nothing interrupts set-passcode
  × survives the popup dying between the two set-passcode writes
  × survives the popup dying between the two change-passcode writes
  ✓ survives the popup dying midway through disable-passcode
  × opens after the desktop WebView profile drops the proof but keeps the shares
  ✓ opens with the new passcode when the legacy re-wrap stays out of the way
  × survives the legacy re-wrap landing in the middle of change-passcode
  the reconcile repairs a proof left disagreeing with the shares
    × rewrites the stale proof under the passcode the shares answer to
    × leaves the lock accepting the new passcode once no sealed share is left
    ✓ writes nothing when the stored state already agrees
    ✓ never writes a proof when no passcode is in play
```

`×` marks a case that fails without this change. The failure output is the corruption itself — the app serving a `VLT\x02` blob where the key share should be:

```
- "ecdsaShare": "ecdsa-key-share-plaintext",
- "servedCiphertext": false,
+ "ecdsaShare": "VkxUAmqQpLhCl2q7hBqOvpa+5zQY7VZium4oiDuwoIABkzZbPX6LUQ...",
+ "servedCiphertext": true,
```

The passing cases are controls: they use the same harness and pass either way. `writes nothing when the stored state already agrees` asserts on the `chrome.storage.local.set` call count, so the widened render gate cannot regress into a write on every unlock.

**`core/ui/passcodeEncryption/core/passcodeLock.test.ts`** covers the four lock predicates directly — 19 cases over `isPasscodeRequired`, `verifyPasscode`, `mayNeedPasscodeSampleRewrite`, and `needsPasscodeSampleRewrite`, including the stale sample, the legacy sample, and the "no passcode in play" guard. Unlike `clients/extension/tests/**` this path **is** inside the typechecked program.

Each production change was reverted individually to confirm none is decorative:

| reverted | goes red |
|---|---|
| sealed-share detection in `isPasscodeRequired` | set-passcode, desktop |
| share authority in `verifyPasscode` | set-passcode, change-passcode, desktop |
| re-read guard in the legacy re-wrap | legacy re-wrap race |
| stale-sample detection in `needsPasscodeSampleRewrite` | 1 core case, 2 reconcile cases |
| widened sync gate in `mayNeedPasscodeSampleRewrite` | 1 core case, no integration case |

That last row is a known coverage limit worth stating: the integration tests drive the mutation directly rather than rendering `PasscodeEncryptionUpgrade`, so the synchronous render gate — the thing that decides whether the repair fires at all in the real app — is covered only by the unit test.

The crash tests model app behaviour by calling `isPasscodeRequired` and `verifyPasscode` directly rather than restating their rules, so they cannot drift from what the app does.

`clients/extension/tests/unit/vitest.config.ts` now collects `.test.tsx` as well as `.test.ts`, since the crash test renders hooks.

## Behaviour change worth flagging

The synchronous gate now answers true whenever any vault is recognizably sealed, so the post-unlock reconcile runs on **every unlock** for every passcode user — in the extension, effectively every popup open. Previously it did not run at all for a healthy user.

The cost is one extra PBKDF2 derivation, spent opening the sample to check whether it is stale: **~74 ms measured** at the 600 k iteration count. It runs off the UI thread in a component that renders nothing, after unlock, and `EnterPasscode` is untouched — so nothing lands on the unlock critical path. The repair path itself spends a second derivation re-proving the passcode against the sealed shares before it is allowed to replace anything.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

`yarn check` clean. Root suite 999 tests / 146 files, extension unit 576 tests / 46 files — all passing. Full CI green.

## Additional context

Three things a reviewer should weigh:

1. **Sealed-share detection is heuristic by nature.** Only the PBKDF2 format carries a header; legacy `SHA-256(passcode)` blobs are headerless and indistinguishable from plaintext. So `vaultKeySharesArePasscodeEncrypted` answers "definitely sealed", never "definitely plain" — a legacy-only vault whose proof is lost still cannot be detected. The codebase already dispatches on this same header when decrypting, so this is not a new class of assumption.

2. **`encryptedSample` is now a fallback rather than the authority — but it is kept in agreement.** It still decides when no vault is recognizably sealed: a passcode set before any vault exists, or legacy headerless shares. Removing it entirely is the migration the issue names as the real fix.

3. **`verifyPasscode` accepts the passcode that opens the *first* sealed vault.** That is the right call for recovery — requiring all of them would brick on a single divergent vault. It relies on shares never diverging across vaults, which holds because every share write is atomic per backend: one `chrome.storage.local.set` on the extension, one `tx.Commit` in `SaveVaultsKeyShares` on desktop. Worth stating explicitly, since the design now depends on that invariant.

### Not addressed here

- **Acceptance criterion 3** — the desktop proof still lives in the WebView's localStorage while the shares live in SQLite. This change makes that loss survivable rather than preventing it: with the shares as the authority, a WebView2 reset or a `vultisig.db` restore now unlocks normally, and the reconcile writes the proof back. The remaining exposure is legacy headerless shares, which cannot be recognized as sealed. Co-locating them needs a new SQLite migration, a Go `Store` method, regenerated Wails bindings, and a one-time carry-over of the existing localStorage value — whose own failure mode is the original brick. That is its own PR. **`Fixes #4599` will close the issue with this criterion unchecked, so it needs a linked follow-up issue before merge.**

- **The state an interrupted disable-passcode leaves.** Its write ordering is safe for share access — the shares are already plaintext when the proof write is lost — and the crash test covers that. But the resulting state is a phantom lock: the proof survives, so the lock screen still appears and settings still report passcode encryption as on, while the shares sit unencrypted at rest. Turning it off then fails, because `useDisablePasscodeMutation` tries to decrypt shares that are already plaintext (`OperationError: The provided data is too small`). This predates the PR and is outside what #4599 asks for, but it is a real dead end and deserves its own issue. The fix is small now that `vaultKeySharesArePasscodeEncrypted` exists: skip decryption for vaults that are not recognizably sealed.

- **`clients/extension/tests/**` is not typechecked.** `clients/extension/tsconfig.app.json` includes only `src`, and `clients/extension/tests/tsconfig.json` has `"files": []`, so its program collects no files. The new `passcodeLock.test.ts` is deliberately colocated in `core/ui` for that reason; the crash test was typechecked separately.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #4599
- **Confidence**: high on the extension paths (covered by the injected-crash tests); medium on desktop, where the WebView2 scenario is simulated rather than exercised against a real profile reset
- **Needs human review for**: the decision to keep write ordering unchanged and make disagreement self-repairing instead, rather than reordering or making the writes atomic; and whether the extra per-unlock derivation is an acceptable price for detecting a stale proof

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved passcode recovery after interrupted setup, changes, disabling, or app crashes.
  * Passcode verification now works reliably with current and legacy encrypted vault data.
  * Improved handling of legacy encryption upgrades and concurrent storage updates.
  * More accurately determines when passcode protection or setup is required across settings and vault flows.
  * Repairs stale or missing passcode verification data when appropriate.

* **Tests**
  * Added comprehensive coverage for passcode setup, changes, recovery, disabling, verification, and legacy upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
