### PR TITLE
fix(extension): delegate EIP-1193 calls on the window.vultisig container

### DIFF
--- a/clients/extension/src/inpage/utils/eip1193Delegates.ts
+++ b/clients/extension/src/inpage/utils/eip1193Delegates.ts
@@ -1,0 +1,35 @@
+const delegatedMethods = [
+  'request',
+  'on',
+  'removeListener',
+  'isConnected',
+] as const
+
+type DelegatedMethod = (typeof delegatedMethods)[number]
+
+type InstallEip1193DelegatesInput = {
+  container: object
+  evmProvider: Record<DelegatedMethod, (...args: never[]) => unknown>
+}
+
+/**
+ * Adds the EIP-1193 surface (`request`, `on`, `removeListener`,
+ * `isConnected`) to the multi-chain `window.vultisig` container, bound to
+ * the EVM provider. Legacy integrations probe `window.<walletname>`
+ * directly and assume it IS the provider; the delegates keep those flows
+ * working while `window.vultisig.ethereum` stays the canonical provider.
+ * Defined non-enumerable so consumers that iterate the container's keys
+ * (the `window.xfi`-style chain-per-key pattern) keep seeing only chain
+ * entries, and non-writable so dapp code can't clobber them.
+ */
+export const installEip1193Delegates = ({
+  container,
+  evmProvider,
+}: InstallEip1193DelegatesInput) => {
+  for (const method of delegatedMethods) {
+    Object.defineProperty(container, method, {
+      value: evmProvider[method].bind(evmProvider),
+      enumerable: false,
+    })
+  }
+}

--- a/clients/extension/src/inpage/utils/windowInjector.ts
+++ b/clients/extension/src/inpage/utils/windowInjector.ts
@@ -14,6 +14,7 @@ import { Solana } from '../providers/solana'
 import { registerWallet } from '../providers/solana/register'
 import { UTXO } from '../providers/utxo'
 import { createXrplProvider, installXrplAdapter } from '../providers/xrpl'
+import { installEip1193Delegates } from './eip1193Delegates'
 
 // Wallet-picker descriptor pushed to `window.terraWallets` /
 // `window.interchainWallets`. Mirrors the `STATION_INFO` shape the official
@@ -46,6 +47,14 @@ export const injectToWindow = () => {
     getVault: async () => callBackground({ exportVault: {} }),
     getVaults: async () => callPopup({ exportVaults: {} }),
   }
