### PR TITLE
fix(tron): include memo fee in network estimates

### DIFF
--- a/core/inpage-provider/popup/view/resolvers/sendTx/SendTxOverview.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/SendTxOverview.tsx
@@ -23,6 +23,7 @@ import { useAssertWalletCore } from '@core/ui/chain/providers/WalletCoreProvider
 import { BlockaidEvmSimulationView } from '@core/ui/chain/security/blockaid/tx/blockaidEvmSimulationView'
 import { useEvmContractCallInfoQuery } from '@core/ui/chain/tx/utils/useEvmContractCallInfoQuery'
 import { useUniversalRouterSwap } from '@core/ui/chain/tx/utils/useUniversalRouterSwap'
+import { getKeysignFeeAmount } from '@core/ui/mpc/keysign/fee/tronMemoFee'
 import { VerifyKeysignStart } from '@core/ui/mpc/keysign/start/VerifyKeysignStart'
 import { SignAminoDisplay } from '@core/ui/mpc/keysign/tx/components/SignAminoDisplay'
 import { SignDirectDisplay } from '@core/ui/mpc/keysign/tx/components/SignDirectDisplay'
@@ -68,7 +69,6 @@ import { parseBlockaidSuiSimulation } from '@vultisig/core-chain/security/blocka
 import { BlockaidSolanaSimulationInfo } from '@vultisig/core-chain/security/blockaid/tx/simulation/core'
 import { FeeSettings } from '@vultisig/core-mpc/keysign/chainSpecific/FeeSettings'
 import { getBlockchainSpecificValue } from '@vultisig/core-mpc/keysign/chainSpecific/KeysignChainSpecific'
-import { getFeeAmount } from '@vultisig/core-mpc/keysign/fee'
 import { getKeysignChain } from '@vultisig/core-mpc/keysign/utils/getKeysignChain'
 import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
@@ -135,7 +135,7 @@ export const SendTxOverview = ({
       walletCore,
     ],
     queryFn: () =>
-      getFeeAmount({
+      getKeysignFeeAmount({
         keysignPayload: shouldBePresent(keysignPayloadQuery.data),
         walletCore,
         publicKey: shouldBePresent(publicKey),

--- a/core/ui/mpc/keysign/fee/tronMemoFee.test.ts
+++ b/core/ui/mpc/keysign/fee/tronMemoFee.test.ts
@@ -55,6 +55,33 @@ describe('fetchTronMemoFee', () => {
   ])('falls back to 1 TRX for %s', async (_, fetcher) => {
     await expect(fetchTronMemoFee(fetcher)).resolves.toBe(1_000_000n)
   })
+
+  it('aborts a stalled request and falls back to 1 TRX', async () => {
+    vi.useFakeTimers()
+
+    try {
+      let requestSignal: AbortSignal | undefined
+      const fetcher = vi.fn<typeof fetch>().mockImplementation((_, init) => {
+        requestSignal = init?.signal ?? undefined
+
+        return new Promise<Response>((_, reject) => {
+          requestSignal?.addEventListener(
+            'abort',
+            () => reject(new DOMException('Aborted', 'AbortError')),
+            { once: true }
+          )
+        })
+      })
+
+      const result = fetchTronMemoFee(fetcher)
+      await vi.advanceTimersByTimeAsync(10_000)
+
+      await expect(result).resolves.toBe(1_000_000n)
+      expect(requestSignal?.aborted).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })
 
 describe('paysTronMemoFee', () => {

--- a/core/ui/mpc/keysign/fee/tronMemoFee.test.ts
+++ b/core/ui/mpc/keysign/fee/tronMemoFee.test.ts
@@ -1,0 +1,128 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  addTronMemoFee,
+  fetchTronMemoFee,
+  paysTronMemoFee,
+} from './tronMemoFee'
+
+describe('fetchTronMemoFee', () => {
+  it('reads getMemoFee from the chain parameters', async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          chainParameter: [{ key: 'getMemoFee', value: 2_000_000 }],
+        }),
+        { status: 200 }
+      )
+    )
+
+    await expect(fetchTronMemoFee(fetcher)).resolves.toBe(2_000_000n)
+    expect(fetcher).toHaveBeenCalledWith(
+      expect.stringMatching(/\/wallet\/getchainparameters$/),
+      expect.objectContaining({ method: 'POST', body: '{}' })
+    )
+  })
+
+  it.each([
+    ['an RPC failure', vi.fn<typeof fetch>().mockRejectedValue(new Error())],
+    [
+      'a failed response',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(new Response(null, { status: 500 })),
+    ],
+    [
+      'a missing parameter',
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(
+          new Response(JSON.stringify({ chainParameter: [] }), { status: 200 })
+        ),
+    ],
+    [
+      'a malformed parameter',
+      vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            chainParameter: [{ key: 'getMemoFee', value: -1 }],
+          }),
+          { status: 200 }
+        )
+      ),
+    ],
+  ])('falls back to 1 TRX for %s', async (_, fetcher) => {
+    await expect(fetchTronMemoFee(fetcher)).resolves.toBe(1_000_000n)
+  })
+})
+
+describe('paysTronMemoFee', () => {
+  const nativeTron = {
+    chain: Chain.Tron,
+    isNativeToken: true,
+  }
+
+  it.each(['memo', ' ', 'freeze:bandwidth', 'FREEZE:', 'FREEZE:CPU'])(
+    'charges a signed memo: %s',
+    memo => {
+      expect(paysTronMemoFee({ ...nativeTron, memo })).toBe(true)
+    }
+  )
+
+  it.each([
+    'FREEZE:BANDWIDTH',
+    'FREEZE:ENERGY',
+    'UNFREEZE:BANDWIDTH',
+    'UNFREEZE:ENERGY',
+  ])('does not charge the unsigned staking marker: %s', memo => {
+    expect(paysTronMemoFee({ ...nativeTron, memo })).toBe(false)
+  })
+
+  it('does not charge an empty memo, another chain, or a TRC20 transfer', () => {
+    expect(paysTronMemoFee({ ...nativeTron, memo: '' })).toBe(false)
+    expect(
+      paysTronMemoFee({
+        chain: Chain.Ethereum,
+        isNativeToken: true,
+        memo: 'memo',
+      })
+    ).toBe(false)
+    expect(
+      paysTronMemoFee({
+        chain: Chain.Tron,
+        isNativeToken: false,
+        memo: 'memo',
+      })
+    ).toBe(false)
+  })
+})
+
+describe('addTronMemoFee', () => {
+  it('adds the chain memo fee to the existing bandwidth estimate', async () => {
+    await expect(
+      addTronMemoFee({
+        fee: 800_000n,
+        chain: Chain.Tron,
+        isNativeToken: true,
+        memo: 'memo',
+        memoFee: async () => 1_000_000n,
+      })
+    ).resolves.toBe(1_800_000n)
+  })
+
+  it('does not request the memo fee when no signed memo is present', async () => {
+    const memoFee = vi.fn(async () => 1_000_000n)
+
+    await expect(
+      addTronMemoFee({
+        fee: 800_000n,
+        chain: Chain.Tron,
+        isNativeToken: true,
+        memo: '',
+        memoFee,
+      })
+    ).resolves.toBe(800_000n)
+    expect(memoFee).not.toHaveBeenCalled()
+  })
+})

