### PR TITLE
feat(defi): Kamino Earn withdraw flow

### DIFF
--- a/core/ui/defi/chain/solana/kamino/KaminoAmountField.tsx
+++ b/core/ui/defi/chain/solana/kamino/KaminoAmountField.tsx
@@ -1,0 +1,110 @@
+import { ActionAmountInputSurface } from '@core/ui/vault/components/action-form/ActionAmountInputSurface'
+import { ActionFieldDivider } from '@core/ui/vault/components/action-form/ActionFieldDivider'
+import { ActionInputContainer } from '@core/ui/vault/components/action-form/ActionInputContainer'
+import { getPercentageShareAmount } from '@core/ui/vault/deposit/utils/percentageShare'
+import { AmountTextInput } from '@lib/ui/inputs/AmountTextInput'
+import { Slider } from '@lib/ui/inputs/Slider'
+import { HStack, VStack } from '@lib/ui/layout/Stack'
+import { Text } from '@lib/ui/text'
+import { getColor } from '@lib/ui/theme/getters'
+import { formatAmount } from '@vultisig/lib-utils/formatAmount'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+
+type KaminoAmountFieldProps = {
+  value: number | null
+  onChange: (value: number | null) => void
+  ticker: string
+  decimals: number
+  /** The spendable balance, in human units, that 100% resolves to. */
+  balance: number
+  /** The same balance in base units — what a percentage is taken of. */
+  balanceUnits: bigint
+  /** Label for the balance row, e.g. "Balance available" or "Available to withdraw". */
+  balanceLabel: string
+  error?: string
+}
+
+/**
+ * Amount entry for the Kamino forms, in the shape the app's other amount
+ * steps use: one labelled surface holding a large centred value, a percentage
+ * slider, and the balance the percentage is taken of.
+ *
+ * The percentage resolves against BASE UNITS rather than the displayed
+ * figure — taking a fraction of a rounded display value would drift from the
+ * balance it claims to be a fraction of.
+ */
+export const KaminoAmountField = ({
+  value,
+  onChange,
+  ticker,
+  decimals,
+  balance,
+  balanceUnits,
+  balanceLabel,
+  error,
+}: KaminoAmountFieldProps) => {
+  const { t } = useTranslation()
+
+  const percentage =
+    value === null || balance === 0
+      ? 0
+      : Math.min(100, Math.round((value / balance) * 100))
+
+  return (
+    <ActionInputContainer>
+      <Text weight="600" size={16}>
+        {t('amount')}
+      </Text>
+      <ActionFieldDivider />
+      <VStack gap={12} flexGrow>
+        <ActionAmountInputSurface>
+          <AmountTextInput
+            value={value}
+            onValueChange={onChange}
+            placeholder="0"
+            shouldBePositive
+            unit={ticker}
+          />
+        </ActionAmountInputSurface>
+        {error ? (
+          <Text color="danger" size={13}>
+            {error}
+          </Text>
+        ) : null}
+        <Slider
+          value={percentage}
+          onChange={next =>
+            onChange(
+              Number(
+                getPercentageShareAmount({
+                  balanceUnits,
+                  percentage: next,
+                  decimals,
+                })
+              )
+            )
+          }
+          min={0}
+          max={100}
+          showLabels
+          showDots
+        />
+        <HStack justifyContent="space-between" alignItems="center">
+          <BalanceLabel>{balanceLabel}:</BalanceLabel>
+          <BalanceValue>{formatAmount(balance, { ticker })}</BalanceValue>
+        </HStack>
+      </VStack>
+    </ActionInputContainer>
+  )
+}
+
+const BalanceLabel = styled(Text).attrs({ size: 13 })`
+  color: ${getColor('text')};
+  line-height: 18px;
+`
+
+const BalanceValue = styled(Text).attrs({ size: 14 })`
+  color: ${getColor('textShyExtra')};
+  line-height: 20px;
+`

--- a/core/ui/defi/chain/solana/kamino/KaminoMissingAddress.tsx
+++ b/core/ui/defi/chain/solana/kamino/KaminoMissingAddress.tsx
@@ -1,0 +1,21 @@
+import { VStack } from '@lib/ui/layout/Stack'
+import { Text } from '@lib/ui/text'
+import { useTranslation } from 'react-i18next'
+
+/**
+ * Shown when the current vault has no Solana address — a key-import vault
+ * without a Solana public key. There is nothing to deposit from or withdraw
+ * to, and the position read is disabled without an address, so saying so beats
+ * a spinner that never resolves.
+ */
+export const KaminoMissingAddress = () => {
+  const { t } = useTranslation()
+
+  return (
+    <VStack flexGrow alignItems="center" justifyContent="center" gap={8}>
+      <Text size={14} color="shy" centerHorizontally>
+        {t('kamino_earn_no_solana_address')}
+      </Text>
+    </VStack>
+  )
+}

--- a/core/ui/defi/chain/solana/kamino/KaminoVaultCard.tsx
+++ b/core/ui/defi/chain/solana/kamino/KaminoVaultCard.tsx
@@ -144,16 +144,51 @@ export const KaminoVaultCard = ({
         </HStack>
       )}
 
-      <Button
-        onClick={() =>
-          navigate({
-            id: 'kaminoDeposit',
-            state: { vaultAddress: info.descriptor.address },
-          })
-        }
-      >
-        {t('kamino_earn_deposit')}
-      </Button>
+      <HStack gap={8}>
+        {/*
+         * Withdraw appears once the vault is known to hold something, and
+         * while that is still unknown: a position must never be made
+         * unreachable by a read that failed. Deposit takes the whole width
+         * when it is alone, because a half-width button beside empty space
+         * reads as a control that is missing rather than one that is absent.
+         */}
+        {position.status === 'settled' && !hasPosition ? (
+          <Button
+            onClick={() =>
+              navigate({
+                id: 'kaminoDeposit',
+                state: { vaultAddress: info.descriptor.address },
+              })
+            }
+          >
+            {t('kamino_earn_deposit')}
+          </Button>
+        ) : (
+          <>
+            <Button
+              kind="secondary"
+              onClick={() =>
+                navigate({
+                  id: 'kaminoWithdraw',
+                  state: { vaultAddress: info.descriptor.address },
+                })
+              }
+            >
+              {t('kamino_earn_withdraw')}
+            </Button>
+            <Button
+              onClick={() =>
+                navigate({
+                  id: 'kaminoDeposit',
+                  state: { vaultAddress: info.descriptor.address },
+                })
+              }
+            >
+              {t('kamino_earn_deposit')}
+            </Button>
+          </>
+        )}
+      </HStack>
     </Container>
   )
 }

--- a/core/ui/defi/chain/solana/kamino/deposit/KaminoDepositForm.tsx
+++ b/core/ui/defi/chain/solana/kamino/deposit/KaminoDepositForm.tsx
@@ -2,7 +2,6 @@ import { useBalanceQuery } from '@core/ui/chain/coin/queries/useBalanceQuery'
 import { useFormatFiatAmount } from '@core/ui/chain/hooks/useFormatFiatAmount'
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { Button } from '@lib/ui/buttons/Button'
-import { AmountTextInput } from '@lib/ui/inputs/AmountTextInput'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { PageContent } from '@lib/ui/page/PageContent'
 import { PageFooter } from '@lib/ui/page/PageFooter'
@@ -21,6 +20,8 @@ import { extractAccountCoinKey } from '@vultisig/core-chain/coin/AccountCoin'
 import { formatAmount } from '@vultisig/lib-utils/formatAmount'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+
