### PR TITLE
fix(security): show Blockaid scan failures as unavailable

### DIFF
--- a/core/ui/chain/security/blockaid/tx/BlockaidTxScanStatus.stories.tsx
+++ b/core/ui/chain/security/blockaid/tx/BlockaidTxScanStatus.stories.tsx
@@ -1,0 +1,44 @@
+import { getResolvedQuery, Query } from '@lib/ui/query/Query'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import styled from 'styled-components'
+
+import { BlockaidTxScanStatus } from './BlockaidTxScanStatus'
+import { BlockaidTxScanResult } from './queries/blockaidTxValidation'
+
+const meta = {
+  title: 'Chain/Security/BlockaidTxScanStatus',
+  component: BlockaidTxScanStatus,
+  decorators: [
+    Story => (
+      <StatusSurface>
+        <Story />
+      </StatusSurface>
+    ),
+  ],
+} satisfies Meta<typeof BlockaidTxScanStatus>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const StatusSurface = styled.div`
+  width: min(100%, 460px);
+  margin: 32px auto;
+`
+
+const providerErrorQuery: Query<BlockaidTxScanResult | undefined> = {
+  data: undefined,
+  error: new Error('Blockaid could not complete the transaction scan'),
+  isPending: false,
+}
+
+export const ProviderError: Story = {
+  args: {
+    value: providerErrorQuery,
+  },
+}
+
+export const Benign: Story = {
+  args: {
+    value: getResolvedQuery(null),
+  },
+}

--- a/core/ui/chain/security/blockaid/tx/queries/blockaidTxValidation.test.ts
+++ b/core/ui/chain/security/blockaid/tx/queries/blockaidTxValidation.test.ts
@@ -1,0 +1,68 @@
+import { getTxBlockaidValidation } from '@vultisig/core-chain/security/blockaid/tx/validation'
+import {
+  BlockaidValidation,
+  parseBlockaidValidation,
+} from '@vultisig/core-chain/security/blockaid/tx/validation/api/core'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getBlockaidTxValidationQuery } from './blockaidTxValidation'
+
+vi.mock('@vultisig/core-chain/security/blockaid/tx/validation', () => ({
+  getTxBlockaidValidation: vi.fn(),
+}))
+
+vi.mock(
+  '@vultisig/core-chain/security/blockaid/tx/validation/api/core',
+  () => ({
+    parseBlockaidValidation: vi.fn(),
+  })
+)
+
+const input = {} as Parameters<typeof getBlockaidTxValidationQuery>[0]
+
+const runQuery = () => getBlockaidTxValidationQuery(input).queryFn()
+
+describe('getBlockaidTxValidationQuery', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it.each([{ result_type: 'Error' }, { status: 'Error' }])(
+    'rejects a provider-side scan error: %o',
+    async validation => {
+      vi.mocked(getTxBlockaidValidation).mockResolvedValue(
+        validation as unknown as BlockaidValidation
+      )
+
+      await expect(runQuery()).rejects.toThrow(
+        'Blockaid could not complete the transaction scan'
+      )
+      expect(parseBlockaidValidation).not.toHaveBeenCalled()
+    }
+  )
+
+  it('preserves a successful benign scan result', async () => {
+    const validation: BlockaidValidation = { result_type: 'Benign' }
+    vi.mocked(getTxBlockaidValidation).mockResolvedValue(validation)
+    vi.mocked(parseBlockaidValidation).mockReturnValue(null)
+
+    await expect(runQuery()).resolves.toBeNull()
+    expect(parseBlockaidValidation).toHaveBeenCalledWith(validation)
+  })
+
+  it('preserves a successful risky scan result and description', async () => {
+    const validation: BlockaidValidation = {
+      result_type: 'Malicious',
+      description: 'Known malicious destination',
+    }
+    vi.mocked(getTxBlockaidValidation).mockResolvedValue(validation)
+    vi.mocked(parseBlockaidValidation).mockReturnValue({
+      level: 'high',
+    })
+
+    await expect(runQuery()).resolves.toEqual({
+      level: 'high',
+      description: 'Known malicious destination',
+    })
+  })
+})

--- a/core/ui/chain/security/blockaid/tx/queries/blockaidTxValidation.test.ts
+++ b/core/ui/chain/security/blockaid/tx/queries/blockaidTxValidation.test.ts
@@ -1,8 +1,10 @@
+import { UtxoChain } from '@vultisig/core-chain/Chain'
 import { getTxBlockaidValidation } from '@vultisig/core-chain/security/blockaid/tx/validation'
 import {
   BlockaidValidation,
   parseBlockaidValidation,
 } from '@vultisig/core-chain/security/blockaid/tx/validation/api/core'
+import { BlockaidTxValidationInput } from '@vultisig/core-chain/security/blockaid/tx/validation/resolver'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getBlockaidTxValidationQuery } from './blockaidTxValidation'
@@ -18,7 +20,10 @@ vi.mock(
   })
 )
 
-const input = {} as Parameters<typeof getBlockaidTxValidationQuery>[0]
+const input = {
+  chain: UtxoChain.Bitcoin,
+  data: { raw_transaction: 'synthetic-transaction' },
+} satisfies BlockaidTxValidationInput
 
 const runQuery = () => getBlockaidTxValidationQuery(input).queryFn()
 
