### PR TITLE
fix: never discard a completed keygen share when auto-locked

### DIFF
--- a/clients/extension/tests/unit/keygenWhileAutoLocked.test.tsx
+++ b/clients/extension/tests/unit/keygenWhileAutoLocked.test.tsx
@@ -1,0 +1,323 @@
+// @vitest-environment happy-dom
+/**
+ * Regression tests for
+ * https://github.com/vultisig/vultisig-windows/issues/4598: a keygen/reshare
+ * ceremony completing while the passcode auto-lock has fired used to throw
+ * away the new key share — the save mutation read the live (nulled) passcode
+ * and threw before persisting anything, while the peers had already committed
+ * the reshared share set.
+ *
+ * Two guarantees are pinned down, for the reshare operation specifically (the
+ * longest unattended window):
+ *
+ * - the auto-lock defers while a keygen flow is mounted, so the passcode is
+ *   still in hand when the ceremony completes
+ * - even with the passcode gone, `SaveVaultStep` defers the save until unlock
+ *   instead of firing a mutation that discards the share's only copy
+ *
+ * The save path below `SaveVaultStep` is production code: the real vault
+ * mutations, the real PBKDF2 passcode cipher, and the real extension storage
+ * adapters writing through `chrome.storage.local`. Only WalletCore address
+ * derivation and presentational chrome are stubbed.
+ */
+import { passcodeEncryptionStorage } from '@core/extension/storage/passcodeEncryption'
+import { vaultsStorage } from '@core/extension/storage/vaults'
+import { KeygenOperationProvider } from '@core/ui/mpc/keygen/state/currentKeygenOperationType'
+import { PasscodeAutoLock } from '@core/ui/passcodeEncryption/autoLock/PasscodeAutoLock'
+import { PasscodeAutoLockHoldsProvider } from '@core/ui/passcodeEncryption/autoLock/passcodeAutoLockHolds'
+import { encryptSample } from '@core/ui/passcodeEncryption/core/sample'
+import {
+  decryptVaultAllKeyShares,
+  encryptVaultAllKeyShares,
+} from '@core/ui/passcodeEncryption/core/vaultKeyShares'
+import {
+  PasscodeProvider,
+  usePasscode,
+} from '@core/ui/passcodeEncryption/state/passcode'
+import { StorageKey } from '@core/ui/storage/StorageKey'
+import { VaultsProvider } from '@core/ui/storage/vaults'
+import { SaveVaultStep } from '@core/ui/vault/save/SaveVaultStep'
+import { darkTheme } from '@lib/ui/theme/darkTheme'
+import { ThemeProvider } from '@lib/ui/theme/ThemeProvider'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { Vault } from '@vultisig/core-mpc/vault/Vault'
+import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
+import { ReactNode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// The Spinner in the pending state reaches the Lottie player (needs a real
+// canvas) and the Rive runtime (fetches WASM from a CDN at import time).
+// Nothing under test animates.
+vi.mock('lottie-react', () => ({ default: () => null }))
+vi.mock('@lib/ui/animations/Animation', () => ({ Animation: () => null }))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+  Trans: ({ children }: { children?: ReactNode }) => children ?? null,
+}))
+
+// The header pulls in navigation; the save behavior under test does not.
+vi.mock('@core/ui/flow/FlowPageHeader', () => ({
+  FlowPageHeader: () => null,
+}))
+
+// Address derivation needs the WalletCore WASM; the save path only threads the
+// result into coin records.
+vi.mock('@core/ui/chain/providers/WalletCoreProvider', () => ({
+  useAssertWalletCore: () => ({}),
+}))
+
+vi.mock('@vultisig/core-chain/publicKey/address/getChainAddress', () => ({
+  getChainAddress: ({ chain }: { chain: string }) => `address-${chain}`,
+}))
+
+type CoreStub = Record<string, unknown>
+
+const coreHolder: { value: CoreStub | undefined } = vi.hoisted(() => ({
+  value: undefined,
+}))
+
+vi.mock('@core/ui/state/core', () => ({
+  useCore: () => shouldBePresent(coreHolder.value),
+}))
+
+const currentVaultIdHolder: { value: string | null } = { value: null }
+
+coreHolder.value = {
+  ...vaultsStorage,
+  ...passcodeEncryptionStorage,
+  createCoins: async () => {},
+  setCurrentVaultId: async (value: string | null) => {
+    currentVaultIdHolder.value = value
+  },
+  setFriendReferral: async () => {},
+  getPasscodeAutoLock: async () => 1,
+  setPasscodeUnlockSession: async () => {},
+}
+
+const passcode = '135790'
+
+const oldEcdsaShare = 'old-ecdsa-key-share'
+const oldEddsaShare = 'old-eddsa-key-share'
+const newEcdsaShare = 'reshared-ecdsa-key-share'
+const newEddsaShare = 'reshared-eddsa-key-share'
+
+const baseVault: Omit<Vault, 'keyShares'> = {
+  name: 'Test Vault',
+  publicKeys: { ecdsa: 'ecdsa-public-key', eddsa: 'eddsa-public-key' },
+  signers: ['device-1', 'device-2'],
+  hexChainCode: 'chain-code',
+  localPartyId: 'device-1',
+  libType: 'DKLS',
+  isBackedUp: true,
+  order: 0,
+}
+
+/** The ceremony's in-memory result: same vault id, brand-new plaintext shares. */
+const resharedVault: Vault = {
+  ...baseVault,
+  keyShares: { ecdsa: newEcdsaShare, eddsa: newEddsaShare },
+}
+
+const autoLockMs = 60_000
+
+const makeQueryClient = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+
+  queryClient.setQueryData([StorageKey.passcodeAutoLock], 1)
+
+  return queryClient
+}
+
+/**
+ * Seeds storage the way it looks mid-reshare: the pre-reshare vault sealed
+ * under the passcode, with the passcode proof beside it.
+ */
+const seedSealedVault = async () => {
+  const sealed = await encryptVaultAllKeyShares({
+    keyShares: { ecdsa: oldEcdsaShare, eddsa: oldEddsaShare },
+    chainKeyShares: undefined,
+    keyShareMldsa: undefined,
+    key: passcode,
+  })
+
+  const storedVault: Vault = {
+    ...baseVault,
+    keyShares: {
+      ecdsa: shouldBePresent(sealed.keyShares.ecdsa),
+      eddsa: shouldBePresent(sealed.keyShares.eddsa),
+    },
+  }
+
+  await chrome.storage.local.set({ [StorageKey.vaults]: [storedVault] })
+
+  const encryptedSample = await encryptSample({
+    key: passcode,
+    value: 'sample',
+  })
+  await passcodeEncryptionStorage.setPasscodeEncryption({ encryptedSample })
+
+  return { storedVault, encryptedSample }
+}
+
+/**
+ * Renders the in-memory passcode for assertions and unlocks on click, the way
+ * `EnterPasscode` would.
+ */
+const PasscodeProbe = () => {
+  const [value, setValue] = usePasscode()
+
+  return (
+    <button data-testid="unlock" onClick={() => setValue(passcode)}>
+      <span data-testid="passcode-probe">{String(value)}</span>
+    </button>
+  )
+}
+
+const observedPasscode = () => screen.getByTestId('passcode-probe').textContent
+
+afterEach(() => {
+  vi.useRealTimers()
+  currentVaultIdHolder.value = null
+})
+
+describe('auto-lock holds while a reshare flow is mounted', () => {
+  const renderAutoLock = (withReshareFlow: boolean) => (
+    <QueryClientProvider client={makeQueryClient()}>
+      <PasscodeProvider initialValue={passcode}>
+        <PasscodeAutoLockHoldsProvider>
+          <PasscodeAutoLock />
+          <PasscodeProbe />
+          {withReshareFlow && (
+            <KeygenOperationProvider value={{ reshare: 'regular' }}>
+              <div />
+            </KeygenOperationProvider>
+          )}
+        </PasscodeAutoLockHoldsProvider>
+      </PasscodeProvider>
+    </QueryClientProvider>
+  )
+
+  it('locks after the interval when no keygen flow is mounted', () => {
+    vi.useFakeTimers()
+
+    render(renderAutoLock(false))
+    expect(observedPasscode()).toBe(passcode)
+
+    act(() => {
+      vi.advanceTimersByTime(autoLockMs + 1)
+    })
+
+    expect(observedPasscode()).toBe('null')
+  })
+
+  it('keeps the passcode through many idle intervals, then locks one interval after the flow unmounts', () => {
+    vi.useFakeTimers()
+
+    const { rerender } = render(renderAutoLock(true))
+
+    // A reshare can sit unattended far past the lock interval waiting on the
+    // peer device; the hold must survive every deferred firing.
+    for (let i = 0; i < 3; i++) {
+      act(() => {
+        vi.advanceTimersByTime(autoLockMs + 1)
+      })
+      expect(observedPasscode()).toBe(passcode)
+    }
+
+    rerender(renderAutoLock(false))
+
+    act(() => {
+      vi.advanceTimersByTime(autoLockMs + 1)
+    })
+
+    expect(observedPasscode()).toBe('null')
+  })
+})
+
+describe('a reshare completing while locked never discards the new share', () => {
+  const renderSaveVaultStep = async (passcodeInMemory: string | null) => {
+    const { storedVault } = await seedSealedVault()
+
+    const queryClient = makeQueryClient()
+    queryClient.setQueryData(
+      [StorageKey.passcodeEncryption],
+      await passcodeEncryptionStorage.getPasscodeEncryption()
+    )
+
+    const onFinish = vi.fn()
+
+    const view = render(
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={darkTheme}>
+          <PasscodeProvider initialValue={passcodeInMemory}>
+            <VaultsProvider value={[{ ...storedVault, coins: [] }]}>
+              <PasscodeProbe />
+              <SaveVaultStep
+                value={resharedVault}
+                title="reshare"
+                onBack={() => {}}
+                onFinish={onFinish}
+              />
+            </VaultsProvider>
+          </PasscodeProvider>
+        </ThemeProvider>
+      </QueryClientProvider>
+    )
+
+    return { view, onFinish, storedVault }
+  }
+
+  const expectStoredShares = async (expected: {
+    ecdsa: string
+    eddsa: string
+  }) => {
+    const [stored] = await vaultsStorage.getVaults()
+
+    // Sealed at rest: the plaintext must not be what storage holds…
+    expect(stored.keyShares.ecdsa).not.toBe(expected.ecdsa)
+    expect(stored.keyShares.eddsa).not.toBe(expected.eddsa)
+
+    // …but the passcode must open it to exactly the expected shares.
+    const opened = await decryptVaultAllKeyShares({
+      keyShares: stored.keyShares,
+      chainKeyShares: stored.chainKeyShares,
+      keyShareMldsa: stored.keyShareMldsa,
+      key: passcode,
+    })
+
+    expect(opened.keyShares).toEqual(expected)
+  }
+
+  it('defers the save while locked and persists the sealed share on unlock', async () => {
+    const { view, onFinish } = await renderSaveVaultStep(null)
+
+    // Let any wrongly-fired mutation settle before asserting nothing moved.
+    await act(async () => {})
+
+    expect(onFinish).not.toHaveBeenCalled()
+    expect(view.container.textContent).toContain('saving_vault')
+    expect(view.container.textContent).not.toContain('failed_to_save_vault')
+    await expectStoredShares({ ecdsa: oldEcdsaShare, eddsa: oldEddsaShare })
+
+    fireEvent.click(view.getByTestId('unlock'))
+
+    await waitFor(() => expect(onFinish).toHaveBeenCalledOnce())
+
+    const vaults = await vaultsStorage.getVaults()
+    expect(vaults).toHaveLength(1)
+    await expectStoredShares({ ecdsa: newEcdsaShare, eddsa: newEddsaShare })
+    expect(currentVaultIdHolder.value).toBe(baseVault.publicKeys.ecdsa)
+  })
+
+  it('saves immediately when the app is unlocked', async () => {
+    const { onFinish } = await renderSaveVaultStep(passcode)
+
+    await waitFor(() => expect(onFinish).toHaveBeenCalledOnce())
+
+    await expectStoredShares({ ecdsa: newEcdsaShare, eddsa: newEddsaShare })
+  })
+})