+
+  // Legacy EVM integrations (web3-onboard custom entries, hand-rolled dapp
+  // allowlists) call `window.vultisig.request(...)` directly instead of
+  // going through EIP-6963 or `window.vultisig.ethereum` (#4626).
+  installEip1193Delegates({
+    container: vultisigProvider,
+    evmProvider: ethereumProvider,
+  })
 
   Object.defineProperty(window, 'vultisig', {
     value: vultisigProvider,

--- a/clients/extension/tests/e2e/global.d.ts
+++ b/clients/extension/tests/e2e/global.d.ts
@@ -2,6 +2,11 @@
  * Type declarations for the providers injected by VultiConnect.
  * Used in Playwright evaluate() calls.
  */
+type ProviderRequest = (args: {
+  method: string
+  params?: unknown[]
+}) => Promise<unknown>
+
 interface EthereumProvider {
   isMetaMask: boolean
   isVultiConnect: boolean
@@ -113,20 +118,26 @@ interface VultisigProvider {
   litecoin: UTXOProvider
   zcash: UTXOProvider
   cosmos: CosmosProvider
-  dash: { chainId: string; request: Function }
+  dash: { chainId: string; request: ProviderRequest }
   ethereum: EthereumProvider
   keplr: KeplrProvider
   mayachain: CosmosProvider
   polkadot: PolkadotInjected
-  ripple: { request: Function }
+  ripple: { request: ProviderRequest }
   solana: SolanaProvider
-  sui: { request: Function }
+  sui: { request: ProviderRequest }
   thorchain: CosmosProvider
   tron: TronLinkProvider
-  cardano: { request: Function }
+  cardano: { request: ProviderRequest }
   plugin: unknown
   getVault(): Promise<unknown>
   getVaults(): Promise<unknown>
+  // Non-enumerable EIP-1193 delegates bound to `ethereum` for legacy
+  // integrations that treat `window.vultisig` as the provider itself
+  request: EthereumProvider['request']
+  on: EthereumProvider['on']
+  removeListener: EthereumProvider['removeListener']
+  isConnected: EthereumProvider['isConnected']
 }
 
 declare global {

--- a/clients/extension/tests/e2e/specs/dapp-provider.spec.ts
+++ b/clients/extension/tests/e2e/specs/dapp-provider.spec.ts
@@ -8,6 +8,7 @@
  * - wallet_switchEthereumChain - chainChanged event fires
  * - reject connection returns UserRejectedRequest error
  * - window.vultisig and its Solana provider are injected
+ * - window.vultisig delegates the EIP-1193 surface without losing cross-chain keys
  */
 
 import { test, expect } from '../fixtures/extension-loader'
@@ -385,5 +386,48 @@ test.describe('DApp Provider', () => {
       })
 
     await page.close()
+  })
+
+  test('window.vultisig delegates the EIP-1193 surface without losing cross-chain keys', async ({ context }) => {
+    const page = await context.newPage()
+
+    try {
+      await page.goto(dappUrl)
+      await page.waitForLoadState('domcontentloaded')
+      await page.waitForFunction(() => !!window.vultisig, null, { timeout: 10000 })
+
+      const delegatedMethods = ['request', 'on', 'removeListener', 'isConnected']
+
+      const result = await page.evaluate(async (delegated) => {
+        const keys = Object.keys(window.vultisig)
+        return {
+          delegateTypes: delegated.map(
+            (method) => typeof Reflect.get(window.vultisig, method)
+          ),
+          // Legacy path and canonical provider must answer identically
+          chainIdViaContainer: await window.vultisig.request({ method: 'eth_chainId' }),
+          chainIdViaProvider: await window.vultisig.ethereum.request({ method: 'eth_chainId' }),
+          isConnectedMatchesProvider:
+            window.vultisig.isConnected() === window.vultisig.ethereum.isConnected(),
+          enumerableDelegates: keys.filter((key) => delegated.includes(key)),
+          crossChainKeysIntact: [
+            'ethereum',
+            'solana',
+            'thorchain',
+            'xrpl',
+            'getVault',
+            'getVaults',
+          ].every((key) => keys.includes(key)),
+        }
+      }, delegatedMethods)
+
+      expect(result.delegateTypes).toEqual(['function', 'function', 'function', 'function'])
+      expect(result.chainIdViaContainer).toBe(result.chainIdViaProvider)
+      expect(result.isConnectedMatchesProvider).toBe(true)
+      expect(result.enumerableDelegates).toEqual([])
+      expect(result.crossChainKeysIntact).toBe(true)
+    } finally {
+      await page.close()
+    }
   })
 })

--- a/clients/extension/tests/unit/eip1193Delegates.test.ts
+++ b/clients/extension/tests/unit/eip1193Delegates.test.ts
@@ -1,0 +1,107 @@
+import { installEip1193Delegates } from '@clients/extension/src/inpage/utils/eip1193Delegates'
+import EventEmitter from 'events'
+import { describe, expect, it, vi } from 'vitest'
+
+const delegatedMethods = [
+  'request',
+  'on',
+  'removeListener',
+  'isConnected',
+] as const
+
+class FakeEvmProvider extends EventEmitter {
+  connected = false
+  handled: string[] = []
+
+  isConnected() {
+    return this.connected
+  }
+
+  async request({ method }: { method: string }) {
+    // Relies on `this`, so an unbound delegate would throw here
+    this.handled.push(method)
+    return `result:${method}`
+  }
+}
+
+const setup = () => {
+  const evmProvider = new FakeEvmProvider()
+  const container = {
+    ethereum: evmProvider,
+    solana: { isSolana: true },
+    xrpl: { isXrpl: true },
+    getVaults: async () => [],
+  }
+  installEip1193Delegates({ container, evmProvider })
+  return { container, evmProvider }
+}
+
+describe('installEip1193Delegates', () => {
+  it('forwards request to the EVM provider with a bound this', async () => {
+    const { container, evmProvider } = setup()
+
+    const request = Reflect.get(container, 'request')
+    await expect(request({ method: 'eth_chainId' })).resolves.toBe(
+      'result:eth_chainId'
+    )
+    expect(evmProvider.handled).toEqual(['eth_chainId'])
+  })
+
+  it('reflects the provider connection state through isConnected', () => {
+    const { container, evmProvider } = setup()
+
+    const isConnected = Reflect.get(container, 'isConnected')
+    expect(isConnected()).toBe(false)
+    evmProvider.connected = true
+    expect(isConnected()).toBe(true)
+  })
+
+  it('wires on/removeListener to the provider event emitter', () => {
+    const { container, evmProvider } = setup()
+    const listener = vi.fn()
+
+    Reflect.get(container, 'on')('accountsChanged', listener)
+    evmProvider.emit('accountsChanged', ['0xabc'])
+    expect(listener).toHaveBeenCalledWith(['0xabc'])
+
+    Reflect.get(container, 'removeListener')('accountsChanged', listener)
+    evmProvider.emit('accountsChanged', [])
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the delegates out of key enumeration and spreads', () => {
+    const { container } = setup()
+    const expectedKeys = ['ethereum', 'solana', 'xrpl', 'getVaults']
+
+    expect(Object.keys(container)).toEqual(expectedKeys)
+    expect(Object.keys({ ...container })).toEqual(expectedKeys)
+  })
+
+  it('remains feature-detectable by direct property access', () => {
+    const { container } = setup()
+
+    for (const method of delegatedMethods) {
+      expect(typeof Reflect.get(container, method)).toBe('function')
+    }
+  })
+
+  it('defines the delegates as non-writable and non-configurable', () => {
+    const { container } = setup()
+
+    for (const method of delegatedMethods) {
+      expect(Object.getOwnPropertyDescriptor(container, method)).toMatchObject({
+        enumerable: false,
+        writable: false,
+        configurable: false,
+      })
+    }
+  })
+
+  it('leaves existing container members untouched', () => {
+    const { container, evmProvider } = setup()
+
+    expect(container.ethereum).toBe(evmProvider)
+    expect(container.solana).toEqual({ isSolana: true })
+    expect(container.xrpl).toEqual({ isXrpl: true })
+  })
+})


