### PR TITLE
Fix fast keysign to stay on one progress screen

### DIFF
--- a/clients/extension/tests/e2e/specs/send-flow.spec.ts
+++ b/clients/extension/tests/e2e/specs/send-flow.spec.ts
@@ -195,7 +195,37 @@ test.describe('Send Flow', () => {
         path: `test-results/send-before-sign-${chain}-${Date.now()}.png`,
       })
 
+      const connectingProgressHostPromise = page.waitForSelector(
+        '[data-testid="keysign-progress"][data-phase="connecting"]',
+        { state: 'visible', timeout: 15_000 }
+      )
       await sendFlow.sign()
+      const connectingProgressHost = await connectingProgressHostPromise
+      expect(await connectingProgressHost.isVisible()).toBe(true)
+      await expect(
+        page.getByText('Looking for FastVaultServer...')
+      ).toBeHidden()
+      await expect(page.getByTestId('keygen-connecting-progress')).toBeHidden()
+
+      const progressHost = page.getByTestId('keysign-progress')
+      await expect(progressHost).toHaveAttribute('data-phase', 'signing', {
+        timeout: 30_000,
+      })
+      await expect(progressHost).toBeVisible()
+      await expect(
+        page.getByText('Looking for FastVaultServer...')
+      ).toBeHidden()
+      await expect(page.getByTestId('keygen-connecting-progress')).toBeHidden()
+      const signingProgressHost = await progressHost.elementHandle()
+      if (!signingProgressHost) {
+        throw new Error('Fast keysign signing progress host was not mounted')
+      }
+      expect(
+        await signingProgressHost.evaluate(
+          (current, connecting) => current === connecting,
+          connectingProgressHost
+        )
+      ).toBe(true)
 
       // Take screenshot after sign
       await page.screenshot({

--- a/clients/extension/tests/unit/waitForServerStep.test.tsx
+++ b/clients/extension/tests/unit/waitForServerStep.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+
+import { render } from '@testing-library/react'
+import { createElement, ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+const peersQueryState = vi.hoisted(() => ({
+  value: {
+    data: undefined as string[] | undefined,
+    error: null as Error | null,
+    isError: false,
+  },
+}))
+
+vi.mock('@core/ui/mpc/devices/queries/useMpcPeerOptionsQuery', () => ({
+  useMpcPeerOptionsQuery: () => peersQueryState.value,
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('@core/ui/flow/FlowErrorPageContent', () => ({
+  FlowErrorPageContent: () => createElement('div', null, 'error'),
+}))
+
+vi.mock('@lib/ui/page/PageHeader', () => ({
+  PageHeader: () => createElement('header'),
+}))
+
+vi.mock('@lib/ui/query/components/MatchQuery', () => ({
+  MatchQuery: ({
+    error,
+    pending,
+    value,
+  }: {
+    error: (error: Error | null) => ReactNode
+    pending: () => ReactNode
+    value: { error: Error | null; isError: boolean }
+  }) => (value.isError ? error(value.error) : pending()),
+}))
+
+import { WaitForServerStep } from '@core/ui/mpc/fast/WaitForServerStep'
+
+describe('WaitForServerStep', () => {
+  it('reports recovery so a persistent progress host can be restored', () => {
+    const onErrorChange = vi.fn()
+    const view = render(
+      <WaitForServerStep
+        onErrorChange={onErrorChange}
+        onFinish={() => {}}
+        renderPending={() => null}
+      />
+    )
+
+    expect(onErrorChange).toHaveBeenLastCalledWith(false)
+
+    peersQueryState.value = {
+      data: undefined,
+      error: new Error('server unavailable'),
+      isError: true,
+    }
+    view.rerender(
+      <WaitForServerStep
+        onErrorChange={onErrorChange}
+        onFinish={() => {}}
+        renderPending={() => null}
+      />
+    )
+
+    expect(onErrorChange).toHaveBeenLastCalledWith(true)
+
+    peersQueryState.value = {
+      data: undefined,
+      error: null,
+      isError: false,
+    }
+    view.rerender(
+      <WaitForServerStep
+        onErrorChange={onErrorChange}
+        onFinish={() => {}}
+        renderPending={() => null}
+      />
+    )
+
+    expect(onErrorChange).toHaveBeenLastCalledWith(false)
+  })
+})

--- a/core/ui/mpc/fast/WaitForServerStep.tsx
+++ b/core/ui/mpc/fast/WaitForServerStep.tsx
@@ -4,20 +4,37 @@ import { KeygenConnectingAnimation } from '@core/ui/mpc/keygen/progress/KeygenCo
 import { PageHeader } from '@lib/ui/page/PageHeader'
 import { OnFinishProp } from '@lib/ui/props'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
-import { FC, useEffect } from 'react'
+import { FC, ReactNode, useEffect, useLayoutEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
-export const WaitForServerStep: FC<OnFinishProp<string[]>> = ({ onFinish }) => {
+type WaitForServerStepProps = OnFinishProp<string[]> & {
+  onError?: () => void
+  onErrorChange?: (isError: boolean) => void
+  renderPending?: () => ReactNode
+}
+
+export const WaitForServerStep: FC<WaitForServerStepProps> = ({
+  onError,
+  onErrorChange,
+  onFinish,
+  renderPending,
+}) => {
   const { t } = useTranslation()
   const peersQuery = useMpcPeerOptionsQuery()
 
   useEffect(() => {
     if (peersQuery.data) onFinish(peersQuery.data)
   }, [onFinish, peersQuery.data])
+  useLayoutEffect(() => {
+    onErrorChange?.(peersQuery.isError)
+    if (peersQuery.isError) onError?.()
+  }, [onError, onErrorChange, peersQuery.isError])
 
   return (
     <>
-      <PageHeader title={t('connecting_to_server')} hasBorder />
+      {!renderPending || peersQuery.isError ? (
+        <PageHeader title={t('connecting_to_server')} hasBorder />
+      ) : null}
       <MatchQuery
         value={peersQuery}
         error={error => (
@@ -26,7 +43,13 @@ export const WaitForServerStep: FC<OnFinishProp<string[]>> = ({ onFinish }) => {
             error={error}
           />
         )}
-        pending={() => <KeygenConnectingAnimation securityType="fast" />}
+        pending={() =>
+          renderPending ? (
+            renderPending()
+          ) : (
+            <KeygenConnectingAnimation securityType="fast" />
+          )
+        }
       />
     </>
   )

--- a/core/ui/mpc/keygen/progress/KeygenConnectingAnimation.tsx
+++ b/core/ui/mpc/keygen/progress/KeygenConnectingAnimation.tsx
@@ -20,7 +20,7 @@ export const KeygenConnectingAnimation = ({
 }: {
   securityType?: VaultSecurityType
 }) => (
-  <Container>
+  <Container data-testid="keygen-connecting-progress">
     <KeygenLoadingAnimation isConnected={false} securityType={securityType} />
   </Container>
 )

--- a/core/ui/mpc/keysign/KeysignSigningStep.tsx
+++ b/core/ui/mpc/keysign/KeysignSigningStep.tsx
@@ -33,7 +33,7 @@ import { isKeyImportVault } from '@vultisig/core-mpc/vault/Vault'
 import { getLastItem } from '@vultisig/lib-utils/array/getLastItem'
 import { extractErrorMsg } from '@vultisig/lib-utils/error/extractErrorMsg'
 import { getRecordUnionValue } from '@vultisig/lib-utils/record/union/getRecordUnionValue'
-import { useEffect } from 'react'
+import { ReactNode, useEffect, useLayoutEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useCopyToClipboard } from 'react-use'
 
@@ -42,10 +42,18 @@ import { BroadcastError } from './broadcastKeysignTx'
 import { useKeysignMessagePayload } from './state/keysignMessagePayload'
 import { LimitOrderCancelDoneHint } from './tx/LimitOrderCancelDoneHint'
 
-type KeysignSigningStepProps = Partial<OnBackProp> & { toAddressLabel?: string }
+type KeysignSigningStepProps = Partial<OnBackProp> & {
+  onSettled?: () => void
+  onStart?: () => void
+  renderPending?: () => ReactNode
+  toAddressLabel?: string
+}
 
 export const KeysignSigningStep = ({
   onBack,
+  onSettled,
+  onStart,
+  renderPending,
   toAddressLabel,
 }: KeysignSigningStepProps) => {
   const { t } = useTranslation()
@@ -56,6 +64,10 @@ export const KeysignSigningStep = ({
   const { mutate: startKeysign, ...mutationStatus } =
     useKeysignMutation(payload)
   const [, copyToClipboard] = useCopyToClipboard()
+  useLayoutEffect(() => onStart?.(), [onStart])
+  useLayoutEffect(() => {
+    if (mutationStatus.isError || mutationStatus.isSuccess) onSettled?.()
+  }, [mutationStatus.isError, mutationStatus.isSuccess, onSettled])
   useEffect(startKeysign, [startKeysign])
 
   return (
@@ -281,21 +293,25 @@ export const KeysignSigningStep = ({
           />
         )
       }}
-      pending={() => (
-        <>
-          <PageHeader
-            primaryControls={<PageHeaderBackButton onClick={onBack} />}
-            title={t('keysign')}
-            hasBorder
-          />
-          <KeysignSigningState />
-          <PageFooter alignItems="center">
-            <Text color="shy" size={12}>
-              {t('version')} {version}
-            </Text>
-          </PageFooter>
-        </>
-      )}
+      pending={() =>
+        renderPending ? (
+          renderPending()
+        ) : (
+          <>
+            <PageHeader
+              primaryControls={<PageHeaderBackButton onClick={onBack} />}
+              title={t('keysign')}
+              hasBorder
+            />
+            <KeysignSigningState />
+            <PageFooter alignItems="center">
+              <Text color="shy" size={12}>
+                {t('version')} {version}
+              </Text>
+            </PageFooter>
+          </>
+        )
+      }
     />
   )
 }

--- a/core/ui/mpc/keysign/fast/FastKeysignServerStep.tsx
+++ b/core/ui/mpc/keysign/fast/FastKeysignServerStep.tsx
@@ -29,7 +29,7 @@ import { isOneOf } from '@vultisig/lib-utils/array/isOneOf'
 import { attempt } from '@vultisig/lib-utils/attempt'
 import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
 import { assertField } from '@vultisig/lib-utils/record/assertField'
-import { useEffect } from 'react'
+import { ReactNode, useEffect, useLayoutEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -44,12 +44,16 @@ import { getCustomMessageHex } from '../customMessage/getCustomMessageHex'
 import { resolveServerChainForKeyImport } from './utils/resolveServerChainForKeyImport'
 
 type FastKeysignServerStepProps = OnFinishProp & {
+  onError?: () => void
   password: string
+  renderPending?: () => ReactNode
 }
 
 export const FastKeysignServerStep: React.FC<FastKeysignServerStepProps> = ({
+  onError,
   onFinish,
   password,
+  renderPending,
 }) => {
   const { t } = useTranslation()
 
@@ -224,6 +228,9 @@ export const FastKeysignServerStep: React.FC<FastKeysignServerStepProps> = ({
   })
 
   useEffect(mutate, [mutate])
+  useLayoutEffect(() => {
+    if (state.isError) onError?.()
+  }, [onError, state.isError])
 
   const title = t('fast_sign')
 
@@ -239,18 +246,26 @@ export const FastKeysignServerStep: React.FC<FastKeysignServerStepProps> = ({
     <>
       <MatchQuery
         value={state}
-        pending={() => (
-          <>
-            {header}
-            <WaitForServerLoader />
-          </>
-        )}
-        success={() => (
-          <>
-            {header}
-            <WaitForServerLoader />
-          </>
-        )}
+        pending={() =>
+          renderPending ? (
+            renderPending()
+          ) : (
+            <>
+              {header}
+              <WaitForServerLoader />
+            </>
+          )
+        }
+        success={() =>
+          renderPending ? (
+            renderPending()
+          ) : (
+            <>
+              {header}
+              <WaitForServerLoader />
+            </>
+          )
+        }
         error={error => (
           <FullPageFlowErrorState
             title={t('failed_to_connect_with_server')}

--- a/core/ui/mpc/keysign/flow/KeysignSigningState.tsx
+++ b/core/ui/mpc/keysign/flow/KeysignSigningState.tsx
@@ -18,12 +18,18 @@ const signingTickMs = 200
  * Renders the Rive animation with the signing coin's logo (falling back to
  * the chain logo when no coin logo is available).
  */
-export const KeysignSigningState = () => {
+export const KeysignSigningState = ({
+  isConnected = true,
+}: {
+  isConnected?: boolean
+}) => {
   const payload = useKeysignMessagePayload()
   const logoSrc = getKeysignPayloadLogoSrc(payload)
   const [progress, setProgress] = useState(0)
 
   useEffect(() => {
+    if (!isConnected) return
+
     const start = Date.now()
     const interval = setInterval(() => {
       const ratio = Math.min((Date.now() - start) / signingDurationMs, 1)
@@ -32,12 +38,15 @@ export const KeysignSigningState = () => {
     }, signingTickMs)
 
     return () => clearInterval(interval)
-  }, [])
+  }, [isConnected])
 
   return (
-    <Container>
+    <Container
+      data-phase={isConnected ? 'signing' : 'connecting'}
+      data-testid="keysign-progress"
+    >
       <KeysignLoadingAnimation
-        isConnected
+        isConnected={isConnected}
         progress={progress}
         logoSrc={logoSrc}
       />

--- a/core/ui/mpc/keysign/start/StartFastKeysignFlow.tsx
+++ b/core/ui/mpc/keysign/start/StartFastKeysignFlow.tsx
@@ -1,5 +1,7 @@
+import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { WaitForServerStep } from '@core/ui/mpc/fast/WaitForServerStep'
 import { FastKeysignServerStep } from '@core/ui/mpc/keysign/fast/FastKeysignServerStep'
+import { KeysignSigningState } from '@core/ui/mpc/keysign/flow/KeysignSigningState'
 import { KeysignSigningStep } from '@core/ui/mpc/keysign/KeysignSigningStep'
 import { KeysignActionProviderProp } from '@core/ui/mpc/keysign/start/KeysignActionProviderProp'
 import { StartMpcSessionFlow } from '@core/ui/mpc/session/StartMpcSessionFlow'
@@ -9,7 +11,12 @@ import { useCore } from '@core/ui/state/core'
 import { Match } from '@lib/ui/base/Match'
 import { ValueTransfer } from '@lib/ui/base/ValueTransfer'
 import { useStepNavigation } from '@lib/ui/hooks/useStepNavigation'
+import { PageFooter } from '@lib/ui/page/PageFooter'
+import { PageHeader } from '@lib/ui/page/PageHeader'
+import { Text } from '@lib/ui/text'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
+import { useCallback, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import { TransactionRecorderProvider } from '../../../transaction-history/record/TransactionRecorderProvider'
 import { KeysignMessagePayloadProvider } from '../state/keysignMessagePayload'
@@ -20,47 +27,88 @@ const keysignSteps = ['server', 'keysign'] as const
 export const StartFastKeysignFlow = ({
   keysignActionProvider: KeysignActionProvider,
 }: KeysignActionProviderProp) => {
-  const { goBack } = useCore()
+  const { goBack, version } = useCore()
+  const { t } = useTranslation()
   const [{ keysignPayload, password, toAddressLabel, swapQuote }] =
     useCoreViewState<'keysign'>()
+  const [isConnected, setIsConnected] = useState(false)
+  const [showProgress, setShowProgress] = useState(true)
   const { step, toNextStep } = useStepNavigation({
     steps: keysignSteps,
     onExit: goBack,
   })
 
+  const renderPending = useCallback(() => null, [])
+  const hideProgress = useCallback(() => setShowProgress(false), [])
+  const syncProgressWithError = useCallback(
+    (isError: boolean) => setShowProgress(!isError),
+    []
+  )
+  const showSigningProgress = useCallback(() => setIsConnected(true), [])
+
   return (
-    <Match
-      value={step}
-      server={() => (
-        <FastKeysignServerStep
-          onFinish={toNextStep}
-          password={shouldBePresent(password)}
-        />
-      )}
-      keysign={() => (
-        <ValueTransfer<string[]>
-          from={({ onFinish }) => <WaitForServerStep onFinish={onFinish} />}
-          key="peers"
-          to={({ value }) => (
-            <MpcPeersProvider value={value}>
-              <StartMpcSessionFlow
-                render={() => (
-                  <KeysignActionProvider>
-                    <KeysignMessagePayloadProvider value={keysignPayload}>
+    <KeysignMessagePayloadProvider value={keysignPayload}>
+      {showProgress ? (
+        <>
+          <PageHeader
+            primaryControls={<PageHeaderBackButton />}
+            title={t(isConnected ? 'keysign' : 'connecting_to_server')}
+            hasBorder
+          />
+          <KeysignSigningState isConnected={isConnected} />
+          <PageFooter alignItems="center">
+            <Text color="shy" size={12}>
+              {isConnected ? `${t('version')} ${version}` : '\u00a0'}
+            </Text>
+          </PageFooter>
+        </>
+      ) : null}
+      <Match
+        value={step}
+        server={() => (
+          <FastKeysignServerStep
+            onError={hideProgress}
+            onFinish={toNextStep}
+            password={shouldBePresent(password)}
+            renderPending={renderPending}
+          />
+        )}
+        keysign={() => (
+          <ValueTransfer<string[]>
+            from={({ onFinish }) => (
+              <WaitForServerStep
+                onErrorChange={syncProgressWithError}
+                onFinish={onFinish}
+                renderPending={renderPending}
+              />
+            )}
+            key="peers"
+            to={({ value }) => (
+              <MpcPeersProvider value={value}>
+                <StartMpcSessionFlow
+                  onError={hideProgress}
+                  render={() => (
+                    <KeysignActionProvider>
                       <SwapQuoteProvider value={swapQuote}>
                         <TransactionRecorderProvider>
-                          <KeysignSigningStep toAddressLabel={toAddressLabel} />
+                          <KeysignSigningStep
+                            onSettled={hideProgress}
+                            onStart={showSigningProgress}
+                            renderPending={renderPending}
+                            toAddressLabel={toAddressLabel}
+                          />
                         </TransactionRecorderProvider>
                       </SwapQuoteProvider>
-                    </KeysignMessagePayloadProvider>
-                  </KeysignActionProvider>
-                )}
-                value="keysign"
-              />
-            </MpcPeersProvider>
-          )}
-        />
-      )}
-    />
+                    </KeysignActionProvider>
+                  )}
+                  renderPending={renderPending}
+                  value="keysign"
+                />
+              </MpcPeersProvider>
+            )}
+          />
+        )}
+      />
+    </KeysignMessagePayloadProvider>
   )
 }

--- a/core/ui/mpc/session/StartMpcSessionFlow.tsx
+++ b/core/ui/mpc/session/StartMpcSessionFlow.tsx
@@ -1,6 +1,7 @@
 import { VaultSecurityType } from '@core/ui/vault/VaultSecurityType'
 import { ValueTransfer } from '@lib/ui/base/ValueTransfer'
 import { RenderProp, ValueProp } from '@lib/ui/props'
+import { ReactNode } from 'react'
 
 import { MpcSignersProvider } from '../devices/state/signers'
 import { MpcSession } from './MpcSession'
@@ -8,17 +9,23 @@ import { StartMpcSessionStep } from './StartMpcSessionStep'
 
 export const StartMpcSessionFlow = ({
   render,
+  onError,
+  renderPending,
   value,
   securityType,
 }: RenderProp &
   ValueProp<MpcSession> & {
+    onError?: () => void
+    renderPending?: () => ReactNode
     securityType?: VaultSecurityType
   }) => {
   return (
     <ValueTransfer<string[]>
       from={({ onFinish }) => (
         <StartMpcSessionStep
+          onError={onError}
           onFinish={onFinish}
+          renderPending={renderPending}
           value={value}
           securityType={securityType}
         />

--- a/core/ui/mpc/session/StartMpcSessionStep.tsx
+++ b/core/ui/mpc/session/StartMpcSessionStep.tsx
@@ -6,32 +6,45 @@ import { PageContent } from '@lib/ui/page/PageContent'
 import { PageHeader } from '@lib/ui/page/PageHeader'
 import { OnFinishProp, ValueProp } from '@lib/ui/props'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
-import { useEffect } from 'react'
+import { ReactNode, useEffect, useLayoutEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { FlowErrorPageContent } from '../../flow/FlowErrorPageContent'
 
 export const StartMpcSessionStep = ({
   onFinish,
+  onError,
+  renderPending,
   value,
   securityType,
 }: OnFinishProp<string[]> &
   ValueProp<MpcSession> & {
+    onError?: () => void
+    renderPending?: () => ReactNode
     securityType?: VaultSecurityType
   }) => {
   const { t } = useTranslation()
   const { mutate: start, ...status } = useStartMpcSession(onFinish)
 
   useEffect(() => start(), [start])
+  useLayoutEffect(() => {
+    if (status.isError) onError?.()
+  }, [onError, status.isError])
 
   return (
     <>
-      <PageHeader title={t(value)} hasBorder />
+      {!renderPending || status.isError ? (
+        <PageHeader title={t(value)} hasBorder />
+      ) : null}
       <MatchQuery
         value={status}
-        pending={() => (
-          <KeygenConnectingAnimation securityType={securityType} />
-        )}
+        pending={() =>
+          renderPending ? (
+            renderPending()
+          ) : (
+            <KeygenConnectingAnimation securityType={securityType} />
+          )
+        }
         error={error => (
           <PageContent justifyContent="center" alignItems="center">
             <FlowErrorPageContent


### PR DESCRIPTION
Closes #4688
![screenshot-1](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/4688-fast-keysign-single-progress/screenshot-1-1787319178263.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer signing progress states during connection and signing.
  * Signing progress now pauses when connectivity is interrupted and resumes when it returns.
  * Improved loading and pending-state presentation throughout key signing and session setup.
* **Bug Fixes**
  * Improved error and recovery feedback when server, session, or signing steps fail.
  * Refined transition behavior between connecting, signing, and completed states for a smoother send experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->