### PR TITLE
fix: bump tar resolution to patch node-tar DoS advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@bufbuild/protobuf": "^2.12.0",
     "@vultisig/mpc-types": "0.2.3",
     "@vultisig/mpc-wasm": "0.1.7",
-    "tar": ">=7.5.20",
+    "tar": ">=7.5.21",
     "js-yaml@4.1.1": "4.3.1",
     "js-yaml@^4.1.1": "4.3.1",
     "brace-expansion@^1.1.7": "1.1.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16613,16 +16613,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:>=7.5.20":
-  version: 7.5.20
-  resolution: "tar@npm:7.5.20"
+"tar@npm:>=7.5.21":
+  version: 7.5.22
+  resolution: "tar@npm:7.5.22"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/4df4335c6d958b76adf1eaced55889dec3ca1c51f450658a074af80694bb0d9c154a8e93fdf4da617372d1575b121295379993961bbe4cd4b0867c0e5689846a
+  checksum: 10c0/1311f6be85a8157ac4c9147bae43e13923d2a1aae15e4aa1bd5239e4e03d2cf53cfe103dde7f35832fbb4c938b042856bc8e9a0afd29abd05e2d1608788c4fea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

`yarn quality:health` (and therefore `yarn check:all`) was failing on `yarn quality:audit` because of a new high-severity advisory, [GHSA-r292-9mhp-454m](https://github.com/advisories/GHSA-r292-9mhp-454m) (uncontrolled recursion / stack-overflow DoS in `node-tar`, affecting `<=7.5.20`), pulled in transitively via `node-gyp@12.2.0`.

Root cause: the `resolutions` entry in `package.json` pinned `"tar": ">=7.5.20"`, which still allows the vulnerable `7.5.20` to resolve. Bumped the floor to `">=7.5.21"` so yarn resolves the patched `7.5.22` instead.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] `yarn quality:health` and `yarn check` pass locally

## Additional context

Dependency-only fix (`package.json` + `yarn.lock`), no application code changed.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: none (`yarn quality:health` failure reported directly)
- **Confidence**: high
- **Needs human review for**: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the required `tar` version to improve compatibility and address the latest supported patch level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->