--- a/core/ui/CoreApp.tsx
+++ b/core/ui/CoreApp.tsx
@@ -1,6 +1,7 @@
 import './mpc/bootstrapMpcEngine'
 
 import { WalletCoreProvider } from '@core/ui/chain/providers/WalletCoreProvider'
+import { PasscodeAutoLockHoldsProvider } from '@core/ui/passcodeEncryption/autoLock/passcodeAutoLockHolds'
 import { PasscodeGuard } from '@core/ui/passcodeEncryption/guard/PasscodeGuard'
 import { StartupSplashProvider } from '@core/ui/product/startupSplash'
 import { ResponsivenessProvider } from '@core/ui/providers/ResponsivenessProvider'
@@ -72,11 +73,13 @@ export const CoreApp = ({
                 <ToastProvider>
                   <NotificationBannerProvider>
                     <ResponsivenessProvider>
-                      <Container>
-                        {children}
-                        {!isLimited && <VaultDependentContent />}
-                      </Container>
-                      <PasscodeGuard />
+                      <PasscodeAutoLockHoldsProvider>
+                        <Container>
+                          {children}
+                          {!isLimited && <VaultDependentContent />}
+                        </Container>
+                        <PasscodeGuard />
+                      </PasscodeAutoLockHoldsProvider>
                     </ResponsivenessProvider>
                   </NotificationBannerProvider>
                 </ToastProvider>

--- a/core/ui/mpc/keygen/state/currentKeygenOperationType.ts
+++ b/core/ui/mpc/keygen/state/currentKeygenOperationType.ts
@@ -1,5 +1,0 @@
-import { setupValueProvider } from '@lib/ui/state/setupValueProvider'
-import { KeygenOperation } from '@vultisig/core-mpc/keygen/KeygenOperation'
-
-export const [KeygenOperationProvider, useKeygenOperation] =
-  setupValueProvider<KeygenOperation>('KeygenOperation')

--- a/core/ui/mpc/keygen/state/currentKeygenOperationType.tsx
+++ b/core/ui/mpc/keygen/state/currentKeygenOperationType.tsx
@@ -1,0 +1,28 @@
+import { ChildrenProp, ValueProp } from '@lib/ui/props'
+import { setupValueProvider } from '@lib/ui/state/setupValueProvider'
+import { KeygenOperation } from '@vultisig/core-mpc/keygen/KeygenOperation'
+
+import { PasscodeAutoLockHold } from '../../../passcodeEncryption/autoLock/PasscodeAutoLockHold'
+
+const [KeygenOperationValueProvider, useKeygenOperation] =
+  setupValueProvider<KeygenOperation>('KeygenOperation')
+
+export { useKeygenOperation }
+
+/**
+ * Marks the subtree as a keygen flow and, for as long as it is mounted, holds
+ * the passcode auto-lock. A ceremony can sit for minutes waiting on peer
+ * devices with no local interaction; if the auto-lock cleared the passcode in
+ * that window, the completed key share could not be sealed and persisted —
+ * and for a reshare the peers have already committed the new share set, so
+ * discarding this device's share is unrecoverable (#4598).
+ */
+export const KeygenOperationProvider = ({
+  value,
+  children,
+}: ValueProp<KeygenOperation> & ChildrenProp) => (
+  <KeygenOperationValueProvider value={value}>
+    <PasscodeAutoLockHold />
+    {children}
+  </KeygenOperationValueProvider>
+)

--- a/core/ui/passcodeEncryption/autoLock/PasscodeAutoLock.tsx
+++ b/core/ui/passcodeEncryption/autoLock/PasscodeAutoLock.tsx
@@ -6,11 +6,14 @@ import { useCore } from '../../state/core'
 import { usePasscodeAutoLock } from '../../storage/passcodeAutoLock'
 import { computePasscodeUnlockSessionExpiresAt } from '../../storage/passcodeUnlockSession'
 import { usePasscode } from '../state/passcode'
+import { usePasscodeAutoLockHolds } from './passcodeAutoLockHolds'
 
 export const PasscodeAutoLock = () => {
   const [passcode, setPasscode] = usePasscode()
   const passcodeAutoLock = shouldBePresent(usePasscodeAutoLock())
   const { setPasscodeUnlockSession } = useCore()
+  const [autoLockHolds] = usePasscodeAutoLockHolds()
+  const isHeld = autoLockHolds > 0
 
   const [lastInteractionAt, setLastInteractionAt] = useState<number | null>(
     null
@@ -71,6 +74,16 @@ export const PasscodeAutoLock = () => {
     const lockDelayMs = convertDuration(passcodeAutoLock, 'min', 'ms')
 
     timeoutRef.current = setTimeout(() => {
+      // A held lock (an active keygen ceremony) defers instead of firing:
+      // clearing the passcode mid-ceremony would make the completed key share
+      // impossible to seal and persist (#4598). Bumping the interaction
+      // timestamp re-arms the timer, so the lock lands one full interval
+      // after the hold is released at the latest.
+      if (isHeld) {
+        setLastInteractionAt(Date.now())
+        return
+      }
+
       setPasscode(null)
     }, lockDelayMs)
 
@@ -86,6 +99,7 @@ export const PasscodeAutoLock = () => {
       }
     }
   }, [
+    isHeld,
     lastInteractionAt,
     passcode,
     passcodeAutoLock,

--- a/core/ui/passcodeEncryption/autoLock/PasscodeAutoLockHold.tsx
+++ b/core/ui/passcodeEncryption/autoLock/PasscodeAutoLockHold.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react'
+
+import { usePasscodeAutoLockHolds } from './passcodeAutoLockHolds'
+
+/**
+ * Keeps the inactivity auto-lock from clearing the passcode while mounted.
+ * Held by flows that must not lose the in-memory passcode to inactivity: an
+ * MPC keygen ceremony can spend minutes waiting on peer devices with no local
+ * interaction, and once the peers commit, the new key share can only be sealed
+ * and persisted while the passcode is still in hand (#4598). Renders nothing.
+ */
+export const PasscodeAutoLockHold = () => {
+  const [, setHolds] = usePasscodeAutoLockHolds()
+
+  useEffect(() => {
+    setHolds(count => count + 1)
+
+    return () => setHolds(count => count - 1)
+  }, [setHolds])
+
+  return null
+}

--- a/core/ui/passcodeEncryption/autoLock/passcodeAutoLockHolds.tsx
+++ b/core/ui/passcodeEncryption/autoLock/passcodeAutoLockHolds.tsx
@@ -1,0 +1,8 @@
+import { setupStateProvider } from '@lib/ui/state/setupStateProvider'
+
+/**
+ * Count of mounted `PasscodeAutoLockHold`s. While it is above zero the
+ * inactivity auto-lock defers clearing the passcode instead of firing.
+ */
+export const [PasscodeAutoLockHoldsProvider, usePasscodeAutoLockHolds] =
+  setupStateProvider<number>('passcodeAutoLockHolds', 0)

--- a/core/ui/vault/save/SaveVaultStep.tsx
+++ b/core/ui/vault/save/SaveVaultStep.tsx
@@ -11,6 +11,8 @@ import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { FlowErrorPageContent } from '../../flow/FlowErrorPageContent'
+import { usePasscode } from '../../passcodeEncryption/state/passcode'
+import { useIsPasscodeRequired } from '../../passcodeEncryption/state/useIsPasscodeRequired'
 
 export const SaveVaultStep: React.FC<
   ValueProp<Vault> &
@@ -34,15 +36,29 @@ export const SaveVaultStep: React.FC<
     },
   })
 
+  const hasPasscodeEncryption = useIsPasscodeRequired()
+  const [passcode] = usePasscode()
+
+  // Saving seals the key shares with the in-memory passcode. If the app is
+  // locked when the ceremony completes, defer the save until unlock instead of
+  // firing a mutation that throws and discards the only copy of the new share
+  // (#4598) — the passcode prompt is already on screen at that point.
+  const canSealKeyShares = !hasPasscodeEncryption || passcode !== null
+
   useEffect(() => {
+    if (!canSealKeyShares) {
+      return
+    }
+
     mutate({ vault: value, pendingReferral: referral ?? '' })
-  }, [mutate, value, referral])
+  }, [canSealKeyShares, mutate, value, referral])
 
   return (
     <>
       <FlowPageHeader title={title} />
       <MatchQuery
         value={mutationState}
+        inactive={() => <FlowPendingPageContent title={t('saving_vault')} />}
         pending={() => <FlowPendingPageContent title={t('saving_vault')} />}
         success={() => null}
         error={error => (


### PR DESCRIPTION
## Description

A keygen/reshare ceremony can sit past the passcode auto-lock interval waiting on peer devices. If the lock fired in that window, `useCreateVaultMutation` read the nulled passcode and threw before `createVault` ran, discarding the only local copy of the new key share — while the peers had already committed the reshared set. For a 2-of-2 fast vault that is permanent loss of funds.

Fixes #4598

Two layers, matching the acceptance criteria:

- **Auto-lock cannot fire during a keygen flow.** Every keygen flow (create, reshare, keyimport, singleKeygen, plugin reshare, and the joining device) already mounts `KeygenOperationProvider` at flow entry, so that provider now holds the auto-lock via a ref-counted `PasscodeAutoLockHold` for as long as the flow is mounted — all existing mount sites and any future flow inherit the hold for free. While held, `PasscodeAutoLock` defers the timer instead of clearing the passcode; the lock lands at most one interval after the flow unmounts.
- **A ceremony completing while locked persists its share.** `SaveVaultStep` no longer fires a save that is guaranteed to throw: with the passcode gone it waits (the unlock prompt is already on screen) and re-fires the moment the passcode returns. Any future regression in the hold degrades to "user asked to unlock" instead of a destroyed share.

Regression test (reshare specifically, the longest unattended window) follows the #4599 crash-test pattern — real vault mutations, real PBKDF2 cipher, real extension storage adapters: the hold survives three idle lock intervals and locks after the flow unmounts; a reshare completing while locked defers, then persists the new share sealed and decryptable on unlock.

**Tradeoff, stated explicitly:** the hold is unbounded while a keygen screen is mounted, so a reshare QR left open keeps the app unlocked past the configured auto-lock. Entering the flow is a deliberate act, and the `SaveVaultStep` backstop means a lock that does fire can no longer cost a share. A time cap on the hold is easy to add later if wanted.

## Which feature is affected?
- [x] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional context

- Cross-platform status (android#5548 same class, iOS clean, SDK spec sdk#1838) is tracked in the issue itself.
- Validation: new tests 4/4, full extension unit suite 603/603, core/ui keygen/passcode/vault tests green, lint and knip clean. `yarn typecheck` carries 80 pre-existing errors on `main` (installed `@vultisig/core-chain` missing the new kamino modules) — identical count with and without this change, none in touched files.
- Manual verification still worth doing: a secure-vault reshare left waiting >1 min with auto-lock set to 1 minute should complete and persist; I could not co-sign a secure ceremony myself.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #4598
- **Confidence**: high
- **Needs human review for**: the auto-lock hold tradeoff (app stays unlocked while a keygen screen is mounted)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-lock now pauses during active key-generation and resharing flows.
  * Vault saves wait for passcode unlock when encryption is required, preventing reshared key data from being discarded.

* **Bug Fixes**
  * Improved reliability of vault saves during passcode auto-lock.
  * Added regression coverage for deferred and immediate save scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->