--- a/core/ui/mpc/keysign/fee/tronMemoFee.ts
+++ b/core/ui/mpc/keysign/fee/tronMemoFee.ts
@@ -1,0 +1,121 @@
+import { getTronStakingDisplay } from '@core/ui/chain/tx/getTronStakingDisplay'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { tronRpcUrl } from '@vultisig/core-chain/chains/tron/config'
+import { isFeeCoin } from '@vultisig/core-chain/coin/utils/isFeeCoin'
+import { getFeeAmount } from '@vultisig/core-mpc/keysign/fee'
+import { getSendFeeEstimate } from '@vultisig/core-mpc/keysign/send/getSendFeeEstimate'
+import { getKeysignChain } from '@vultisig/core-mpc/keysign/utils/getKeysignChain'
+
+const defaultTronMemoFee = 1_000_000n
+
+type TronChainParameter = {
+  key?: unknown
+  value?: unknown
+}
+
+type TronChainParametersResponse = {
+  chainParameter?: unknown
+}
+
+const parseMemoFee = (value: unknown): bigint | undefined => {
+  if (typeof value === 'bigint') return value >= 0n ? value : undefined
+
+  if (typeof value === 'number') {
+    return Number.isSafeInteger(value) && value >= 0 ? BigInt(value) : undefined
+  }
+
+  if (typeof value === 'string' && /^\d+$/.test(value)) {
+    return BigInt(value)
+  }
+
+  return undefined
+}
+
+export const fetchTronMemoFee = async (
+  fetcher: typeof fetch = fetch
+): Promise<bigint> => {
+  try {
+    const response = await fetcher(`${tronRpcUrl}/wallet/getchainparameters`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    })
+
+    if (!response.ok) return defaultTronMemoFee
+
+    const data = (await response.json()) as TronChainParametersResponse
+    if (!Array.isArray(data.chainParameter)) return defaultTronMemoFee
+
+    const memoParameter = (data.chainParameter as TronChainParameter[]).find(
+      parameter => parameter.key === 'getMemoFee'
+    )
+
+    return parseMemoFee(memoParameter?.value) ?? defaultTronMemoFee
+  } catch {
+    return defaultTronMemoFee
+  }
+}
+
+let tronMemoFeePromise: Promise<bigint> | undefined
+
+const getTronMemoFee = () => {
+  tronMemoFeePromise ??= fetchTronMemoFee()
+  return tronMemoFeePromise
+}
+
+type TronMemoFeeInput = {
+  chain: Chain
+  isNativeToken: boolean
+  memo?: string
+}
+
+export const paysTronMemoFee = ({
+  chain,
+  isNativeToken,
+  memo,
+}: TronMemoFeeInput) =>
+  chain === Chain.Tron &&
+  isNativeToken &&
+  !!memo &&
+  !getTronStakingDisplay({ chain, memo })
+
+type AddTronMemoFeeInput = TronMemoFeeInput & {
+  fee: bigint
+  memoFee?: () => Promise<bigint>
+}
+
+export const addTronMemoFee = async ({
+  fee,
+  memoFee = getTronMemoFee,
+  ...input
+}: AddTronMemoFeeInput) =>
+  paysTronMemoFee(input) ? fee + (await memoFee()) : fee
+
+type GetKeysignFeeAmountInput = Parameters<typeof getFeeAmount>[0]
+
+export const getKeysignFeeAmount = async (input: GetKeysignFeeAmountInput) => {
+  const fee = await getFeeAmount(input)
+  const { keysignPayload } = input
+
+  return addTronMemoFee({
+    fee,
+    chain: getKeysignChain(keysignPayload),
+    isNativeToken: keysignPayload.coin?.isNativeToken ?? false,
+    memo: keysignPayload.memo,
+  })
+}
+
+type GetSendFeeEstimateInput = Parameters<typeof getSendFeeEstimate>[0]
+
+export const getSendFeeEstimateWithTronMemo = async (
+  input: GetSendFeeEstimateInput
+) => {
+  const fee = await getSendFeeEstimate(input)
+
+  return addTronMemoFee({
+    fee,
+    chain: input.coin.chain,
+    isNativeToken: isFeeCoin(input.coin),
+    memo: input.memo,
+  })
+}