### PR DESCRIPTION
Closes #4626

## Problem

`window.vultisig` is the frozen multi-chain container — the actual EIP-1193 provider lives at `window.vultisig.ethereum`, which is also what we announce via EIP-6963 and install as `window.ethereum`. Legacy integrations (web3-onboard custom injected entries, hand-rolled dapp allowlists, registries whose schema is just a window property name) probe `window.<walletname>` directly and assume it IS the provider, so `window.vultisig.request()` threw.

## Change

`installEip1193Delegates` binds `request`, `on`, `removeListener`, and `isConnected` to the EVM provider and defines them on the container before it is frozen onto the window. Binding is required rather than cosmetic: `on`/`removeListener` live on the `EventEmitter` prototype, so a spread would miss them and unbound copies would break `this`.

The delegates are:
- **non-enumerable** — consumers that iterate the container's keys (the `window.xfi`-style chain-per-key pattern) keep seeing only chain entries, so the shim can't leak into spreads or `Object.keys`
- **non-writable / non-configurable** — dapp code can't clobber them, consistent with the container being non-writable at the window level

Cross-chain semantics are untouched: every chain provider, `xrpl`, `getVault`/`getVaults` stay exactly as before, and EIP-6963 announcement / `window.ethereum` behavior is unchanged.

## Misclassification sweep

Per the issue's hard requirement, checked the known multi-chain detection patterns:
- **web3-onboard** has no built-in Vultisig module — the custom per-dapp entries are exactly the callers this fixes
- **RainbowKit** targets `vultisig.ethereum` (rainbow-me/rainbowkit#2692), unaffected
- **wagmi/viem** discover via EIP-6963 and `window.ethereum`, no container sniffing
- **Cosmos/Terra/XRPL/Solana** ecosystems detect via their own globals (`keplr`, `station`, `gemWallet`, wallet-standard), all untouched
- Enumeration-based classification is covered by the non-enumerable design and asserted in tests

## Testing

- 7 new unit tests (`eip1193Delegates.test.ts`): forwarding with bound `this`, live event wiring through a real `EventEmitter`, invisibility to `Object.keys`/spreads, feature-detectability by direct access, descriptor flags, container members untouched
- New e2e test in `dapp-provider.spec.ts`: `window.vultisig.request({method: 'eth_chainId'})` answers identically to `window.vultisig.ethereum.request(...)`, delegates stay out of key enumeration, and all cross-chain keys survive
- Extension unit suite 586/586, extension + e2e typecheck clean, ESLint clean, knip passes

Note: root `yarn typecheck` currently fails with 15 pre-existing errors in `core/ui/vault/swap/**` against `@vultisig/core-chain@2.37.0` — verified identical on clean `main`, unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added EIP-1193 provider compatibility for `window.vultisig`, enabling legacy dapps to use standard request, connection, and event-listener methods.
  - Provider methods now reflect the active Ethereum connection while preserving access to supported cross-chain providers.

- **Bug Fixes**
  - Improved provider integration by preventing delegated methods from being accidentally replaced or exposed during provider enumeration.

- **Tests**
  - Added coverage for provider forwarding, connection state, event handling, feature detection, and cross-chain behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->