+import { KaminoAmountField } from '../KaminoAmountField'
 
 type KaminoDepositFormProps = OnFinishProp<KaminoTokenAmount> & {
   vault: KaminoVaultInfo
@@ -79,25 +80,17 @@ export const KaminoDepositForm = ({
         hasBorder
       />
       <PageContent gap={16} flexGrow scrollable>
-        <AmountTextInput
-          label={t('amount')}
+        <KaminoAmountField
           value={value}
-          onValueChange={setValue}
-          suggestion={
-            <Button kind="link" onClick={() => setValue(balance)} type="button">
-              {t('max')}
-            </Button>
-          }
+          onChange={setValue}
+          ticker={coin.ticker}
+          decimals={coin.decimals}
+          balance={balance}
+          balanceUnits={balanceUnits}
+          balanceLabel={t('balance_available')}
+          error={error}
         />
         <VStack gap={8}>
-          <HStack justifyContent="space-between">
-            <Text size={13} color="shy">
-              {t('balance')}
-            </Text>
-            <Text size={13} color="supporting">
-              {formatAmount(balance, { ticker: coin.ticker })}
-            </Text>
-          </HStack>
           <HStack justifyContent="space-between">
             <Text size={13} color="shy">
               {t('kamino_earn_minimum_deposit')}
@@ -117,11 +110,6 @@ export const KaminoDepositForm = ({
             </HStack>
           ) : null}
         </VStack>
-        {error ? (
-          <Text size={13} color="danger">
-            {error}
-          </Text>
-        ) : null}
       </PageContent>
       <PageFooter>
         <Button

--- a/core/ui/defi/chain/solana/kamino/deposit/KaminoDepositPage.tsx
+++ b/core/ui/defi/chain/solana/kamino/deposit/KaminoDepositPage.tsx
@@ -6,6 +6,7 @@ import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
 import { Chain } from '@vultisig/core-chain/Chain'
 
 import { DefiPositionErrorState } from '../../../tabs/DefiPositionErrorState'
+import { KaminoMissingAddress } from '../KaminoMissingAddress'
 import { useKaminoVaultsQuery } from '../queries/useKaminoVaultsQuery'
 import { KaminoDepositFlow } from './KaminoDepositFlow'
 
@@ -22,6 +23,12 @@ export const KaminoDepositPage = () => {
   const [{ vaultAddress }] = useCoreViewState<'kaminoDeposit'>()
   const owner = useCurrentVaultAddress(Chain.Solana)
   const vaultsQuery = useKaminoVaultsQuery()
+
+  // A vault with no Solana address has nothing to act on, so the flow would
+  // otherwise open on a form it can neither fund nor sign.
+  if (!owner) {
+    return <KaminoMissingAddress />
+  }
 
   return (
     <MatchQuery

--- a/core/ui/defi/chain/solana/kamino/withdraw/KaminoWithdrawFlow.tsx
+++ b/core/ui/defi/chain/solana/kamino/withdraw/KaminoWithdrawFlow.tsx
@@ -1,0 +1,55 @@
+import { useCoinPricesQuery } from '@core/ui/chain/coin/price/queries/useCoinPricesQuery'
+import { ValueTransfer } from '@lib/ui/base/ValueTransfer'
+import { KaminoVaultInfo } from '@vultisig/core-chain/chains/solana/kamino/models'
+import { KaminoSharePosition } from '@vultisig/core-chain/chains/solana/kamino/position'
+import { KaminoWithdrawRequest } from '@vultisig/core-chain/chains/solana/kamino/tx/validate'
+import { coinKeyToString } from '@vultisig/core-chain/coin/Coin'
+
+import { kaminoUnderlyingCoin } from '../underlyingCoin'
+import { KaminoWithdrawForm } from './KaminoWithdrawForm'
+import { KaminoWithdrawVerify } from './KaminoWithdrawVerify'
+
+type KaminoWithdrawFlowProps = {
+  vault: KaminoVaultInfo
+  position: KaminoSharePosition
+  /** The holder's Solana address. */
+  owner: string
+}
+
+/**
+ * The two steps of a withdrawal from one vault, sharing the coin and its price
+ * so the amount the form bounds is the amount the review screen prices.
+ */
+export const KaminoWithdrawFlow = ({
+  vault,
+  position,
+  owner,
+}: KaminoWithdrawFlowProps) => {
+  const coin = { ...kaminoUnderlyingCoin(vault.descriptor), address: owner }
+  const pricesQuery = useCoinPricesQuery({ coins: [coin] })
+  const priceUsd =
+    pricesQuery.data?.[coinKeyToString({ chain: coin.chain, id: coin.id })] ?? 0
+
+  return (
+    <ValueTransfer<KaminoWithdrawRequest>
+      from={({ onFinish }) => (
+        <KaminoWithdrawForm
+          vault={vault}
+          coin={coin}
+          position={position}
+          priceUsd={priceUsd}
+          onFinish={onFinish}
+        />
+      )}
+      to={({ value, onBack }) => (
+        <KaminoWithdrawVerify
+          vault={vault}
+          coin={coin}
+          request={value}
+          priceUsd={priceUsd}
+          onBack={onBack}
+        />
+      )}
+    />
+  )
+}

--- a/core/ui/defi/chain/solana/kamino/withdraw/KaminoWithdrawForm.tsx
+++ b/core/ui/defi/chain/solana/kamino/withdraw/KaminoWithdrawForm.tsx
@@ -45,7 +45,6 @@ export const KaminoWithdrawForm = ({
   const { t } = useTranslation()
   const formatFiatAmount = useFormatFiatAmount()
   const [value, setValue] = useState<number | null>(null)
-  const [isMax, setIsMax] = useState(false)
 
   const spendableTokens = kaminoShareToTokenValue({
     shares: position.spendable,
@@ -55,6 +54,11 @@ export const KaminoWithdrawForm = ({
   const available = spendableTokens
     ? fromChainAmount(spendableTokens.baseUnits, coin.decimals)
     : 0
+
+  // Derived, never tracked: a flag set by one control goes stale the moment
+  // another moves the value, and the max path must engage whichever control
+  // reached the balance — the slider at 100%, or the amount typed out in full.
+  const isMax = value !== null && available > 0 && value >= available
 
   const shares =
     value === null || value <= 0
@@ -116,10 +120,7 @@ export const KaminoWithdrawForm = ({
       <PageContent gap={16} flexGrow scrollable>
         <KaminoAmountField
           value={value}
-          onChange={next => {
-            setValue(next)
-            setIsMax(false)
-          }}
+          onChange={setValue}
           ticker={coin.ticker}
           decimals={coin.decimals}
           balance={available}

--- a/core/ui/defi/chain/solana/kamino/withdraw/KaminoWithdrawForm.tsx
+++ b/core/ui/defi/chain/solana/kamino/withdraw/KaminoWithdrawForm.tsx
@@ -1,0 +1,157 @@
+import { useFormatFiatAmount } from '@core/ui/chain/hooks/useFormatFiatAmount'
+import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
+import { Button } from '@lib/ui/buttons/Button'
+import { HStack } from '@lib/ui/layout/Stack'
+import { PageContent } from '@lib/ui/page/PageContent'
+import { PageFooter } from '@lib/ui/page/PageFooter'
+import { PageHeader } from '@lib/ui/page/PageHeader'
+import { OnFinishProp } from '@lib/ui/props'
+import { WarningBlock } from '@lib/ui/status/WarningBlock'
+import { Text } from '@lib/ui/text'
+import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
+import { kaminoShareToTokenValue } from '@vultisig/core-chain/chains/solana/kamino/amount'
+import { KaminoVaultInfo } from '@vultisig/core-chain/chains/solana/kamino/models'
+import { KaminoSharePosition } from '@vultisig/core-chain/chains/solana/kamino/position'
+import { KaminoWithdrawRequest } from '@vultisig/core-chain/chains/solana/kamino/tx/validate'
+import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+import { formatAmount } from '@vultisig/lib-utils/formatAmount'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { KaminoAmountField } from '../KaminoAmountField'
+import { resolveWithdrawShares } from './resolveWithdrawShares'
+
+type KaminoWithdrawFormProps = OnFinishProp<KaminoWithdrawRequest> & {
+  vault: KaminoVaultInfo
+  coin: AccountCoin
+  position: KaminoSharePosition
+  priceUsd: number
+}
+
+/**
+ * Amount entry for a Kamino withdrawal.
+ *
+ * Denominated in the underlying token, because that is what a holder thinks
+ * in — the shares the chain actually burns are resolved by the chain package's
+ * exact arithmetic, never here.
+ */
+export const KaminoWithdrawForm = ({
+  vault,
+  coin,
+  position,
+  priceUsd,
+  onFinish,
+}: KaminoWithdrawFormProps) => {
+  const { t } = useTranslation()
+  const formatFiatAmount = useFormatFiatAmount()
+  const [value, setValue] = useState<number | null>(null)
+  const [isMax, setIsMax] = useState(false)
+
+  const spendableTokens = kaminoShareToTokenValue({
+    shares: position.spendable,
+    tokensPerShare: vault.tokensPerShare,
+    tokenDecimals: coin.decimals,
+  })
+  const available = spendableTokens
+    ? fromChainAmount(spendableTokens.baseUnits, coin.decimals)
+    : 0
+
+  const shares =
+    value === null || value <= 0
+      ? undefined
+      : resolveWithdrawShares({
+          tokenAmount: value,
+          tokenDecimals: coin.decimals,
+          tokensPerShare: vault.tokensPerShare,
+          position,
+          isMax,
+        })
+
+  const minWithdrawTokens = kaminoShareToTokenValue({
+    shares: vault.minWithdraw,
+    tokensPerShare: vault.tokensPerShare,
+    tokenDecimals: coin.decimals,
+  })
+
+  const error =
+    value === null || value <= 0
+      ? undefined
+      : !shares
+        ? t('kamino_earn_amount_unavailable')
+        : value > available
+          ? t('insufficient_balance')
+          : shares.baseUnits < vault.minWithdraw.baseUnits
+            ? t('kamino_earn_below_minimum', {
+                amount: formatAmount(
+                  minWithdrawTokens
+                    ? fromChainAmount(
+                        minWithdrawTokens.baseUnits,
+                        coin.decimals
+                      )
+                    : 0,
+                  { ticker: coin.ticker }
+                ),
+              })
+            : undefined
+
+  // Advisory, never blocking: a vault keeps only a small share of its assets
+  // liquid, so a withdrawal above that buffer is the ordinary case rather than
+  // an exception — it settles once the vault frees the funds.
+  const exceedsLiquidBuffer =
+    vault.tokensAvailable !== undefined &&
+    value !== null &&
+    spendableTokens !== undefined &&
+    error === undefined &&
+    value > fromChainAmount(vault.tokensAvailable.baseUnits, coin.decimals)
+
+  const canContinue = shares !== undefined && error === undefined
+
+  return (
+    <>
+      <PageHeader
+        primaryControls={<PageHeaderBackButton />}
+        title={vault.name}
+        hasBorder
+      />
+      <PageContent gap={16} flexGrow scrollable>
+        <KaminoAmountField
+          value={value}
+          onChange={next => {
+            setValue(next)
+            setIsMax(false)
+          }}
+          ticker={coin.ticker}
+          decimals={coin.decimals}
+          balance={available}
+          balanceUnits={spendableTokens?.baseUnits ?? 0n}
+          balanceLabel={t('kamino_earn_available_to_withdraw')}
+          error={error}
+        />
+        {priceUsd > 0 && value !== null && value > 0 ? (
+          <HStack justifyContent="space-between">
+            <Text size={13} color="shy">
+              {t('value')}
+            </Text>
+            <Text size={13} color="supporting">
+              {formatFiatAmount(value * priceUsd)}
+            </Text>
+          </HStack>
+        ) : null}
+        {exceedsLiquidBuffer ? (
+          <WarningBlock>{t('kamino_earn_delayed_liquidity')}</WarningBlock>
+        ) : null}
+      </PageContent>
+      <PageFooter>
+        <Button
+          disabled={!canContinue}
+          onClick={() => {
+            if (!shares) return
+            onFinish({ shares, unstakedShares: position.unstaked })
+          }}
+        >
+          {t('continue')}
+        </Button>
+      </PageFooter>
+    </>
+  )
+}

--- a/core/ui/defi/chain/solana/kamino/withdraw/KaminoWithdrawPage.tsx
+++ b/core/ui/defi/chain/solana/kamino/withdraw/KaminoWithdrawPage.tsx
@@ -1,0 +1,78 @@
+import { useCoreViewState } from '@core/ui/navigation/hooks/useCoreViewState'
+import { useCurrentVaultAddress } from '@core/ui/vault/state/currentVaultCoins'
+import { VStack } from '@lib/ui/layout/Stack'
+import { Spinner } from '@lib/ui/loaders/Spinner'
+import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
+import { Chain } from '@vultisig/core-chain/Chain'
+
+import { DefiPositionErrorState } from '../../../tabs/DefiPositionErrorState'
+import { useKaminoPositionsQuery } from '../queries/useKaminoPositionsQuery'
+import { useKaminoVaultsQuery } from '../queries/useKaminoVaultsQuery'
+import { KaminoWithdrawFlow } from './KaminoWithdrawFlow'
+
+const Pending = () => (
+  <VStack flexGrow alignItems="center" justifyContent="center">
+    <Spinner size={24} />
+  </VStack>
+)
+
+/**
+ * Withdraw flow for one curated Kamino vault.
+ *
+ * The vault and the position are both re-read here rather than carried in
+ * navigation state: the share rate and the staked/unstaked split decide how
+ * much can be withdrawn and which transaction shape the API will build, and a
+ * figure captured when the card rendered could already be stale.
+ *
+ * The position is required, not optional — there is nothing to withdraw from a
+ * vault whose balance could not be read, and guessing one is how a partial
+ * withdrawal turns into a full exit.
+ */
+export const KaminoWithdrawPage = () => {
+  const [{ vaultAddress }] = useCoreViewState<'kaminoWithdraw'>()
+  const owner = useCurrentVaultAddress(Chain.Solana)
+  const vaultsQuery = useKaminoVaultsQuery()
+  const positionsQuery = useKaminoPositionsQuery(owner)
+
+  return (
+    <MatchQuery
+      value={vaultsQuery}
+      pending={Pending}
+      error={() => <DefiPositionErrorState onRetry={vaultsQuery.refetch} />}
+      success={vaults => {
+        const vault = vaults.find(
+          ({ descriptor }) => descriptor.address === vaultAddress
+        )
+        if (!vault) {
+          return <DefiPositionErrorState onRetry={vaultsQuery.refetch} />
+        }
+
+        return (
+          <MatchQuery
+            value={positionsQuery}
+            pending={Pending}
+            error={() => (
+              <DefiPositionErrorState onRetry={positionsQuery.refetch} />
+            )}
+            success={positions => {
+              const position = positions[vaultAddress]?.shares
+              if (!position) {
+                return (
+                  <DefiPositionErrorState onRetry={positionsQuery.refetch} />
+                )
+              }
+
+              return (
+                <KaminoWithdrawFlow
+                  vault={vault}
+                  position={position}
+                  owner={owner}
+                />
+              )
+            }}
+          />
+        )
+      }}
+    />
+  )
+}

--- a/core/ui/defi/chain/solana/kamino/withdraw/KaminoWithdrawPage.tsx
+++ b/core/ui/defi/chain/solana/kamino/withdraw/KaminoWithdrawPage.tsx
@@ -6,6 +6,7 @@ import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
 import { Chain } from '@vultisig/core-chain/Chain'
 
 import { DefiPositionErrorState } from '../../../tabs/DefiPositionErrorState'
+import { KaminoMissingAddress } from '../KaminoMissingAddress'
 import { useKaminoPositionsQuery } from '../queries/useKaminoPositionsQuery'
 import { useKaminoVaultsQuery } from '../queries/useKaminoVaultsQuery'
 import { KaminoWithdrawFlow } from './KaminoWithdrawFlow'
@@ -33,6 +34,13 @@ export const KaminoWithdrawPage = () => {
   const owner = useCurrentVaultAddress(Chain.Solana)
   const vaultsQuery = useKaminoVaultsQuery()
   const positionsQuery = useKaminoPositionsQuery(owner)
+
+  // A vault with no Solana address has nothing to act on, and the position
+  // read is disabled without one — so it would otherwise sit on a spinner
+  // that never resolves.
+  if (!owner) {
+    return <KaminoMissingAddress />
+  }
 
   return (
     <MatchQuery

--- a/core/ui/defi/chain/solana/kamino/withdraw/KaminoWithdrawVerify.tsx
+++ b/core/ui/defi/chain/solana/kamino/withdraw/KaminoWithdrawVerify.tsx
@@ -1,0 +1,122 @@
+import { useFormatFiatAmount } from '@core/ui/chain/hooks/useFormatFiatAmount'
+import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
+import { StartKeysignPromptWithRefresh } from '@core/ui/mpc/keysign/start/StartKeysignPromptWithRefresh'
+import { List } from '@lib/ui/list'
+import { ListItem } from '@lib/ui/list/item'
+import { PageContent } from '@lib/ui/page/PageContent'
+import { PageFooter } from '@lib/ui/page/PageFooter'
+import { PageHeader } from '@lib/ui/page/PageHeader'
+import { OnBackProp } from '@lib/ui/props'
+import { Text } from '@lib/ui/text'
+import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
+import { kaminoShareToTokenValue } from '@vultisig/core-chain/chains/solana/kamino/amount'
+import { KaminoVaultInfo } from '@vultisig/core-chain/chains/solana/kamino/models'
+import { KaminoWithdrawRequest } from '@vultisig/core-chain/chains/solana/kamino/tx/validate'
+import { kaminoUnstakeShares } from '@vultisig/core-chain/chains/solana/kamino/tx/validate'
+import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+import { extractErrorMsg } from '@vultisig/lib-utils/error/extractErrorMsg'
+import { formatAmount } from '@vultisig/lib-utils/formatAmount'
+import { useTranslation } from 'react-i18next'
+
+import { useKaminoWithdrawKeysignPayloadQuery } from './queries/useKaminoWithdrawKeysignPayloadQuery'
+
+type KaminoWithdrawVerifyProps = OnBackProp & {
+  vault: KaminoVaultInfo
+  coin: AccountCoin
+  request: KaminoWithdrawRequest
+  priceUsd: number
+}
+
+/**
+ * Review step for a Kamino withdrawal. Names the share count being burned as
+ * well as what it is worth, because shares are what the instruction carries
+ * and the token figure moves with the vault's rate.
+ */
+export const KaminoWithdrawVerify = ({
+  vault,
+  coin,
+  request,
+  priceUsd,
+  onBack,
+}: KaminoWithdrawVerifyProps) => {
+  const { t } = useTranslation()
+  const formatFiatAmount = useFormatFiatAmount()
+  const keysignPayloadQuery = useKaminoWithdrawKeysignPayloadQuery({
+    vault,
+    coin,
+    request,
+  })
+  const { data, error, isPending } = keysignPayloadQuery
+
+  const tokenValue = kaminoShareToTokenValue({
+    shares: request.shares,
+    tokensPerShare: vault.tokensPerShare,
+    tokenDecimals: coin.decimals,
+  })
+  const humanAmount = tokenValue
+    ? fromChainAmount(tokenValue.baseUnits, coin.decimals)
+    : 0
+
+  // A withdrawal that has to release shares from the farm first runs two extra
+  // instructions; saying so explains why this one differs from the last.
+  const releasesFromFarm = kaminoUnstakeShares(request).baseUnits > 0n
+
+  const promptProps = isPending
+    ? { disabledMessage: t('loading') }
+    : error
+      ? { disabledMessage: extractErrorMsg(error) }
+      : { keysignPayload: { keysign: data } }
+
+  return (
+    <>
+      <PageHeader
+        primaryControls={<PageHeaderBackButton onClick={onBack} />}
+        title={t('verify')}
+        hasBorder
+      />
+      <PageContent gap={16} flexGrow scrollable>
+        <List>
+          <ListItem
+            title={t('kamino_earn_withdraw_from')}
+            extra={vault.name}
+            hoverable={false}
+          />
+          <ListItem
+            title={t('kamino_earn_you_receive')}
+            extra={formatAmount(humanAmount, { ticker: coin.ticker })}
+            hoverable={false}
+          />
+          {priceUsd > 0 ? (
+            <ListItem
+              title={t('value')}
+              extra={formatFiatAmount(humanAmount * priceUsd)}
+              hoverable={false}
+            />
+          ) : null}
+          <ListItem
+            title={t('kamino_earn_shares_burned')}
+            extra={formatAmount(
+              fromChainAmount(request.shares.baseUnits, request.shares.decimals)
+            )}
+            hoverable={false}
+          />
+        </List>
+        <Text size={12} color="shy">
+          {t('kamino_earn_receive_estimate')}
+        </Text>
+        {releasesFromFarm ? (
+          <Text size={12} color="shy">
+            {t('kamino_earn_releases_from_farm')}
+          </Text>
+        ) : null}
+      </PageContent>
+      <PageFooter>
+        <StartKeysignPromptWithRefresh
+          keysignPayloadQuery={keysignPayloadQuery}
+          toKeysignPayload={keysign => ({ keysign })}
+          promptProps={promptProps}
+        />
+      </PageFooter>
+    </>
+  )
+}

--- a/core/ui/defi/chain/solana/kamino/withdraw/KaminoWithdrawVerify.tsx
+++ b/core/ui/defi/chain/solana/kamino/withdraw/KaminoWithdrawVerify.tsx
@@ -53,19 +53,24 @@ export const KaminoWithdrawVerify = ({
     tokensPerShare: vault.tokensPerShare,
     tokenDecimals: coin.decimals,
   })
+  // A conversion that failed is not a zero payout: reporting one would tell
+  // the holder they receive nothing for shares the chain is about to burn.
   const humanAmount = tokenValue
     ? fromChainAmount(tokenValue.baseUnits, coin.decimals)
-    : 0
+    : undefined
 
   // A withdrawal that has to release shares from the farm first runs two extra
   // instructions; saying so explains why this one differs from the last.
   const releasesFromFarm = kaminoUnstakeShares(request).baseUnits > 0n
 
-  const promptProps = isPending
-    ? { disabledMessage: t('loading') }
-    : error
-      ? { disabledMessage: extractErrorMsg(error) }
-      : { keysignPayload: { keysign: data } }
+  const promptProps =
+    humanAmount === undefined
+      ? { disabledMessage: t('kamino_earn_amount_unavailable') }
+      : isPending
+        ? { disabledMessage: t('loading') }
+        : error
+          ? { disabledMessage: extractErrorMsg(error) }
+          : { keysignPayload: { keysign: data } }
 
   return (
     <>
@@ -83,10 +88,14 @@ export const KaminoWithdrawVerify = ({
           />
           <ListItem
             title={t('kamino_earn_you_receive')}
-            extra={formatAmount(humanAmount, { ticker: coin.ticker })}
+            extra={
+              humanAmount === undefined
+                ? t('kamino_earn_amount_unavailable')
+                : formatAmount(humanAmount, { ticker: coin.ticker })
+            }
             hoverable={false}
           />
-          {priceUsd > 0 ? (
+          {priceUsd > 0 && humanAmount !== undefined ? (
             <ListItem
               title={t('value')}
               extra={formatFiatAmount(humanAmount * priceUsd)}

--- a/core/ui/defi/chain/solana/kamino/withdraw/buildKaminoWithdrawKeysignPayload.ts
+++ b/core/ui/defi/chain/solana/kamino/withdraw/buildKaminoWithdrawKeysignPayload.ts
@@ -1,0 +1,131 @@
+import { create } from '@bufbuild/protobuf'
+import { getDynamicPriorityFeePrice } from '@vultisig/core-chain/chains/solana/getDynamicPriorityFeePrice'
+import { KaminoVaultInfo } from '@vultisig/core-chain/chains/solana/kamino/models'
+import { buildKaminoWithdrawTransaction } from '@vultisig/core-chain/chains/solana/kamino/tx/actions'
+import {
+  clampKaminoUnitPrice,
+  kaminoComputeBudget,
+  kaminoExpectedUnitLimit,
+} from '@vultisig/core-chain/chains/solana/kamino/tx/computeBudget'
+import {
+  KaminoWithdrawRequest,
+  validateKaminoTransactionOnline,
+} from '@vultisig/core-chain/chains/solana/kamino/tx/validate'
+import {
+  injectKaminoAttributionMemo,
+  injectKaminoComputeBudget,
+  parseKaminoWireTransaction,
+  refreshKaminoRecentBlockhash,
+  serializeKaminoWireTransaction,
+} from '@vultisig/core-chain/chains/solana/kamino/tx/wire'
+import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+import { KeysignLibType } from '@vultisig/core-mpc/mpcLib'
+import { toCommCoin } from '@vultisig/core-mpc/types/utils/commCoin'
+import {
+  KeysignPayload,
+  KeysignPayloadSchema,
+} from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { SignSolanaSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/wasm_execute_contract_payload_pb'
+import { attempt } from '@vultisig/lib-utils/attempt'
+
+type BuildKaminoWithdrawKeysignPayloadInput = {
+  vault: KaminoVaultInfo
+  /** The vault's underlying coin, carrying the holder's Solana address. */
+  coin: AccountCoin
+  /**
+   * The shares to burn, and how the position was split when it was read. The
+   * split is not decoration: it decides whether the API builds the plain
+   * withdraw or the one that releases shares from the farm first, and the
+   * validator refuses the shape it was not told to expect.
+   */
+  request: KaminoWithdrawRequest
+  hexPublicKey: string
+  vaultId: string
+  localPartyId: string
+  libType: KeysignLibType
+}
+
+/**
+ * Builds the keysign payload for one Kamino Earn withdrawal.
+ *
+ * Same shape and the same ordering contract as the deposit builder — inject
+ * the budget and the attribution memo, replace the blockhash, then validate,
+ * so what is checked is what is signed — with one asymmetry that matters: the
+ * amount here is in SHARES, the inverse of deposit's unit. The API takes the
+ * same `amount` field for both actions, so the typed amounts are what keep the
+ * two from crossing, and an amount at or above the holder's balance is
+ * rewritten by Kamino to `u64::MAX` — withdraw everything. The share count
+ * this receives has already been kept strictly below that balance; the
+ * validator pins it again against the bytes.
+ */
+export const buildKaminoWithdrawKeysignPayload = async ({
+  vault,
+  coin,
+  request,
+  hexPublicKey,
+  vaultId,
+  localPartyId,
+  libType,
+}: BuildKaminoWithdrawKeysignPayloadInput): Promise<KeysignPayload> => {
+  const built = await buildKaminoWithdrawTransaction({
+    owner: coin.address,
+    vaultAddress: vault.descriptor.address,
+    shares: request.shares,
+  })
+
+  const parsed = parseKaminoWireTransaction(built)
+  if (!parsed) {
+    throw new Error('Kamino returned a transaction this app cannot read')
+  }
+
+  const sampled = await attempt(() => getDynamicPriorityFeePrice())
+  const sampledPrice = 'data' in sampled ? sampled.data : undefined
+  const unitPriceMicroLamports = clampKaminoUnitPrice(
+    sampledPrice === undefined
+      ? kaminoComputeBudget.fallbackUnitPriceMicroLamports
+      : BigInt(sampledPrice)
+  )
+  const unitLimit = kaminoExpectedUnitLimit({
+    operation: 'withdraw',
+    descriptor: vault.descriptor,
+  })
+
+  const transaction = await refreshKaminoRecentBlockhash(
+    injectKaminoAttributionMemo(
+      injectKaminoComputeBudget({
+        transaction: parsed,
+        unitLimit,
+        unitPriceMicroLamports,
+      })
+    )
+  )
+
+  await validateKaminoTransactionOnline({
+    transaction,
+    intent: {
+      operation: { withdraw: request },
+      vault,
+      owner: coin.address,
+      priorityFee: { unitLimit, unitPriceMicroLamports },
+      carriesAttributionMemo: true,
+    },
+  })
+
+  return create(KeysignPayloadSchema, {
+    coin: toCommCoin({ ...coin, hexPublicKey }),
+    toAddress: vault.descriptor.address,
+    // The share count the instruction burns, in share base units — not the
+    // token amount the holder receives, which the vault decides at settlement.
+    toAmount: request.shares.baseUnits.toString(),
+    memo: '',
+    vaultLocalPartyId: localPartyId,
+    vaultPublicKeyEcdsa: vaultId,
+    libType,
+    signData: {
+      case: 'signSolana',
+      value: create(SignSolanaSchema, {
+        rawTransactions: [serializeKaminoWireTransaction(transaction)],
+      }),
+    },
+  })
+}

--- a/core/ui/defi/chain/solana/kamino/withdraw/buildKaminoWithdrawKeysignPayload.ts
+++ b/core/ui/defi/chain/solana/kamino/withdraw/buildKaminoWithdrawKeysignPayload.ts
@@ -1,5 +1,6 @@
 import { create } from '@bufbuild/protobuf'
 import { getDynamicPriorityFeePrice } from '@vultisig/core-chain/chains/solana/getDynamicPriorityFeePrice'
+import { kaminoShareToTokenValue } from '@vultisig/core-chain/chains/solana/kamino/amount'
 import { KaminoVaultInfo } from '@vultisig/core-chain/chains/solana/kamino/models'
 import { buildKaminoWithdrawTransaction } from '@vultisig/core-chain/chains/solana/kamino/tx/actions'
 import {
@@ -67,6 +68,21 @@ export const buildKaminoWithdrawKeysignPayload = async ({
   localPartyId,
   libType,
 }: BuildKaminoWithdrawKeysignPayloadInput): Promise<KeysignPayload> => {
+  // What the holder receives, in the COIN's units. Every generic surface —
+  // history, QR export, the ceremony's own views — formats `toAmount` with
+  // `coin.decimals`, so putting a share count there would misreport a vault
+  // whose share and token scales differ by three orders of magnitude. The
+  // share count stays where it belongs: the instruction argument, which the
+  // validator pins.
+  const receives = kaminoShareToTokenValue({
+    shares: request.shares,
+    tokensPerShare: vault.tokensPerShare,
+    tokenDecimals: coin.decimals,
+  })
+  if (!receives) {
+    throw new Error('Kamino withdrawal amount could not be converted')
+  }
+
   const built = await buildKaminoWithdrawTransaction({
     owner: coin.address,
     vaultAddress: vault.descriptor.address,
@@ -114,9 +130,7 @@ export const buildKaminoWithdrawKeysignPayload = async ({
   return create(KeysignPayloadSchema, {
     coin: toCommCoin({ ...coin, hexPublicKey }),
     toAddress: vault.descriptor.address,
-    // The share count the instruction burns, in share base units — not the
-    // token amount the holder receives, which the vault decides at settlement.
-    toAmount: request.shares.baseUnits.toString(),
+    toAmount: receives.baseUnits.toString(),
     memo: '',
     vaultLocalPartyId: localPartyId,
     vaultPublicKeyEcdsa: vaultId,

--- a/core/ui/defi/chain/solana/kamino/withdraw/queries/useKaminoWithdrawKeysignPayloadQuery.ts
+++ b/core/ui/defi/chain/solana/kamino/withdraw/queries/useKaminoWithdrawKeysignPayloadQuery.ts
@@ -1,0 +1,65 @@
+import { useAssertWalletCore } from '@core/ui/chain/providers/WalletCoreProvider'
+import {
+  useCurrentVault,
+  useCurrentVaultNullablePublicKey,
+} from '@core/ui/vault/state/currentVault'
+import { noRefetchQueryOptions } from '@lib/ui/query/utils/options'
+import { useQuery } from '@tanstack/react-query'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { KaminoVaultInfo } from '@vultisig/core-chain/chains/solana/kamino/models'
+import { KaminoWithdrawRequest } from '@vultisig/core-chain/chains/solana/kamino/tx/validate'
+import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+import { toKeysignLibType } from '@vultisig/core-mpc/types/utils/libType'
+import { getVaultId } from '@vultisig/core-mpc/vault/Vault'
+import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
+
+import { buildKaminoWithdrawKeysignPayload } from '../buildKaminoWithdrawKeysignPayload'
+
+type UseKaminoWithdrawKeysignPayloadQueryInput = {
+  vault: KaminoVaultInfo
+  coin: AccountCoin
+  request: KaminoWithdrawRequest
+}
+
+/**
+ * The keysign payload for one Kamino withdrawal. Frozen, and rebuilt by the
+ * confirm button the moment signing starts — see the deposit query for why the
+ * blockhash and the fail-closed gates both depend on that.
+ */
+export const useKaminoWithdrawKeysignPayloadQuery = ({
+  vault,
+  coin,
+  request,
+}: UseKaminoWithdrawKeysignPayloadQueryInput) => {
+  const currentVault = useCurrentVault()
+  const publicKey = useCurrentVaultNullablePublicKey(Chain.Solana)
+  useAssertWalletCore()
+
+  const hexPublicKey = publicKey
+    ? Buffer.from(publicKey.data()).toString('hex')
+    : undefined
+
+  return useQuery({
+    queryKey: [
+      'kaminoWithdrawKeysignPayload',
+      {
+        vaultAddress: vault.descriptor.address,
+        owner: coin.address,
+        shares: request.shares.baseUnits.toString(),
+        unstakedShares: request.unstakedShares.baseUnits.toString(),
+      },
+    ] as const,
+    enabled: hexPublicKey !== undefined,
+    queryFn: () =>
+      buildKaminoWithdrawKeysignPayload({
+        vault,
+        coin,
+        request,
+        hexPublicKey: shouldBePresent(hexPublicKey, 'Solana public key'),
+        vaultId: getVaultId(currentVault),
+        localPartyId: currentVault.localPartyId,
+        libType: toKeysignLibType(currentVault),
+      }),
+    ...noRefetchQueryOptions,
+  })
+}

--- a/core/ui/defi/chain/solana/kamino/withdraw/resolveWithdrawShares.test.ts
+++ b/core/ui/defi/chain/solana/kamino/withdraw/resolveWithdrawShares.test.ts
@@ -51,6 +51,21 @@ describe('resolveWithdrawShares', () => {
     expect(shares!.baseUnits).toBeLessThan(position.total.baseUnits)
   })
 
+  it('reaching the spendable balance takes the max path, not the conversion', () => {
+    // The regression this guards: with the max path unreachable, a full
+    // withdrawal goes through the truncating conversion and strands dust in
+    // the vault. Typing the balance out in full must behave exactly like
+    // dragging the slider to 100%.
+    const availableTokens = 1.053604
+    const viaConversion = resolve(availableTokens)
+    const viaMax = resolve(availableTokens, true)
+
+    expect(viaMax).toBe(position.spendable)
+    expect(viaConversion?.baseUnits).toBeLessThanOrEqual(
+      position.spendable.baseUnits
+    )
+  })
+
   it('refuses an amount it cannot convert', () => {
     const zeroRate = parseKaminoRate('0')!
     expect(

--- a/core/ui/defi/chain/solana/kamino/withdraw/resolveWithdrawShares.test.ts
+++ b/core/ui/defi/chain/solana/kamino/withdraw/resolveWithdrawShares.test.ts
@@ -1,0 +1,75 @@
+import {
+  kaminoShareAmount,
+  kaminoTokenAmount,
+} from '@vultisig/core-chain/chains/solana/kamino/amount'
+import { parseKaminoRate } from '@vultisig/core-chain/chains/solana/kamino/rate'
+import { describe, expect, it } from 'vitest'
+
+import { resolveWithdrawShares } from './resolveWithdrawShares'
+
+const tokensPerShare = parseKaminoRate('1.0536041812651029025')!
+
+const position = {
+  staked: kaminoShareAmount(900_000n, 6),
+  unstaked: kaminoShareAmount(100_000n, 6),
+  total: kaminoShareAmount(1_000_000n, 6),
+  spendable: kaminoShareAmount(999_999n, 6),
+  accountsForItsTotal: true,
+  isPlausible: true,
+}
+
+const resolve = (tokenAmount: number, isMax = false) =>
+  resolveWithdrawShares({
+    tokenAmount,
+    tokenDecimals: 6,
+    tokensPerShare,
+    position,
+    isMax,
+  })
+
+describe('resolveWithdrawShares', () => {
+  it('sends the held balance itself for a max withdraw', () => {
+    // Never a share count derived from a token figure: the derivation
+    // truncates and would strand dust, and rounding the other way asks for
+    // more than the position holds.
+    expect(resolve(0, true)).toBe(position.spendable)
+  })
+
+  it('converts a typed amount through exact integer arithmetic', () => {
+    // 1 USDC at a rate above parity is less than 1 share.
+    expect(resolve(1)?.baseUnits).toBe(949_123n)
+  })
+
+  it('never asks for more than the position can spend', () => {
+    // The rate moves between the read and the keystroke, so a typed amount can
+    // outrun the balance — and over-asking is what Kamino turns into a full exit.
+    expect(resolve(1_000_000)?.baseUnits).toBe(position.spendable.baseUnits)
+  })
+
+  it('stays strictly below the reported total, so the sentinel is unreachable', () => {
+    const shares = resolve(0, true)
+    expect(shares!.baseUnits).toBeLessThan(position.total.baseUnits)
+  })
+
+  it('refuses an amount it cannot convert', () => {
+    const zeroRate = parseKaminoRate('0')!
+    expect(
+      resolveWithdrawShares({
+        tokenAmount: 1,
+        tokenDecimals: 6,
+        tokensPerShare: zeroRate,
+        position,
+        isMax: false,
+      })
+    ).toBeUndefined()
+  })
+})
+
+// A token amount is what the holder types; shares are what the chain burns.
+// Pinned so a refactor cannot quietly swap the units.
+describe('unit discipline', () => {
+  it('returns shares, not tokens', () => {
+    expect(resolve(1)?.unit).toBe('kaminoShare')
+    expect(kaminoTokenAmount(1n, 6).unit).toBe('kaminoToken')
+  })
+})

--- a/core/ui/defi/chain/solana/kamino/withdraw/resolveWithdrawShares.ts
+++ b/core/ui/defi/chain/solana/kamino/withdraw/resolveWithdrawShares.ts
@@ -1,0 +1,60 @@
+import { toChainAmount } from '@vultisig/core-chain/amount/toChainAmount'
+import {
+  KaminoShareAmount,
+  kaminoTokenAmount,
+  kaminoTokenToShareAmount,
+} from '@vultisig/core-chain/chains/solana/kamino/amount'
+import { KaminoSharePosition } from '@vultisig/core-chain/chains/solana/kamino/position'
+import { KaminoRate } from '@vultisig/core-chain/chains/solana/kamino/rate'
+
+type ResolveWithdrawSharesInput = {
+  /** What the holder typed, in the underlying token. */
+  tokenAmount: number
+  tokenDecimals: number
+  /** Underlying tokens per share, exact. */
+  tokensPerShare: KaminoRate
+  position: KaminoSharePosition
+  /**
+   * Whether the holder asked for everything. A max withdraw sends the held
+   * share balance ITSELF rather than a share count derived from a token
+   * figure: the derivation truncates, so it would leave dust behind, and
+   * rounding the other way would ask for more than the position holds — which
+   * Kamino rewrites to its withdraw-everything sentinel.
+   */
+  isMax: boolean
+}
+
+/**
+ * The share count a withdrawal should burn.
+ *
+ * Every conversion is the chain package's exact integer arithmetic — no float
+ * math here — and the result is capped at the position's spendable balance,
+ * which already sits strictly below the reported total so the sentinel can
+ * never be named. `undefined` when the amount cannot be converted at all.
+ */
+export const resolveWithdrawShares = ({
+  tokenAmount,
+  tokenDecimals,
+  tokensPerShare,
+  position,
+  isMax,
+}: ResolveWithdrawSharesInput): KaminoShareAmount | undefined => {
+  if (isMax) return position.spendable
+
+  const shares = kaminoTokenToShareAmount({
+    tokens: kaminoTokenAmount(
+      toChainAmount(tokenAmount, tokenDecimals),
+      tokenDecimals
+    ),
+    tokensPerShare,
+    shareDecimals: position.spendable.decimals,
+  })
+  if (!shares) return undefined
+
+  // A typed amount can still outrun the balance — the rate moves between the
+  // read and the keystroke — and asking for more than is held is the one
+  // request Kamino answers by emptying the position.
+  return shares.baseUnits > position.spendable.baseUnits
+    ? position.spendable
+    : shares
+}

--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -1918,7 +1918,7 @@ export const de = {
   kamino_earn_releases_from_farm:
     'Ein Teil dieser Position ist gestakt, daher wird er bei der Auszahlung zuerst freigegeben.',
   kamino_earn_shares_burned: 'Aktien verbrannt',
-  kamino_earn_withdraw: 'Zurückziehen',
+  kamino_earn_withdraw: 'Aus dem Tresor abheben',
   kamino_earn_withdraw_from: 'Zurückziehen von',
   kamino_earn_you_receive: 'Sie erhalten',
 }

--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -1921,4 +1921,6 @@ export const de = {
   kamino_earn_withdraw: 'Aus dem Tresor abheben',
   kamino_earn_withdraw_from: 'Zurückziehen von',
   kamino_earn_you_receive: 'Sie erhalten',
+  kamino_earn_no_solana_address:
+    'Dieser Tresor hat keine Solana-Adresse, daher ist Kamino Earn nicht verfügbar.',
 }

--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -1908,4 +1908,17 @@ export const de = {
   kamino_earn_deposit: 'Einzahlung in den Tresor',
   kamino_earn_deposit_to: 'Einzahlung an',
   kamino_earn_minimum_deposit: 'Mindesteinzahlung',
+  kamino_earn_amount_unavailable:
+    'Dieser Betrag kann momentan nicht umgerechnet werden. Bitte versuchen Sie es später erneut.',
+  kamino_earn_available_to_withdraw: 'Verfügbar zum Abheben',
+  kamino_earn_delayed_liquidity:
+    'Dies ist mehr Flüssigkeit, als der Tresor derzeit fasst, daher kann es länger dauern, bis sich die Lage beruhigt hat.',
+  kamino_earn_receive_estimate:
+    'Der endgültige Betrag wird bei der Abwicklung der Auszahlung festgelegt und kann geringfügig abweichen.',
+  kamino_earn_releases_from_farm:
+    'Ein Teil dieser Position ist gestakt, daher wird er bei der Auszahlung zuerst freigegeben.',
+  kamino_earn_shares_burned: 'Aktien verbrannt',
+  kamino_earn_withdraw: 'Zurückziehen',
+  kamino_earn_withdraw_from: 'Zurückziehen von',
+  kamino_earn_you_receive: 'Sie erhalten',
 }

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -1430,6 +1430,19 @@ export const en = {
   kamino_earn_deposit: 'Deposit into vault',
   kamino_earn_deposit_to: 'Deposit to',
   kamino_earn_minimum_deposit: 'Minimum deposit',
+  kamino_earn_amount_unavailable:
+    'This amount cannot be converted right now. Try again in a moment.',
+  kamino_earn_available_to_withdraw: 'Available to withdraw',
+  kamino_earn_delayed_liquidity:
+    'This is more than the vault currently holds liquid, so it may take longer to settle.',
+  kamino_earn_receive_estimate:
+    'The final amount is set when the withdrawal settles and may differ slightly.',
+  kamino_earn_releases_from_farm:
+    'Part of this position is staked, so the withdrawal releases it first.',
+  kamino_earn_shares_burned: 'Shares burned',
+  kamino_earn_withdraw: 'Withdraw',
+  kamino_earn_withdraw_from: 'Withdraw from',
+  kamino_earn_you_receive: 'You receive',
   kamino_earn_apy_30d: 'APY (30d)',
   kamino_earn_curated_by: 'Curated by {{curator}}',
   kamino_earn_no_position: 'You have nothing in this vault yet',

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -1443,6 +1443,8 @@ export const en = {
   kamino_earn_withdraw: 'Withdraw from vault',
   kamino_earn_withdraw_from: 'Withdraw from',
   kamino_earn_you_receive: 'You receive',
+  kamino_earn_no_solana_address:
+    'This vault has no Solana address, so Kamino Earn is unavailable.',
   kamino_earn_apy_30d: 'APY (30d)',
   kamino_earn_curated_by: 'Curated by {{curator}}',
   kamino_earn_no_position: 'You have nothing in this vault yet',

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -1440,7 +1440,7 @@ export const en = {
   kamino_earn_releases_from_farm:
     'Part of this position is staked, so the withdrawal releases it first.',
   kamino_earn_shares_burned: 'Shares burned',
-  kamino_earn_withdraw: 'Withdraw',
+  kamino_earn_withdraw: 'Withdraw from vault',
   kamino_earn_withdraw_from: 'Withdraw from',
   kamino_earn_you_receive: 'You receive',
   kamino_earn_apy_30d: 'APY (30d)',

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -1894,4 +1894,17 @@ export const es = {
   kamino_earn_deposit: 'Depositar en la bóveda',
   kamino_earn_deposit_to: 'Depositar en',
   kamino_earn_minimum_deposit: 'Depósito mínimo',
+  kamino_earn_amount_unavailable:
+    'Este importe no se puede convertir en este momento. Inténtelo de nuevo en un instante.',
+  kamino_earn_available_to_withdraw: 'Disponible para retirar',
+  kamino_earn_delayed_liquidity:
+    'Esta cantidad supera la capacidad actual de la bóveda en cuanto a líquido, por lo que podría tardar más tiempo en estabilizarse.',
+  kamino_earn_receive_estimate:
+    'El importe final se fija cuando se procesa el retiro y puede variar ligeramente.',
+  kamino_earn_releases_from_farm:
+    'Parte de esta posición está en staking, por lo que el retiro la libera primero.',
+  kamino_earn_shares_burned: 'Acciones quemadas',
+  kamino_earn_withdraw: 'Retirar',
+  kamino_earn_withdraw_from: 'Retirarse de',
+  kamino_earn_you_receive: 'Usted recibe',
 }

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -1907,4 +1907,6 @@ export const es = {
   kamino_earn_withdraw: 'Retirar de la bóveda',
   kamino_earn_withdraw_from: 'Retirarse de',
   kamino_earn_you_receive: 'Usted recibe',
+  kamino_earn_no_solana_address:
+    'Esta bóveda no tiene dirección de Solana, por lo que Kamino Earn no está disponible.',
 }

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -1904,7 +1904,7 @@ export const es = {
   kamino_earn_releases_from_farm:
     'Parte de esta posición está en staking, por lo que el retiro la libera primero.',
   kamino_earn_shares_burned: 'Acciones quemadas',
-  kamino_earn_withdraw: 'Retirar',
+  kamino_earn_withdraw: 'Retirar de la bóveda',
   kamino_earn_withdraw_from: 'Retirarse de',
   kamino_earn_you_receive: 'Usted recibe',
 }

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -1864,4 +1864,17 @@ export const hr = {
   kamino_earn_deposit: 'Polog u trezor',
   kamino_earn_deposit_to: 'Uplata na',
   kamino_earn_minimum_deposit: 'Minimalni depozit',
+  kamino_earn_amount_unavailable:
+    'Ovaj iznos trenutno nije moguće pretvoriti. Pokušajte ponovno za trenutak.',
+  kamino_earn_available_to_withdraw: 'Dostupno za isplatu',
+  kamino_earn_delayed_liquidity:
+    'To je više nego što trezor trenutno sadrži tekućinu, pa bi moglo trebati dulje da se slegne.',
+  kamino_earn_receive_estimate:
+    'Konačni iznos se utvrđuje prilikom isplate i može se neznatno razlikovati.',
+  kamino_earn_releases_from_farm:
+    'Dio ove pozicije je uložen, pa se povlačenjem prvo oslobađa.',
+  kamino_earn_shares_burned: 'Spaljene dionice',
+  kamino_earn_withdraw: 'Povući',
+  kamino_earn_withdraw_from: 'Povuci se iz',
+  kamino_earn_you_receive: 'Primate',
 }

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -1877,4 +1877,6 @@ export const hr = {
   kamino_earn_withdraw: 'Isplata iz trezora',
   kamino_earn_withdraw_from: 'Povuci se iz',
   kamino_earn_you_receive: 'Primate',
+  kamino_earn_no_solana_address:
+    'Ovaj trezor nema Solana adresu, tako da Kamino Earn nije dostupan.',
 }

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -1874,7 +1874,7 @@ export const hr = {
   kamino_earn_releases_from_farm:
     'Dio ove pozicije je uložen, pa se povlačenjem prvo oslobađa.',
   kamino_earn_shares_burned: 'Spaljene dionice',
-  kamino_earn_withdraw: 'Povući',
+  kamino_earn_withdraw: 'Isplata iz trezora',
   kamino_earn_withdraw_from: 'Povuci se iz',
   kamino_earn_you_receive: 'Primate',
 }

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -1913,4 +1913,6 @@ export const it = {
   kamino_earn_withdraw: 'Prelevare dal caveau',
   kamino_earn_withdraw_from: 'Ritirarsi da',
   kamino_earn_you_receive: 'Tu ricevi',
+  kamino_earn_no_solana_address:
+    'Questo caveau non ha un indirizzo Solana, quindi Kamino Earn non è disponibile.',
 }

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -1910,7 +1910,7 @@ export const it = {
   kamino_earn_releases_from_farm:
     'Una parte di questa posizione è bloccata, quindi il prelievo la sblocca per prima.',
   kamino_earn_shares_burned: 'azioni bruciate',
-  kamino_earn_withdraw: 'Ritirare',
+  kamino_earn_withdraw: 'Prelevare dal caveau',
   kamino_earn_withdraw_from: 'Ritirarsi da',
   kamino_earn_you_receive: 'Tu ricevi',
 }

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -1900,4 +1900,17 @@ export const it = {
   kamino_earn_deposit: 'Depositare nel caveau',
   kamino_earn_deposit_to: 'Deposito a',
   kamino_earn_minimum_deposit: 'Deposito minimo',
+  kamino_earn_amount_unavailable:
+    'Questo importo non può essere convertito al momento. Riprova tra un attimo.',
+  kamino_earn_available_to_withdraw: 'Disponibile per il prelievo',
+  kamino_earn_delayed_liquidity:
+    'Si tratta di una somma superiore alla quantità di liquidi attualmente contenuta nel caveau, pertanto la liquidazione potrebbe richiedere più tempo.',
+  kamino_earn_receive_estimate:
+    "L'importo finale viene stabilito al momento della liquidazione del prelievo e potrebbe variare leggermente.",
+  kamino_earn_releases_from_farm:
+    'Una parte di questa posizione è bloccata, quindi il prelievo la sblocca per prima.',
+  kamino_earn_shares_burned: 'azioni bruciate',
+  kamino_earn_withdraw: 'Ritirare',
+  kamino_earn_withdraw_from: 'Ritirarsi da',
+  kamino_earn_you_receive: 'Tu ricevi',
 }

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -1864,7 +1864,7 @@ export const ko = {
   kamino_earn_releases_from_farm:
     '이 포지션의 일부는 스테이킹되어 있으므로, 출금 시 스테이킹된 부분이 먼저 해제됩니다.',
   kamino_earn_shares_burned: '주식이 불탔다',
-  kamino_earn_withdraw: '철회하다',
+  kamino_earn_withdraw: '금고에서 인출',
   kamino_earn_withdraw_from: '인출하다',
   kamino_earn_you_receive: '당신은 받습니다',
 }

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -1867,4 +1867,6 @@ export const ko = {
   kamino_earn_withdraw: '금고에서 인출',
   kamino_earn_withdraw_from: '인출하다',
   kamino_earn_you_receive: '당신은 받습니다',
+  kamino_earn_no_solana_address:
+    '이 금고에는 솔라나 주소가 없으므로 카미노 언(Kamino Earn)을 이용할 수 없습니다.',
 }

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -1854,4 +1854,17 @@ export const ko = {
   kamino_earn_deposit: '금고에 예치',
   kamino_earn_deposit_to: '입금',
   kamino_earn_minimum_deposit: '최소 예치금',
+  kamino_earn_amount_unavailable:
+    '지금은 이 금액으로 환전할 수 없습니다. 잠시 후 다시 시도해 주세요.',
+  kamino_earn_available_to_withdraw: '인출 가능',
+  kamino_earn_delayed_liquidity:
+    '이는 현재 금고에 보관된 액체보다 많은 양이므로 안정화되는 데 더 오랜 시간이 걸릴 수 있습니다.',
+  kamino_earn_receive_estimate:
+    '최종 금액은 인출이 완료될 때 확정되며, 약간의 차이가 있을 수 있습니다.',
+  kamino_earn_releases_from_farm:
+    '이 포지션의 일부는 스테이킹되어 있으므로, 출금 시 스테이킹된 부분이 먼저 해제됩니다.',
+  kamino_earn_shares_burned: '주식이 불탔다',
+  kamino_earn_withdraw: '철회하다',
+  kamino_earn_withdraw_from: '인출하다',
+  kamino_earn_you_receive: '당신은 받습니다',
 }

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -1887,7 +1887,7 @@ export const nl = {
   kamino_earn_releases_from_farm:
     'Een deel van deze positie is gestaked, dus bij een opname wordt dat deel eerst vrijgegeven.',
   kamino_earn_shares_burned: 'Aandelen verbrand',
-  kamino_earn_withdraw: 'Terugtrekken',
+  kamino_earn_withdraw: 'Opname uit de kluis',
   kamino_earn_withdraw_from: 'Terugtrekken uit',
   kamino_earn_you_receive: 'U ontvangt',
 }

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -1877,4 +1877,17 @@ export const nl = {
   kamino_earn_deposit: 'Storten in de kluis',
   kamino_earn_deposit_to: 'Storten aan',
   kamino_earn_minimum_deposit: 'Minimale storting',
+  kamino_earn_amount_unavailable:
+    'Dit bedrag kan momenteel niet worden omgerekend. Probeer het over een moment opnieuw.',
+  kamino_earn_available_to_withdraw: 'Beschikbaar om op te nemen',
+  kamino_earn_delayed_liquidity:
+    'Dit is meer dan de kluis momenteel aan vloeistof kan bevatten, dus het kan langer duren voordat het bezinkt.',
+  kamino_earn_receive_estimate:
+    'Het definitieve bedrag wordt vastgesteld wanneer de opname is verwerkt en kan enigszins afwijken.',
+  kamino_earn_releases_from_farm:
+    'Een deel van deze positie is gestaked, dus bij een opname wordt dat deel eerst vrijgegeven.',
+  kamino_earn_shares_burned: 'Aandelen verbrand',
+  kamino_earn_withdraw: 'Terugtrekken',
+  kamino_earn_withdraw_from: 'Terugtrekken uit',
+  kamino_earn_you_receive: 'U ontvangt',
 }

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -1890,4 +1890,6 @@ export const nl = {
   kamino_earn_withdraw: 'Opname uit de kluis',
   kamino_earn_withdraw_from: 'Terugtrekken uit',
   kamino_earn_you_receive: 'U ontvangt',
+  kamino_earn_no_solana_address:
+    'Deze kluis heeft geen adres in Solana, dus Kamino Earn is niet beschikbaar.',
 }

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -1907,7 +1907,7 @@ export const pt = {
   kamino_earn_releases_from_farm:
     'Parte dessa posição está em staking, portanto, o saque a libera primeiro.',
   kamino_earn_shares_burned: 'Ações queimadas',
-  kamino_earn_withdraw: 'Retirar',
+  kamino_earn_withdraw: 'Retirar do cofre',
   kamino_earn_withdraw_from: 'Retirar-se de',
   kamino_earn_you_receive: 'Você recebe',
 }

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -1910,4 +1910,6 @@ export const pt = {
   kamino_earn_withdraw: 'Retirar do cofre',
   kamino_earn_withdraw_from: 'Retirar-se de',
   kamino_earn_you_receive: 'Você recebe',
+  kamino_earn_no_solana_address:
+    'Este cofre não possui endereço Solana, portanto o Kamino Earn está indisponível.',
 }

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -1897,4 +1897,17 @@ export const pt = {
   kamino_earn_deposit: 'Depositar no cofre',
   kamino_earn_deposit_to: 'Depositar em',
   kamino_earn_minimum_deposit: 'depósito mínimo',
+  kamino_earn_amount_unavailable:
+    'Este valor não pode ser convertido neste momento. Tente novamente em instantes.',
+  kamino_earn_available_to_withdraw: 'Disponível para retirada',
+  kamino_earn_delayed_liquidity:
+    'Essa quantidade de líquido é maior do que a capacidade atual do cofre, portanto, pode levar mais tempo para que a água seque.',
+  kamino_earn_receive_estimate:
+    'O valor final é definido quando o saque é liquidado e pode variar ligeiramente.',
+  kamino_earn_releases_from_farm:
+    'Parte dessa posição está em staking, portanto, o saque a libera primeiro.',
+  kamino_earn_shares_burned: 'Ações queimadas',
+  kamino_earn_withdraw: 'Retirar',
+  kamino_earn_withdraw_from: 'Retirar-se de',
+  kamino_earn_you_receive: 'Você recebe',
 }

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -1873,4 +1873,17 @@ export const ru = {
   kamino_earn_deposit: 'Внести в хранилище',
   kamino_earn_deposit_to: 'Внести депозит',
   kamino_earn_minimum_deposit: 'Минимальный депозит',
+  kamino_earn_amount_unavailable:
+    'В данный момент конвертация этой суммы невозможна. Попробуйте позже.',
+  kamino_earn_available_to_withdraw: 'Доступно для вывода средств',
+  kamino_earn_delayed_liquidity:
+    'Это больше, чем вмещает хранилище в данный момент жидкости, поэтому для оседания может потребоваться больше времени.',
+  kamino_earn_receive_estimate:
+    'Окончательная сумма устанавливается при расчете вывода средств и может незначительно отличаться.',
+  kamino_earn_releases_from_farm:
+    'Часть этой позиции заблокирована, поэтому при выводе средств сначала освобождается именно она.',
+  kamino_earn_shares_burned: 'Сгорели акции',
+  kamino_earn_withdraw: 'Отзывать',
+  kamino_earn_withdraw_from: 'Выйти из',
+  kamino_earn_you_receive: 'Вы получаете',
 }

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -1883,7 +1883,7 @@ export const ru = {
   kamino_earn_releases_from_farm:
     'Часть этой позиции заблокирована, поэтому при выводе средств сначала освобождается именно она.',
   kamino_earn_shares_burned: 'Сгорели акции',
-  kamino_earn_withdraw: 'Отзывать',
+  kamino_earn_withdraw: 'Извлечь из хранилища',
   kamino_earn_withdraw_from: 'Выйти из',
   kamino_earn_you_receive: 'Вы получаете',
 }

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -1886,4 +1886,6 @@ export const ru = {
   kamino_earn_withdraw: 'Извлечь из хранилища',
   kamino_earn_withdraw_from: 'Выйти из',
   kamino_earn_you_receive: 'Вы получаете',
+  kamino_earn_no_solana_address:
+    'У этого хранилища нет адреса на Солане, поэтому Kamino Earn недоступен.',
 }

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -1747,7 +1747,7 @@ export const zh = {
   kamino_earn_releases_from_farm:
     '这部分仓位已进行质押，因此提款会首先释放这部分质押仓位。',
   kamino_earn_shares_burned: '股票被烧毁',
-  kamino_earn_withdraw: '提取',
+  kamino_earn_withdraw: '从金库提取',
   kamino_earn_withdraw_from: '退出',
   kamino_earn_you_receive: '您收到',
 }

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -1750,4 +1750,6 @@ export const zh = {
   kamino_earn_withdraw: '从金库提取',
   kamino_earn_withdraw_from: '退出',
   kamino_earn_you_receive: '您收到',
+  kamino_earn_no_solana_address:
+    '该保险库没有 Solana 地址，因此 Kamino Earn 不可用。',
 }

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -1739,4 +1739,15 @@ export const zh = {
   kamino_earn_deposit: '存入金库',
   kamino_earn_deposit_to: '存款',
   kamino_earn_minimum_deposit: '最低存款',
+  kamino_earn_amount_unavailable: '此金额目前无法转换，请稍后再试。',
+  kamino_earn_available_to_withdraw: '可提取',
+  kamino_earn_delayed_liquidity:
+    '这比金库目前容纳的液体量还要多，因此可能需要更长时间才能稳定下来。',
+  kamino_earn_receive_estimate: '最终金额在提款结算时确定，可能会略有不同。',
+  kamino_earn_releases_from_farm:
+    '这部分仓位已进行质押，因此提款会首先释放这部分质押仓位。',
+  kamino_earn_shares_burned: '股票被烧毁',
+  kamino_earn_withdraw: '提取',
+  kamino_earn_withdraw_from: '退出',
+  kamino_earn_you_receive: '您收到',
 }

--- a/core/ui/navigation/CoreView.ts
+++ b/core/ui/navigation/CoreView.ts
@@ -130,6 +130,7 @@ export type CoreView =
   | { id: 'manageDefiChains' }
   | { id: 'manageDefiPositions'; state: { chain: Chain; returnTab?: string } }
   | { id: 'kaminoDeposit'; state: { vaultAddress: string } }
+  | { id: 'kaminoWithdraw'; state: { vaultAddress: string } }
   | {
       id: 'tonStake'
       state: {

--- a/core/ui/navigation/sharedViews.tsx
+++ b/core/ui/navigation/sharedViews.tsx
@@ -8,6 +8,7 @@ import { AddressPage } from '@core/ui/chain/coin/address'
 import { TonStakePage } from '@core/ui/chain/ton/staking/TonStakePage'
 import { DeeplinkPage } from '@core/ui/deeplink/components/DeeplinkPage'
 import { KaminoDepositPage } from '@core/ui/defi/chain/solana/kamino/deposit/KaminoDepositPage'
+import { KaminoWithdrawPage } from '@core/ui/defi/chain/solana/kamino/withdraw/KaminoWithdrawPage'
 import { ReshareVaultPage } from '@core/ui/mpc/keygen/reshare/ReshareVaultPage'
 import { CoreViewId } from '@core/ui/navigation/CoreView'
 import { ChooseVaultsView } from '@core/ui/notifications/choose-vaults/ChooseVaultsView'
@@ -87,6 +88,7 @@ export type SharedViewId = Extract<
   | 'manageDefiChains'
   | 'manageDefiPositions'
   | 'kaminoDeposit'
+  | 'kaminoWithdraw'
   | 'tonStake'
   | 'limitOrders'
   | 'cancelLimitOrder'
@@ -163,6 +165,7 @@ export const sharedViews: Views<SharedViewId> = {
   manageDefiChains: ManageDefiChainsPage,
   manageDefiPositions: ManageDefiPositionsPage,
   kaminoDeposit: KaminoDepositPage,
+  kaminoWithdraw: KaminoWithdrawPage,
   tonStake: TonStakePage,
   lpPositionForm: LpPositionFormPage,
   manageVaultChains: ManageVaultChainsPage,


### PR DESCRIPTION
Closes #4669. Third Windows-side slice of the Kamino Earn integration (#4541).

> **Stacked on #4695** (`feat/4668-kamino-deposit-flow`), which is itself stacked on #4692. Review those first — this PR's diff is against #4695, and GitHub retargets the base as each merges.

Adds the withdraw flow behind the vault card, and moves both Kamino amount steps onto the amount surface the rest of the app uses.

## Amount entry

The first pass used a plain text field, which did not match the app's other amount steps. Both Kamino forms now use the established surface — a labelled container holding a large centred value, a percentage slider, and the balance the percentage is taken of — built from the same `action-form` primitives (`ActionInputContainer`, `ActionFieldDivider`, `ActionAmountInputSurface`, `Slider`) that the stake, bond and unbond forms use. The percentage resolves against **base units**, not the rounded display figure, so a fraction is a fraction of the real balance.

## The two rules that keep a partial withdrawal partial

The amount is entered in the underlying token — what a holder thinks in — but the shares the chain burns are resolved by the chain package's exact integer arithmetic. No float math in the UI layer.

1. **A max withdrawal sends the held share balance itself**, never a share count derived from a token figure. The derivation truncates, so it would strand dust; rounding the other way asks for more than the position holds.
2. **Every result is capped at the spendable balance**, which sits strictly below the reported total. Asking for the whole balance is the one request Kamino answers by rewriting the amount to `u64::MAX` — withdraw everything. The rate can move between the position read and the keystroke, so the cap is applied to typed amounts too.

Both are pinned by tests, including one asserting the resolved count stays strictly below the reported total.

## Farm-staked positions and delayed liquidity

The request carries how the position was split when it was read, because that decides whether the API builds the plain withdrawal or the one that releases shares from the farm first — and the validator refuses the shape it was not told to expect. The review screen says when a release is involved, so a longer transaction is explained rather than surprising.

Exceeding the vault's liquid buffer is surfaced as a **notice, not an error**: a vault keeps only a small share of its assets liquid (well under 1% on the launch vaults), so a withdrawal above that buffer is the ordinary case and settles late rather than failing. Blocking it would refuse most real withdrawals.

## Not in here

Verify-screen decoding (#4670).

## Testing

`yarn check` clean, 1,084 tests including 6 new, extension build green. Translations generated with `yarn translate`.

**Two gaps worth naming.** The received amount shown is the exact share→token conversion at the current rate; the ~0.01% anti-sniping penalty is **not** reflected, because that would need a simulation round trip — the screen labels it as settling-time-dependent rather than claiming exactness. And as with #4695 I have no edit access to the Figma file, so the layout follows in-app convention rather than the design. Neither is verified on-chain yet: partial and full withdrawals from a Fast Vault are the remaining acceptance checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kamino Earn withdrawal flows with amount entry, balance validation, liquidity warnings, transaction review, and signing.
  * Added withdrawal navigation from vault cards, with controls adapting to position status.
  * Added percentage-based amount selection and estimated received values.
* **Localization**
  * Added Kamino withdrawal messaging across supported languages.
* **Bug Fixes**
  * Improved withdrawal amount conversion, balance clamping, and handling of unavailable liquidity.
* **Tests**
  * Added coverage for withdrawal amount and share calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->