### PR TITLE
fix(defi): make Transfer the stake card's last, secondary action

### DIFF
--- a/core/ui/defi/chain/components/stake/StakeCard.tsx
+++ b/core/ui/defi/chain/components/stake/StakeCard.tsx
@@ -90,6 +90,13 @@ type Props = {
   isPendingAction?: boolean
   infoUrl?: string
   onTransfer?: () => void
+  /**
+   * Coin the transfer actually moves. For receipt-backed positions this is the
+   * receipt token (e.g. sRUJI), not the coin shown in the card header.
+   */
+  transferCoin?: Coin
+  /** Base-unit balance of {@link Props.transferCoin}, once resolved. */
+  transferAmount?: bigint
 }
 
 export const StakeCard = ({
@@ -116,12 +123,21 @@ export const StakeCard = ({
   isPendingAction = false,
   infoUrl,
   onTransfer,
+  transferCoin,
+  transferAmount,
 }: Props) => {
   const { t, i18n } = useTranslation()
   const formatFiatAmount = useFormatFiatAmount()
   const unstakeAllowed = canUnstake ?? true
   const unstakeDisabled = actionsDisabled || !unstakeAllowed || isPendingAction
   const stakeDisabled = actionsDisabled || isPendingAction
+  const transferLabel =
+    transferCoin && transferAmount !== undefined
+      ? `${t('transfer')} ${formatAmount(
+          fromChainAmount(transferAmount, transferCoin.decimals),
+          { ticker: transferCoin.ticker }
+        )}`
+      : t('transfer')
   const unstakeMessage =
     !unstakeAllowed && unstakeAvailableDate
       ? t('unstake_available_on', {
@@ -272,21 +288,6 @@ export const StakeCard = ({
             : null}
         </StatRow>
 
-        {onTransfer && (
-          <ActionsRow>
-            {renderAction(
-              <Button
-                onClick={onTransfer}
-                disabled={actionsDisabled || isPendingAction}
-                icon={<ArrowUpRightIcon />}
-              >
-                {t('transfer')}
-              </Button>,
-              { width: '100%' }
-            )}
-          </ActionsRow>
-        )}
-
         <ActionsRow>
           {isSkeleton ? (
             <>
@@ -329,6 +330,22 @@ export const StakeCard = ({
             </>
           )}
         </ActionsRow>
+
+        {onTransfer && (
+          <ActionsRow>
+            {renderAction(
+              <Button
+                kind="secondary"
+                onClick={onTransfer}
+                disabled={actionsDisabled || isPendingAction}
+                icon={<ArrowUpRightIcon />}
+              >
+                {transferLabel}
+              </Button>,
+              { width: '100%' }
+            )}
+          </ActionsRow>
+        )}
         {isPendingAction ? (
           <Text size={12} color="primary">
             {t('adding_coin_to_vault')}

--- a/core/ui/defi/chain/components/stake/TransferableStakeCard.tsx
+++ b/core/ui/defi/chain/components/stake/TransferableStakeCard.tsx
@@ -1,0 +1,35 @@
+import { useBalanceQuery } from '@core/ui/chain/coin/queries/useBalanceQuery'
+import { useCurrentVaultAddress } from '@core/ui/vault/state/currentVaultCoins'
+import { Coin, extractCoinKey } from '@vultisig/core-chain/coin/Coin'
+import { ComponentProps } from 'react'
+
+import { StakeCard } from './StakeCard'
+
+type TransferableStakeCardProps = Omit<
+  ComponentProps<typeof StakeCard>,
+  'transferAmount'
+> & {
+  transferCoin: Coin
+}
+
+/**
+ * Stake card whose Transfer button is labelled with the balance the send flow
+ * will actually move. Receipt-backed positions need this: the auto-compounding
+ * RUJI card shows a RUJI-denominated amount while Transfer sends sRUJI shares,
+ * so the label has to come from the receipt balance rather than the card's own
+ * amount. Until the balance resolves the button falls back to a bare "Transfer".
+ */
+export const TransferableStakeCard = ({
+  transferCoin,
+  ...props
+}: TransferableStakeCardProps) => {
+  const address = useCurrentVaultAddress(transferCoin.chain)
+  const { data } = useBalanceQuery({
+    ...extractCoinKey(transferCoin),
+    address,
+  })
+
+  return (
+    <StakeCard {...props} transferCoin={transferCoin} transferAmount={data} />
+  )
+}

--- a/core/ui/defi/chain/tabs/StakedPositions.tsx
+++ b/core/ui/defi/chain/tabs/StakedPositions.tsx
@@ -13,6 +13,7 @@ import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { StakeCard } from '../components/stake/StakeCard'
+import { TransferableStakeCard } from '../components/stake/TransferableStakeCard'
 import type { StakeUiTranslationKey } from '../config/stakeUiResolver'
 import {
   resolveStakeActions,
@@ -313,42 +314,48 @@ const ThorchainStakedPositions = () => {
           })
         }
 
-        return (
-          <StakeCard
+        const cardProps = {
+          coin: token,
+          title: resolveStakeTitle({
+            position,
+            coin: token,
+            translate,
+          }),
+          amount: position.amount,
+          fiat: position.fiatValue,
+          apr: position.apr,
+          estimatedReward: position.estimatedReward,
+          rewards: position.rewards,
+          rewardTicker: position.rewardTicker,
+          nextPayout: position.nextPayout,
+          actionsDisabled: cardActionsDisabled,
+          actionsDisabledReason,
+          canUnstake: position.canUnstake,
+          unstakeAvailableDate: position.unstakeAvailableDate,
+          stakeLabel,
+          unstakeLabel,
+          hideStats,
+          isPendingAction: pendingEnableById[position.id],
+          onStake: () => handleNavigate(stakeAction),
+          onUnstake: () => handleNavigate(unstakeAction),
+          onWithdrawRewards:
+            position.rewards && position.rewards > 0
+              ? () => handleNavigate('withdraw_ruji_rewards')
+              : undefined,
+          infoUrl: position.id === 'thor-stake-stcy' ? stcyInfoUrl : undefined,
+        }
+
+        // The transferable variant reads the receipt token's own balance, so
+        // the Transfer label matches what the send flow will move.
+        return canTransfer && transferToken ? (
+          <TransferableStakeCard
             key={position.id}
-            coin={token}
-            title={resolveStakeTitle({
-              position,
-              coin: token,
-              translate,
-            })}
-            amount={position.amount}
-            fiat={position.fiatValue}
-            apr={position.apr}
-            estimatedReward={position.estimatedReward}
-            rewards={position.rewards}
-            rewardTicker={position.rewardTicker}
-            nextPayout={position.nextPayout}
-            actionsDisabled={cardActionsDisabled}
-            actionsDisabledReason={actionsDisabledReason}
-            canUnstake={position.canUnstake}
-            unstakeAvailableDate={position.unstakeAvailableDate}
-            stakeLabel={stakeLabel}
-            unstakeLabel={unstakeLabel}
-            hideStats={hideStats}
-            isPendingAction={pendingEnableById[position.id]}
-            onStake={() => handleNavigate(stakeAction)}
-            onUnstake={() => handleNavigate(unstakeAction)}
-            onWithdrawRewards={
-              position.rewards && position.rewards > 0
-                ? () => handleNavigate('withdraw_ruji_rewards')
-                : undefined
-            }
-            infoUrl={
-              position.id === 'thor-stake-stcy' ? stcyInfoUrl : undefined
-            }
-            onTransfer={canTransfer ? handleTransfer : undefined}
+            {...cardProps}
+            onTransfer={handleTransfer}
+            transferCoin={transferToken}
           />
+        ) : (
+          <StakeCard key={position.id} {...cardProps} />
         )
       })}
     </VStack>


### PR DESCRIPTION
## What

Closes #4547.

The staked-position card rendered three of its four actions as primary buttons, with Transfer sitting second. Per Figma only Withdraw and Stake are primary, and Transfer is a secondary full-width button at the bottom carrying the amount it will send.

| | Before | After |
|---|---|---|
| Withdraw | primary, first | unchanged |
| Unstake / Stake | row, last | row, middle |
| Transfer | primary, second, plain label | **secondary, last, amount in label** |

The issue also flagged the card's hand-rolled `ActionButton`; that was already resolved by #4620, so this change is scoped to hierarchy, order, and the label.

## Why the amount comes from a balance query

The Transfer label uses the receipt token's own balance rather than the position amount shown on the card. They are not the same number:

| Position | Card amount | Transfer sends | Same? |
|---|---|---|---|
| sTCY | share balance | sTCY | yes |
| ybRUNE | share balance | ybRUNE | yes |
| RUJI (auto-compounding) | `liquidSize`, the sRUJI receipt priced in RUJI | sRUJI shares | **no** |

Labelling the button with the card's amount would promise a number the send screen then contradicts. `TransferableStakeCard` reads the balance the same way the send flow will, so the two always agree; the button falls back to a bare "Transfer" until it resolves.

## Scope

Shared `core/ui`, so this covers desktop and the extension, and every chain using `StakeCard`.

## Testing

- `yarn check` clean (typecheck + lint + knip)
- `yarn vitest run core/ui/defi` — 29 passed
- `yarn build:extension` succeeded

## Note for the reviewer

The Figma buttons draw the icon inside a circular badge pinned to the left edge. The shared `Button` renders icons inline, so the cards do not have it — #4620 removed the per-card `ActionIcon` badge on the reading that the design system places icons inline. Deliberately left alone here; it belongs in the shared Button, across `StakeCard`, `BondNodeItem` and `LpPositions` together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transfer support for eligible staked positions with transferable receipt tokens.
  * Transfer actions now display the available transferable amount when applicable.
  * Transfer controls appear separately from stake and unstake actions with updated secondary styling.
* **Bug Fixes**
  * Preserved existing staking, unstaking, reward withdrawal, disabled-state, and information-link behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->