--- a/core/ui/mpc/keysign/fee/tronMemoFee.ts
+++ b/core/ui/mpc/keysign/fee/tronMemoFee.ts
@@ -5,8 +5,10 @@ import { isFeeCoin } from '@vultisig/core-chain/coin/utils/isFeeCoin'
 import { getFeeAmount } from '@vultisig/core-mpc/keysign/fee'
 import { getSendFeeEstimate } from '@vultisig/core-mpc/keysign/send/getSendFeeEstimate'
 import { getKeysignChain } from '@vultisig/core-mpc/keysign/utils/getKeysignChain'
+import { attempt } from '@vultisig/lib-utils/attempt'
 
 const defaultTronMemoFee = 1_000_000n
+const tronMemoFeeRequestTimeoutMs = 10_000
 
 type TronChainParameter = {
   key?: unknown
@@ -34,25 +36,41 @@ const parseMemoFee = (value: unknown): bigint | undefined => {
 export const fetchTronMemoFee = async (
   fetcher: typeof fetch = fetch
 ): Promise<bigint> => {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    tronMemoFeeRequestTimeoutMs
+  )
+
   try {
-    const response = await fetcher(`${tronRpcUrl}/wallet/getchainparameters`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: '{}',
+    const result = await attempt(async () => {
+      const response = await fetcher(
+        `${tronRpcUrl}/wallet/getchainparameters`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: '{}',
+          signal: controller.signal,
+        }
+      )
+
+      if (!response.ok) return undefined
+
+      const data = (await response.json()) as TronChainParametersResponse
+      if (!Array.isArray(data.chainParameter)) return undefined
+
+      const memoParameter = (data.chainParameter as TronChainParameter[]).find(
+        parameter => parameter.key === 'getMemoFee'
+      )
+
+      return parseMemoFee(memoParameter?.value)
     })
 
-    if (!response.ok) return defaultTronMemoFee
-
-    const data = (await response.json()) as TronChainParametersResponse
-    if (!Array.isArray(data.chainParameter)) return defaultTronMemoFee
-
-    const memoParameter = (data.chainParameter as TronChainParameter[]).find(
-      parameter => parameter.key === 'getMemoFee'
-    )
-
-    return parseMemoFee(memoParameter?.value) ?? defaultTronMemoFee
-  } catch {
-    return defaultTronMemoFee
+    return 'error' in result
+      ? defaultTronMemoFee
+      : (result.data ?? defaultTronMemoFee)
+  } finally {
+    clearTimeout(timeoutId)
   }
 }
 

--- a/core/ui/mpc/keysign/fee/useKeysignFee.ts
+++ b/core/ui/mpc/keysign/fee/useKeysignFee.ts
@@ -1,12 +1,12 @@
 import { useQuery } from '@tanstack/react-query'
 import { getChainKind } from '@vultisig/core-chain/ChainKind'
 import { getBlockchainSpecificValue } from '@vultisig/core-mpc/keysign/chainSpecific/KeysignChainSpecific'
-import { getFeeAmount } from '@vultisig/core-mpc/keysign/fee'
 import { getKeysignChain } from '@vultisig/core-mpc/keysign/utils/getKeysignChain'
 import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
 
 import { useAssertWalletCore } from '../../../chain/providers/WalletCoreProvider'
 import { useCurrentVaultNullablePublicKey } from '../../../vault/state/currentVault'
+import { getKeysignFeeAmount } from './tronMemoFee'
 
 export const useKeysignFee = (keysignPayload: KeysignPayload) => {
   const chain = getKeysignChain(keysignPayload)
@@ -17,7 +17,7 @@ export const useKeysignFee = (keysignPayload: KeysignPayload) => {
     queryKey: ['keysignFee', keysignPayload, publicKey, walletCore],
     queryFn: () => {
       if (publicKey !== null) {
-        return getFeeAmount({
+        return getKeysignFeeAmount({
           keysignPayload,
           walletCore,
           publicKey,

--- a/core/ui/vault/send/queries/useSendFeeEstimateQuery.ts
+++ b/core/ui/vault/send/queries/useSendFeeEstimateQuery.ts
@@ -8,12 +8,12 @@ import { noRefetchQueryOptions } from '@lib/ui/query/utils/options'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { extractAccountCoinKey } from '@vultisig/core-chain/coin/AccountCoin'
 import { BuildKeysignPayloadError } from '@vultisig/core-mpc/keysign/error'
-import { getSendFeeEstimate } from '@vultisig/core-mpc/keysign/send/getSendFeeEstimate'
 import { toKeysignLibType } from '@vultisig/core-mpc/types/utils/libType'
 import { getVaultId } from '@vultisig/core-mpc/vault/Vault'
 import { omit } from '@vultisig/lib-utils/record/omit'
 import { useMemo } from 'react'
 
+import { getSendFeeEstimateWithTronMemo } from '../../../mpc/keysign/fee/tronMemoFee'
 import { useSendDestinationTag } from '../state/destinationTag'
 import { useSendMemo } from '../state/memo'
 import { useSendReceiver } from '../state/receiver'
@@ -64,7 +64,7 @@ export const useSendFeeEstimateQuery = () => {
       'sendFeeEstimate',
       input ? omit(input, 'walletCore', 'publicKey') : null,
     ],
-    queryFn: () => getSendFeeEstimate(input!),
+    queryFn: () => getSendFeeEstimateWithTronMemo(input!),
     enabled: !!receiver && balance != null && input != null,
     placeholderData: keepPreviousData,
     ...noRefetchQueryOptions,

--- a/core/ui/vault/swap/queries/useSwapFeesQuery.ts
+++ b/core/ui/vault/swap/queries/useSwapFeesQuery.ts
@@ -2,10 +2,10 @@ import { useTransformQueryDataAsync } from '@lib/ui/query/hooks/useTransformQuer
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { areEqualCoins } from '@vultisig/core-chain/coin/Coin'
 import { SwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
-import { getFeeAmount } from '@vultisig/core-mpc/keysign/fee'
 import { useCallback, useMemo } from 'react'
 
 import { useAssertWalletCore } from '../../../chain/providers/WalletCoreProvider'
+import { getKeysignFeeAmount } from '../../../mpc/keysign/fee/tronMemoFee'
 import { useCurrentVaultPublicKey } from '../../state/currentVault'
 import { useCurrentVaultCoins } from '../../state/currentVaultCoins'
 import { getSwapQuoteAffiliateBps } from '../affiliate/affiliateBps'
@@ -40,7 +40,7 @@ export const useSwapFeesQuery = (swapQuote: SwapQuote) => {
 
         const network = {
           ...fromFeeCoin,
-          amount: await getFeeAmount({
+          amount: await getKeysignFeeAmount({
             keysignPayload,
             walletCore,
             publicKey,


### PR DESCRIPTION
Closes #4420
Closes #4420.

Native TRON transactions with a signed non-empty memo now include the live `getMemoFee` chain parameter in every desktop fee estimate, with the network default as a fallback. TRC20 transfers and internal staking markers remain unchanged.

Real desktop QA prepared a 0.1 TRX send with memo `qa memo`; Send Overview displayed `Est. Network Fee 1 TRX` before signing, and no transaction was broadcast.

![screenshot-1](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/4420-tron-memo-fee/screenshot-1-1787041724688.jpg)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Tron memo fees in transaction, key signing, sending, and swap fee estimates.
  * Fees are applied only to eligible native Tron transactions, excluding staking-related actions.
  * Added fallback handling when Tron fee information is unavailable or invalid.

* **Tests**
  * Added coverage for fee retrieval, fallback behavior, eligibility detection, and fee calculation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->