### PR TITLE
Fix stale max-send verification

### DIFF
--- a/clients/extension/tests/e2e/specs/send-flow.spec.ts
+++ b/clients/extension/tests/e2e/specs/send-flow.spec.ts
@@ -13,22 +13,36 @@
  * - Tests skip gracefully if chain has insufficient funds
  */
 
-import { test, expect } from '../fixtures/extension-loader'
-import { VaultPage } from '../page-objects/VaultPage.po'
-import { SendFlow } from '../page-objects/SendFlow.po'
-import { KeysignProgress } from '../page-objects/KeysignProgress.po'
-import { selectChainsForRun, updateStaleness, SUPPORTED_CHAINS, type ChainId } from '../helpers/chain-rotation'
+import { expect, test } from '../fixtures/extension-loader'
+import {
+  type ChainId,
+  selectChainsForRun,
+  SUPPORTED_CHAINS,
+  updateStaleness,
+} from '../helpers/chain-rotation'
+import {
+  readChromeStorage,
+  writeChromeStorage,
+} from '../helpers/chrome-storage'
 import { waitForTxConfirmation } from '../helpers/tx-confirmation'
-import { ensureVaultExists, getVaultConfigFromEnv } from '../helpers/vault-import'
-import { getVaultAddresses, getAddressForChain } from '../helpers/vault-addresses'
+import {
+  getAddressForChain,
+  getVaultAddresses,
+} from '../helpers/vault-addresses'
+import {
+  ensureVaultExists,
+  getVaultConfigFromEnv,
+} from '../helpers/vault-import'
+import { KeysignProgress } from '../page-objects/KeysignProgress.po'
+import { SendFlow } from '../page-objects/SendFlow.po'
+import { VaultPage } from '../page-objects/VaultPage.po'
 
 // Skip if fund-dependent tests not enabled
-const ENABLE_TX_TESTS = process.env.ENABLE_TX_SIGNING_TESTS === 'true'
+const enableTxTests = process.env.ENABLE_TX_SIGNING_TESTS === 'true'
 
 function isChainId(value: string): value is ChainId {
   return Object.hasOwn(SUPPORTED_CHAINS, value)
 }
