### PR TITLE
fix(extension): surface dApp requests when the popup opens behind the browser

### DIFF
--- a/clients/extension/src/background/common.ts
+++ b/clients/extension/src/background/common.ts
@@ -1,5 +1,6 @@
 import { runBackgroundEventsAgent } from '@core/inpage-provider/background/events/background'
 import { runInpageProviderBridgeBackgroundAgent } from '@core/inpage-provider/bridge/background'
+import { resetPendingRequestsBadge } from '@core/inpage-provider/popup/resolvers/background/pendingRequestsBadge'
 
 import { getIsSidePanelEnabled } from '../storage/isSidePanelEnabled'
 import { registerFastVaultPasswordCacheExpiry } from './registerFastVaultPasswordCacheExpiry'
@@ -8,6 +9,7 @@ registerFastVaultPasswordCacheExpiry()
 
 /**
  * Bootstraps the extension background: locks down built-in prototypes (non-Firefox),
+ * clears any pending-request badge left by an earlier service worker generation,
  * starts the inpage-provider bridge and background event agents, applies the persisted
  * side panel behavior on Chromium, and wires the dev WebSocket reload when enabled.
  */
@@ -28,6 +30,8 @@ export const initExtensionBackground = () => {
       Boolean.prototype,
     ].forEach(Object.freeze)
   }
+
+  resetPendingRequestsBadge()
 
   runInpageProviderBridgeBackgroundAgent()
 

--- a/core/inpage-provider/popup/resolvers/background/inNewWindow.test.ts
+++ b/core/inpage-provider/popup/resolvers/background/inNewWindow.test.ts
@@ -2,16 +2,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { inNewWindow } from './inNewWindow'
 
+type WindowFixture = Pick<
+  chrome.windows.Window,
+  'id' | 'left' | 'top' | 'width' | 'height' | 'state'
+>
+
 type ChromeStub = {
-  lastFocused: chrome.windows.Window
+  lastFocused: WindowFixture
   created: chrome.windows.CreateData[]
-  updates: Array<[number, chrome.windows.UpdateInfo]>
+  updates: Array<{ windowId: number; info: chrome.windows.UpdateInfo }>
   badgeTexts: string[]
 }
 
