### PR TITLE
fix(defi): sort portfolio chain list by displayed balance

### DIFF
--- a/clients/extension/tests/e2e/fixtures/extension-loader.ts
+++ b/clients/extension/tests/e2e/fixtures/extension-loader.ts
@@ -53,8 +53,10 @@ export const test = base.extend<{
 }>({
   context: async ({}, use) => {
     const videoDir = process.env.EXTENSION_QA_VIDEO_DIR
+    const browserChannel = process.env.PLAYWRIGHT_BROWSER_CHANNEL
     const context = await chromium.launchPersistentContext('', {
       headless: false,
+      ...(browserChannel ? { channel: browserChannel } : {}),
       ...(videoDir
         ? {
             viewport: { width: 1280, height: 720 },

--- a/core/ui/defi/page/components/DefiChainsList.tsx
+++ b/core/ui/defi/page/components/DefiChainsList.tsx
@@ -1,7 +1,5 @@
 import { ChainsEmptyState } from '@core/ui/chain/components/ChainsEmptyState'
-import { orderChainItemsForProduct } from '@core/ui/chain/utils/orderChainItemsForProduct'
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
-import { currentProductBrand } from '@core/ui/product/brand'
 import { useIsCircleIncluded } from '@core/ui/storage/circleVisibility'
 import {
   isSupportedDefiChain,
@@ -12,13 +10,18 @@ import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { Center } from '@lib/ui/layout/Center'
 import { List } from '@lib/ui/list'
 import { Spinner } from '@lib/ui/loaders/Spinner'
-import { useDeferredValue, useMemo } from 'react'
+import { useDeferredValue } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useTheme } from 'styled-components'
 
 import { CircleDefiItem } from '../../protocols/circle/CircleDefiItem'
 import { circleName } from '../../protocols/circle/core/config'
+import { useCircleAccountUsdcFiatBalanceQuery } from '../../protocols/circle/queries/useCircleAccountUsdcFiatBalanceQuery'
 import { useDefiChainPortfolios } from '../hooks/useDefiPortfolios'
+import {
+  DefiPortfolioRow,
+  orderDefiPortfolioRows,
+} from '../utils/orderDefiPortfolioRows'
 import { DefiChainItem } from './DefiChainItem'
 import { useSearchChain } from './state/searchChainProvider'
 
@@ -26,49 +29,45 @@ export const DefiChainsList = () => {
   const { data: chainPortfolios = [], isPending } = useDefiChainPortfolios()
   const defiChains = useDefiChains()
   const isCircleVisible = useIsCircleIncluded()
+  const circleFiatBalanceQuery = useCircleAccountUsdcFiatBalanceQuery()
   const [searchQuery] = useSearchChain()
   const deferredQuery = useDeferredValue(searchQuery)
   const { t } = useTranslation()
   const navigate = useCoreNavigate()
   const { iconStyle } = useTheme()
-  const isStation = currentProductBrand === 'station'
 
   const normalizedQuery = deferredQuery.trim().toLowerCase()
 
-  const defiChainBalances = useMemo(() => {
-    return chainPortfolios.filter(
-      ({ chain }) => isSupportedDefiChain(chain) && defiChains.includes(chain)
-    )
-  }, [chainPortfolios, defiChains])
+  const defiChainBalances = chainPortfolios.filter(
+    ({ chain }) => isSupportedDefiChain(chain) && defiChains.includes(chain)
+  )
 
-  const filteredBalances = useMemo(() => {
-    if (!normalizedQuery) {
-      return orderChainItemsForProduct({
-        items: defiChainBalances,
-        getChain: item => item.chain,
-        productBrand: currentProductBrand,
-      })
-    }
-
-    const filtered = defiChainBalances.filter(({ chain }) => {
-      const normalizedChain = String(chain).toLowerCase()
-      if (normalizedChain.includes(normalizedQuery)) {
-        return true
-      }
-      return false
-    })
-
-    return orderChainItemsForProduct({
-      items: filtered,
-      getChain: item => item.chain,
-      productBrand: currentProductBrand,
-    })
-  }, [normalizedQuery, defiChainBalances])
+  const filteredBalances = normalizedQuery
+    ? defiChainBalances.filter(({ chain }) =>
+        String(chain).toLowerCase().includes(normalizedQuery)
+      )
+    : defiChainBalances
 
   const handleCustomize = () => navigate({ id: 'manageDefiChains' })
   const showCircle =
     isCircleVisible &&
     (!normalizedQuery || circleName.toLowerCase().includes(normalizedQuery))
+
+  const chainRows: DefiPortfolioRow[] = filteredBalances.map(portfolio => ({
+    kind: 'chain',
+    portfolio,
+  }))
+
+  // Circle ranks by the same fiat its row displays; an unresolved balance
+  // ranks as zero, matching the `0` the row renders until the query lands.
+  const rows = orderDefiPortfolioRows(
+    showCircle
+      ? [
+          ...chainRows,
+          { kind: 'circle', totalFiat: circleFiatBalanceQuery.data ?? 0 },
+        ]
+      : chainRows
+  )
 
   if (defiChainBalances.length === 0 && !showCircle) {
     if (isPending) {
@@ -113,11 +112,13 @@ export const DefiChainsList = () => {
       border={iconStyle === 'station' ? 'solid' : undefined}
       radius={iconStyle === 'station' ? 24 : undefined}
     >
-      {showCircle && !isStation && <CircleDefiItem />}
-      {filteredBalances.map(balance => (
-        <DefiChainItem key={balance.chain} balance={balance} />
-      ))}
-      {showCircle && isStation && <CircleDefiItem />}
+      {rows.map(row =>
+        row.kind === 'circle' ? (
+          <CircleDefiItem key={circleName} />
+        ) : (
+          <DefiChainItem key={row.portfolio.chain} balance={row.portfolio} />
+        )
+      )}
     </List>
   )
 }

--- a/core/ui/defi/page/components/DefiChainsList.tsx
+++ b/core/ui/defi/page/components/DefiChainsList.tsx
@@ -25,6 +25,11 @@ import {
 import { DefiChainItem } from './DefiChainItem'
 import { useSearchChain } from './state/searchChainProvider'
 
+/**
+ * The DeFi tab's portfolio list. Rows are ordered by the fiat value each one
+ * displays, descending, with the Circle yield account ranked alongside the
+ * chains rather than pinned to either end.
+ */
 export const DefiChainsList = () => {
   const { data: chainPortfolios = [], isPending } = useDefiChainPortfolios()
   const defiChains = useDefiChains()

--- a/core/ui/defi/page/utils/orderDefiPortfolioRows.test.ts
+++ b/core/ui/defi/page/utils/orderDefiPortfolioRows.test.ts
@@ -1,0 +1,80 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { describe, expect, it } from 'vitest'
+
+import { DefiChainPortfolio } from '../hooks/useDefiPortfolios'
+import {
+  DefiPortfolioRow,
+  orderDefiPortfolioRows,
+} from './orderDefiPortfolioRows'
+
+const chainRow = (chain: Chain, totalFiat: number): DefiPortfolioRow => ({
+  kind: 'chain',
+  portfolio: {
+    chain,
+    totalFiat,
+    positionsWithBalanceCount: 1,
+    isLoading: false,
+  } satisfies DefiChainPortfolio,
+})
+
+const names = (rows: DefiPortfolioRow[]) =>
+  rows.map(row => (row.kind === 'chain' ? row.portfolio.chain : 'Circle'))
+
+describe('orderDefiPortfolioRows', () => {
+  it('orders chains by fiat descending', () => {
+    const rows = orderDefiPortfolioRows([
+      chainRow(Chain.TerraClassic, 4.24),
+      chainRow(Chain.Tron, 1.75),
+      chainRow(Chain.Solana, 11.03),
+    ])
+
+    expect(names(rows)).toEqual([Chain.Solana, Chain.TerraClassic, Chain.Tron])
+  })
+
+  it('keeps a zero-balance Circle below funded chains', () => {
+    const rows = orderDefiPortfolioRows([
+      { kind: 'circle', totalFiat: 0 },
+      chainRow(Chain.Solana, 11.03),
+      chainRow(Chain.Tron, 1.75),
+    ])
+
+    expect(names(rows)).toEqual([Chain.Solana, Chain.Tron, 'Circle'])
+  })
+
+  it('ranks a funded Circle among the chains by its fiat', () => {
+    const rows = orderDefiPortfolioRows([
+      chainRow(Chain.Solana, 11.03),
+      { kind: 'circle', totalFiat: 5 },
+      chainRow(Chain.Tron, 1.75),
+    ])
+
+    expect(names(rows)).toEqual([Chain.Solana, 'Circle', Chain.Tron])
+  })
+
+  it('breaks fiat ties by display name so equal rows stay stable', () => {
+    const rows = orderDefiPortfolioRows([
+      chainRow(Chain.Tron, 0),
+      chainRow(Chain.Solana, 0),
+      { kind: 'circle', totalFiat: 0 },
+      chainRow(Chain.THORChain, 0),
+    ])
+
+    expect(names(rows)).toEqual([
+      'Circle',
+      Chain.Solana,
+      Chain.THORChain,
+      Chain.Tron,
+    ])
+  })
+
+  it('does not mutate the input', () => {
+    const input: DefiPortfolioRow[] = [
+      chainRow(Chain.Tron, 1),
+      chainRow(Chain.Solana, 9),
+    ]
+
+    orderDefiPortfolioRows(input)
+
+    expect(names(input)).toEqual([Chain.Tron, Chain.Solana])
+  })
+})

--- a/core/ui/defi/page/utils/orderDefiPortfolioRows.test.ts
+++ b/core/ui/defi/page/utils/orderDefiPortfolioRows.test.ts
@@ -7,7 +7,12 @@ import {
   orderDefiPortfolioRows,
 } from './orderDefiPortfolioRows'
 
-const chainRow = (chain: Chain, totalFiat: number): DefiPortfolioRow => ({
+type ChainRowInput = {
+  chain: Chain
+  totalFiat: number
+}
+
+const chainRow = ({ chain, totalFiat }: ChainRowInput): DefiPortfolioRow => ({
   kind: 'chain',
   portfolio: {
     chain,
@@ -23,9 +28,9 @@ const names = (rows: DefiPortfolioRow[]) =>
 describe('orderDefiPortfolioRows', () => {
   it('orders chains by fiat descending', () => {
     const rows = orderDefiPortfolioRows([
-      chainRow(Chain.TerraClassic, 4.24),
-      chainRow(Chain.Tron, 1.75),
-      chainRow(Chain.Solana, 11.03),
+      chainRow({ chain: Chain.TerraClassic, totalFiat: 4.24 }),
+      chainRow({ chain: Chain.Tron, totalFiat: 1.75 }),
+      chainRow({ chain: Chain.Solana, totalFiat: 11.03 }),
     ])
 
     expect(names(rows)).toEqual([Chain.Solana, Chain.TerraClassic, Chain.Tron])
@@ -34,8 +39,8 @@ describe('orderDefiPortfolioRows', () => {
   it('keeps a zero-balance Circle below funded chains', () => {
     const rows = orderDefiPortfolioRows([
       { kind: 'circle', totalFiat: 0 },
-      chainRow(Chain.Solana, 11.03),
-      chainRow(Chain.Tron, 1.75),
+      chainRow({ chain: Chain.Solana, totalFiat: 11.03 }),
+      chainRow({ chain: Chain.Tron, totalFiat: 1.75 }),
     ])
 
     expect(names(rows)).toEqual([Chain.Solana, Chain.Tron, 'Circle'])
@@ -43,9 +48,9 @@ describe('orderDefiPortfolioRows', () => {
 
   it('ranks a funded Circle among the chains by its fiat', () => {
     const rows = orderDefiPortfolioRows([
-      chainRow(Chain.Solana, 11.03),
+      chainRow({ chain: Chain.Solana, totalFiat: 11.03 }),
       { kind: 'circle', totalFiat: 5 },
-      chainRow(Chain.Tron, 1.75),
+      chainRow({ chain: Chain.Tron, totalFiat: 1.75 }),
     ])
 
     expect(names(rows)).toEqual([Chain.Solana, 'Circle', Chain.Tron])
@@ -53,10 +58,10 @@ describe('orderDefiPortfolioRows', () => {
 
   it('breaks fiat ties by display name so equal rows stay stable', () => {
     const rows = orderDefiPortfolioRows([
-      chainRow(Chain.Tron, 0),
-      chainRow(Chain.Solana, 0),
+      chainRow({ chain: Chain.Tron, totalFiat: 0 }),
+      chainRow({ chain: Chain.Solana, totalFiat: 0 }),
       { kind: 'circle', totalFiat: 0 },
-      chainRow(Chain.THORChain, 0),
+      chainRow({ chain: Chain.THORChain, totalFiat: 0 }),
     ])
 
     expect(names(rows)).toEqual([
@@ -69,8 +74,8 @@ describe('orderDefiPortfolioRows', () => {
 
   it('does not mutate the input', () => {
     const input: DefiPortfolioRow[] = [
-      chainRow(Chain.Tron, 1),
-      chainRow(Chain.Solana, 9),
+      chainRow({ chain: Chain.Tron, totalFiat: 1 }),
+      chainRow({ chain: Chain.Solana, totalFiat: 9 }),
     ]
 
     orderDefiPortfolioRows(input)

--- a/core/ui/defi/page/utils/orderDefiPortfolioRows.ts
+++ b/core/ui/defi/page/utils/orderDefiPortfolioRows.ts
@@ -1,0 +1,36 @@
+import { circleName } from '../../protocols/circle/core/config'
+import { DefiChainPortfolio } from '../hooks/useDefiPortfolios'
+
+/**
+ * A row of the DeFi portfolio list: either an enabled chain's rollup or the
+ * Circle yield account, which carries fiat but no chain of its own.
+ */
+export type DefiPortfolioRow =
+  | { kind: 'chain'; portfolio: DefiChainPortfolio }
+  | { kind: 'circle'; totalFiat: number }
+
+const getRowFiat = (row: DefiPortfolioRow) =>
+  row.kind === 'chain' ? row.portfolio.totalFiat : row.totalFiat
+
+const getRowName = (row: DefiPortfolioRow) =>
+  row.kind === 'chain' ? String(row.portfolio.chain) : circleName
+
+/**
+ * Orders the DeFi portfolio rows the way the Wallet tab orders chains: by the
+ * fiat value each row displays, descending. Circle is ranked by its yield fiat
+ * alongside the chains rather than pinned to an end of the list.
+ *
+ * Ties fall back to the row's display name so rows with equal fiat — notably
+ * the many zero-balance chains — keep a stable order across re-renders while
+ * per-chain balances are still resolving.
+ */
+export const orderDefiPortfolioRows = (
+  rows: readonly DefiPortfolioRow[]
+): DefiPortfolioRow[] =>
+  [...rows].sort((a, b) => {
+    const fiatDiff = getRowFiat(b) - getRowFiat(a)
+
+    if (fiatDiff !== 0) return fiatDiff
+
+    return getRowName(a).localeCompare(getRowName(b))
+  })


### PR DESCRIPTION
Closes #4715

## Problem

The DeFi portfolio ordered its rows alphabetically through `orderChainItemsForProduct` (`chain.localeCompare` plus a Station Terra pin), while the Wallet tab orders chains by fiat descending. Each row already carried `totalFiat` from `useDefiChainPortfolios` and never used it, so a funded chain could sit below a near-empty one — e.g. Solana $11.03 under TerraClassic $4.24 and Tron $1.75.

Circle was positioned structurally rather than by value (pinned first for Vultisig, last for Station), so a $0 Circle sat above funded chains.

## Change

- New `orderDefiPortfolioRows` util sorts rows by the fiat each one displays, descending.
- Circle participates in that same sort, ranked by its yield fiat, instead of being pinned to either end.
- Ties fall back to the row's display name. This matters because the many zero-balance chains would otherwise order non-deterministically, and each chain's balance resolves on its own query — the tie-break keeps unresolved rows from shuffling under the user as prices land.
- Circle's fiat is lifted into `DefiChainsList` so it can be compared against the chain rows.
- Dropped the manual `useMemo`s in the touched component per the React Compiler rule.

Manage DeFi chains keeps `orderChainItemsForProduct` untouched — that picker is not a portfolio, so its alphabetical order and Station Terra pin stand. The Wallet-tab sort is unchanged.

## Note for reviewers

This removes the Station-specific Circle placement (Circle pinned last). The issue specifies Circle should participate in the value sort for the portfolio list, so it now sorts by value for both brands. Flagging it explicitly in case that placement was intentional for Station.

## Verification

- `yarn vitest run core/ui/defi core/ui/chain/utils` — 40 passed (was 35 on `main`; +5 from the new util's tests)
- Typecheck and lint clean on the touched files

`yarn check:all` does not currently pass on a clean `main` in my environment: the installed `@vultisig/core-chain` is stale relative to the Kamino source, producing ~30 `TS2307 Cannot find module '@vultisig/core-chain/chains/solana/kamino/*'` errors and 5 failing test files. I verified these are identical before and after this change by stashing it. CI should be authoritative here.

## Acceptance criteria

- [x] Solana $11, TerraClassic $4, Tron $2 → Solana first (covered by test)
- [x] A $0 Circle is not above a funded chain (covered by test)
- [x] Manage-chains screen unchanged
- [ ] `yarn check:all` — blocked locally by the pre-existing Kamino issue above; deferring to CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - DeFi portfolio entries are now ranked by displayed fiat value, with alphabetical ordering used for ties.
  - Circle’s yield account appears alongside chain portfolios according to its balance, including when its balance is zero.
  - Portfolio rows now follow a consistent ordering across supported chains and account types.

- **Bug Fixes**
  - Improved consistency in how DeFi portfolio rows are filtered, displayed, and ordered.
  - Preserved portfolio data while applying sorting and display updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->