### PR TITLE
fix(swap): denominate the limit price in the sell asset

### DIFF
--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -1777,7 +1777,6 @@ export const de = {
   swap_limit_asset: 'Vermögenswert',
   swap_limit_buy: 'Kaufen',
   swap_limit_execute_when: 'Ausführen, wenn',
-  swap_limit_one_unit: '1 {{ticker}}',
   swap_limit_sell: 'Verkaufen',
   swap_limit_blocker_chain_unavailable:
     'Diese Kette wurde vorübergehend auf THORChain angehalten.',
@@ -1893,4 +1892,6 @@ export const de = {
   swap_route_eta_hours: '~{{hours}}h',
   swap_route_eta_hours_minutes: '~{{hours}}h {{minutes}}m',
   swap_route_eta_minutes: '~{{minutes}}m',
+  swap_limit_is_worth: 'wert ist',
+  swap_limit_when_one: 'Wenn 1',
 }

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -1194,8 +1194,9 @@ export const en = {
   swap_limit_asset: 'Asset',
   swap_limit_buy: 'Buy',
   swap_limit_execute_when: 'Execute when',
-  swap_limit_one_unit: '1 {{ticker}}',
+  swap_limit_is_worth: 'is worth',
   swap_limit_sell: 'Sell',
+  swap_limit_when_one: 'When 1',
   swap_limit_blocker_chain_unavailable:
     'This chain is temporarily halted on THORChain',
   swap_limit_blocker_insufficient_balance: 'Amount exceeds your balance',

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -1763,7 +1763,6 @@ export const es = {
   swap_limit_asset: 'Activo',
   swap_limit_buy: 'Comprar',
   swap_limit_execute_when: 'Ejecutar cuando',
-  swap_limit_one_unit: '1 {{ticker}}',
   swap_limit_sell: 'Vender',
   swap_limit_blocker_chain_unavailable:
     'Esta cadena se ha detenido temporalmente en THORChain',
@@ -1879,4 +1878,6 @@ export const es = {
   swap_route_eta_hours: '~{{hours}}h',
   swap_route_eta_hours_minutes: '~{{hours}}h {{minutes}}m',
   swap_route_eta_minutes: '~{{minutes}}m',
+  swap_limit_is_worth: 'valga',
+  swap_limit_when_one: 'Cuando 1',
 }

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -1735,7 +1735,6 @@ export const hr = {
   swap_limit_asset: 'Imovina',
   swap_limit_buy: 'Kupiti',
   swap_limit_execute_when: 'Izvrši kada',
-  swap_limit_one_unit: '1 {{ticker}}',
   swap_limit_sell: 'Prodavati',
   swap_limit_blocker_chain_unavailable:
     'Ovaj lanac je privremeno zaustavljen na THORChain',
@@ -1849,4 +1848,6 @@ export const hr = {
   swap_route_eta_hours: '~{{hours}}h',
   swap_route_eta_hours_minutes: '~{{hours}}h {{minutes}}m',
   swap_route_eta_minutes: '~{{minutes}}m',
+  swap_limit_is_worth: 'vrijedi',
+  swap_limit_when_one: 'Kada 1',
 }

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -1769,7 +1769,6 @@ export const it = {
   swap_limit_asset: 'Risorsa',
   swap_limit_buy: 'Acquistare',
   swap_limit_execute_when: 'Eseguire quando',
-  swap_limit_one_unit: '1 {{ticker}}',
   swap_limit_sell: 'Vendere',
   swap_limit_blocker_chain_unavailable:
     'Questa catena è temporaneamente interrotta su THORChain',
@@ -1885,4 +1884,6 @@ export const it = {
   swap_route_eta_hours: '~{{hours}}h',
   swap_route_eta_hours_minutes: '~{{hours}}h {{minutes}}m',
   swap_route_eta_minutes: '~{{minutes}}m',
+  swap_limit_is_worth: 'vale',
+  swap_limit_when_one: 'Quando 1',
 }

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -1725,7 +1725,6 @@ export const ko = {
   swap_limit_asset: '유산',
   swap_limit_buy: '구입하다',
   swap_limit_execute_when: '실행 시점',
-  swap_limit_one_unit: '1 {{ticker}}',
   swap_limit_sell: '팔다',
   swap_limit_blocker_chain_unavailable:
     '이 체인은 THORChain 에서 일시적으로 중단되었습니다.',
@@ -1839,4 +1838,6 @@ export const ko = {
   swap_route_eta_hours: '~{{hours}}시간',
   swap_route_eta_hours_minutes: '~{{hours}}시간 {{minutes}}분',
   swap_route_eta_minutes: '~{{minutes}}분',
+  swap_limit_is_worth: '의 가치가',
+  swap_limit_when_one: '1',
 }

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -1747,7 +1747,6 @@ export const nl = {
   swap_limit_asset: 'Bezit',
   swap_limit_buy: 'Kopen',
   swap_limit_execute_when: 'Uitvoeren wanneer',
-  swap_limit_one_unit: '1 {{ticker}}',
   swap_limit_sell: 'Verkopen',
   swap_limit_blocker_chain_unavailable:
     'Deze keten is tijdelijk gestopt op THORChain',
@@ -1862,4 +1861,6 @@ export const nl = {
   swap_route_eta_hours: '~{{hours}}h',
   swap_route_eta_hours_minutes: '~{{hours}}h {{minutes}}m',
   swap_route_eta_minutes: '~{{minutes}}m',
+  swap_limit_is_worth: 'waard is',
+  swap_limit_when_one: 'Wanneer 1',
 }

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -1765,7 +1765,6 @@ export const pt = {
   swap_limit_asset: 'Ativo',
   swap_limit_buy: 'Comprar',
   swap_limit_execute_when: 'Executar quando',
-  swap_limit_one_unit: '1 {{ticker}}',
   swap_limit_sell: 'Vender',
   swap_limit_blocker_chain_unavailable:
     'Esta cadeia está temporariamente interrompida em THORChain',
@@ -1882,4 +1881,6 @@ export const pt = {
   swap_route_eta_hours: '~{{hours}}h',
   swap_route_eta_hours_minutes: '~{{hours}}h {{minutes}}m',
   swap_route_eta_minutes: '~{{minutes}}m',
+  swap_limit_is_worth: 'valer',
+  swap_limit_when_one: 'Quando 1',
 }

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -1743,7 +1743,6 @@ export const ru = {
   swap_limit_asset: 'Объект',
   swap_limit_buy: 'Купить',
   swap_limit_execute_when: 'Выполнить при',
-  swap_limit_one_unit: '1 {{ticker}}',
   swap_limit_sell: 'Продавать',
   swap_limit_blocker_chain_unavailable:
     'Данная цепочка временно остановлена ​​на THORChain',
@@ -1858,4 +1857,6 @@ export const ru = {
   swap_route_eta_hours: '~{{hours}}ч',
   swap_route_eta_hours_minutes: '~{{hours}}ч {{minutes}}мин',
   swap_route_eta_minutes: '~{{minutes}}мин',
+  swap_limit_is_worth: 'стоит',
+  swap_limit_when_one: 'Когда 1',
 }

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -1620,7 +1620,6 @@ export const zh = {
   swap_limit_asset: '资产',
   swap_limit_buy: '买',
   swap_limit_execute_when: '执行时机',
-  swap_limit_one_unit: '1 {{ticker}}',
   swap_limit_sell: '卖',
   swap_limit_blocker_chain_unavailable: '此链暂时在THORChain处停止。',
   swap_limit_blocker_insufficient_balance: '金额超过您的余额',
@@ -1725,4 +1724,6 @@ export const zh = {
   swap_route_eta_hours: '~{{hours}}小时',
   swap_route_eta_hours_minutes: '~{{hours}}小时{{minutes}}分',
   swap_route_eta_minutes: '~{{minutes}}分',
+  swap_limit_is_worth: '价值达到',
+  swap_limit_when_one: '当 1',
 }

--- a/core/ui/vault/swap/form/LimitSwapForm.tsx
+++ b/core/ui/vault/swap/form/LimitSwapForm.tsx
@@ -45,12 +45,7 @@ import {
 import { useAdvancedSwapQueueEnabledQuery } from '../limit/queries/useAdvancedSwapQueueEnabledQuery'
 import { useLimitMarketPriceQuery } from '../limit/queries/useLimitMarketPriceQuery'
 import { useLimitSwapSupportedChainsQuery } from '../limit/queries/useLimitSwapSupportedChainsQuery'
-import {
-  fiatUnitPriceToRate,
-  rateToFiatUnitPrice,
-  rateToUnitPrice,
-  unitPriceToRate,
-} from '../limit/rate'
+import { rateToSellUnitFiatValue, sellUnitFiatValueToRate } from '../limit/rate'
 import { useFromAmount } from '../state/fromAmount'
 import { useSwapFromCoin } from '../state/fromCoin'
 import { useSwapToCoin } from '../state/toCoin'
@@ -79,8 +74,8 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
     useState<LimitSwapExpiryHours>(defaultExpiryHours)
 
   // The entered price is meaningless without the exact pair it was typed
-  // against (fiat mode divides by the sell coin's price; asset mode is
-  // sell-per-buy for this pair), so clear it whenever the pair changes —
+  // against (fiat mode anchors on the buy coin's price; asset mode is the
+  // buy-per-sell rate for this pair), so clear it whenever the pair changes —
   // including via the reverse button — rather than carrying a stale value into
   // the new pair.
   const pairKey = `${coinKeyToString(fromCoinKey)}>${coinKeyToString(toCoinKey)}`
@@ -94,7 +89,7 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
   const { data: marketRate, isFetching: isMarketPriceLoading } =
     useLimitMarketPriceQuery({ fromCoin, toCoin })
   const { data: balance } = useBalanceQuery(extractAccountCoinKey(fromCoin))
-  const { data: fromCoinFiatPrice } = useCoinPriceQuery({ coin: fromCoinKey })
+  const { data: toCoinFiatPrice } = useCoinPriceQuery({ coin: toCoinKey })
 
   // The rate (buy units per sell unit) is authoritative -- it is what the memo's
   // LIM encodes. Fiat entry converts into it once, here, rather than being
@@ -108,16 +103,17 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
       return null
     }
 
-    // Both modes express the price of ONE buy unit -- in fiat, or in sell-asset
-    // units ("1 ETH = 0.02 BTC"). Only the unit differs, never the meaning.
+    // Both modes express what ONE sell unit is worth -- in buy-asset units
+    // ("When 1 ETH is worth 0.02 BTC", the rate itself) or in fiat. Only the
+    // unit differs, never the meaning.
     if (unit === 'fiat') {
-      return fiatUnitPriceToRate({
-        fiatUnitPrice: entered,
-        sellCoinFiatPrice: fromCoinFiatPrice,
+      return sellUnitFiatValueToRate({
+        fiatValue: entered,
+        buyCoinFiatPrice: toCoinFiatPrice,
       })
     }
 
-    return unitPriceToRate({ unitPrice: entered })
+    return entered
   })()
 
   // Quantize to the memo's representable precision: a rate from a division has
@@ -128,11 +124,11 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
 
   const toInputValue = (forRate: number, forUnit: LimitPriceUnit) =>
     forUnit === 'fiat'
-      ? rateToFiatUnitPrice({
+      ? rateToSellUnitFiatValue({
           rate: forRate,
-          sellCoinFiatPrice: fromCoinFiatPrice,
+          buyCoinFiatPrice: toCoinFiatPrice,
         })
-      : rateToUnitPrice({ rate: forRate })
+      : forRate
 
   const setPriceFromRate = (nextRate: number, forUnit: LimitPriceUnit) => {
     const next = toInputValue(nextRate, forUnit)
@@ -265,18 +261,18 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
       ? getLimitPriceWarning({ price: rate, marketPrice: marketRate })
       : undefined
 
-  const formatUnitPrice = (value: number) =>
+  const formatDisplayPrice = (value: number) =>
     unit === 'fiat'
       ? `$${formatNumber(value, 2)}`
-      : `${formatNumber(value)} ${fromCoin.ticker}`
+      : `${formatNumber(value)} ${toCoin.ticker}`
 
-  const marketUnitPrice = marketRate
+  const marketDisplayPrice = marketRate
     ? unit === 'fiat'
-      ? rateToFiatUnitPrice({
+      ? rateToSellUnitFiatValue({
           rate: marketRate,
-          sellCoinFiatPrice: fromCoinFiatPrice,
+          buyCoinFiatPrice: toCoinFiatPrice,
         })
-      : rateToUnitPrice({ rate: marketRate })
+      : marketRate
     : null
 
   // The receive amount is the memo's truncated LIM, not amount x rate: showing a
@@ -293,31 +289,30 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
         )
       : null
 
+  // The secondary line mirrors the same unit price in the other unit, so both
+  // readings of the order's trigger stay visible at once.
   const secondaryLabel = (() => {
     if (unit === 'fiat') {
-      return receiveAmount !== null
-        ? `${formatNumber(receiveAmount)} ${toCoin.ticker}`
+      return rate !== null
+        ? `${formatNumber(rate)} ${toCoin.ticker}`
         : undefined
     }
 
     const fiat =
       rate !== null
-        ? rateToFiatUnitPrice({ rate, sellCoinFiatPrice: fromCoinFiatPrice })
+        ? rateToSellUnitFiatValue({ rate, buyCoinFiatPrice: toCoinFiatPrice })
         : null
 
     return fiat !== null ? `$${formatNumber(fiat, 2)}` : undefined
   })()
 
-  // Fiat price of one buy unit, only when the (ungated, independently-loaded)
+  // Fiat value of one sell unit, only when the (ungated, independently-loaded)
   // fiat query has actually resolved — a `?? 0` here would show "$0.00" as the
-  // target price instead of falling back to the asset ratio.
+  // target price instead of falling back to the asset rate.
   const targetFiatPrice =
     rate !== null
-      ? rateToFiatUnitPrice({ rate, sellCoinFiatPrice: fromCoinFiatPrice })
+      ? rateToSellUnitFiatValue({ rate, buyCoinFiatPrice: toCoinFiatPrice })
       : null
-  // Always the asset ratio (sell units per buy unit), never `$`-prefixed, so it
-  // is a correct fallback regardless of the live unit toggle.
-  const targetAssetPrice = rate !== null ? rateToUnitPrice({ rate }) : null
 
   // Hand off through the page-level flow (like the market form) so the review
   // screen replaces the whole form — header and Market/Limit tabs included —
@@ -342,9 +337,7 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
       expectedToAmount,
       memo: memoValue,
       unitPrice:
-        targetAssetPrice !== null
-          ? `${formatNumber(targetAssetPrice)} ${fromCoin.ticker}`
-          : undefined,
+        rate !== null ? `${formatNumber(rate)} ${toCoin.ticker}` : undefined,
       targetPriceLabel:
         targetFiatPrice !== null
           ? `$${formatNumber(targetFiatPrice, 2)}`
@@ -375,7 +368,7 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
               onEdit={() => setStep('asset')}
             />
             <LimitExecuteWhen
-              toCoin={toCoin}
+              fromCoin={fromCoin}
               priceInput={priceInput}
               onPriceInputChange={value => {
                 setPriceInput(value)
@@ -383,12 +376,12 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
               }}
               unit={unit}
               onUnitChange={handleUnitChange}
-              valueSuffix={unit === 'fiat' ? undefined : fromCoin.ticker}
+              valueSuffix={unit === 'fiat' ? undefined : toCoin.ticker}
               valuePrefix={unit === 'fiat' ? '$' : undefined}
               secondaryLabel={secondaryLabel}
               marketLabel={
-                marketUnitPrice !== null
-                  ? formatUnitPrice(marketUnitPrice)
+                marketDisplayPrice !== null
+                  ? formatDisplayPrice(marketDisplayPrice)
                   : undefined
               }
               hasMarketPrice={Boolean(marketRate)}

--- a/core/ui/vault/swap/form/LimitSwapForm.tsx
+++ b/core/ui/vault/swap/form/LimitSwapForm.tsx
@@ -89,7 +89,11 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
   const { data: marketRate, isFetching: isMarketPriceLoading } =
     useLimitMarketPriceQuery({ fromCoin, toCoin })
   const { data: balance } = useBalanceQuery(extractAccountCoinKey(fromCoin))
-  const { data: toCoinFiatPrice } = useCoinPriceQuery({ coin: toCoinKey })
+  // The full vault coin, not the bare view-state key: the price query resolves
+  // a fiat price through the coin's priceProviderId, which the key lacks — with
+  // the key alone the query errors and fiat mode (entry, presets, market label)
+  // silently dies.
+  const { data: toCoinFiatPrice } = useCoinPriceQuery({ coin: toCoin })
 
   // The rate (buy units per sell unit) is authoritative -- it is what the memo's
   // LIM encodes. Fiat entry converts into it once, here, rather than being
@@ -140,15 +144,21 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
     forUnit: LimitPriceUnit
   }
 
+  // Returns whether the input was actually populated, so callers don't mark
+  // state (like an active preset) for a price that never made it into the field
+  // — fiat conversion can fail while the fiat price is still loading.
   const setPriceFromRate = ({ nextRate, forUnit }: SetPriceFromRateInput) => {
     const next = toInputValue({ forRate: nextRate, forUnit })
 
-    if (next !== null) {
-      // toFixed keeps plain decimal notation (a Number round-trip would emit
-      // "1e-8" for tiny values, which parseLimitPrice then rejects); strip the
-      // trailing zeros it pads.
-      setPriceInput(next.toFixed(8).replace(/\.?0+$/, ''))
+    if (next === null) {
+      return false
     }
+
+    // toFixed keeps plain decimal notation (a Number round-trip would emit
+    // "1e-8" for tiny values, which parseLimitPrice then rejects); strip the
+    // trailing zeros it pads.
+    setPriceInput(next.toFixed(8).replace(/\.?0+$/, ''))
+    return true
   }
 
   // Switching units re-expresses the same rate rather than clearing it, so the
@@ -398,18 +408,23 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
               activePreset={activePreset}
               onPresetSelect={preset => {
                 if (marketRate) {
-                  setPriceFromRate({
+                  const applied = setPriceFromRate({
                     nextRate: getPresetPrice({
                       marketPrice: marketRate,
                       preset,
                     }),
                     forUnit: unit,
                   })
+
                   // Remembered rather than re-derived from the live market: the
                   // market moves between the click and the next render, so
                   // comparing the stored rate against a freshly computed preset
-                  // price deselected the pill on the next tick.
-                  setActivePreset(preset)
+                  // price deselected the pill on the next tick. Only remembered
+                  // when the price landed in the field — a highlighted pill
+                  // over an empty input would claim a choice that wasn't made.
+                  if (applied) {
+                    setActivePreset(preset)
+                  }
                 }
               }}
               expiryHours={expiryHours}

--- a/core/ui/vault/swap/form/LimitSwapForm.tsx
+++ b/core/ui/vault/swap/form/LimitSwapForm.tsx
@@ -122,7 +122,12 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
   // and signed LIM all agreeing on the value the memo will hold.
   const rate = rawRate === null ? null : quantizeTargetPrice(rawRate)
 
-  const toInputValue = (forRate: number, forUnit: LimitPriceUnit) =>
+  type ToInputValueInput = {
+    forRate: number
+    forUnit: LimitPriceUnit
+  }
+
+  const toInputValue = ({ forRate, forUnit }: ToInputValueInput) =>
     forUnit === 'fiat'
       ? rateToSellUnitFiatValue({
           rate: forRate,
@@ -130,8 +135,13 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
         })
       : forRate
 
-  const setPriceFromRate = (nextRate: number, forUnit: LimitPriceUnit) => {
-    const next = toInputValue(nextRate, forUnit)
+  type SetPriceFromRateInput = {
+    nextRate: number
+    forUnit: LimitPriceUnit
+  }
+
+  const setPriceFromRate = ({ nextRate, forUnit }: SetPriceFromRateInput) => {
+    const next = toInputValue({ forRate: nextRate, forUnit })
 
     if (next !== null) {
       // toFixed keeps plain decimal notation (a Number round-trip would emit
@@ -146,7 +156,7 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
   const handleUnitChange = (nextUnit: LimitPriceUnit) => {
     if (nextUnit !== unit) {
       if (rate !== null) {
-        setPriceFromRate(rate, nextUnit)
+        setPriceFromRate({ nextRate: rate, forUnit: nextUnit })
       }
       setUnit(nextUnit)
     }
@@ -388,10 +398,13 @@ export const LimitSwapForm: FC<OnFinishProp<LimitOrderReviewData>> = ({
               activePreset={activePreset}
               onPresetSelect={preset => {
                 if (marketRate) {
-                  setPriceFromRate(
-                    getPresetPrice({ marketPrice: marketRate, preset }),
-                    unit
-                  )
+                  setPriceFromRate({
+                    nextRate: getPresetPrice({
+                      marketPrice: marketRate,
+                      preset,
+                    }),
+                    forUnit: unit,
+                  })
                   // Remembered rather than re-derived from the live market: the
                   // market moves between the click and the next render, so
                   // comparing the stored rate against a freshly computed preset

--- a/core/ui/vault/swap/limit/LimitExecuteWhen.tsx
+++ b/core/ui/vault/swap/limit/LimitExecuteWhen.tsx
@@ -25,7 +25,8 @@ export const limitPriceUnits = ['asset', 'fiat'] as const
 export type LimitPriceUnit = (typeof limitPriceUnits)[number]
 
 type LimitExecuteWhenProps = {
-  toCoin: Coin
+  /** The sell asset the header prices: "When 1 <sell ticker> is worth". */
+  fromCoin: Coin
   /** Raw text in the price field, in the active unit. */
   priceInput: string
   onPriceInputChange: (value: string) => void
@@ -33,7 +34,7 @@ type LimitExecuteWhenProps = {
   onUnitChange: (unit: LimitPriceUnit) => void
   /** Rendered before the value (`$` in fiat mode). */
   valuePrefix: string | undefined
-  /** Rendered after the value (the buy ticker in token mode). */
+  /** Rendered after the value (the buy ticker in asset mode). */
   valueSuffix: string | undefined
   /** Secondary line under the value: the other representation. */
   secondaryLabel: string | undefined
@@ -51,13 +52,13 @@ type LimitExecuteWhenProps = {
 /**
  * The price step: what the order waits for.
  *
- * The price is entered against one unit of the *buy* asset ("1 BTC is worth …"),
- * which is how the design reads it. The authoritative value the memo encodes is
- * still the asset-to-asset rate — see `rate.ts` for why fiat entry converts once
- * rather than being stored.
+ * The price is denominated in the *sell* asset: "When 1 ETH is worth …". Asset
+ * mode edits the rate itself (buy units per sell unit) — exactly what the memo's
+ * LIM encodes — and fiat mode edits the fiat value of one sell unit. See
+ * `rate.ts` for why fiat entry converts once rather than being stored.
  */
 export const LimitExecuteWhen: FC<LimitExecuteWhenProps> = ({
-  toCoin,
+  fromCoin,
   priceInput,
   onPriceInputChange,
   unit,
@@ -93,9 +94,12 @@ export const LimitExecuteWhen: FC<LimitExecuteWhenProps> = ({
       <PriceRow>
         <VStack gap={6} alignItems="center">
           <HStack alignItems="center" gap={6}>
-            <CoinIcon coin={toCoin} style={{ fontSize: 20 }} />
             <Text size={13} color="supporting">
-              {t('swap_limit_one_unit', { ticker: toCoin.ticker })}
+              {t('swap_limit_when_one')}
+            </Text>
+            <CoinIcon coin={fromCoin} style={{ fontSize: 20 }} />
+            <Text size={13} color="supporting">
+              {`${fromCoin.ticker} ${t('swap_limit_is_worth')}`}
             </Text>
           </HStack>
           <ValueRow>

--- a/core/ui/vault/swap/limit/LimitOrderReview.tsx
+++ b/core/ui/vault/swap/limit/LimitOrderReview.tsx
@@ -34,9 +34,9 @@ export type LimitOrderReviewData = {
   expectedToAmount: bigint
   /** The `=<` memo to sign. */
   memo: string
-  /** Target price of one buy unit, in sell-asset units. */
+  /** Target worth of one sell unit, in buy-asset units. */
   unitPrice: string | undefined
-  /** Target price of one buy unit, in fiat. */
+  /** Target worth of one sell unit, in fiat. */
   targetPriceLabel: string | undefined
   expiryHours: LimitSwapExpiryHours
 }

--- a/core/ui/vault/swap/limit/memo.test.ts
+++ b/core/ui/vault/swap/limit/memo.test.ts
@@ -131,6 +131,15 @@ describe('buildLimitSwapMemoForCoins', () => {
   it('builds the same memo from an asset-mode and a fiat-mode entry', () => {
     const rate = 0.0295
     const btcFiatPrice = 64_260
+    // Fixed independently of the conversion helpers (0.0295 x 64,260), so a
+    // shared orientation bug in the fiat round trip cannot cancel itself out.
+    const fiatValue = 1_895.67
+
+    expect(
+      shouldBePresent(
+        rateToSellUnitFiatValue({ rate, buyCoinFiatPrice: btcFiatPrice })
+      )
+    ).toBeCloseTo(fiatValue, 2)
 
     const build = (targetPrice: number) =>
       buildLimitSwapMemoForCoins({
@@ -145,12 +154,7 @@ describe('buildLimitSwapMemoForCoins', () => {
     const assetEntry = quantizeTargetPrice(rate)
     const fiatEntry = quantizeTargetPrice(
       shouldBePresent(
-        sellUnitFiatValueToRate({
-          fiatValue: shouldBePresent(
-            rateToSellUnitFiatValue({ rate, buyCoinFiatPrice: btcFiatPrice })
-          ),
-          buyCoinFiatPrice: btcFiatPrice,
-        })
+        sellUnitFiatValueToRate({ fiatValue, buyCoinFiatPrice: btcFiatPrice })
       )
     )
 

--- a/core/ui/vault/swap/limit/memo.test.ts
+++ b/core/ui/vault/swap/limit/memo.test.ts
@@ -7,6 +7,8 @@ import {
   buildLimitSwapMemoForCoins,
   getLimitSwapExpectedToAmount,
 } from './memo'
+import { quantizeTargetPrice } from './price'
+import { rateToSellUnitFiatValue, sellUnitFiatValueToRate } from './rate'
 
 const ethCoin: Coin = { chain: Chain.Ethereum, ticker: 'ETH', decimals: 18 }
 const btcCoin: Coin = { chain: Chain.Bitcoin, ticker: 'BTC', decimals: 8 }
@@ -121,6 +123,41 @@ describe('buildLimitSwapMemoForCoins', () => {
         destinationAddress: evmAddress,
       })
     ).toThrow()
+  })
+
+  // The form's display orientation must never leak into the signed order: the
+  // same target entered in asset mode (the rate itself) or through its fiat
+  // mirror has to land on a byte-identical memo.
+  it('builds the same memo from an asset-mode and a fiat-mode entry', () => {
+    const rate = 0.0295
+    const btcFiatPrice = 64_260
+
+    const build = (targetPrice: number) =>
+      buildLimitSwapMemoForCoins({
+        fromCoin: ethCoin,
+        toCoin: btcCoin,
+        amount: 10n ** 18n,
+        targetPrice,
+        expiryHours: 12,
+        destinationAddress: btcAddress,
+      })
+
+    const assetEntry = quantizeTargetPrice(rate)
+    const fiatEntry = quantizeTargetPrice(
+      shouldBePresent(
+        sellUnitFiatValueToRate({
+          fiatValue: shouldBePresent(
+            rateToSellUnitFiatValue({ rate, buyCoinFiatPrice: btcFiatPrice })
+          ),
+          buyCoinFiatPrice: btcFiatPrice,
+        })
+      )
+    )
+
+    expect(build(fiatEntry)).toBe(build(assetEntry))
+    expect(build(assetEntry)).toBe(
+      `=<:BTC.BTC:${btcAddress}:2950000/7200/0:v0:50`
+    )
   })
 })
 

--- a/core/ui/vault/swap/limit/rate.test.ts
+++ b/core/ui/vault/swap/limit/rate.test.ts
@@ -1,81 +1,67 @@
 import { describe, expect, it } from 'vitest'
 
-import {
-  fiatUnitPriceToRate,
-  rateToFiatUnitPrice,
-  rateToUnitPrice,
-  unitPriceToRate,
-} from './rate'
+import { rateToSellUnitFiatValue, sellUnitFiatValueToRate } from './rate'
 
-// Sell USDT, buy BTC at $65,800.13 -- the Figma reference values.
-const btcPerUsdt = 1 / 65_800.13
+// Sell ETH, buy BTC: 1 ETH is worth 0.02950822 BTC with BTC at ~$64,260.
+const btcPerEth = 0.02950822
+const btcFiatPrice = 64_260
 
-describe('rateToUnitPrice', () => {
-  it('inverts a rate into sell units per buy unit', () => {
-    expect(rateToUnitPrice({ rate: btcPerUsdt })).toBeCloseTo(65_800.13, 2)
+describe('rateToSellUnitFiatValue', () => {
+  it('prices one sell unit in fiat via the buy asset price', () => {
+    expect(
+      rateToSellUnitFiatValue({
+        rate: btcPerEth,
+        buyCoinFiatPrice: btcFiatPrice,
+      })
+    ).toBeCloseTo(1_896.2, 1)
   })
 
   it.each([0, -1])('returns null for a %s rate', rate => {
-    expect(rateToUnitPrice({ rate })).toBeNull()
+    expect(
+      rateToSellUnitFiatValue({ rate, buyCoinFiatPrice: btcFiatPrice })
+    ).toBeNull()
   })
+
+  it.each([undefined, 0])(
+    'returns null without a usable buy price (%s)',
+    buyCoinFiatPrice => {
+      expect(
+        rateToSellUnitFiatValue({ rate: btcPerEth, buyCoinFiatPrice })
+      ).toBeNull()
+    }
+  )
 })
 
-describe('unitPriceToRate', () => {
-  it('round-trips with rateToUnitPrice', () => {
-    const unitPrice = rateToUnitPrice({ rate: btcPerUsdt })
-
-    expect(unitPriceToRate({ unitPrice: unitPrice as number })).toBeCloseTo(
-      btcPerUsdt,
-      12
-    )
-  })
-
-  it.each([0, -1])('returns null for a %s unit price', unitPrice => {
-    expect(unitPriceToRate({ unitPrice })).toBeNull()
-  })
-})
-
-describe('fiatUnitPriceToRate', () => {
-  it('converts a fiat price per buy unit using the sell coin price', () => {
+describe('sellUnitFiatValueToRate', () => {
+  it('round-trips with rateToSellUnitFiatValue', () => {
     expect(
-      fiatUnitPriceToRate({ fiatUnitPrice: 65_800.13, sellCoinFiatPrice: 1 })
-    ).toBeCloseTo(btcPerUsdt, 12)
+      sellUnitFiatValueToRate({
+        fiatValue: btcPerEth * btcFiatPrice,
+        buyCoinFiatPrice: btcFiatPrice,
+      })
+    ).toBeCloseTo(btcPerEth, 12)
   })
 
-  it('handles a sell asset that is not a dollar stablecoin', () => {
-    // Sell ETH at $2,000, buy BTC at $60,000 -> 1 ETH buys 1/30 BTC.
+  it('handles a buy asset that is not a dollar stablecoin', () => {
+    // 1 ETH worth $2,000 with BTC at $60,000 -> 1 ETH buys 1/30 BTC.
     expect(
-      fiatUnitPriceToRate({ fiatUnitPrice: 60_000, sellCoinFiatPrice: 2_000 })
+      sellUnitFiatValueToRate({ fiatValue: 2_000, buyCoinFiatPrice: 60_000 })
     ).toBeCloseTo(1 / 30, 12)
   })
 
   // Fabricating a rate here would become the signed LIM.
   it.each([undefined, 0])(
-    'returns null without a usable sell price (%s)',
-    sellCoinFiatPrice => {
+    'returns null without a usable buy price (%s)',
+    buyCoinFiatPrice => {
       expect(
-        fiatUnitPriceToRate({ fiatUnitPrice: 65_800, sellCoinFiatPrice })
+        sellUnitFiatValueToRate({ fiatValue: 1_896.2, buyCoinFiatPrice })
       ).toBeNull()
     }
   )
 
-  it('returns null for a non-positive fiat price', () => {
+  it('returns null for a non-positive fiat value', () => {
     expect(
-      fiatUnitPriceToRate({ fiatUnitPrice: 0, sellCoinFiatPrice: 1 })
-    ).toBeNull()
-  })
-})
-
-describe('rateToFiatUnitPrice', () => {
-  it('is the inverse of fiatUnitPriceToRate', () => {
-    expect(
-      rateToFiatUnitPrice({ rate: btcPerUsdt, sellCoinFiatPrice: 1 })
-    ).toBeCloseTo(65_800.13, 2)
-  })
-
-  it('returns null without a sell price', () => {
-    expect(
-      rateToFiatUnitPrice({ rate: btcPerUsdt, sellCoinFiatPrice: undefined })
+      sellUnitFiatValueToRate({ fiatValue: 0, buyCoinFiatPrice: btcFiatPrice })
     ).toBeNull()
   })
 })

--- a/core/ui/vault/swap/limit/rate.ts
+++ b/core/ui/vault/swap/limit/rate.ts
@@ -2,73 +2,53 @@
  * Price conversions for the limit form.
  *
  * The authoritative value is always the **rate**: buy-asset units per sell-asset
- * unit, which is exactly what the memo's LIM encodes. Fiat is a display and
- * entry convenience that converts to a rate once, at input.
+ * unit, which is exactly what the memo's LIM encodes. It is also what asset mode
+ * displays and edits directly ("When 1 ETH is worth 0.0295 BTC"), so asset entry
+ * needs no conversion. Fiat is a display and entry convenience that converts to
+ * a rate once, at input.
  *
- * Keeping the rate authoritative is a fund-safety decision, matching iOS: if the
- * fiat figure were the source of truth, a drifting or bad price feed between
- * entry and signing would silently change the order the user actually commits
- * to.
+ * Keeping the rate authoritative is a fund-safety decision: if the fiat figure
+ * were the source of truth, a drifting or bad price feed between entry and
+ * signing would silently change the order the user actually commits to.
  */
 
-type RateToUnitPriceInput = {
+type RateToSellUnitFiatValueInput = {
   /** Buy-asset units per sell-asset unit. */
   rate: number
+  /** Fiat price of one buy-asset unit. */
+  buyCoinFiatPrice: number | undefined
 }
 
 /**
- * Sell-asset units needed to buy one unit of the buy asset — the inverse of the
- * rate, and the orientation the form displays ("1 BTC is worth …").
- */
-export const rateToUnitPrice = ({
-  rate,
-}: RateToUnitPriceInput): number | null => (rate > 0 ? 1 / rate : null)
-
-type UnitPriceToRateInput = {
-  /** Sell-asset units per one buy-asset unit. */
-  unitPrice: number
-}
-
-/** Inverse of {@link rateToUnitPrice}. */
-export const unitPriceToRate = ({
-  unitPrice,
-}: UnitPriceToRateInput): number | null =>
-  unitPrice > 0 ? 1 / unitPrice : null
-
-type FiatUnitPriceToRateInput = {
-  /** Fiat price of one buy-asset unit, as entered. */
-  fiatUnitPrice: number
-  /** Fiat price of one sell-asset unit. */
-  sellCoinFiatPrice: number | undefined
-}
-
-/**
- * Convert a fiat price per buy-asset unit into a rate.
+ * Fiat value of one sell-asset unit at the target rate — the figure fiat mode
+ * shows under "When 1 ETH is worth".
  *
- * Returns `null` without a sell-asset fiat price rather than guessing — a
+ * Returns `null` without a buy-asset fiat price rather than guessing.
+ */
+export const rateToSellUnitFiatValue = ({
+  rate,
+  buyCoinFiatPrice,
+}: RateToSellUnitFiatValueInput): number | null =>
+  rate > 0 && buyCoinFiatPrice && buyCoinFiatPrice > 0
+    ? rate * buyCoinFiatPrice
+    : null
+
+type SellUnitFiatValueToRateInput = {
+  /** Fiat value of one sell-asset unit, as entered. */
+  fiatValue: number
+  buyCoinFiatPrice: number | undefined
+}
+
+/**
+ * Convert an entered fiat value of one sell-asset unit into a rate.
+ *
+ * Returns `null` without a buy-asset fiat price rather than guessing — a
  * fabricated rate here would become the signed LIM.
  */
-export const fiatUnitPriceToRate = ({
-  fiatUnitPrice,
-  sellCoinFiatPrice,
-}: FiatUnitPriceToRateInput): number | null =>
-  fiatUnitPrice > 0 && sellCoinFiatPrice && sellCoinFiatPrice > 0
-    ? sellCoinFiatPrice / fiatUnitPrice
+export const sellUnitFiatValueToRate = ({
+  fiatValue,
+  buyCoinFiatPrice,
+}: SellUnitFiatValueToRateInput): number | null =>
+  fiatValue > 0 && buyCoinFiatPrice && buyCoinFiatPrice > 0
+    ? fiatValue / buyCoinFiatPrice
     : null
-
-type RateToFiatUnitPriceInput = {
-  rate: number
-  sellCoinFiatPrice: number | undefined
-}
-
-/** Fiat price of one buy-asset unit implied by a rate. */
-export const rateToFiatUnitPrice = ({
-  rate,
-  sellCoinFiatPrice,
-}: RateToFiatUnitPriceInput): number | null => {
-  const unitPrice = rateToUnitPrice({ rate })
-
-  return unitPrice !== null && sellCoinFiatPrice && sellCoinFiatPrice > 0
-    ? unitPrice * sellCoinFiatPrice
-    : null
-}


### PR DESCRIPTION
Fixes #4674

## What changed

The limit form's price step now reads "When 1 <sell ticker> is worth …", denominated in the sell asset:

- **Asset mode** edits the rate itself (buy units per sell unit) — the exact value the memo's LIM encodes — instead of its inverse. The value is suffixed with the buy ticker: "When 1 ETH is worth `0.0295` BTC".
- **Fiat mode** edits the fiat value of one sell unit, converted to the rate once at input via the buy coin's fiat price (`rate = fiatValue / buyCoinFiatPrice`).
- The market label, the secondary line (which now mirrors the same unit price in the other unit), and the review screen's target-price strings follow the same orientation.
- Because the displayed number is now the rate itself, the +1/+5/+10% presets move the on-screen price in the same direction (previously "+5%" made the displayed inverse price go *down* ~4.76%).

`rate.ts` shrinks to two conversions (`rateToSellUnitFiatValue`, `sellUnitFiatValueToRate`); the four buy-unit-oriented helpers are gone.

## What didn't change

The authoritative value is still the quantized rate, and the memo/LIM path (`buildLimitSwapMemoForCoins`, `quantizeTargetPrice`, keysign payload) is untouched — an order placed at a given rate produces the same memo as before.

## i18n

`swap_limit_one_unit` is replaced by `swap_limit_when_one` / `swap_limit_is_worth`. Locales were synced with `yarn translate`; the machine output for the split fragments was hand-reviewed and corrected where it picked the wrong sense of "worth" (es, pt, de, nl, zh, ko).

## Validation

`yarn check:all` — all suites pass (977 + 565 + 26 tests, i18n integrity green). The `quality:docs` external-link check flaked once on an unrelated pre-existing doc link and passes on re-run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Limit-swap pricing now consistently shows the value of one sell-asset unit in the selected buy asset.
  - Fiat-based pricing uses the buy asset’s current fiat value.
  - Updated rate displays, labels, input suffixes, review details, presets, and submitted prices for consistency.
  - Invalid fiat conversions no longer activate pricing presets.
  - Changing the asset pair still clears previously entered pricing.

- **Localization**
  - Updated limit-swap pricing text across supported languages.
  - Added localized route selection and route-estimate messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->