@@ -27,19 +32,18 @@ describe('getBlockaidTxValidationQuery', () => {
     vi.resetAllMocks()
   })
 
-  it.each([{ result_type: 'Error' }, { status: 'Error' }])(
-    'rejects a provider-side scan error: %o',
-    async validation => {
-      vi.mocked(getTxBlockaidValidation).mockResolvedValue(
-        validation as unknown as BlockaidValidation
-      )
+  it.each([
+    { result_type: 'Error' },
+    { result_type: 'Benign', status: 'Error' },
+  ])('rejects a provider-side scan error: %o', async validation => {
+    vi.mocked(getTxBlockaidValidation).mockResolvedValue(validation)
 
-      await expect(runQuery()).rejects.toThrow(
-        'Blockaid could not complete the transaction scan'
-      )
-      expect(parseBlockaidValidation).not.toHaveBeenCalled()
-    }
-  )
+    await expect(runQuery()).rejects.toThrow(
+      'Blockaid could not complete the transaction scan'
+    )
+    expect(getTxBlockaidValidation).toHaveBeenCalledWith(input)
+    expect(parseBlockaidValidation).not.toHaveBeenCalled()
+  })
 
   it('preserves a successful benign scan result', async () => {
     const validation: BlockaidValidation = { result_type: 'Benign' }

--- a/core/ui/chain/security/blockaid/tx/queries/blockaidTxValidation.test.ts
+++ b/core/ui/chain/security/blockaid/tx/queries/blockaidTxValidation.test.ts
@@ -34,7 +34,11 @@ describe('getBlockaidTxValidationQuery', () => {
 
   it.each([
     { result_type: 'Error' },
+    { result_type: 'error' },
+    { result_type: 'eRrOr' },
     { result_type: 'Benign', status: 'Error' },
+    { result_type: 'Benign', status: 'error' },
+    { result_type: 'Benign', status: 'eRrOr' },
   ])('rejects a provider-side scan error: %o', async validation => {
     vi.mocked(getTxBlockaidValidation).mockResolvedValue(validation)
 

--- a/core/ui/chain/security/blockaid/tx/queries/blockaidTxValidation.ts
+++ b/core/ui/chain/security/blockaid/tx/queries/blockaidTxValidation.ts
@@ -12,6 +12,17 @@ export type BlockaidTxScanResult = {
   description?: string
 } | null
 
+type BlockaidValidationWithStatus = BlockaidValidation & {
+  status?: unknown
+}
+
+const isBlockaidErrorValue = (value: unknown) =>
+  typeof value === 'string' && value.toLowerCase() === 'error'
+
+const isBlockaidValidationError = (validation: BlockaidValidation) =>
+  isBlockaidErrorValue(validation.result_type) ||
+  isBlockaidErrorValue((validation as BlockaidValidationWithStatus).status)
+
 const getValidationDescription = ({
   description,
   features,
@@ -35,6 +46,11 @@ export const getBlockaidTxValidationQuery = (
   queryKey: ['blockaidTxValidation', input],
   queryFn: async (): Promise<BlockaidTxScanResult> => {
     const validation = await getTxBlockaidValidation(input)
+
+    if (isBlockaidValidationError(validation)) {
+      throw new Error('Blockaid could not complete the transaction scan')
+    }
+
     const result = parseBlockaidValidation(validation)
 
     if (!result) {

--- a/core/ui/chain/security/blockaid/tx/queries/blockaidTxValidation.ts
+++ b/core/ui/chain/security/blockaid/tx/queries/blockaidTxValidation.ts
@@ -12,16 +12,12 @@ export type BlockaidTxScanResult = {
   description?: string
 } | null
 
-type BlockaidValidationWithStatus = BlockaidValidation & {
-  status?: unknown
-}
-
 const isBlockaidErrorValue = (value: unknown) =>
   typeof value === 'string' && value.toLowerCase() === 'error'
 
 const isBlockaidValidationError = (validation: BlockaidValidation) =>
   isBlockaidErrorValue(validation.result_type) ||
-  isBlockaidErrorValue((validation as BlockaidValidationWithStatus).status)
+  ('status' in validation && isBlockaidErrorValue(validation.status))
 
 const getValidationDescription = ({
   description,


### PR DESCRIPTION
Closes #4478
Blockaid HTTP-200 provider failures now reach the existing neutral not-scanned state instead of the benign green result. Live Vultisig proxy QA reproduced status Error / Simulation failed, and the committed query rejected it while confirmed-benign rendering remained unchanged.

![screenshot-1](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/4478-blockaid-scan-error-state/screenshot-1-1787041759603.png)
![screenshot-2](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/4478-blockaid-scan-error-state/screenshot-2-1787041759603.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction security validation to recognize provider-reported errors, regardless of capitalization.
  * Prevented invalid provider responses from being processed as scan results.

* **Tests**
  * Added coverage for provider errors, benign results, and malicious results with descriptions.

* **Documentation**
  * Added interactive examples demonstrating provider-error and benign transaction scan states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->