### PR TITLE
feat(banners): add a never-return dismiss policy and use it for QBTC claim

### DIFF
--- a/core/ui/storage/dismissedBanners.test.ts
+++ b/core/ui/storage/dismissedBanners.test.ts
@@ -2,12 +2,31 @@ import { convertDuration } from '@vultisig/lib-utils/time/convertDuration'
 import { describe, expect, it } from 'vitest'
 
 import {
-  bannerDismissalTtl,
+  BannerDismissPolicy,
+  bannerDismissPolicy,
+  BannerId,
   DismissedBanners,
   isBannerDismissed,
   migrateDismissedBanners,
   recordBannerDismissal,
 } from './dismissedBanners'
+
+const ttlOf = (id: BannerId) => {
+  const policy = bannerDismissPolicy[id]
+
+  if (!('ttl' in policy)) {
+    throw new Error(`Expected a TTL policy for ${id}`)
+  }
+
+  return policy.ttl
+}
+
+const permanentPolicy = (
+  id: BannerId
+): Record<BannerId, BannerDismissPolicy> => ({
+  ...bannerDismissPolicy,
+  [id]: { permanent: null },
+})
 
 const now = convertDuration(100, 'd', 'ms')
 
@@ -68,7 +87,7 @@ describe('isBannerDismissed', () => {
   })
 
   it('keeps the banner dismissed while within its TTL', () => {
-    const dismissedAt = now - bannerDismissalTtl.buyVultPromo + 1
+    const dismissedAt = now - ttlOf('buyVultPromo') + 1
 
     expect(
       isBannerDismissed({
@@ -81,7 +100,7 @@ describe('isBannerDismissed', () => {
   })
 
   it('ignores the dismissal once the TTL has elapsed', () => {
-    const dismissedAt = now - bannerDismissalTtl.buyVultPromo
+    const dismissedAt = now - ttlOf('buyVultPromo')
 
     expect(
       isBannerDismissed({
@@ -93,18 +112,18 @@ describe('isBannerDismissed', () => {
     ).toBe(false)
   })
 
-  it('resurfaces the QBTC claim banner once its cooldown elapses', () => {
+  it('resurfaces a vault-scoped TTL banner once its cooldown elapses', () => {
     const banners: DismissedBanners = {
       global: {},
       byVault: {
         [vaultA]: {
-          qbtcClaim: { dismissedAt: now - bannerDismissalTtl.qbtcClaim },
+          vaultBackup: { dismissedAt: now - ttlOf('vaultBackup') },
         },
       },
     }
 
     expect(
-      isBannerDismissed({ banners, id: 'qbtcClaim', now, vaultId: vaultA })
+      isBannerDismissed({ banners, id: 'vaultBackup', now, vaultId: vaultA })
     ).toBe(false)
   })
 
@@ -220,5 +239,112 @@ describe('recordBannerDismissal', () => {
         [vaultA]: { vaultBackup: { dismissedAt: now } },
       },
     })
+  })
+})
+
+describe('isBannerDismissed with a permanent policy', () => {
+  it('keeps the banner hidden long after any TTL would have elapsed', () => {
+    const dismissedAt = now - convertDuration(3650, 'd', 'ms')
+
+    expect(
+      isBannerDismissed({
+        banners: { global: { buyVultPromo: { dismissedAt } }, byVault: {} },
+        id: 'buyVultPromo',
+        now,
+        vaultId: vaultA,
+        policy: permanentPolicy('buyVultPromo'),
+      })
+    ).toBe(true)
+  })
+
+  it('still shows a permanent-policy banner that was never dismissed', () => {
+    expect(
+      isBannerDismissed({
+        banners: empty,
+        id: 'buyVultPromo',
+        now,
+        vaultId: vaultA,
+        policy: permanentPolicy('buyVultPromo'),
+      })
+    ).toBe(false)
+  })
+
+  it('leaves other banners on their own TTL', () => {
+    const dismissedAt = now - convertDuration(10, 'd', 'ms')
+    const banners: DismissedBanners = {
+      global: {
+        buyVultPromo: { dismissedAt },
+        migrate: { dismissedAt },
+      },
+      byVault: {},
+    }
+    const policy = permanentPolicy('migrate')
+
+    // migrate is permanent, buyVultPromo keeps its elapsed 7d TTL.
+    expect(
+      isBannerDismissed({
+        banners,
+        id: 'migrate',
+        now,
+        vaultId: vaultA,
+        policy,
+      })
+    ).toBe(true)
+    expect(
+      isBannerDismissed({
+        banners,
+        id: 'buyVultPromo',
+        now,
+        vaultId: vaultA,
+        policy,
+      })
+    ).toBe(false)
+  })
+
+  it('honors a permanent policy for a legacy dismissal after migration', () => {
+    const banners = migrateDismissedBanners({ stored: ['followOnX'], now })
+    const laterThanAnyTtl = now + convertDuration(3650, 'd', 'ms')
+
+    expect(
+      isBannerDismissed({
+        banners,
+        id: 'followOnX',
+        now: laterThanAnyTtl,
+        vaultId: vaultA,
+        policy: permanentPolicy('followOnX'),
+      })
+    ).toBe(true)
+  })
+
+  it('keeps a dismissed qbtcClaim hidden on its vault for good', () => {
+    const banners = recordBannerDismissal({
+      banners: empty,
+      id: 'qbtcClaim',
+      now,
+      vaultId: vaultA,
+    })
+    const laterThanAnyTtl = now + convertDuration(3650, 'd', 'ms')
+
+    expect(
+      isBannerDismissed({
+        banners,
+        id: 'qbtcClaim',
+        now: laterThanAnyTtl,
+        vaultId: vaultA,
+      })
+    ).toBe(true)
+  })
+
+  it('leaves qbtcClaim showing on a vault it was not dismissed on', () => {
+    const banners = recordBannerDismissal({
+      banners: empty,
+      id: 'qbtcClaim',
+      now,
+      vaultId: vaultA,
+    })
+
+    expect(
+      isBannerDismissed({ banners, id: 'qbtcClaim', now, vaultId: vaultB })
+    ).toBe(false)
   })
 })

--- a/core/ui/storage/dismissedBanners.tsx
+++ b/core/ui/storage/dismissedBanners.tsx
@@ -2,6 +2,7 @@ import { useRefetchQueries } from '@lib/ui/query/hooks/useRefetchQueries'
 import { noRefetchQueryOptions } from '@lib/ui/query/utils/options'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { match } from '@vultisig/lib-utils/match'
+import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
 import { convertDuration } from '@vultisig/lib-utils/time/convertDuration'
 
 import { useCore } from '../state/core'
@@ -52,23 +53,33 @@ export type StoredDismissedBanners =
   | LegacyDismissedBannerIds
 
 /**
- * Per-banner cooldown (in ms) after dismissal, after which the banner may show
- * again. Configurable per banner rather than hard-coded in carousel logic.
+ * What a dismissal means for a given banner: `ttl` lets it resurface once that
+ * many ms have elapsed, `permanent` keeps it hidden for good.
  */
-export const bannerDismissalTtl: Record<BannerId, number> = {
-  buyVultPromo: convertDuration(7, 'd', 'ms'),
-  followOnX: convertDuration(15, 'd', 'ms'),
-  migrate: convertDuration(15, 'd', 'ms'),
-  agentNavigationCoachmark: convertDuration(15, 'd', 'ms'),
-  rujiraStaking: convertDuration(7, 'd', 'ms'),
-  vaultBackup: convertDuration(7, 'd', 'ms'),
-  referralCode: convertDuration(7, 'd', 'ms'),
-  kamino: convertDuration(7, 'd', 'ms'),
-  // Deliberately a TTL rather than a permanent dismissal: this banner is gated
-  // on the current vault, but the dismissal is stored per profile (#4769), so a
-  // dismissal on a vault with nothing to claim would otherwise hide the banner
-  // for good on a vault that does have claimable UTXOs.
-  qbtcClaim: convertDuration(7, 'd', 'ms'),
+export type BannerDismissPolicy = { ttl: number } | { permanent: null }
+
+/**
+ * Per-banner dismissal policy, assigned here next to the scope so a banner's
+ * whole dismiss behaviour reads from one place rather than leaking into the
+ * carousel. These are the local fallback: notification#33 settled that banners
+ * are not served from the notification service, so there is no remote policy to
+ * override them.
+ */
+export const bannerDismissPolicy: Record<BannerId, BannerDismissPolicy> = {
+  buyVultPromo: { ttl: convertDuration(7, 'd', 'ms') },
+  followOnX: { ttl: convertDuration(15, 'd', 'ms') },
+  migrate: { ttl: convertDuration(15, 'd', 'ms') },
+  agentNavigationCoachmark: { ttl: convertDuration(15, 'd', 'ms') },
+  rujiraStaking: { ttl: convertDuration(7, 'd', 'ms') },
+  vaultBackup: { ttl: convertDuration(7, 'd', 'ms') },
+  referralCode: { ttl: convertDuration(7, 'd', 'ms') },
+  kamino: { ttl: convertDuration(7, 'd', 'ms') },
+  // A campaign whose claim keeps its own entry point on the QBTC chain page, so
+  // a closed card has nothing to come back for. This was a 7d TTL only because
+  // dismissals were stored per profile (#4769) and a dismissal on a vault with
+  // nothing to claim would have hidden it on a vault that could; #4770 scoped it
+  // to the vault, so the reason for the TTL is gone.
+  qbtcClaim: { permanent: null },
 }
 
 /**
@@ -138,18 +149,20 @@ type IsBannerDismissedInput = {
   id: BannerId
   now: number
   vaultId: string
+  policy?: Record<BannerId, BannerDismissPolicy>
 }
 
 /**
- * A banner counts as dismissed only while it is within its TTL window, and only
- * against the record its scope names. Once the TTL has elapsed the dismissal is
- * ignored and the banner can show again.
+ * Whether a dismissal still hides the banner, read against the record its scope
+ * names. A `permanent` policy hides it for good; a `ttl` policy only hides it
+ * until that window has elapsed.
  */
 export const isBannerDismissed = ({
   banners,
   id,
   now,
   vaultId,
+  policy = bannerDismissPolicy,
 }: IsBannerDismissedInput): boolean => {
   const dismissal = match(bannerDismissScope[id], {
     global: () => banners.global[id],
@@ -160,7 +173,10 @@ export const isBannerDismissed = ({
     return false
   }
 
-  return now - dismissal.dismissedAt < bannerDismissalTtl[id]
+  return matchRecordUnion<BannerDismissPolicy, boolean>(policy[id], {
+    ttl: ms => now - dismissal.dismissedAt < ms,
+    permanent: () => true,
+  })
 }
 
 type RecordBannerDismissalInput = {


### PR DESCRIPTION
## Problem

Home promo banners only supported a TTL dismissal, so every dismissed banner eventually came back. Ops needs to mark a campaign as dismissed for good — see #4713.

## Change

- `bannerDismissalTtl: Record<BannerId, number>` becomes `bannerDismissPolicy: Record<BannerId, BannerDismissPolicy>`, a record union `{ ttl: number } | { permanent: null }`.
- `isBannerDismissed` branches on it with `matchRecordUnion`, so a third policy kind can't be added silently.
- It sits next to `bannerDismissScope` from #4770 and the two compose cleanly: the **scope** picks which record a dismissal is read from (`global` vs `byVault`), the **policy** decides whether that dismissal has expired.

## `qbtcClaim` is the never-return banner

Its entry in `main` carried this comment:

> *Deliberately a TTL rather than a permanent dismissal: this banner is gated on the current vault, but the dismissal is stored per profile (#4769), so a dismissal on a vault with nothing to claim would otherwise hide the banner for good on a vault that does have claimable UTXOs.*

That constraint is gone: #4769 is closed and #4770 scoped dismissals to the vault. The claim also keeps its own entry point on the QBTC chain page (`QbtcClaimSection`), so a closed card has nothing to come back for.

This matches what the siblings shipped — Android vultisig/vultisig-android#5709 (through the policy, as here) and iOS vultisig/vultisig-ios#5278. **Every other banner keeps the TTL it had.**

## Remote policy

The ticket asked to honor a policy served from vultisig/notification#34. That is settled, not pending: on vultisig/notification#33 @johnnyluo ruled it out — *"notification is optional, user can turn it off, and for windows app / extensions, it doesn't have the same notification system like iOS and android... no changes on the notification service"*.

So there is no contract to honor. iOS (vultisig/vultisig-ios#5261) and Android (vultisig/vultisig-android#5681) reached the same conclusion and shipped the hardcoded assignment. The optional `policy` input stays as the seam should that ever change.

## Notes

**No storage change was required.** Both backends — desktop `persistentStorage` and extension `chrome.storage` — already persist `dismissedAt` indefinitely. What made banners return was purely the in-memory comparison, so a permanent dismissal survives relaunch on both platforms with no storage work.

## Testing

`dismissedBanners.test.ts`: 21 tests green. Added coverage for a permanent dismissal outlasting a 3650-day gap, a permanent-policy banner never dismissed still showing, per-banner policy isolation, a permanent policy over a migrated legacy dismissal, and `qbtcClaim` specifically — hidden for good on its own vault, still showing on another. Verified they bite: reverting `qbtcClaim` to a TTL fails the QBTC test.

`yarn test`: 1527 tests green. One unrelated file fails to load (`keysignPayload/build.test.ts` — a missing `@vultisig/core-chain/chains/ton/comment` specifier from a stale package build), and `yarn typecheck` / `yarn validate-public` report 20 errors and a missing `mnta.png` — all reproduced identically on a clean `origin/main`.

Closes #4713

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Banner dismissal behavior now supports both time-limited and permanent dismissals.
  - Different banners can use different dismissal policies, including permanent dismissal for selected banners.
  - Existing dismissal records continue to be recognized under the updated behavior.

- **Bug Fixes**
  - Improved handling of expired, never-dismissed, and migrated banner dismissals.
  - Corrected vault-scoped dismissal behavior for applicable banners.
  - Improved consistency when applying dismissal rules across banners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->