### PR TITLE
fix(extension): unblank the popup after storage migrations succeed

### DIFF
--- a/clients/extension/tests/unit/storageMigrationsManagerRendering.test.tsx
+++ b/clients/extension/tests/unit/storageMigrationsManagerRendering.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+/**
+ * Rendering contract of the storage migrations gate. The whole extension app
+ * mounts behind StorageMigrationsManager, so its MatchQuery must land on a
+ * branch that renders something for every mutation outcome. A void migration
+ * result once left it on the null `inactive` branch forever, shipping a
+ * blank popup with no error anywhere.
+ */
+import { migrateExtensionStorage } from '@core/extension/storage/migrations/migrateExtensionStorage'
+import { StorageMigrationsManager } from '@core/extension/storage/migrations/StorageMigrationManager'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@core/extension/storage/migrations/migrateExtensionStorage', () => ({
+  migrateExtensionStorage: vi.fn(),
+}))
+
+vi.mock('@core/ui/state/core', () => ({
+  useCore: () => ({ version: '0.2.2' }),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('@core/ui/product/ProductLogoBlock', () => ({
+  ProductLogoBlock: () => <div data-testid="splash" />,
+}))
+
+vi.mock('@core/ui/flow/FlowErrorPageContent', () => ({
+  FlowErrorPageContent: ({ title }: { title: string }) => (
+    <div data-testid="migration-error">{title}</div>
+  ),
+}))
+
+const renderManager = () =>
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <StorageMigrationsManager>
+        <div data-testid="app-content" />
+      </StorageMigrationsManager>
+    </QueryClientProvider>
+  )
+
+describe('StorageMigrationsManager', () => {
+  beforeEach(() => {
+    vi.mocked(migrateExtensionStorage).mockReset()
+  })
+
+  it('renders children once migrations complete', async () => {
+    vi.mocked(migrateExtensionStorage).mockResolvedValueOnce(undefined)
+
+    renderManager()
+
+    expect(await screen.findByTestId('app-content')).toBeTruthy()
+    expect(vi.mocked(migrateExtensionStorage)).toHaveBeenCalledWith('0.2.2')
+  })
+
+  it('shows the migration error page when migrating fails', async () => {
+    vi.mocked(migrateExtensionStorage).mockRejectedValueOnce(
+      new Error('migration failed')
+    )
+
+    renderManager()
+
+    expect(await screen.findByTestId('migration-error')).toBeTruthy()
+  })
+})

--- a/core/extension/storage/migrations/StorageMigrationManager.tsx
+++ b/core/extension/storage/migrations/StorageMigrationManager.tsx
@@ -14,7 +14,13 @@ export const StorageMigrationsManager = ({ children }: ChildrenProp) => {
   const { version } = useCore()
 
   const { mutate: migrate, ...mutationStatus } = useMutation({
-    mutationFn: () => migrateExtensionStorage(version),
+    // MatchQuery only takes the success branch for defined data, so a void
+    // mutation would keep the whole app on the null `inactive` branch after
+    // migrations finish
+    mutationFn: async () => {
+      await migrateExtensionStorage(version)
+      return true
+    },
   })
 
   useEffect(() => {


### PR DESCRIPTION
## Problem

Since #4672, clicking the extension opens a permanently blank popup — dark background, no content, and nothing in the console. It affects fresh installs and existing profiles alike.

## Root cause

The whole app mounts behind `StorageMigrationsManager`, which renders through `MatchQuery`. `MatchQuery` only takes the `success` branch when `value.data !== undefined`; anything else falls through to the default `inactive` branch, which renders `null`.

#4672 refactored the migration mutation from a function that ended with `return true` to:

```ts
mutationFn: () => migrateExtensionStorage(version),  // Promise<void>
```

The migrations actually run and succeed — but the mutation resolves `undefined`, so `MatchQuery` never matches `success` and the app stays on the null `inactive` branch forever. No error is thrown anywhere, which is why the popup is silently blank.

Diagnosed by loading the built extension in headless Chromium and walking the React fiber tree from `#root`: the tree is alive down to `StorageMigrationsManager → MatchQuery`, which is a childless leaf. A build of the commit just before #4672 continues past it into the app.

## Change

- Resolve a defined value (`true`) from the mutation again, with a comment documenting the MatchQuery constraint so the next refactor doesn't reintroduce this.
- Add `storageMigrationsManagerRendering.test.tsx`: mounts `StorageMigrationsManager` through a real `QueryClient` and asserts children render once migrations complete (and that the error page shows on failure). The test fails against current `main` and passes with the fix — #4672's own unit tests only covered the storage side of `migrateExtensionStorage`, so the rendering gap shipped green.

## Testing

- New rendering test verified red on unfixed `main`, green with the fix
- Verified end-to-end by rebuilding the extension and loading it in Chromium: popup renders the onboarding screen again
- Extension unit suite 581/581, extension + root typecheck clean, ESLint clean, knip passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved extension storage migration handling so the extension continues loading after successful migrations.
  - Resolved an issue that could prevent normal extension content from appearing after migration.
  - Migration failures now display the appropriate error page for clearer recovery guidance.

- **Tests**
  - Added coverage for successful storage migrations and migration error states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->