### PR TITLE
Harden passcode policy and attempt throttling

### DIFF
--- a/clients/extension/tests/e2e/specs/passcode-lock-layering.spec.ts
+++ b/clients/extension/tests/e2e/specs/passcode-lock-layering.spec.ts
@@ -32,7 +32,7 @@ import {
 } from '../helpers/vault-import'
 import { VaultPage } from '../page-objects/VaultPage.po'
 
-const passcode = '13579'
+const passcode = '135790'
 const autoLockMinutes = 1
 // Exact `en.ts` strings. `getByText` matches case-insensitively, but
 // `topLayerTextAt` compares raw textContent, so the casing has to be right.
@@ -97,14 +97,14 @@ const enablePasscode = async (page: Page) => {
 
   await page.getByText('OFF', { exact: true }).first().click()
 
-  // Two PasscodeInputs, each a row of five single-character boxes that advance
-  // focus on input — so typing five characters fills one row.
+  // Two PasscodeInputs, each a row of six single-character boxes that advance
+  // focus on input — so typing six characters fills one row.
   const digitBoxes = page.locator('input[type="password"]')
-  await expect(digitBoxes).toHaveCount(10)
+  await expect(digitBoxes).toHaveCount(12)
 
   await digitBoxes.first().click()
   await page.keyboard.type(passcode)
-  await digitBoxes.nth(5).click()
+  await digitBoxes.nth(6).click()
   await page.keyboard.type(passcode)
 
   await page.getByRole('button', { name: /set passcode/i }).click()

--- a/clients/extension/tests/unit/passcodeCrashRecovery.test.tsx
+++ b/clients/extension/tests/unit/passcodeCrashRecovery.test.tsx
@@ -71,8 +71,8 @@ vi.mock('@core/ui/state/core', () => ({
 
 coreHolder.value = { ...vaultsStorage, ...passcodeEncryptionStorage }
 
-const passcode = '123456'
-const newPasscode = '654321'
+const passcode = '135790'
+const newPasscode = '246801'
 
 const ecdsaShare = 'ecdsa-key-share-plaintext'
 const eddsaShare = 'eddsa-key-share-plaintext'

--- a/core/ui/passcodeEncryption/core/config.ts
+++ b/core/ui/passcodeEncryption/core/config.ts
@@ -1,3 +1,7 @@
 export const passcodeEncryptionConfig = {
-  passcodeLength: 5,
+  passcodeLength: 6,
+  legacyPasscodeLength: 5,
+  freeAttempts: 3,
+  baseDelayMs: 5_000,
+  maximumDelayMs: 15 * 60 * 1_000,
 } as const

--- a/core/ui/passcodeEncryption/core/passcodeAttemptThrottle.test.ts
+++ b/core/ui/passcodeEncryption/core/passcodeAttemptThrottle.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { PasscodeAttemptState } from './passcodeAttemptThrottle'
+import {
+  getPasscodeAttemptDelayMs,
+  recordFailedPasscodeAttempt,
+  withPasscodeOperationLock,
+} from './passcodeAttemptThrottle'
+
+describe('passcodeAttemptThrottle', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('allows three slips before applying an escalating delay', () => {
+    let state: PasscodeAttemptState | undefined
+    const now = 1_000
+
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+      state = recordFailedPasscodeAttempt({ state, now })
+      expect(getPasscodeAttemptDelayMs({ state, now })).toBe(0)
+    }
+
+    state = recordFailedPasscodeAttempt({ state, now })
+    expect(getPasscodeAttemptDelayMs({ state, now })).toBe(5_000)
+
+    state = recordFailedPasscodeAttempt({ state, now })
+    expect(getPasscodeAttemptDelayMs({ state, now })).toBe(10_000)
+
+    state = recordFailedPasscodeAttempt({ state, now })
+    expect(getPasscodeAttemptDelayMs({ state, now })).toBe(20_000)
+  })
+
+  it('counts down, resists a backwards clock jump, and caps at 15 minutes', () => {
+    const fourthFailure = { failedAttempts: 4, lastFailedAt: 10_000 }
+
+    expect(
+      getPasscodeAttemptDelayMs({ state: fourthFailure, now: 12_000 })
+    ).toBe(3_000)
+    expect(
+      getPasscodeAttemptDelayMs({ state: fourthFailure, now: 9_000 })
+    ).toBe(5_000)
+
+    const manyFailures = { failedAttempts: 100, lastFailedAt: 10_000 }
+    expect(
+      getPasscodeAttemptDelayMs({ state: manyFailures, now: 10_000 })
+    ).toBe(900_000)
+  })
+
+  it('serializes attempt mutations through the shared browser lock', async () => {
+    const request = vi.fn(
+      async (_name: string, operation: () => Promise<string>) => operation()
+    )
+    vi.stubGlobal('navigator', { locks: { request } })
+
+    await expect(
+      withPasscodeOperationLock(async () => 'complete')
+    ).resolves.toBe('complete')
+    expect(request).toHaveBeenCalledWith(
+      'vultisig-passcode-operation',
+      expect.any(Function)
+    )
+  })
+
+  it('keeps attempt handling available when Web Locks are unavailable', async () => {
+    vi.stubGlobal('navigator', {})
+
+    await expect(
+      withPasscodeOperationLock(async () => 'complete')
+    ).resolves.toBe('complete')
+  })
+})

--- a/core/ui/passcodeEncryption/core/passcodeAttemptThrottle.ts
+++ b/core/ui/passcodeEncryption/core/passcodeAttemptThrottle.ts
@@ -1,0 +1,69 @@
+import { passcodeEncryptionConfig } from './config'
+
+/** Persisted state used to calculate the delay before another unlock attempt. */
+export type PasscodeAttemptState = {
+  failedAttempts: number
+  lastFailedAt: number
+}
+
+type GetPasscodeAttemptDelayMsInput = {
+  state: PasscodeAttemptState | undefined
+  now: number
+}
+
+type RecordFailedPasscodeAttemptInput = {
+  state: PasscodeAttemptState | undefined
+  now: number
+}
+
+const getDelayMs = (failedAttempts: number): number => {
+  const delayedAttempt = failedAttempts - passcodeEncryptionConfig.freeAttempts
+
+  if (delayedAttempt <= 0) {
+    return 0
+  }
+
+  const exponent = Math.min(delayedAttempt - 1, 16)
+
+  return Math.min(
+    passcodeEncryptionConfig.baseDelayMs * 2 ** exponent,
+    passcodeEncryptionConfig.maximumDelayMs
+  )
+}
+
+/** Returns the remaining retry delay, including exponential backoff and its cap. */
+export const getPasscodeAttemptDelayMs = ({
+  state,
+  now,
+}: GetPasscodeAttemptDelayMsInput): number => {
+  if (!state) {
+    return 0
+  }
+
+  const delay = getDelayMs(state.failedAttempts)
+  const elapsed = Math.max(0, now - state.lastFailedAt)
+
+  return Math.max(0, delay - elapsed)
+}
+
+/** Advances persisted failure state at the supplied clock time. */
+export const recordFailedPasscodeAttempt = ({
+  state,
+  now,
+}: RecordFailedPasscodeAttemptInput): PasscodeAttemptState => ({
+  failedAttempts: Math.max(0, state?.failedAttempts ?? 0) + 1,
+  lastFailedAt: now,
+})
+
+const passcodeOperationLockName = 'vultisig-passcode-operation'
+
+/** Serializes passcode reads and writes across same-origin windows when supported. */
+export const withPasscodeOperationLock = async <T>(
+  operation: () => Promise<T>
+): Promise<T> => {
+  if (typeof navigator === 'undefined' || !navigator.locks) {
+    return operation()
+  }
+
+  return navigator.locks.request(passcodeOperationLockName, () => operation())
+}

--- a/core/ui/passcodeEncryption/core/passcodePolicy.test.ts
+++ b/core/ui/passcodeEncryption/core/passcodePolicy.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getStoredPasscodeLength,
+  isValidNewPasscode,
+  isWeakPasscode,
+} from './passcodePolicy'
+
+describe('passcodePolicy', () => {
+  it('requires six digits for new passcodes', () => {
+    expect(isValidNewPasscode('135790')).toBe(true)
+    expect(isValidNewPasscode('13579')).toBe(false)
+    expect(isValidNewPasscode('1357901')).toBe(false)
+    expect(isValidNewPasscode('13579a')).toBe(false)
+  })
+
+  it('rejects repeated digits and sequential runs', () => {
+    expect(isWeakPasscode('000000')).toBe(true)
+    expect(isWeakPasscode('123456')).toBe(true)
+    expect(isWeakPasscode('654321')).toBe(true)
+    expect(isWeakPasscode('124680')).toBe(false)
+  })
+
+  it('keeps legacy installations unlockable while new records use six digits', () => {
+    expect(getStoredPasscodeLength()).toBe(5)
+    expect(getStoredPasscodeLength(5)).toBe(5)
+    expect(getStoredPasscodeLength(6)).toBe(6)
+    expect(getStoredPasscodeLength(99)).toBe(6)
+  })
+})

--- a/core/ui/passcodeEncryption/core/passcodePolicy.ts
+++ b/core/ui/passcodeEncryption/core/passcodePolicy.ts
@@ -1,0 +1,34 @@
+import { passcodeEncryptionConfig } from './config'
+
+export const isWeakPasscode = (passcode: string): boolean => {
+  if (new Set(passcode).size === 1) {
+    return true
+  }
+
+  const digits = [...passcode].map(Number)
+  const isSequential = (step: 1 | -1) =>
+    digits.every(
+      (digit, index) => index === 0 || digit === digits[index - 1] + step
+    )
+
+  return isSequential(1) || isSequential(-1)
+}
+
+export const isValidNewPasscode = (passcode: string): boolean =>
+  /^\d+$/.test(passcode) &&
+  passcode.length === passcodeEncryptionConfig.passcodeLength &&
+  !isWeakPasscode(passcode)
+
+export const assertValidNewPasscode = (passcode: string) => {
+  if (!isValidNewPasscode(passcode)) {
+    throw new Error(
+      `Passcode must be ${passcodeEncryptionConfig.passcodeLength} non-repeated, non-sequential digits`
+    )
+  }
+}
+
+export const getStoredPasscodeLength = (length?: number): number =>
+  length === undefined ||
+  length === passcodeEncryptionConfig.legacyPasscodeLength
+    ? passcodeEncryptionConfig.legacyPasscodeLength
+    : passcodeEncryptionConfig.passcodeLength

--- a/core/ui/passcodeEncryption/guard/EnterPasscode.tsx
+++ b/core/ui/passcodeEncryption/guard/EnterPasscode.tsx
@@ -1,15 +1,23 @@
-import { passcodeEncryptionConfig } from '@core/ui/passcodeEncryption/core/config'
+import {
+  getPasscodeAttemptDelayMs,
+  recordFailedPasscodeAttempt,
+  withPasscodeOperationLock,
+} from '@core/ui/passcodeEncryption/core/passcodeAttemptThrottle'
 import { verifyPasscode } from '@core/ui/passcodeEncryption/core/passcodeLock'
+import { getStoredPasscodeLength } from '@core/ui/passcodeEncryption/core/passcodePolicy'
 import { PasscodeInput } from '@core/ui/passcodeEncryption/manage/PasscodeInput'
 import { usePasscode } from '@core/ui/passcodeEncryption/state/passcode'
+import { useCore } from '@core/ui/state/core'
 import { usePasscodeEncryption } from '@core/ui/storage/passcodeEncryption'
-import { useVaults } from '@core/ui/storage/vaults'
+import { StorageKey } from '@core/ui/storage/StorageKey'
 import { takeWholeSpace } from '@lib/ui/css/takeWholeSpace'
 import { VStack, vStack } from '@lib/ui/layout/Stack'
 import { panel } from '@lib/ui/panel/Panel'
+import { useRefetchQueries } from '@lib/ui/query/hooks/useRefetchQueries'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
-import { useEffect, useState } from 'react'
+import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
@@ -46,49 +54,165 @@ const Content = styled.div`
 `
 
 export const EnterPasscode = () => {
-  const { t } = useTranslation()
+  const { i18n, t } = useTranslation()
+  const { getPasscodeEncryption, getVaults, setPasscodeEncryption } = useCore()
+  const refetchQueries = useRefetchQueries()
 
   const passcodeEncryption = usePasscodeEncryption()
-  const vaults = useVaults()
-
   const [inputValue, setInputValue] = useState<string | null>(null)
   const [, setPasscode] = usePasscode()
   const [isInvalid, setIsInvalid] = useState(false)
+  const [isVerifying, setIsVerifying] = useState(false)
+  const isVerifyingRef = useRef(false)
+  const [attemptState, setAttemptState] = useState(
+    passcodeEncryption?.attemptState
+  )
+  const [now, setNow] = useState(Date.now)
 
-  const isComplete =
-    !!inputValue &&
-    inputValue.length === passcodeEncryptionConfig.passcodeLength
+  const passcodeLength = getStoredPasscodeLength(
+    passcodeEncryption?.passcodeLength
+  )
+  const retryDelayMs = getPasscodeAttemptDelayMs({ state: attemptState, now })
+  const isLockedOut = retryDelayMs > 0
+
+  const isComplete = !!inputValue && inputValue.length === passcodeLength
+
+  useEffect(() => {
+    setAttemptState(passcodeEncryption?.attemptState)
+  }, [passcodeEncryption?.attemptState])
+
+  useEffect(() => {
+    if (!isLockedOut) {
+      return
+    }
+
+    const interval = window.setInterval(() => setNow(Date.now()), 1_000)
+
+    return () => window.clearInterval(interval)
+  }, [isLockedOut])
 
   // Validate only once the full passcode is entered, and asynchronously:
   // verifyPasscode runs the PBKDF2 key derivation, so validating synchronously
   // on every keystroke would block the UI. On success the passcode unlocks the
   // app.
   useEffect(() => {
-    if (!isComplete) {
-      setIsInvalid(false)
+    if (!isComplete || isLockedOut || isVerifyingRef.current) {
       return
     }
 
     let cancelled = false
 
-    verifyPasscode({
-      vaults,
-      encryptedSample: passcodeEncryption?.encryptedSample ?? null,
-      passcode: inputValue,
-    }).then(isValid => {
-      if (cancelled) return
+    const verifyEnteredPasscode = async () => {
+      isVerifyingRef.current = true
+      setIsVerifying(true)
 
-      setIsInvalid(!isValid)
+      await withPasscodeOperationLock(async () => {
+        const [current, currentVaults] = await Promise.all([
+          getPasscodeEncryption().then(shouldBePresent),
+          getVaults(),
+        ])
+        const activeAttemptState =
+          (attemptState?.failedAttempts ?? 0) >
+          (current.attemptState?.failedAttempts ?? 0)
+            ? attemptState
+            : current.attemptState
+        const currentDelay = getPasscodeAttemptDelayMs({
+          state: activeAttemptState,
+          now: Date.now(),
+        })
 
-      if (isValid) {
-        setPasscode(inputValue)
-      }
-    })
+        if (currentDelay > 0) {
+          if (!cancelled) {
+            setAttemptState(activeAttemptState)
+            setInputValue(null)
+            setNow(Date.now())
+          }
+          return
+        }
+
+        const isValid = await verifyPasscode({
+          vaults: currentVaults,
+          encryptedSample: current.encryptedSample,
+          passcode: inputValue,
+        })
+
+        if (!isValid) {
+          const nextAttemptState = recordFailedPasscodeAttempt({
+            state: activeAttemptState,
+            now: Date.now(),
+          })
+
+          await setPasscodeEncryption({
+            ...current,
+            attemptState: nextAttemptState,
+          })
+          await refetchQueries([StorageKey.passcodeEncryption])
+
+          if (!cancelled) {
+            setAttemptState(nextAttemptState)
+            setInputValue(null)
+            setIsInvalid(true)
+            setNow(Date.now())
+          }
+          return
+        }
+
+        const cleared = { ...current }
+        delete cleared.attemptState
+        await setPasscodeEncryption(cleared)
+        await refetchQueries([StorageKey.passcodeEncryption])
+
+        if (!cancelled) {
+          setIsInvalid(false)
+          setPasscode(inputValue)
+        }
+      })
+    }
+
+    verifyEnteredPasscode()
+      .catch(() => {
+        if (!cancelled) {
+          setInputValue(null)
+          setIsInvalid(true)
+        }
+      })
+      .finally(() => {
+        isVerifyingRef.current = false
+        if (!cancelled) {
+          setIsVerifying(false)
+        }
+      })
 
     return () => {
       cancelled = true
     }
-  }, [isComplete, inputValue, passcodeEncryption, vaults, setPasscode])
+  }, [
+    attemptState,
+    getPasscodeEncryption,
+    getVaults,
+    inputValue,
+    isComplete,
+    isLockedOut,
+    refetchQueries,
+    setPasscode,
+    setPasscodeEncryption,
+  ])
+
+  const validation =
+    isVerifying || isLockedOut ? 'loading' : isInvalid ? 'invalid' : undefined
+  const retrySeconds = Math.ceil(retryDelayMs / 1_000)
+  const retryTime = new Intl.RelativeTimeFormat(
+    i18n.resolvedLanguage ?? i18n.language,
+    { numeric: 'always' }
+  ).format(retrySeconds, 'second')
+
+  const validationMessages = isLockedOut
+    ? {
+        loading: `${t('try_again')} ${retryTime}`,
+      }
+    : isInvalid
+      ? { invalid: t('invalid_passcode') }
+      : undefined
 
   return (
     <Wrapper>
@@ -103,11 +227,13 @@ export const EnterPasscode = () => {
         </VStack>
         <Content>
           <PasscodeInput
-            onChange={setInputValue}
-            validation={isInvalid ? 'invalid' : undefined}
-            validationMessages={
-              isInvalid ? { invalid: t('invalid_passcode') } : undefined
-            }
+            length={passcodeLength}
+            onChange={value => {
+              setInputValue(value)
+              setIsInvalid(false)
+            }}
+            validation={validation}
+            validationMessages={validationMessages}
             value={inputValue}
             autoFocus
           />

--- a/core/ui/passcodeEncryption/manage/PasscodeInput.tsx
+++ b/core/ui/passcodeEncryption/manage/PasscodeInput.tsx
@@ -12,6 +12,7 @@ type PasscodeInputProps = InputProps<string | null> &
     Pick<MultiCharacterInputProps, 'validation' | 'validationMessages'>
   > & {
     autoFocus?: boolean
+    length?: number
   }
 
 export const PasscodeInput = ({
@@ -21,6 +22,7 @@ export const PasscodeInput = ({
   label,
   validation,
   validationMessages,
+  length = passcodeEncryptionConfig.passcodeLength,
 }: PasscodeInputProps) => {
   return (
     <>
@@ -28,7 +30,7 @@ export const PasscodeInput = ({
       <MultiCharacterInput
         autoFocusFirst={autoFocus}
         includePasteButton={false}
-        length={passcodeEncryptionConfig.passcodeLength}
+        length={length}
         onChange={newValue => onChange(newValue)}
         validation={validation}
         validationMessages={validationMessages}

--- a/core/ui/passcodeEncryption/manage/SetPasscode.tsx
+++ b/core/ui/passcodeEncryption/manage/SetPasscode.tsx
@@ -1,3 +1,5 @@
+import { passcodeEncryptionConfig } from '@core/ui/passcodeEncryption/core/config'
+import { isWeakPasscode } from '@core/ui/passcodeEncryption/core/passcodePolicy'
 import { EnablePasscodeInput } from '@core/ui/passcodeEncryption/manage/EnablePasscodeInput'
 import { PasscodeInput } from '@core/ui/passcodeEncryption/manage/PasscodeInput'
 import { useSetPasscodeMutation } from '@core/ui/passcodeEncryption/mutations/useSetPasscodeMutation'
@@ -29,6 +31,13 @@ export const SetPasscode = () => {
 
     if (!confirmPasscode) {
       return t('confirm_passcode')
+    }
+
+    if (
+      passcode.length === passcodeEncryptionConfig.passcodeLength &&
+      isWeakPasscode(passcode)
+    ) {
+      return t('invalid_passcode')
     }
 
     if (passcode !== confirmPasscode) {
@@ -65,6 +74,13 @@ export const SetPasscode = () => {
               label={t('enter_passcode')}
               onChange={setPasscode}
               value={passcode}
+              validation={
+                passcode?.length === passcodeEncryptionConfig.passcodeLength &&
+                isWeakPasscode(passcode)
+                  ? 'invalid'
+                  : undefined
+              }
+              validationMessages={{ invalid: t('invalid_passcode') }}
               autoFocus
             />
             <PasscodeInput

--- a/core/ui/passcodeEncryption/manage/change/ChangePasscode.tsx
+++ b/core/ui/passcodeEncryption/manage/change/ChangePasscode.tsx
@@ -1,4 +1,5 @@
 import { passcodeEncryptionConfig } from '@core/ui/passcodeEncryption/core/config'
+import { isWeakPasscode } from '@core/ui/passcodeEncryption/core/passcodePolicy'
 import { useChangePasscodeMutation } from '@core/ui/passcodeEncryption/manage/change/mutations/changePasscode'
 import { PasscodeInput } from '@core/ui/passcodeEncryption/manage/PasscodeInput'
 import { usePasscode } from '@core/ui/passcodeEncryption/state/passcode'
@@ -46,13 +47,22 @@ export const ChangePasscode = () => {
       return t('confirm_new_passcode')
     }
 
+    if (
+      newPasscode.length === passcodeEncryptionConfig.passcodeLength &&
+      isWeakPasscode(newPasscode)
+    ) {
+      return t('invalid_passcode')
+    }
+
     if (newPasscode !== confirmNewPasscode) {
       return t('passcodes_do_not_match')
     }
   }, [confirmNewPasscode, currentPasscode, newPasscode, passcode, t])
 
   const currentPasscodeFull =
-    currentPasscode?.length === passcodeEncryptionConfig.passcodeLength
+    !!currentPasscode &&
+    !!passcode &&
+    currentPasscode.length === passcode.length
 
   const currentPasscodeValidation =
     currentPasscodeFull && currentPasscode !== passcode
@@ -122,12 +132,23 @@ export const ChangePasscode = () => {
                   ? { invalid: t('incorrect_passcode') }
                   : undefined
               }
+              length={
+                passcode?.length ?? passcodeEncryptionConfig.passcodeLength
+              }
               autoFocus
             />
             <PasscodeInput
               label={t('new_passcode')}
               onChange={setNewPasscode}
               value={newPasscode}
+              validation={
+                newPasscode?.length ===
+                  passcodeEncryptionConfig.passcodeLength &&
+                isWeakPasscode(newPasscode)
+                  ? 'invalid'
+                  : undefined
+              }
+              validationMessages={{ invalid: t('invalid_passcode') }}
             />
             <PasscodeInput
               label={t('confirm_new_passcode')}

--- a/core/ui/passcodeEncryption/manage/change/mutations/changePasscode.ts
+++ b/core/ui/passcodeEncryption/manage/change/mutations/changePasscode.ts
@@ -1,3 +1,6 @@
+import { passcodeEncryptionConfig } from '@core/ui/passcodeEncryption/core/config'
+import { withPasscodeOperationLock } from '@core/ui/passcodeEncryption/core/passcodeAttemptThrottle'
+import { assertValidNewPasscode } from '@core/ui/passcodeEncryption/core/passcodePolicy'
 import { encryptSample } from '@core/ui/passcodeEncryption/core/sample'
 import {
   decryptVaultAllKeyShares,
@@ -7,52 +10,61 @@ import {
 import { usePasscode } from '@core/ui/passcodeEncryption/state/passcode'
 import { useCore } from '@core/ui/state/core'
 import { StorageKey } from '@core/ui/storage/StorageKey'
-import { useVaults } from '@core/ui/storage/vaults'
 import { useRefetchQueries } from '@lib/ui/query/hooks/useRefetchQueries'
 import { useMutation } from '@tanstack/react-query'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { v4 as uuidv4 } from 'uuid'
 
 export const useChangePasscodeMutation = () => {
-  const { setPasscodeEncryption, updateVaultsKeyShares } = useCore()
+  const {
+    getPasscodeEncryption,
+    getVaults,
+    setPasscodeEncryption,
+    updateVaultsKeyShares,
+  } = useCore()
   const refetchQueries = useRefetchQueries()
-  const vaults = useVaults()
   const [oldPasscode, setPasscode] = usePasscode()
 
   return useMutation({
-    mutationFn: async (newPasscode: string) => {
-      const key = shouldBePresent(oldPasscode, 'passcode')
-      const sample = uuidv4()
+    mutationFn: async (newPasscode: string) =>
+      withPasscodeOperationLock(async () => {
+        assertValidNewPasscode(newPasscode)
+        const key = shouldBePresent(oldPasscode, 'passcode')
+        const sample = uuidv4()
+        const vaults = await getVaults()
 
-      const encryptedSample = await encryptSample({
-        key: newPasscode,
-        value: sample,
-      })
+        const encryptedSample = await encryptSample({
+          key: newPasscode,
+          value: sample,
+        })
 
-      const vaultsKeyShares = await mapVaultsKeyShares({
-        vaults,
-        transform: async vault => {
-          const decrypted = await decryptVaultAllKeyShares({
-            key,
-            keyShares: vault.keyShares,
-            chainKeyShares: vault.chainKeyShares,
-            keyShareMldsa: vault.keyShareMldsa,
-          })
-          return encryptVaultAllKeyShares({
-            ...decrypted,
-            key: newPasscode,
-          })
-        },
-      })
+        const vaultsKeyShares = await mapVaultsKeyShares({
+          vaults,
+          transform: async vault => {
+            const decrypted = await decryptVaultAllKeyShares({
+              key,
+              keyShares: vault.keyShares,
+              chainKeyShares: vault.chainKeyShares,
+              keyShareMldsa: vault.keyShareMldsa,
+            })
+            return encryptVaultAllKeyShares({
+              ...decrypted,
+              key: newPasscode,
+            })
+          },
+        })
 
-      await updateVaultsKeyShares(vaultsKeyShares)
-      await refetchQueries([StorageKey.vaults])
+        await updateVaultsKeyShares(vaultsKeyShares)
+        await refetchQueries([StorageKey.vaults])
 
-      setPasscode(newPasscode)
-      await setPasscodeEncryption({
-        encryptedSample,
-      })
-      await refetchQueries([StorageKey.passcodeEncryption])
-    },
+        setPasscode(newPasscode)
+        const latestPasscodeEncryption = await getPasscodeEncryption()
+        await setPasscodeEncryption({
+          encryptedSample,
+          passcodeLength: passcodeEncryptionConfig.passcodeLength,
+          attemptState: latestPasscodeEncryption?.attemptState,
+        })
+        await refetchQueries([StorageKey.passcodeEncryption])
+      }),
   })
 }

--- a/core/ui/passcodeEncryption/mutations/useDisablePasscodeMutation.ts
+++ b/core/ui/passcodeEncryption/mutations/useDisablePasscodeMutation.ts
@@ -1,3 +1,4 @@
+import { withPasscodeOperationLock } from '@core/ui/passcodeEncryption/core/passcodeAttemptThrottle'
 import {
   decryptVaultAllKeyShares,
   mapVaultsKeyShares,
@@ -5,37 +6,37 @@ import {
 import { usePasscode } from '@core/ui/passcodeEncryption/state/passcode'
 import { useCore } from '@core/ui/state/core'
 import { StorageKey } from '@core/ui/storage/StorageKey'
-import { useVaults } from '@core/ui/storage/vaults'
 import { useRefetchQueries } from '@lib/ui/query/hooks/useRefetchQueries'
 import { useMutation } from '@tanstack/react-query'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 
 export const useDisablePasscodeMutation = () => {
-  const { setPasscodeEncryption, updateVaultsKeyShares } = useCore()
+  const { getVaults, setPasscodeEncryption, updateVaultsKeyShares } = useCore()
   const refetchQueries = useRefetchQueries()
   const [passcode, setPasscode] = usePasscode()
-  const vaults = useVaults()
 
   return useMutation({
-    mutationFn: async () => {
-      const key = shouldBePresent(passcode, 'passcode')
+    mutationFn: async () =>
+      withPasscodeOperationLock(async () => {
+        const key = shouldBePresent(passcode, 'passcode')
+        const vaults = await getVaults()
 
-      const vaultsKeyShares = await mapVaultsKeyShares({
-        vaults,
-        transform: vault =>
-          decryptVaultAllKeyShares({
-            key,
-            keyShares: vault.keyShares,
-            chainKeyShares: vault.chainKeyShares,
-            keyShareMldsa: vault.keyShareMldsa,
-          }),
-      })
+        const vaultsKeyShares = await mapVaultsKeyShares({
+          vaults,
+          transform: vault =>
+            decryptVaultAllKeyShares({
+              key,
+              keyShares: vault.keyShares,
+              chainKeyShares: vault.chainKeyShares,
+              keyShareMldsa: vault.keyShareMldsa,
+            }),
+        })
 
-      await updateVaultsKeyShares(vaultsKeyShares)
-      await refetchQueries([StorageKey.vaults])
-      setPasscode(null)
-      await setPasscodeEncryption(null)
-      await refetchQueries([StorageKey.passcodeEncryption])
-    },
+        await updateVaultsKeyShares(vaultsKeyShares)
+        await refetchQueries([StorageKey.vaults])
+        setPasscode(null)
+        await setPasscodeEncryption(null)
+        await refetchQueries([StorageKey.passcodeEncryption])
+      }),
   })
 }

--- a/core/ui/passcodeEncryption/mutations/useSetPasscodeMutation.ts
+++ b/core/ui/passcodeEncryption/mutations/useSetPasscodeMutation.ts
@@ -4,7 +4,9 @@ import { v4 as uuidv4 } from 'uuid'
 
 import { useCore } from '../../state/core'
 import { StorageKey } from '../../storage/StorageKey'
-import { useVaults } from '../../storage/vaults'
+import { passcodeEncryptionConfig } from '../core/config'
+import { withPasscodeOperationLock } from '../core/passcodeAttemptThrottle'
+import { assertValidNewPasscode } from '../core/passcodePolicy'
 import { encryptSample } from '../core/sample'
 import {
   encryptVaultAllKeyShares,
@@ -13,39 +15,42 @@ import {
 import { usePasscode } from '../state/passcode'
 
 export const useSetPasscodeMutation = () => {
-  const { setPasscodeEncryption, updateVaultsKeyShares } = useCore()
+  const { getVaults, setPasscodeEncryption, updateVaultsKeyShares } = useCore()
   const refetchQueries = useRefetchQueries()
-  const vaults = useVaults()
   const [, setPasscode] = usePasscode()
 
   return useMutation({
-    mutationFn: async (passcode: string) => {
-      const sample = uuidv4()
+    mutationFn: async (passcode: string) =>
+      withPasscodeOperationLock(async () => {
+        assertValidNewPasscode(passcode)
+        const sample = uuidv4()
+        const vaults = await getVaults()
 
-      const encryptedSample = await encryptSample({
-        key: passcode,
-        value: sample,
-      })
+        const encryptedSample = await encryptSample({
+          key: passcode,
+          value: sample,
+        })
 
-      const vaultsKeyShares = await mapVaultsKeyShares({
-        vaults,
-        transform: vault =>
-          encryptVaultAllKeyShares({
-            keyShares: vault.keyShares,
-            chainKeyShares: vault.chainKeyShares,
-            keyShareMldsa: vault.keyShareMldsa,
-            key: passcode,
-          }),
-      })
+        const vaultsKeyShares = await mapVaultsKeyShares({
+          vaults,
+          transform: vault =>
+            encryptVaultAllKeyShares({
+              keyShares: vault.keyShares,
+              chainKeyShares: vault.chainKeyShares,
+              keyShareMldsa: vault.keyShareMldsa,
+              key: passcode,
+            }),
+        })
 
-      await updateVaultsKeyShares(vaultsKeyShares)
-      await refetchQueries([StorageKey.vaults])
+        await updateVaultsKeyShares(vaultsKeyShares)
+        await refetchQueries([StorageKey.vaults])
 
-      setPasscode(passcode)
-      await setPasscodeEncryption({
-        encryptedSample,
-      })
-      await refetchQueries([StorageKey.passcodeEncryption])
-    },
+        setPasscode(passcode)
+        await setPasscodeEncryption({
+          encryptedSample,
+          passcodeLength: passcodeEncryptionConfig.passcodeLength,
+        })
+        await refetchQueries([StorageKey.passcodeEncryption])
+      }),
   })
 }

--- a/core/ui/passcodeEncryption/mutations/useUpgradePasscodeEncryptionMutation.ts
+++ b/core/ui/passcodeEncryption/mutations/useUpgradePasscodeEncryptionMutation.ts
@@ -1,6 +1,5 @@
 import { useCore } from '@core/ui/state/core'
 import { StorageKey } from '@core/ui/storage/StorageKey'
-import { useVaults } from '@core/ui/storage/vaults'
 import { useRefetchQueries } from '@lib/ui/query/hooks/useRefetchQueries'
 import { useMutation } from '@tanstack/react-query'
 import { getVaultId } from '@vultisig/core-mpc/vault/Vault'
@@ -8,6 +7,7 @@ import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { useRef } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
+import { withPasscodeOperationLock } from '../core/passcodeAttemptThrottle'
 import { needsPasscodeSampleRewrite } from '../core/passcodeLock'
 import { encryptSample } from '../core/sample'
 import {
@@ -34,7 +34,6 @@ export const useUpgradePasscodeEncryptionMutation = () => {
   } = useCore()
   const refetchQueries = useRefetchQueries()
   const [passcode] = usePasscode()
-  const vaults = useVaults()
 
   // Latest active passcode, so a concurrent change/disable (which captures and
   // rewrites under a different key) makes this background upgrade abort before
@@ -56,69 +55,78 @@ export const useUpgradePasscodeEncryptionMutation = () => {
   }
 
   return useMutation({
-    mutationFn: async () => {
-      const key = shouldBePresent(passcode, 'passcode')
+    mutationFn: async () =>
+      withPasscodeOperationLock(async () => {
+        const key = shouldBePresent(passcode, 'passcode')
 
-      const isPasscodeStale = () => livePasscodeRef.current !== key
+        const isPasscodeStale = () => livePasscodeRef.current !== key
 
-      const legacyVaults = vaults.filter(vaultKeySharesNeedPasscodeUpgrade)
+        const vaults = await getVaults()
+        const legacyVaults = vaults.filter(vaultKeySharesNeedPasscodeUpgrade)
 
-      if (legacyVaults.length > 0) {
-        const vaultsKeyShares = await mapVaultsKeyShares({
-          vaults: legacyVaults,
-          transform: async vault => {
-            const decrypted = await decryptVaultAllKeyShares({
-              key,
-              keyShares: vault.keyShares,
-              chainKeyShares: vault.chainKeyShares,
-              keyShareMldsa: vault.keyShareMldsa,
-            })
-            return encryptVaultAllKeyShares({ ...decrypted, key })
-          },
-        })
-
-        if (isPasscodeStale()) return
-
-        // The ref above only moves once a concurrent change-passcode reaches
-        // its own `setPasscode`, which is after it has already rewritten every
-        // vault — so it is not enough on its own. Re-read what is stored and
-        // keep only the records that still want this re-wrap; anything another
-        // flow has since rewritten is left alone.
-        const storedVaults = await getVaults()
-        const stillLegacy = Object.fromEntries(
-          Object.entries(vaultsKeyShares).filter(([vaultId]) => {
-            const stored = storedVaults.find(v => getVaultId(v) === vaultId)
-
-            return (
-              stored !== undefined && vaultKeySharesNeedPasscodeUpgrade(stored)
-            )
+        if (legacyVaults.length > 0) {
+          const vaultsKeyShares = await mapVaultsKeyShares({
+            vaults: legacyVaults,
+            transform: async vault => {
+              const decrypted = await decryptVaultAllKeyShares({
+                key,
+                keyShares: vault.keyShares,
+                chainKeyShares: vault.chainKeyShares,
+                keyShareMldsa: vault.keyShareMldsa,
+              })
+              return encryptVaultAllKeyShares({ ...decrypted, key })
+            },
           })
-        )
 
-        if (Object.keys(stillLegacy).length > 0) {
-          await updateVaultsKeyShares(stillLegacy)
-          await refetchQueries([StorageKey.vaults])
+          if (isPasscodeStale()) return
+
+          // The ref above only moves once a concurrent change-passcode reaches
+          // its own `setPasscode`, which is after it has already rewritten every
+          // vault — so it is not enough on its own. Re-read what is stored and
+          // keep only the records that still want this re-wrap; anything another
+          // flow has since rewritten is left alone.
+          const storedVaults = await getVaults()
+          const stillLegacy = Object.fromEntries(
+            Object.entries(vaultsKeyShares).filter(([vaultId]) => {
+              const stored = storedVaults.find(v => getVaultId(v) === vaultId)
+
+              return (
+                stored !== undefined &&
+                vaultKeySharesNeedPasscodeUpgrade(stored)
+              )
+            })
+          )
+
+          if (Object.keys(stillLegacy).length > 0) {
+            await updateVaultsKeyShares(stillLegacy)
+            await refetchQueries([StorageKey.vaults])
+          }
         }
-      }
 
-      // Whether the sample is stale needs a decryption attempt, so unlike the
-      // re-wrap above this decides off stored state from the start rather than
-      // off the snapshot this render captured.
-      const wantsSample = await readSampleRewriteNeed(key)
+        // Whether the sample is stale needs a decryption attempt, so unlike the
+        // re-wrap above this decides off stored state from the start rather than
+        // off the snapshot this render captured.
+        const wantsSample = await readSampleRewriteNeed(key)
 
-      if (wantsSample) {
-        const encrypted = await encryptSample({ key, value: uuidv4() })
+        if (wantsSample) {
+          const encrypted = await encryptSample({ key, value: uuidv4() })
 
-        if (isPasscodeStale()) return
+          if (isPasscodeStale()) return
 
-        // Re-read for the same reason as the vault re-write: a concurrent
-        // change-passcode may have written its own sample while this one was
-        // being derived.
-        if (!(await readSampleRewriteNeed(key))) return
+          // Re-read for the same reason as the vault re-write: a concurrent
+          // change-passcode may have written its own sample while this one was
+          // being derived.
+          if (!(await readSampleRewriteNeed(key))) return
 
-        await setPasscodeEncryption({ encryptedSample: encrypted })
-        await refetchQueries([StorageKey.passcodeEncryption])
-      }
-    },
+          const latestPasscodeEncryption = await getPasscodeEncryption()
+          await setPasscodeEncryption({
+            ...latestPasscodeEncryption,
+            encryptedSample: encrypted,
+            passcodeLength:
+              latestPasscodeEncryption?.passcodeLength ?? key.length,
+          })
+          await refetchQueries([StorageKey.passcodeEncryption])
+        }
+      }),
   })
 }

--- a/core/ui/storage/passcodeEncryption.tsx
+++ b/core/ui/storage/passcodeEncryption.tsx
@@ -2,11 +2,14 @@ import { noRefetchQueryOptions } from '@lib/ui/query/utils/options'
 import { useQuery } from '@tanstack/react-query'
 import { shouldBeDefined } from '@vultisig/lib-utils/assert/shouldBeDefined'
 
+import type { PasscodeAttemptState } from '../passcodeEncryption/core/passcodeAttemptThrottle'
 import { useCore } from '../state/core'
 import { StorageKey } from './StorageKey'
 
 type PasscodeEncryption = {
   encryptedSample: string
+  passcodeLength?: number
+  attemptState?: PasscodeAttemptState
 }
 
 export type PasscodeEncryptionValue = PasscodeEncryption | null


### PR DESCRIPTION
Closes #4603
Fixes #4603

New passcodes use six digits and reject repeated or fully sequential values. Existing five-digit installations retain unlock compatibility. Incorrect attempts now persist an escalating backoff across reloads, capped at 15 minutes, without wiping data; only a successful unlock clears the attempt state.

Real runtime QA exercised the built Windows desktop app and the built extension in an isolated Chromium profile. The extension persisted the fourth-attempt delay across reload, disabled all six inputs during the countdown, then cleared the throttle only after the correct passcode unlocked the app.

![screenshot-1](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/4603-passcode-throttle/screenshot-1-1787041915577.png)
![screenshot-2](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/4603-passcode-throttle/screenshot-2-1787041915577.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Passcodes now use six digits by default while supporting existing five-digit passcodes.
  * Added protection against repeated and sequential passcodes.
  * Added retry throttling with increasing delays and a maximum lockout period.
  * Added loading, countdown, and lockout feedback during verification.

* **Bug Fixes**
  * Improved compatibility when changing or upgrading passcode-encrypted data.
  * Prevented invalid passcodes from being submitted or stored.
  * Improved reliability when multiple passcode operations occur simultaneously.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->