-
 function getConfiguredSendChains(): ChainId[] | null {
   const raw = process.env.VULTISIG_E2E_SEND_CHAINS
   if (!raw) {
@@ -44,7 +58,7 @@ function getConfiguredSendChains(): ChainId[] | null {
     if (!isChainId(chain)) {
       throw new Error(
         `Unsupported VULTISIG_E2E_SEND_CHAINS value: ${chain}. ` +
-        `Supported chains: ${Object.keys(SUPPORTED_CHAINS).join(', ')}`
+          `Supported chains: ${Object.keys(SUPPORTED_CHAINS).join(', ')}`
       )
     }
     chains.push(chain)
@@ -59,7 +73,10 @@ function getSendAmount(chain: ChainId): string {
     return SUPPORTED_CHAINS[chain].minSend
   }
 
-  if (!/^\d+(\.\d+)?$/.test(configuredAmount) || Number(configuredAmount) <= 0) {
+  if (
+    !/^\d+(\.\d+)?$/.test(configuredAmount) ||
+    Number(configuredAmount) <= 0
+  ) {
     throw new Error(
       `Invalid VULTISIG_E2E_SEND_AMOUNT: "${configuredAmount}". Expected a positive decimal amount.`
     )
@@ -69,7 +86,8 @@ function getSendAmount(chain: ChainId): string {
 }
 
 // Get chains to test this run (outside test context for sharing)
-const selectedChains = getConfiguredSendChains() ?? selectChainsForRun(2, 0).sendChains
+const selectedChains =
+  getConfiguredSendChains() ?? selectChainsForRun(2, 0).sendChains
 
 test.describe('Send Flow', () => {
   test.beforeAll(async () => {
@@ -83,7 +101,12 @@ test.describe('Send Flow', () => {
       console.log('⚠️ No vault config, tests will likely fail')
       return
     }
-    const imported = await ensureVaultExists(context, extensionId, config.vaultPath, config.password)
+    const imported = await ensureVaultExists(
+      context,
+      extensionId,
+      config.vaultPath,
+      config.password
+    )
     if (imported) {
       console.log('✅ Vault imported for send test')
     } else {
@@ -91,8 +114,11 @@ test.describe('Send Flow', () => {
     }
   })
 
-  test('send native token on chain 1 - broadcasts and confirms', async ({ context, extensionId }) => {
-    test.skip(!ENABLE_TX_TESTS, 'TX signing tests disabled')
+  test('send native token on chain 1 - broadcasts and confirms', async ({
+    context,
+    extensionId,
+  }) => {
+    test.skip(!enableTxTests, 'TX signing tests disabled')
 
     const chain = selectedChains[0]
     if (!chain) {
@@ -105,7 +131,9 @@ test.describe('Send Flow', () => {
     // Get own address from chrome storage (SELF-SEND to recycle funds)
     const ownAddress = await getAddressForChain(context, chainInfo.symbol)
     if (!ownAddress) {
-      console.log(`Could not get own address for ${chain} (${chainInfo.symbol}), skipping`)
+      console.log(
+        `Could not get own address for ${chain} (${chainInfo.symbol}), skipping`
+      )
       // Debug: dump all addresses
       const allAddrs = await getVaultAddresses(context)
       console.log('All vault addresses:', allAddrs)
@@ -113,7 +141,9 @@ test.describe('Send Flow', () => {
       return
     }
     const sendAmount = getSendAmount(chain)
-    console.log(`Self-send on ${chain}: ${ownAddress} (amount: ${sendAmount} ${chainInfo.symbol})`)
+    console.log(
+      `Self-send on ${chain}: ${ownAddress} (amount: ${sendAmount} ${chainInfo.symbol})`
+    )
 
     const page = await context.newPage()
     const vaultPage = new VaultPage(page, extensionId)
@@ -139,45 +169,61 @@ test.describe('Send Flow', () => {
       // Check if we can continue (validates address, amount, balance)
       const canContinue = await sendFlow.isContinueEnabled()
       if (!canContinue) {
-        console.log(`⚠️ Continue button disabled for ${chain} - likely insufficient balance`)
+        console.log(
+          `⚠️ Continue button disabled for ${chain} - likely insufficient balance`
+        )
         // Take a screenshot for debugging
-        await page.screenshot({ path: `test-results/send-disabled-${chain}-${Date.now()}.png` })
+        await page.screenshot({
+          path: `test-results/send-disabled-${chain}-${Date.now()}.png`,
+        })
         test.skip()
         return
       }
 
       // Continue to confirmation
       await sendFlow.continue()
-      
+
       // Take screenshot before terms
-      await page.screenshot({ path: `test-results/send-verify-${chain}-${Date.now()}.png` })
-      
+      await page.screenshot({
+        path: `test-results/send-verify-${chain}-${Date.now()}.png`,
+      })
+
       await sendFlow.acceptTerms()
-      
+
       // Take screenshot before sign
-      await page.screenshot({ path: `test-results/send-before-sign-${chain}-${Date.now()}.png` })
-      
+      await page.screenshot({
+        path: `test-results/send-before-sign-${chain}-${Date.now()}.png`,
+      })
+
       await sendFlow.sign()
 
       // Take screenshot after sign
-      await page.screenshot({ path: `test-results/send-after-sign-${chain}-${Date.now()}.png` })
+      await page.screenshot({
+        path: `test-results/send-after-sign-${chain}-${Date.now()}.png`,
+      })
 
       // Wait for keysign progress with better error handling
       try {
         await keysignProgress.waitForView(30_000)
       } catch (e) {
         console.log(`⚠️ Keysign progress view not found - taking screenshot`)
-        await page.screenshot({ path: `test-results/send-no-progress-${chain}-${Date.now()}.png` })
+        await page.screenshot({
+          path: `test-results/send-no-progress-${chain}-${Date.now()}.png`,
+        })
         throw e
       }
 
       // Take screenshot during keysign
-      await page.screenshot({ path: `test-results/send-keysign-${chain}-${Date.now()}.png` })
+      await page.screenshot({
+        path: `test-results/send-keysign-${chain}-${Date.now()}.png`,
+      })
 
       const result = await keysignProgress.waitForComplete(120_000)
 
       // Take screenshot of final state
-      await page.screenshot({ path: `test-results/send-result-${chain}-${Date.now()}.png` })
+      await page.screenshot({
+        path: `test-results/send-result-${chain}-${Date.now()}.png`,
+      })
 
       if (result === 'success') {
         const txHash = await keysignProgress.getTxHash()
@@ -185,7 +231,11 @@ test.describe('Send Flow', () => {
 
         if (txHash) {
           console.log(`✅ ${chain} send tx: ${txHash}`)
-          const confirmation = await waitForTxConfirmation(chain, txHash, 120_000)
+          const confirmation = await waitForTxConfirmation(
+            chain,
+            txHash,
+            120_000
+          )
           expect(confirmation.confirmed).toBe(true)
           updateStaleness([chain], true)
         }
@@ -202,8 +252,11 @@ test.describe('Send Flow', () => {
     }
   })
 
-  test('send native token on chain 2 - broadcasts and confirms', async ({ context, extensionId }) => {
-    test.skip(!ENABLE_TX_TESTS, 'TX signing tests disabled')
+  test('send native token on chain 2 - broadcasts and confirms', async ({
+    context,
+    extensionId,
+  }) => {
+    test.skip(!enableTxTests, 'TX signing tests disabled')
 
     const chain = selectedChains[1]
     if (!chain) {
@@ -215,12 +268,16 @@ test.describe('Send Flow', () => {
 
     const ownAddress = await getAddressForChain(context, chainInfo.symbol)
     if (!ownAddress) {
-      console.log(`Could not get own address for ${chain} (${chainInfo.symbol}), skipping`)
+      console.log(
+        `Could not get own address for ${chain} (${chainInfo.symbol}), skipping`
+      )
       test.skip()
       return
     }
     const sendAmount = getSendAmount(chain)
-    console.log(`Self-send on ${chain}: ${ownAddress} (amount: ${sendAmount} ${chainInfo.symbol})`)
+    console.log(
+      `Self-send on ${chain}: ${ownAddress} (amount: ${sendAmount} ${chainInfo.symbol})`
+    )
 
     const page = await context.newPage()
     const vaultPage = new VaultPage(page, extensionId)
@@ -254,7 +311,11 @@ test.describe('Send Flow', () => {
 
         if (txHash) {
           console.log(`✅ ${chain} send tx: ${txHash}`)
-          const confirmation = await waitForTxConfirmation(chain, txHash, 120_000)
+          const confirmation = await waitForTxConfirmation(
+            chain,
+            txHash,
+            120_000
+          )
           expect(confirmation.confirmed).toBe(true)
           updateStaleness([chain], true)
         }
@@ -271,7 +332,10 @@ test.describe('Send Flow', () => {
     }
   })
 
-  test('send flow shows correct details on verify page', async ({ context, extensionId }) => {
+  test('send flow shows correct details on verify page', async ({
+    context,
+    extensionId,
+  }) => {
     const page = await context.newPage()
     const vaultPage = new VaultPage(page, extensionId)
     const sendFlow = new SendFlow(page, extensionId)
@@ -309,7 +373,9 @@ test.describe('Send Flow', () => {
           expect(hasAmount || hasAddress).toBe(true)
         }
       } else {
-        console.log('Continue button not enabled — likely validation error on dead address')
+        console.log(
+          'Continue button not enabled — likely validation error on dead address'
+        )
       }
     } catch (error) {
       console.log('Could not verify send flow details:', error)
@@ -318,8 +384,155 @@ test.describe('Send Flow', () => {
     }
   })
 
-  test('balance updates after successful send', async ({ context, extensionId }) => {
-    test.skip(!ENABLE_TX_TESTS, 'TX signing tests disabled')
+  test('max send ignores a persisted balance and Verify shows the planned Bitcoin amount', async ({
+    context,
+    extensionId,
+  }) => {
+    test.skip(!enableTxTests, 'Fund-dependent QA vault is not enabled')
+
+    const ownAddress = await getAddressForChain(context, 'BTC')
+    expect(ownAddress).toBeTruthy()
+
+    const currentVaultId = await readChromeStorage<string>(
+      context,
+      'currentVaultId'
+    )
+    const vaultsCoins = await readChromeStorage<
+      Record<
+        string,
+        Array<{ chain: string; id?: string; address: string; ticker?: string }>
+      >
+    >(context, 'vaultsCoins')
+    const bitcoinCoin = vaultsCoins?.[currentVaultId ?? '']?.find(
+      coin => coin.chain === 'Bitcoin' && coin.ticker === 'BTC'
+    )
+    expect(bitcoinCoin).toBeTruthy()
+
+    const balanceInput = {
+      chain: bitcoinCoin!.chain,
+      id: bitcoinCoin!.id,
+      address: bitcoinCoin!.address,
+    }
+    const balanceKey = [
+      balanceInput.chain,
+      balanceInput.id,
+      balanceInput.address,
+    ]
+      .filter(value => value !== undefined)
+      .join(':')
+    const queryKey = ['coinBalance', balanceInput]
+    const staleBalance = 999_999_999_999n
+    const persistedAt = Date.now() - 60_000
+    const persistedClient = {
+      timestamp: Date.now(),
+      buster: 'v3',
+      clientState: {
+        mutations: [],
+        queries: [
+          {
+            queryKey,
+            queryHash: JSON.stringify([
+              'coinBalance',
+              {
+                address: balanceInput.address,
+                chain: balanceInput.chain,
+                ...(balanceInput.id === undefined
+                  ? {}
+                  : { id: balanceInput.id }),
+              },
+            ]),
+            state: {
+              data: { [balanceKey]: staleBalance },
+              dataUpdateCount: 1,
+              dataUpdatedAt: persistedAt,
+              error: null,
+              errorUpdateCount: 0,
+              errorUpdatedAt: 0,
+              fetchFailureCount: 0,
+              fetchFailureReason: null,
+              fetchMeta: null,
+              isInvalidated: false,
+              status: 'success',
+              fetchStatus: 'idle',
+            },
+          },
+        ],
+      },
+    }
+    await writeChromeStorage(
+      context,
+      'queriesPersister',
+      JSON.stringify(persistedClient, (_, value) =>
+        typeof value === 'bigint' ? `${value}n` : value
+      )
+    )
+
+    const page = await context.newPage()
+    const vaultPage = new VaultPage(page, extensionId)
+    const sendFlow = new SendFlow(page, extensionId)
+
+    try {
+      await vaultPage.goto()
+      await vaultPage.waitForView(15_000)
+      await navigateToSend(page)
+      await sendFlow.waitForView(10_000)
+      await sendFlow.selectCoin('BTC')
+      await sendFlow.fillAddress(ownAddress!)
+
+      const availableBalanceDisplay = page.locator(
+        '[data-testid="send-available-balance"]'
+      )
+      await expect(availableBalanceDisplay).toContainText('BTC', {
+        timeout: 20_000,
+      })
+      await expect(page.getByText(/9999\.99999999 BTC/)).toHaveCount(0)
+      const availableBalanceMatch = (
+        await availableBalanceDisplay.innerText()
+      ).match(/([0-9]+(?:\.[0-9]+)?)\s*BTC/)
+      expect(availableBalanceMatch).toBeTruthy()
+      const availableBalance = Number(availableBalanceMatch![1])
+      expect(availableBalance).toBeGreaterThan(0)
+
+      await sendFlow.clickMax()
+      await expect(sendFlow.amountInput).not.toHaveValue('')
+      const formAmount = Number(await sendFlow.amountInput.inputValue())
+      expect(formAmount).toBeGreaterThan(0)
+      expect(formAmount).toBeLessThanOrEqual(availableBalance)
+
+      await sendFlow.continue()
+      await expect(
+        page.getByText("You're sending", { exact: true })
+      ).toBeVisible({ timeout: 30_000 })
+
+      const verifyAmountDisplay = page
+        .locator('[data-testid="transaction-overview-amount"]')
+        .first()
+      await expect(verifyAmountDisplay).toContainText('BTC', {
+        timeout: 30_000,
+      })
+      const verifyAmountText = await verifyAmountDisplay.innerText()
+      const verifyAmountMatch = verifyAmountText.match(
+        /([0-9]+(?:\.[0-9]+)?)\s*BTC/
+      )
+      expect(verifyAmountMatch).toBeTruthy()
+      const verifyAmount = Number(verifyAmountMatch![1])
+      expect(verifyAmount).toBeGreaterThan(0)
+      expect(verifyAmount).toBeLessThanOrEqual(formAmount)
+
+      await page.screenshot({
+        path: 'test-results/max-send-verify-bitcoin.png',
+        fullPage: true,
+      })
+    } finally {
+      await page.close()
+    }
+  })
+
+  test('balance updates after successful send', async ({
+    context,
+    extensionId,
+  }) => {
+    test.skip(!enableTxTests, 'TX signing tests disabled')
 
     const page = await context.newPage()
     const vaultPage = new VaultPage(page, extensionId)
@@ -357,7 +570,9 @@ test.describe('Send Flow', () => {
  * Clicking the "Send" text does nothing — we must click the <button> sibling
  * that contains the SVG icon.
  */
-async function navigateToSend(page: import('@playwright/test').Page): Promise<void> {
+async function navigateToSend(
+  page: import('@playwright/test').Page
+): Promise<void> {
   // Try data-testid first (in case it gets added later)
   const sendByTestId = page.locator('[data-testid="send-button"]')
   if (await sendByTestId.isVisible({ timeout: 2000 }).catch(() => false)) {

--- a/core/ui/mpc/keysign/verify/components/TransactionOverviewAmount.tsx
+++ b/core/ui/mpc/keysign/verify/components/TransactionOverviewAmount.tsx
@@ -23,7 +23,11 @@ type HeroAmountProps = {
 
 const HeroAmount = ({ coin, amount, highPrecision }: HeroAmountProps) => (
   <VStack gap={2}>
-    <HStack alignItems="center" gap={4}>
+    <HStack
+      alignItems="center"
+      gap={4}
+      data-testid="transaction-overview-amount"
+    >
       <Text as="span" size={17}>
         {formatAmount(
           amount,

--- a/core/ui/vault/send/amount/ManageAmountInputField.tsx
+++ b/core/ui/vault/send/amount/ManageAmountInputField.tsx
@@ -1,5 +1,4 @@
 import { useCoinPriceQuery } from '@core/ui/chain/coin/price/queries/useCoinPriceQuery'
-import { useBalanceQuery } from '@core/ui/chain/coin/queries/useBalanceQuery'
 import { AmountInReverseCurrencyDisplay } from '@core/ui/vault/send/amount/AmountInReverseCurrencyDisplay'
 import { AmountSuggestion } from '@core/ui/vault/send/amount/AmountSuggestion'
 import { CurrencySwitch } from '@core/ui/vault/send/amount/AmountSwitch'
@@ -11,6 +10,7 @@ import { HorizontalLine } from '@core/ui/vault/send/components/HorizontalLine'
 import { SendInputContainer } from '@core/ui/vault/send/components/SendInputContainer'
 import { ManageDestinationTag } from '@core/ui/vault/send/memo/ManageDestinationTag'
 import { ManageMemo } from '@core/ui/vault/send/memo/ManageMemo'
+import { useSendBalanceQuery } from '@core/ui/vault/send/queries/useSendBalanceQuery'
 import { useSendFeeEstimateQuery } from '@core/ui/vault/send/queries/useSendFeeEstimateQuery'
 import { useSendValidationQuery } from '@core/ui/vault/send/queries/useSendValidationQuery'
 import { useSendAmount } from '@core/ui/vault/send/state/amount'
@@ -54,7 +54,7 @@ export const ManageAmountInputField = () => {
   const coin = useCurrentSendCoin()
   const coinPriceQuery = useCoinPriceQuery({ coin })
   const feeEstimateQuery = useSendFeeEstimateQuery()
-  const balanceQuery = useBalanceQuery(extractAccountCoinKey(coin))
+  const balanceQuery = useSendBalanceQuery(extractAccountCoinKey(coin))
   const balance = balanceQuery.data
   const isNative = isFeeCoin(coin)
 
@@ -248,6 +248,7 @@ export const ManageAmountInputField = () => {
                 <TotalBalanceWrapper
                   justifyContent="space-between"
                   alignItems="center"
+                  data-testid="send-available-balance"
                 >
                   <Text as="span" size={14} color="contrast">
                     {t('balance_available')}:

--- a/core/ui/vault/send/amount/useSpendableSendAmount.ts
+++ b/core/ui/vault/send/amount/useSpendableSendAmount.ts
@@ -1,7 +1,7 @@
 import { extractAccountCoinKey } from '@vultisig/core-chain/coin/AccountCoin'
 import { isFeeCoin } from '@vultisig/core-chain/coin/utils/isFeeCoin'
 
-import { useBalanceQuery } from '../../../chain/coin/queries/useBalanceQuery'
+import { useSendBalanceQuery } from '../queries/useSendBalanceQuery'
 import { useSendFeeEstimateQuery } from '../queries/useSendFeeEstimateQuery'
 import { useSendAmount } from '../state/amount'
 import { useCurrentSendCoin } from '../state/sendCoin'
@@ -16,7 +16,7 @@ import { adjustAmountForFee } from './adjustAmountForFee'
 export const useSpendableSendAmount = () => {
   const coin = useCurrentSendCoin()
   const [amount] = useSendAmount()
-  const balanceQuery = useBalanceQuery(extractAccountCoinKey(coin))
+  const balanceQuery = useSendBalanceQuery(extractAccountCoinKey(coin))
   const feeEstimateQuery = useSendFeeEstimateQuery()
 
   const balance = balanceQuery.data

--- a/core/ui/vault/send/keysignPayload/query.ts
+++ b/core/ui/vault/send/keysignPayload/query.ts
@@ -22,6 +22,7 @@ import { useSendDestinationTag } from '../state/destinationTag'
 import { useSendMemo } from '../state/memo'
 import { useSendReceiver } from '../state/receiver'
 import { useCurrentSendCoin } from '../state/sendCoin'
+import { reconcileUtxoPlanAmount } from './reconcileUtxoPlanAmount'
 
 type UseSendKeysignPayloadQueryProps = {
   feeSettings?: FeeSettings
@@ -71,7 +72,15 @@ export const useSendKeysignPayloadQuery = ({
 
   return useQuery({
     queryKey: ['sendTxKeysignPayload', omit(input, 'walletCore', 'publicKey')],
-    queryFn: () => buildSendKeysignPayload(input),
+    queryFn: async () => {
+      const keysignPayload = await buildSendKeysignPayload(input)
+
+      return reconcileUtxoPlanAmount({
+        keysignPayload,
+        publicKey: input.publicKey,
+        walletCore: input.walletCore,
+      })
+    },
     ...noRefetchQueryOptions,
     retry: (failureCount, error) => {
       if (error instanceof BuildKeysignPayloadError) {

--- a/core/ui/vault/send/keysignPayload/reconcileUtxoPlanAmount.integration.test.ts
+++ b/core/ui/vault/send/keysignPayload/reconcileUtxoPlanAmount.integration.test.ts
@@ -1,0 +1,56 @@
+import { create } from '@bufbuild/protobuf'
+import { initWasm, WalletCore } from '@trustwallet/wallet-core'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { toCommCoin } from '@vultisig/core-mpc/types/utils/commCoin'
+import { UTXOSpecificSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
+import { KeysignPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { UtxoInfoSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/utxo_info_pb'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import { reconcileUtxoPlanAmount } from './reconcileUtxoPlanAmount'
+
+const address = 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh'
+
+describe('reconcileUtxoPlanAmount WalletCore integration', () => {
+  let walletCore: WalletCore
+
+  beforeAll(async () => {
+    walletCore = await initWasm()
+  })
+
+  it('reads the actual one-output max amount from a real Bitcoin plan', async () => {
+    const keysignPayload = create(KeysignPayloadSchema, {
+      coin: toCommCoin({
+        chain: Chain.Bitcoin,
+        ticker: 'BTC',
+        decimals: 8,
+        address,
+        hexPublicKey: `02${'ab'.repeat(32)}`,
+      }),
+      toAddress: address,
+      toAmount: '999999',
+      utxoInfo: [
+        create(UtxoInfoSchema, {
+          hash: 'ff'.repeat(32),
+          amount: 1_000_000n,
+          index: 0,
+        }),
+      ],
+      blockchainSpecific: {
+        case: 'utxoSpecific',
+        value: create(UTXOSpecificSchema, {
+          sendMaxAmount: true,
+          byteFee: '5',
+        }),
+      },
+    })
+
+    const result = await reconcileUtxoPlanAmount({
+      keysignPayload,
+      publicKey: {} as never,
+      walletCore,
+    })
+
+    expect(result.toAmount).toBe('999450')
+  })
+})

--- a/core/ui/vault/send/keysignPayload/reconcileUtxoPlanAmount.test.ts
+++ b/core/ui/vault/send/keysignPayload/reconcileUtxoPlanAmount.test.ts
@@ -1,0 +1,87 @@
+import { create } from '@bufbuild/protobuf'
+import { getUtxoSigningInputs } from '@vultisig/core-mpc/keysign/signingInputs/resolvers/utxo'
+import { UTXOSpecificSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/blockchain_specific_pb'
+import {
+  KeysignPayload,
+  KeysignPayloadSchema,
+} from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { reconcileUtxoPlanAmount } from './reconcileUtxoPlanAmount'
+
+vi.mock('@vultisig/core-mpc/keysign/signingInputs/resolvers/utxo', () => ({
+  getUtxoSigningInputs: vi.fn(),
+}))
+
+const walletCore = {} as never
+const publicKey = {} as never
+
+const getPayload = ({
+  sendMaxAmount,
+  toAmount = '999450',
+}: {
+  sendMaxAmount?: boolean
+  toAmount?: string
+} = {}): KeysignPayload =>
+  create(KeysignPayloadSchema, {
+    toAmount,
+    blockchainSpecific:
+      sendMaxAmount === undefined
+        ? undefined
+        : {
+            case: 'utxoSpecific',
+            value: create(UTXOSpecificSchema, { sendMaxAmount }),
+          },
+  })
+
+describe('reconcileUtxoPlanAmount', () => {
+  beforeEach(() => {
+    vi.mocked(getUtxoSigningInputs).mockReset()
+  })
+
+  it('replaces a max payload amount with the WalletCore plan amount', async () => {
+    vi.mocked(getUtxoSigningInputs).mockResolvedValue([
+      { plan: { amount: { toString: () => '999100' } } } as never,
+    ])
+    const payload = getPayload({ sendMaxAmount: true })
+
+    const result = await reconcileUtxoPlanAmount({
+      keysignPayload: payload,
+      publicKey,
+      walletCore,
+    })
+
+    expect(result.toAmount).toBe('999100')
+    expect(getUtxoSigningInputs).toHaveBeenCalledWith({
+      keysignPayload: payload,
+      publicKey,
+      walletCore,
+    })
+  })
+
+  it('leaves a regular UTXO payload unchanged', async () => {
+    const payload = getPayload({ sendMaxAmount: false })
+
+    await expect(
+      reconcileUtxoPlanAmount({
+        keysignPayload: payload,
+        publicKey,
+        walletCore,
+      })
+    ).resolves.toBe(payload)
+    expect(getUtxoSigningInputs).not.toHaveBeenCalled()
+  })
+
+  it('leaves a non-UTXO payload unchanged', async () => {
+    const payload = getPayload()
+
+    await expect(
+      reconcileUtxoPlanAmount({
+        keysignPayload: payload,
+        publicKey,
+        walletCore,
+      })
+    ).resolves.toBe(payload)
+    expect(getUtxoSigningInputs).not.toHaveBeenCalled()
+  })
+})

--- a/core/ui/vault/send/keysignPayload/reconcileUtxoPlanAmount.ts
+++ b/core/ui/vault/send/keysignPayload/reconcileUtxoPlanAmount.ts
@@ -1,0 +1,44 @@
+import { BuildSendKeysignPayloadInput } from '@vultisig/core-mpc/keysign/send/build'
+import { getUtxoSigningInputs } from '@vultisig/core-mpc/keysign/signingInputs/resolvers/utxo'
+import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
+
+type ReconcileUtxoPlanAmountInput = Pick<
+  BuildSendKeysignPayloadInput,
+  'publicKey' | 'walletCore'
+> & {
+  keysignPayload: KeysignPayload
+}
+
+/**
+ * A UTXO max plan chooses its final amount after accounting for the exact
+ * transaction shape and fee. Keep `toAmount` aligned with that plan so Verify,
+ * signing records, and the transaction itself all describe the same amount.
+ */
+export const reconcileUtxoPlanAmount = async ({
+  keysignPayload,
+  publicKey,
+  walletCore,
+}: ReconcileUtxoPlanAmountInput): Promise<KeysignPayload> => {
+  if (
+    keysignPayload.blockchainSpecific.case !== 'utxoSpecific' ||
+    !keysignPayload.blockchainSpecific.value.sendMaxAmount
+  ) {
+    return keysignPayload
+  }
+
+  const [signingInput] = await getUtxoSigningInputs({
+    keysignPayload,
+    publicKey: shouldBePresent(publicKey, 'UTXO public key'),
+    walletCore,
+  })
+  const plannedAmount = shouldBePresent(
+    signingInput?.plan?.amount,
+    'UTXO signing input plan amount'
+  )
+
+  return {
+    ...keysignPayload,
+    toAmount: plannedAmount.toString(),
+  }
+}

--- a/core/ui/vault/send/queries/useSendBalanceQuery.test.ts
+++ b/core/ui/vault/send/queries/useSendBalanceQuery.test.ts
@@ -1,0 +1,67 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { accountCoinKeyToString } from '@vultisig/core-chain/coin/AccountCoin'
+import { describe, expect, it } from 'vitest'
+
+import {
+  getFreshSendBalanceQuery,
+  getSendBalanceQueryOptions,
+} from './useSendBalanceQuery'
+
+const input = {
+  chain: Chain.Bitcoin,
+  address: 'bc1qfreshbalance',
+} as const
+const balanceKey = accountCoinKeyToString(input)
+const persistedData = { [balanceKey]: 1_000_000n }
+
+describe('getSendBalanceQueryOptions', () => {
+  it('keeps balance persistence while always refreshing on Send mount', () => {
+    expect(getSendBalanceQueryOptions(input)).toMatchObject({
+      meta: { shouldPersist: true },
+      refetchOnMount: 'always',
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      staleTime: 0,
+    })
+  })
+})
+
+describe('getFreshSendBalanceQuery', () => {
+  it('hides a persisted balance until the mounted Send flow refetches it', () => {
+    expect(
+      getFreshSendBalanceQuery({
+        balanceKey,
+        data: persistedData,
+        dataUpdatedAt: 100,
+        error: null,
+        freshnessBoundary: 200,
+      })
+    ).toEqual({ data: undefined, error: null, isPending: true })
+  })
+
+  it('exposes the refreshed balance after the mounted fetch completes', () => {
+    expect(
+      getFreshSendBalanceQuery({
+        balanceKey,
+        data: { [balanceKey]: 900_000n },
+        dataUpdatedAt: 300,
+        error: null,
+        freshnessBoundary: 200,
+      })
+    ).toEqual({ data: 900_000n, error: null, isPending: false })
+  })
+
+  it('does not fall back to persisted data when the refresh fails', () => {
+    const error = new Error('balance refresh failed')
+
+    expect(
+      getFreshSendBalanceQuery({
+        balanceKey,
+        data: persistedData,
+        dataUpdatedAt: 100,
+        error,
+        freshnessBoundary: 200,
+      })
+    ).toEqual({ data: undefined, error, isPending: false })
+  })
+})

--- a/core/ui/vault/send/queries/useSendBalanceQuery.ts
+++ b/core/ui/vault/send/queries/useSendBalanceQuery.ts
@@ -1,0 +1,79 @@
+import { Query } from '@lib/ui/query/Query'
+import { useQuery } from '@tanstack/react-query'
+import {
+  AccountCoinKey,
+  accountCoinKeyToString,
+} from '@vultisig/core-chain/coin/AccountCoin'
+import { CoinBalanceResolverInput } from '@vultisig/core-chain/coin/balance/resolver'
+import { Exact } from '@vultisig/lib-utils/types/Exact'
+import { useMemo, useRef } from 'react'
+
+import { getBalanceQueryOptions } from '../../../chain/coin/queries/useBalancesQuery'
+
+export const getSendBalanceQueryOptions = <T extends CoinBalanceResolverInput>(
+  input: Exact<CoinBalanceResolverInput, T>
+) => ({
+  ...getBalanceQueryOptions(input),
+  refetchOnMount: 'always' as const,
+  staleTime: 0,
+})
+
+type FreshSendBalanceQueryInput<E> = {
+  balanceKey: string
+  data: Record<string, bigint> | undefined
+  dataUpdatedAt: number
+  error: E | null
+  freshnessBoundary: number
+}
+
+export const getFreshSendBalanceQuery = <E>({
+  balanceKey,
+  data,
+  dataUpdatedAt,
+  error,
+  freshnessBoundary,
+}: FreshSendBalanceQueryInput<E>): Query<bigint, E> => {
+  if (dataUpdatedAt < freshnessBoundary) {
+    return {
+      data: undefined,
+      error,
+      isPending: error === null,
+    }
+  }
+
+  return {
+    data: error === null ? data?.[balanceKey] : undefined,
+    error,
+    isPending: false,
+  }
+}
+
+/**
+ * Send must not trust a persisted balance until this mounted flow has fetched
+ * it again. A stale cached amount is hidden while that mandatory refresh runs,
+ * and remains unavailable if the refresh fails.
+ */
+export const useSendBalanceQuery = <T extends CoinBalanceResolverInput>(
+  input: Exact<CoinBalanceResolverInput, T>
+) => {
+  const balanceKey = accountCoinKeyToString(input as AccountCoinKey)
+  const freshness = useRef({ balanceKey, boundary: Date.now() })
+
+  if (freshness.current.balanceKey !== balanceKey) {
+    freshness.current = { balanceKey, boundary: Date.now() }
+  }
+
+  const query = useQuery(getSendBalanceQueryOptions(input))
+
+  return useMemo(
+    () =>
+      getFreshSendBalanceQuery({
+        balanceKey,
+        data: query.data,
+        dataUpdatedAt: query.dataUpdatedAt,
+        error: query.error,
+        freshnessBoundary: freshness.current.boundary,
+      }),
+    [balanceKey, query.data, query.dataUpdatedAt, query.error]
+  )
+}

--- a/core/ui/vault/send/queries/useSendFeeEstimateQuery.ts
+++ b/core/ui/vault/send/queries/useSendFeeEstimateQuery.ts
@@ -1,4 +1,3 @@
-import { useBalanceQuery } from '@core/ui/chain/coin/queries/useBalanceQuery'
 import { useAssertWalletCore } from '@core/ui/chain/providers/WalletCoreProvider'
 import {
   useCurrentVault,
@@ -18,6 +17,7 @@ import { useSendDestinationTag } from '../state/destinationTag'
 import { useSendMemo } from '../state/memo'
 import { useSendReceiver } from '../state/receiver'
 import { useCurrentSendCoin } from '../state/sendCoin'
+import { useSendBalanceQuery } from './useSendBalanceQuery'
 
 export const useSendFeeEstimateQuery = () => {
   const coin = useCurrentSendCoin()
@@ -25,7 +25,7 @@ export const useSendFeeEstimateQuery = () => {
   const [memo] = useSendMemo()
   const { destinationTag } = useSendDestinationTag()
 
-  const balanceQuery = useBalanceQuery(extractAccountCoinKey(coin))
+  const balanceQuery = useSendBalanceQuery(extractAccountCoinKey(coin))
   const balance = balanceQuery.data
 
   const vault = useCurrentVault()

--- a/core/ui/vault/send/queries/useSendValidationQuery.ts
+++ b/core/ui/vault/send/queries/useSendValidationQuery.ts
@@ -6,13 +6,13 @@ import { isRecordEmpty } from '@vultisig/lib-utils/record/isRecordEmpty'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { useBalanceQuery } from '../../../chain/coin/queries/useBalanceQuery'
 import { useAssertWalletCore } from '../../../chain/providers/WalletCoreProvider'
 import { useSpendableSendAmount } from '../amount/useSpendableSendAmount'
 import { validateSendForm } from '../form/validateSendForm'
 import { useSendDestinationTagInput } from '../state/destinationTag'
 import { useSendReceiver } from '../state/receiver'
 import { useCurrentSendCoin } from '../state/sendCoin'
+import { useSendBalanceQuery } from './useSendBalanceQuery'
 import { useSendFeeEstimateQuery } from './useSendFeeEstimateQuery'
 
 export const useSendValidationQuery = () => {
@@ -27,10 +27,10 @@ export const useSendValidationQuery = () => {
   const [destinationTag] = useSendDestinationTagInput()
   const [address] = useSendReceiver()
   const walletCore = useAssertWalletCore()
-  const balanceQuery = useBalanceQuery(extractAccountCoinKey(coin))
+  const balanceQuery = useSendBalanceQuery(extractAccountCoinKey(coin))
   const feeEstimateQuery = useSendFeeEstimateQuery()
 
-  const nativeBalanceQuery = useBalanceQuery(
+  const nativeBalanceQuery = useSendBalanceQuery(
     extractAccountCoinKey({
       ...chainFeeCoin[coin.chain],
       address: coin.address,


### PR DESCRIPTION
Closes #4551
Real extension QA seeded an obsolete persisted Bitcoin balance, refreshed to the live balance on Send, selected Max, and verified that Send Overview displayed the WalletCore-planned amount before signing. No transaction was signed or broadcast.

![screenshot-1](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/4551-max-send-stale-balance/screenshot-1-1787052240004.png)