-const stubChrome = (
-  lastFocused: Partial<chrome.windows.Window> = {}
-): ChromeStub => {
+const stubChrome = (lastFocused: WindowFixture = {}): ChromeStub => {
   const stub: ChromeStub = {
     lastFocused: {
       id: 1,
@@ -20,17 +23,15 @@ const stubChrome = (
       width: 1200,
       height: 800,
       state: 'normal',
-      focused: true,
-      incognito: false,
-      alwaysOnTop: false,
-      type: 'normal',
       ...lastFocused,
-    } as chrome.windows.Window,
+    },
     created: [],
     updates: [],
     badgeTexts: [],
   }
 
+  // These handlers mirror the Chrome API signatures they stand in for, so they
+  // keep Chrome's positional arguments rather than a single input object.
   vi.stubGlobal('chrome', {
     action: {
       setBadgeText: ({ text }: { text: string }) => {
@@ -44,19 +45,19 @@ const stubChrome = (
       getLastFocused: () => Promise.resolve(stub.lastFocused),
       create: (
         data: chrome.windows.CreateData,
-        callback: (window: chrome.windows.Window) => void
+        callback: (window: WindowFixture) => void
       ) => {
         stub.created.push(data)
         callback({
           ...stub.lastFocused,
           id: 99,
-          type: 'popup',
+          state: 'normal',
           left: data.left ?? 0,
           top: data.top ?? 0,
-        } as chrome.windows.Window)
+        })
       },
       update: (windowId: number, info: chrome.windows.UpdateInfo) => {
-        stub.updates.push([windowId, info])
+        stub.updates.push({ windowId, info })
         return Promise.resolve(stub.lastFocused)
       },
       remove: () => Promise.resolve(),
@@ -84,8 +85,8 @@ describe('inNewWindow', () => {
     await inNewWindow({ url: 'popup.html', execute: async () => 'done' })
 
     expect(stub.created[0].focused).toBe(true)
-    expect(stub.updates[0][0]).toBe(99)
-    expect(stub.updates[0][1]).toMatchObject({
+    expect(stub.updates[0].windowId).toBe(99)
+    expect(stub.updates[0].info).toMatchObject({
       focused: true,
       drawAttention: true,
     })

--- a/core/inpage-provider/popup/resolvers/background/inNewWindow.test.ts
+++ b/core/inpage-provider/popup/resolvers/background/inNewWindow.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { inNewWindow } from './inNewWindow'
+
+type ChromeStub = {
+  lastFocused: chrome.windows.Window
+  created: chrome.windows.CreateData[]
+  updates: Array<[number, chrome.windows.UpdateInfo]>
+  badgeTexts: string[]
+}
+
+const stubChrome = (
+  lastFocused: Partial<chrome.windows.Window> = {}
+): ChromeStub => {
+  const stub: ChromeStub = {
+    lastFocused: {
+      id: 1,
+      left: 100,
+      top: 50,
+      width: 1200,
+      height: 800,
+      state: 'normal',
+      focused: true,
+      incognito: false,
+      alwaysOnTop: false,
+      type: 'normal',
+      ...lastFocused,
+    } as chrome.windows.Window,
+    created: [],
+    updates: [],
+    badgeTexts: [],
+  }
+
+  vi.stubGlobal('chrome', {
+    action: {
+      setBadgeText: ({ text }: { text: string }) => {
+        stub.badgeTexts.push(text)
+        return Promise.resolve()
+      },
+      setBadgeBackgroundColor: () => Promise.resolve(),
+      setBadgeTextColor: () => Promise.resolve(),
+    },
+    windows: {
+      getLastFocused: () => Promise.resolve(stub.lastFocused),
+      create: (
+        data: chrome.windows.CreateData,
+        callback: (window: chrome.windows.Window) => void
+      ) => {
+        stub.created.push(data)
+        callback({
+          ...stub.lastFocused,
+          id: 99,
+          type: 'popup',
+          left: data.left ?? 0,
+          top: data.top ?? 0,
+        } as chrome.windows.Window)
+      },
+      update: (windowId: number, info: chrome.windows.UpdateInfo) => {
+        stub.updates.push([windowId, info])
+        return Promise.resolve(stub.lastFocused)
+      },
+      remove: () => Promise.resolve(),
+      onRemoved: {
+        addListener: () => undefined,
+        removeListener: () => undefined,
+      },
+    },
+  })
+
+  return stub
+}
+
+describe('inNewWindow', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    // Badge renders are queued, so let the previous test's renders land on the
+    // stub they were scheduled against instead of the next one.
+    await new Promise(resolve => setTimeout(resolve, 0))
+  })
+
+  it('raises the popup after creating it', async () => {
+    const stub = stubChrome()
+
+    await inNewWindow({ url: 'popup.html', execute: async () => 'done' })
+
+    expect(stub.created[0].focused).toBe(true)
+    expect(stub.updates[0][0]).toBe(99)
+    expect(stub.updates[0][1]).toMatchObject({
+      focused: true,
+      drawAttention: true,
+    })
+  })
+
+  it('anchors the popup to the top right of the browser window', async () => {
+    const stub = stubChrome({ left: -1920, top: 0, width: 1000 })
+
+    await inNewWindow({ url: 'popup.html', execute: async () => 'done' })
+
+    expect(stub.created[0]).toMatchObject({ left: -1920 + 1000 - 480, top: 0 })
+  })
+
+  it('leaves placement to the browser when the popup would not fit inside it', async () => {
+    const stub = stubChrome({ width: 400, height: 300 })
+
+    await inNewWindow({ url: 'popup.html', execute: async () => 'done' })
+
+    expect(stub.created[0].left).toBeUndefined()
+    expect(stub.created[0].top).toBeUndefined()
+  })
+
+  it('leaves placement to the browser when the last focused window is minimized', async () => {
+    const stub = stubChrome({ state: 'minimized', left: -32000, top: -32000 })
+
+    await inNewWindow({ url: 'popup.html', execute: async () => 'done' })
+
+    expect(stub.created[0].left).toBeUndefined()
+    expect(stub.created[0].top).toBeUndefined()
+  })
+
+  it('badges the toolbar icon while a request is pending and clears it after', async () => {
+    const stub = stubChrome()
+
+    await inNewWindow({ url: 'popup.html', execute: async () => 'done' })
+    await vi.waitFor(() => expect(stub.badgeTexts).toEqual(['1', '']))
+  })
+
+  it('keeps the badge up while a queued request waits its turn', async () => {
+    const stub = stubChrome()
+    let releaseFirst: () => void = () => undefined
+    const first = inNewWindow({
+      url: 'popup.html',
+      execute: () =>
+        new Promise<string>(resolve => {
+          releaseFirst = () => resolve('first')
+        }),
+    })
+    const second = inNewWindow({
+      url: 'popup.html',
+      execute: async () => 'second',
+    })
+
+    await vi.waitFor(() =>
+      expect(stub.badgeTexts[stub.badgeTexts.length - 1]).toBe('2')
+    )
+
+    releaseFirst()
+    await expect(first).resolves.toBe('first')
+    await expect(second).resolves.toBe('second')
+
+    await vi.waitFor(() =>
+      expect(stub.badgeTexts[stub.badgeTexts.length - 1]).toBe('')
+    )
+  })
+
+  it('clears the badge when the request fails', async () => {
+    const stub = stubChrome()
+
+    await expect(
+      inNewWindow({
+        url: 'popup.html',
+        execute: async () => {
+          throw new Error('rejected')
+        },
+      })
+    ).rejects.toThrow('rejected')
+
+    await vi.waitFor(() =>
+      expect(stub.badgeTexts[stub.badgeTexts.length - 1]).toBe('')
+    )
+  })
+})

--- a/core/inpage-provider/popup/resolvers/background/inNewWindow.ts
+++ b/core/inpage-provider/popup/resolvers/background/inNewWindow.ts
@@ -1,6 +1,7 @@
 import { attempt } from '@vultisig/lib-utils/attempt'
 
 import { PopupOptions } from '../../resolver'
+import { trackPendingRequest } from './pendingRequestsBadge'
 
 type ExecuteInput = {
   abortSignal: AbortSignal
@@ -18,22 +19,49 @@ const windowHeight = 600
 const getPopupPosition = async (): Promise<
   { left: number; top: number } | undefined
 > => {
-  const result = await attempt(() => chrome.windows.getLastFocused())
+  const result = await attempt(() =>
+    chrome.windows.getLastFocused({ windowTypes: ['normal'] })
+  )
   if ('error' in result) return undefined
-  const lastFocused = result.data
-  const l = lastFocused.left ?? 0
-  const w = lastFocused.width ?? windowWidth
-  const top = lastFocused.top ?? 0
-  const left = Math.max(l + (w - windowWidth), 0)
-  return { left, top }
+
+  const { state, left, top, width, height } = result.data
+
+  // A minimized window reports off-screen coordinates, which would put the
+  // popup where nobody can see it.
+  if (state === 'minimized') return undefined
+
+  if (
+    left === undefined ||
+    top === undefined ||
+    width === undefined ||
+    height === undefined
+  ) {
+    return undefined
+  }
+
+  // Anchoring inside the browser window keeps the popup on the display the
+  // user is looking at, including displays that start at a negative offset. A
+  // browser window too small to hold the popup gets no anchor at all, so the
+  // browser is free to place it somewhere it fits.
+  if (width < windowWidth || height < windowHeight) return undefined
+
+  return { left: left + width - windowWidth, top }
 }
 
 let popupQueue: Promise<unknown> = Promise.resolve()
 
+/**
+ * Opens the extension popup window for a dApp request and resolves once the
+ * user has answered it. Requests are served one at a time; every one of them
+ * badges the toolbar icon for as long as it waits, since the operating system
+ * is free to ignore the raise-to-front and leave the window behind the browser.
+ */
 export const inNewWindow = async <T>({
   url,
   execute,
 }: Input<T>): Promise<T> => {
+  const retirePendingRequest = trackPendingRequest()
+
   const run = async (): Promise<T> => {
     const position = await getPopupPosition()
     const newWindow = await new Promise<chrome.windows.Window | undefined>(
@@ -44,6 +72,7 @@ export const inNewWindow = async <T>({
             type: 'popup',
             height: windowHeight,
             width: windowWidth,
+            focused: true,
             ...(position ?? {}),
           },
           resolve
@@ -53,17 +82,23 @@ export const inNewWindow = async <T>({
     if (!windowId) {
       throw new Error('Failed to create new window')
     }
+
     // Firefox ignores left/top on create; apply via update
-    if (
-      position &&
+    const shouldReposition =
+      position !== undefined &&
       newWindow.state !== 'fullscreen' &&
       (newWindow.left !== position.left || newWindow.top !== position.top)
-    ) {
-      await chrome.windows.update(windowId, {
-        left: position.left,
-        top: position.top,
+
+    // `drawAttention` is the fallback for platforms that refuse to raise a
+    // window on behalf of a background page: it flashes the taskbar entry or
+    // bounces the dock icon instead.
+    await attempt(() =>
+      chrome.windows.update(windowId, {
+        focused: true,
+        drawAttention: true,
+        ...(shouldReposition ? position : {}),
       })
-    }
+    )
 
     const controller = new AbortController()
     const handleRemoved = (removedId: number) => {
@@ -87,7 +122,7 @@ export const inNewWindow = async <T>({
     }
   }
 
-  const next = popupQueue.then(run, run)
+  const next = popupQueue.then(run, run).finally(retirePendingRequest)
   popupQueue = next.catch(() => {})
   return next
 }

--- a/core/inpage-provider/popup/resolvers/background/pendingRequestsBadge.ts
+++ b/core/inpage-provider/popup/resolvers/background/pendingRequestsBadge.ts
@@ -1,0 +1,51 @@
+import { attempt } from '@vultisig/lib-utils/attempt'
+
+const badgeBackgroundColor = '#FF5C5C'
+const badgeTextColor = '#FFFFFF'
+
+let pendingRequests = 0
+let renderQueue: Promise<unknown> = Promise.resolve()
+
+const renderBadge = () => {
+  const render = () =>
+    attempt(async () => {
+      const text = pendingRequests > 0 ? String(pendingRequests) : ''
+      await chrome.action.setBadgeText({ text })
+      if (!text) return
+      await chrome.action.setBadgeBackgroundColor({
+        color: badgeBackgroundColor,
+      })
+      await chrome.action.setBadgeTextColor({ color: badgeTextColor })
+    })
+
+  renderQueue = renderQueue.then(render, render)
+}
+
+/**
+ * Marks a dApp request as awaiting the user and paints the count on the
+ * toolbar icon, so a popup window that opened behind the browser is still
+ * noticed. The returned callback retires that request; the badge clears only
+ * once every pending request has been settled.
+ */
+export const trackPendingRequest = () => {
+  pendingRequests += 1
+  renderBadge()
+
+  let isSettled = false
+
+  return () => {
+    if (isSettled) return
+    isSettled = true
+    pendingRequests = Math.max(pendingRequests - 1, 0)
+    renderBadge()
+  }
+}
+
+/**
+ * Drops a badge inherited from a previous service worker generation, whose
+ * pending requests died along with it.
+ */
+export const resetPendingRequestsBadge = () => {
+  pendingRequests = 0
+  renderBadge()
+}


### PR DESCRIPTION
Closes #4699

## Problem

A pending connect/sign request could go unnoticed in three separate ways:

1. **No raise-to-front.** `windows.create` was called without `focused`, and nothing re-raised the window afterwards. The `focused: true` added in #2939 went away when #3822 replaced window reuse with the serial queue.
2. **The popup could be positioned somewhere invisible.** `getLastFocused()` defaults to `['normal', 'popup']`, so the reference window could be our own previous popup, a devtools window — or a *minimized* one, which reports off-screen coordinates (≈ `-32000` on Windows). `top` was passed through unclamped, and the code then force-applied that position via `windows.update` when the browser had clamped it. `Math.max(left, 0)` also broke multi-monitor: a browser on a display at a negative offset had its popup yanked onto the primary display.
3. **No signal when the OS refuses the raise.** A background service worker cannot steal focus on macOS, and a fullscreen browser owns its own Space, so the window lands behind with nothing to indicate it exists.

## Changes

- **`inNewWindow.ts`** — create the window with `focused: true`, then one best-effort `windows.update({ focused: true, drawAttention: true })`. `drawAttention` is the fallback for platforms that ignore the raise: it bounces the dock icon / flashes the taskbar entry. Positioning now queries only `normal` windows, bails out on minimized ones, keeps coordinates relative to the browser window (negative offsets included), and anchors only when the popup actually fits inside that window — so the forced reposition can no longer push it off-screen.
- **`pendingRequestsBadge.ts`** (new) — a red count on the toolbar icon for every request awaiting an answer, including ones still waiting in the serial queue. This is the part that works regardless of what the OS does with focus. Tracked around the whole queued lifetime, so it clears on approve, reject, window-close, and errors alike.
- **`common.ts`** — clears the badge on background startup, so a service worker that died holding pending requests does not leave a permanent red dot.
- **`inNewWindow.test.ts`** (new) — 7 tests covering the raise, the anchoring rules, and the badge lifecycle.

The serial queue from #3822 and the removal of window reuse from #2939 are untouched.

**Desktop:** not affected. `callPopupFromBackground` → `inNewWindow` is reachable only from `@core/inpage-provider/bridge/background`, whose sole importer is the extension background. Desktop has no dApp popup window to hide.

## Testing

Load the unpacked build and **pin the extension to the toolbar** (the badge lives on the action icon), then trigger a connect or sign request from a dApp:

1. Popup opens at the top-right of the browser window, focused and in front.
2. Switch to another app while the request opens — the dock icon bounces / taskbar entry flashes, and the toolbar icon shows a red **1**.
3. Approve, reject, or close the popup with the X — the badge clears in each case.
4. Fire two requests in quick succession — the badge reads **2**, drops to **1** after the first answer, then clears.
5. Minimize all browser windows and trigger a request from a background window — the browser now places the popup itself instead of putting it off-screen.
6. Put the browser on a secondary display positioned left of / above the primary — the popup lands on that display.
7. Resize the browser below 480×600 and trigger a request — the browser places the popup rather than clipping it.
8. With a request pending, reload the extension from `chrome://extensions` — the stale badge disappears.

Also worth a pass on Firefox (`yarn build:extension:firefox`), where the position-via-`update` path is the one that actually matters.

## Known limitation

If the extension is not pinned, Chrome hides the badge inside the puzzle-piece menu. The manifest already carries the `notifications` permission, so a system notification for pending requests would be a small follow-up — left out here as a separate product decision.

## Validation

`yarn check` clean, full test suite passing (1144 tests), and the extension's own `tsc -b` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a toolbar badge showing the number of pending dApp requests.
  * Badge counts update automatically as requests are completed and clear when none remain.
  * Popups are positioned relative to the last focused browser window and focused on creation.
* **Bug Fixes**
  * Stale badges are cleared when the background service restarts.
  * Improved handling of unavailable window dimensions and cleanup for failed or completed requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->