### PR TITLE
feat(defi): wire the Kamino home banner to Solana Earn

### DIFF
--- a/core/ui/defi/chain/manage/ManageDefiPositionsPage.tsx
+++ b/core/ui/defi/chain/manage/ManageDefiPositionsPage.tsx
@@ -18,7 +18,7 @@ import { Text } from '@lib/ui/text'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { DefiChainPageTab } from '../tabs/config'
+import { DefiChainPageTab } from '../tabs/core'
 import { setLastDefiChainTab } from '../tabs/lastTab'
 import { DefiPositionTile } from './DefiPositionTile'
 import { PositionsEmptyState } from './PositionsEmptyState'

--- a/core/ui/defi/chain/manage/ManageDefiPositionsPage.tsx
+++ b/core/ui/defi/chain/manage/ManageDefiPositionsPage.tsx
@@ -18,7 +18,7 @@ import { Text } from '@lib/ui/text'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { DefiChainPageTab } from '../tabs/core'
+import { isDefiChainPageTab } from '../tabs/core'
 import { setLastDefiChainTab } from '../tabs/lastTab'
 import { DefiPositionTile } from './DefiPositionTile'
 import { PositionsEmptyState } from './PositionsEmptyState'
@@ -31,8 +31,8 @@ export const ManageDefiPositionsPage = () => {
   const { goBack } = useCore()
 
   useEffect(() => {
-    if (returnTab && ['bonded', 'staked', 'earn', 'lps'].includes(returnTab)) {
-      setLastDefiChainTab(chain, returnTab as DefiChainPageTab)
+    if (returnTab && isDefiChainPageTab(returnTab)) {
+      setLastDefiChainTab(chain, returnTab)
     }
   }, [chain, returnTab])
 

--- a/core/ui/defi/chain/solana/kamino/earnSelection.test.ts
+++ b/core/ui/defi/chain/solana/kamino/earnSelection.test.ts
@@ -19,23 +19,20 @@ describe('resolveKaminoEarnSelection', () => {
     })
   })
 
-  it('keeps the chains and positions the user already selected', () => {
+  it('keeps the chains and positions of other chains', () => {
     const { defiChains, defiPositions } = resolveKaminoEarnSelection({
       defiChains: [Chain.THORChain],
-      defiPositions: {
-        [Chain.THORChain]: ['thor-stake-tcy'],
-        [Chain.Solana]: ['solana-stake-sol'],
-      },
+      defiPositions: { [Chain.THORChain]: ['thor-stake-tcy'] },
     })
 
     expect(defiChains).toEqual([Chain.THORChain, Chain.Solana])
     expect(defiPositions).toEqual({
       [Chain.THORChain]: ['thor-stake-tcy'],
-      [Chain.Solana]: ['solana-stake-sol', ...kaminoPositionIds],
+      [Chain.Solana]: kaminoPositionIds,
     })
   })
 
-  it('writes nothing once Solana and a curated vault are selected', () => {
+  it('writes nothing once Solana and the curated vaults are selected', () => {
     expect(
       resolveKaminoEarnSelection({
         defiChains: [Chain.Solana],
@@ -55,17 +52,30 @@ describe('resolveKaminoEarnSelection', () => {
     ).toBeUndefined()
   })
 
-  it('adds the vaults for a Solana chain enabled before Kamino shipped', () => {
+  it('honours a Solana selection that deliberately holds no Kamino vault', () => {
     expect(
       resolveKaminoEarnSelection({
         defiChains: [Chain.Solana],
         defiPositions: { [Chain.Solana]: ['solana-stake-sol'] },
+      }).defiPositions
+    ).toBeUndefined()
+  })
+
+  it('honours a Solana selection emptied of every position', () => {
+    expect(
+      resolveKaminoEarnSelection({
+        defiChains: [Chain.Solana],
+        defiPositions: { [Chain.Solana]: [] },
+      }).defiPositions
+    ).toBeUndefined()
+  })
+
+  it('still adds Solana to the chain list when its positions are already set', () => {
+    expect(
+      resolveKaminoEarnSelection({
+        defiChains: [],
+        defiPositions: { [Chain.Solana]: kaminoPositionIds },
       })
-    ).toEqual({
-      defiChains: undefined,
-      defiPositions: {
-        [Chain.Solana]: ['solana-stake-sol', ...kaminoPositionIds],
-      },
-    })
+    ).toEqual({ defiChains: [Chain.Solana], defiPositions: undefined })
   })
 })

--- a/core/ui/defi/chain/solana/kamino/earnSelection.test.ts
+++ b/core/ui/defi/chain/solana/kamino/earnSelection.test.ts
@@ -1,0 +1,71 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { kaminoVaultRegistry } from '@vultisig/core-chain/chains/solana/kamino/registry'
+import { describe, expect, it } from 'vitest'
+
+import { resolveKaminoEarnSelection } from './earnSelection'
+import { kaminoEarnPositionId } from './positionId'
+
+const kaminoPositionIds = kaminoVaultRegistry.map(({ address }) =>
+  kaminoEarnPositionId(address)
+)
+
+describe('resolveKaminoEarnSelection', () => {
+  it('adds Solana and every curated vault to an untouched selection', () => {
+    expect(
+      resolveKaminoEarnSelection({ defiChains: [], defiPositions: {} })
+    ).toEqual({
+      defiChains: [Chain.Solana],
+      defiPositions: { [Chain.Solana]: kaminoPositionIds },
+    })
+  })
+
+  it('keeps the chains and positions the user already selected', () => {
+    const { defiChains, defiPositions } = resolveKaminoEarnSelection({
+      defiChains: [Chain.THORChain],
+      defiPositions: {
+        [Chain.THORChain]: ['thor-stake-tcy'],
+        [Chain.Solana]: ['solana-stake-sol'],
+      },
+    })
+
+    expect(defiChains).toEqual([Chain.THORChain, Chain.Solana])
+    expect(defiPositions).toEqual({
+      [Chain.THORChain]: ['thor-stake-tcy'],
+      [Chain.Solana]: ['solana-stake-sol', ...kaminoPositionIds],
+    })
+  })
+
+  it('writes nothing once Solana and a curated vault are selected', () => {
+    expect(
+      resolveKaminoEarnSelection({
+        defiChains: [Chain.Solana],
+        defiPositions: { [Chain.Solana]: kaminoPositionIds },
+      })
+    ).toEqual({ defiChains: undefined, defiPositions: undefined })
+  })
+
+  it('leaves a partial vault selection alone rather than re-adding what was turned off', () => {
+    const [firstVaultId] = kaminoPositionIds
+
+    expect(
+      resolveKaminoEarnSelection({
+        defiChains: [Chain.Solana],
+        defiPositions: { [Chain.Solana]: [firstVaultId] },
+      }).defiPositions
+    ).toBeUndefined()
+  })
+
+  it('adds the vaults for a Solana chain enabled before Kamino shipped', () => {
+    expect(
+      resolveKaminoEarnSelection({
+        defiChains: [Chain.Solana],
+        defiPositions: { [Chain.Solana]: ['solana-stake-sol'] },
+      })
+    ).toEqual({
+      defiChains: undefined,
+      defiPositions: {
+        [Chain.Solana]: ['solana-stake-sol', ...kaminoPositionIds],
+      },
+    })
+  })
+})

--- a/core/ui/defi/chain/solana/kamino/earnSelection.ts
+++ b/core/ui/defi/chain/solana/kamino/earnSelection.ts
@@ -1,0 +1,55 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { kaminoVaultRegistry } from '@vultisig/core-chain/chains/solana/kamino/registry'
+
+import { kaminoEarnPositionId } from './positionId'
+
+type ResolveKaminoEarnSelectionInput = {
+  /** The chain list the DeFi tab shows rows for. */
+  defiChains: Chain[]
+  /** The selected DeFi positions, keyed by chain. */
+  defiPositions: Record<string, string[]>
+}
+
+/**
+ * What has to be written before Kamino Earn can show anything. A list is
+ * `undefined` when the stored one already works, so a caller writes only what
+ * it has to.
+ */
+type KaminoEarnSelection = {
+  defiChains?: Chain[]
+  defiPositions?: Record<string, string[]>
+}
+
+/**
+ * Grows the DeFi selection until the Earn tab can show Kamino, without ever
+ * shrinking it: Solana is appended to the chain list, and the curated vaults
+ * are appended to Solana's positions.
+ *
+ * Having any one curated vault selected counts as done. A user who turned
+ * individual vaults off still has an Earn tab with something in it, and
+ * re-adding what they removed would quietly undo that choice.
+ */
+export const resolveKaminoEarnSelection = ({
+  defiChains,
+  defiPositions,
+}: ResolveKaminoEarnSelectionInput): KaminoEarnSelection => {
+  const kaminoPositionIds = kaminoVaultRegistry.map(({ address }) =>
+    kaminoEarnPositionId(address)
+  )
+  const solanaPositions = defiPositions[Chain.Solana] ?? []
+  const hasKaminoPosition = solanaPositions.some(id =>
+    kaminoPositionIds.includes(id)
+  )
+
+  return {
+    defiChains: defiChains.includes(Chain.Solana)
+      ? undefined
+      : [...defiChains, Chain.Solana],
+    defiPositions: hasKaminoPosition
+      ? undefined
+      : {
+          ...defiPositions,
+          [Chain.Solana]: [...solanaPositions, ...kaminoPositionIds],
+        },
+  }
+}

--- a/core/ui/defi/chain/solana/kamino/earnSelection.ts
+++ b/core/ui/defi/chain/solana/kamino/earnSelection.ts
@@ -21,35 +21,34 @@ type KaminoEarnSelection = {
 }
 
 /**
- * Grows the DeFi selection until the Earn tab can show Kamino, without ever
- * shrinking it: Solana is appended to the chain list, and the curated vaults
- * are appended to Solana's positions.
+ * Seeds the DeFi selection so the Earn tab has something to show: Solana is
+ * appended to the chain list, and the curated vaults become Solana's
+ * positions.
  *
- * Having any one curated vault selected counts as done. A user who turned
- * individual vaults off still has an Earn tab with something in it, and
- * re-adding what they removed would quietly undo that choice.
+ * Positions are only ever seeded, never re-seeded. A vault the user turned off
+ * is indistinguishable from one never offered, so the trigger is whether
+ * Solana has a stored position list at all - once it has one, whatever it says
+ * is the user's answer, including an answer of "no Kamino vaults". A user who
+ * opted out that way lands on the Earn tab's own opt-in prompt instead of
+ * having the vaults quietly put back.
  */
 export const resolveKaminoEarnSelection = ({
   defiChains,
   defiPositions,
 }: ResolveKaminoEarnSelectionInput): KaminoEarnSelection => {
-  const kaminoPositionIds = kaminoVaultRegistry.map(({ address }) =>
-    kaminoEarnPositionId(address)
-  )
-  const solanaPositions = defiPositions[Chain.Solana] ?? []
-  const hasKaminoPosition = solanaPositions.some(id =>
-    kaminoPositionIds.includes(id)
-  )
+  const hasSolanaPositions = defiPositions[Chain.Solana] !== undefined
 
   return {
     defiChains: defiChains.includes(Chain.Solana)
       ? undefined
       : [...defiChains, Chain.Solana],
-    defiPositions: hasKaminoPosition
+    defiPositions: hasSolanaPositions
       ? undefined
       : {
           ...defiPositions,
-          [Chain.Solana]: [...solanaPositions, ...kaminoPositionIds],
+          [Chain.Solana]: kaminoVaultRegistry.map(({ address }) =>
+            kaminoEarnPositionId(address)
+          ),
         },
   }
 }

--- a/core/ui/defi/chain/solana/kamino/useOpenKaminoEarn.ts
+++ b/core/ui/defi/chain/solana/kamino/useOpenKaminoEarn.ts
@@ -1,0 +1,51 @@
+import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
+import { useCore } from '@core/ui/state/core'
+import { StorageKey } from '@core/ui/storage/StorageKey'
+import { useRefetchQueries } from '@lib/ui/query/hooks/useRefetchQueries'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { attempt } from '@vultisig/lib-utils/attempt'
+
+import { resolveKaminoEarnSelection } from './earnSelection'
+
+/**
+ * Opens Kamino Earn from outside the DeFi tab, where neither of the lists the
+ * Earn tab reads can be assumed: Solana is not on the DeFi tab until the user
+ * adds it, and the curated vaults are not selected until something selects
+ * them. An entry point that only navigated would land on the "no positions
+ * selected" state, so whatever is missing is added first.
+ *
+ * Writing the selection is best-effort - an Earn tab the user has to populate
+ * themselves still beats a tap that goes nowhere.
+ */
+export const useOpenKaminoEarn = () => {
+  const navigate = useCoreNavigate()
+  const { getDefiChains, setDefiChains, getDefiPositions, setDefiPositions } =
+    useCore()
+  const refetchQueries = useRefetchQueries()
+
+  const selectKaminoEarn = async () => {
+    const selection = resolveKaminoEarnSelection({
+      defiChains: await getDefiChains(),
+      defiPositions: await getDefiPositions(),
+    })
+
+    if (selection.defiChains) {
+      await setDefiChains(selection.defiChains)
+      await refetchQueries([StorageKey.defiChains])
+    }
+
+    if (selection.defiPositions) {
+      await setDefiPositions(selection.defiPositions)
+      await refetchQueries([StorageKey.defiPositions])
+    }
+  }
+
+  return async () => {
+    await attempt(selectKaminoEarn)
+
+    navigate({
+      id: 'defiChainDetail',
+      state: { chain: Chain.Solana, tab: 'earn' },
+    })
+  }
+}

--- a/core/ui/defi/chain/solana/kamino/useOpenKaminoEarn.ts
+++ b/core/ui/defi/chain/solana/kamino/useOpenKaminoEarn.ts
@@ -12,7 +12,8 @@ import { resolveKaminoEarnSelection } from './earnSelection'
  * Earn tab reads can be assumed: Solana is not on the DeFi tab until the user
  * adds it, and the curated vaults are not selected until something selects
  * them. An entry point that only navigated would land on the "no positions
- * selected" state, so whatever is missing is added first.
+ * selected" state, so the selection is seeded first - see
+ * {@link resolveKaminoEarnSelection} for what counts as unseeded.
  *
  * Writing the selection is best-effort - an Earn tab the user has to populate
  * themselves still beats a tap that goes nowhere.

--- a/core/ui/defi/chain/tabs/DefiChainTabs.tsx
+++ b/core/ui/defi/chain/tabs/DefiChainTabs.tsx
@@ -16,6 +16,15 @@ import { getDefiChainTabs } from './config'
 import { DefiChainPageTab } from './core'
 import { getLastDefiChainTab, setLastDefiChainTab } from './lastTab'
 
+/**
+ * The DeFi chain detail page's segmented content, with the segments this chain
+ * has anything to show under.
+ *
+ * Opens the tab the navigation state asked for, falling back to the tab last
+ * left open for this chain and then to the chain's default. A tab this chain
+ * does not offer - a stale one from persisted navigation state, or one meant
+ * for another chain - resets to the first it does.
+ */
 export const DefiChainTabs = () => {
   const { t } = useTranslation()
   const chain = useCurrentDefiChain()

--- a/core/ui/defi/chain/tabs/DefiChainTabs.tsx
+++ b/core/ui/defi/chain/tabs/DefiChainTabs.tsx
@@ -1,4 +1,5 @@
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
+import { useCoreViewState } from '@core/ui/navigation/hooks/useCoreViewState'
 import { Tabs } from '@lib/ui/base/Tabs'
 import { IconButton } from '@lib/ui/buttons/IconButton'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
@@ -11,12 +12,14 @@ import { useTranslation } from 'react-i18next'
 import styled, { css, useTheme } from 'styled-components'
 
 import { useCurrentDefiChain } from '../useCurrentDefiChain'
-import { DefiChainPageTab, getDefiChainTabs } from './config'
+import { getDefiChainTabs } from './config'
+import { DefiChainPageTab } from './core'
 import { getLastDefiChainTab, setLastDefiChainTab } from './lastTab'
 
 export const DefiChainTabs = () => {
   const { t } = useTranslation()
   const chain = useCurrentDefiChain()
+  const [{ tab: requestedTab }] = useCoreViewState<'defiChainDetail'>()
   const includeBonding = chain === Chain.THORChain || chain === Chain.MayaChain
   // LP positions are only modeled for THORChain / MayaChain — the LpPositions
   // tab queries their LP services and would render empty for other chains.
@@ -27,8 +30,11 @@ export const DefiChainTabs = () => {
   const includeEarn = chain === Chain.Solana
 
   const defaultTab: DefiChainPageTab = includeBonding ? 'bonded' : 'staked'
+  // An entry point that named a tab wins over the tab last left open: it is
+  // the only one that knows what the user just asked to see. A tab this chain
+  // does not offer falls through to the reset below.
   const [activeTab, setActiveTab] = useState<DefiChainPageTab>(
-    getLastDefiChainTab(chain) ?? defaultTab
+    requestedTab ?? getLastDefiChainTab(chain) ?? defaultTab
   )
   const { colors } = useTheme()
   const navigate = useCoreNavigate()

--- a/core/ui/defi/chain/tabs/DefiPositionEmptyState.tsx
+++ b/core/ui/defi/chain/tabs/DefiPositionEmptyState.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
 import { useCurrentDefiChain } from '../useCurrentDefiChain'
-import { DefiChainPageTab } from './config'
+import { DefiChainPageTab } from './core'
 
 type DefiPositionEmptyStateProps = {
   returnTab?: DefiChainPageTab

--- a/core/ui/defi/chain/tabs/config.tsx
+++ b/core/ui/defi/chain/tabs/config.tsx
@@ -4,16 +4,10 @@ import { TFunction } from 'i18next'
 
 import { featureFlags } from '../../../featureFlags'
 import { BondedPositions } from './BondedPositions'
+import { DefiChainPageTab } from './core'
 import { EarnPositions } from './EarnPositions'
 import { LpPositions } from './LpPositions'
 import { StakedPositions } from './StakedPositions'
-
-export type DefiChainPageTab =
-  | 'bonded'
-  | 'staked'
-  | 'earn'
-  | 'lps'
-  | 'governance'
 
 type DefiChainTabsOptions = {
   includeBonded?: boolean

--- a/core/ui/defi/chain/tabs/core.ts
+++ b/core/ui/defi/chain/tabs/core.ts
@@ -1,0 +1,11 @@
+/**
+ * The segments the DeFi chain detail page can show. Kept apart from the tab
+ * configuration so navigation state can name a tab without pulling the tab
+ * content components in with it.
+ */
+export type DefiChainPageTab =
+  | 'bonded'
+  | 'staked'
+  | 'earn'
+  | 'lps'
+  | 'governance'

--- a/core/ui/defi/chain/tabs/core.ts
+++ b/core/ui/defi/chain/tabs/core.ts
@@ -1,11 +1,22 @@
+const defiChainPageTabs = [
+  'bonded',
+  'staked',
+  'earn',
+  'lps',
+  'governance',
+] as const
+
 /**
- * The segments the DeFi chain detail page can show. Kept apart from the tab
+ * A segment of the DeFi chain detail page. Kept apart from the tab
  * configuration so navigation state can name a tab without pulling the tab
  * content components in with it.
  */
-export type DefiChainPageTab =
-  | 'bonded'
-  | 'staked'
-  | 'earn'
-  | 'lps'
-  | 'governance'
+export type DefiChainPageTab = (typeof defiChainPageTabs)[number]
+
+/**
+ * Narrows a tab name that arrives as a plain string - persisted navigation
+ * state, an older build's view state - to one the page still has a segment
+ * for.
+ */
+export const isDefiChainPageTab = (value: string): value is DefiChainPageTab =>
+  defiChainPageTabs.some(tab => tab === value)

--- a/core/ui/defi/chain/tabs/lastTab.ts
+++ b/core/ui/defi/chain/tabs/lastTab.ts
@@ -1,6 +1,6 @@
 import { Chain } from '@vultisig/core-chain/Chain'
 
-import { DefiChainPageTab } from './config'
+import { DefiChainPageTab } from './core'
 
 const lastTabByChain: Partial<Record<Chain, DefiChainPageTab>> = {}
 

--- a/core/ui/navigation/CoreView.ts
+++ b/core/ui/navigation/CoreView.ts
@@ -1,3 +1,4 @@
+import { DefiChainPageTab } from '@core/ui/defi/chain/tabs/core'
 import { DefiProtocol } from '@core/ui/defi/protocols/core'
 import { KeyImportInput } from '@core/ui/mpc/keygen/keyimport/state/keyImportInput'
 import { ChainAction } from '@core/ui/vault/deposit/ChainAction'
@@ -126,7 +127,7 @@ export type CoreView =
   | { id: 'uploadQr'; state: { title?: string } }
   | { id: 'vault' }
   | { id: 'defi'; state: { protocol?: DefiProtocol } }
-  | { id: 'defiChainDetail'; state: { chain: Chain; tab?: string } }
+  | { id: 'defiChainDetail'; state: { chain: Chain; tab?: DefiChainPageTab } }
   | { id: 'manageDefiChains' }
   | { id: 'manageDefiPositions'; state: { chain: Chain; returnTab?: string } }
   | { id: 'kaminoDeposit'; state: { vaultAddress: string } }

--- a/core/ui/vault/page/banners/useHomePromoBanners.tsx
+++ b/core/ui/vault/page/banners/useHomePromoBanners.tsx
@@ -1,10 +1,15 @@
+import { useOpenKaminoEarn } from '@core/ui/defi/chain/solana/kamino/useOpenKaminoEarn'
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { vultisigTwitterUrl } from '@core/ui/settings/constants'
 import { useCreateCoinMutation } from '@core/ui/storage/coins'
 import { BannerId } from '@core/ui/storage/dismissedBanners'
 import { useFriendReferralQuery } from '@core/ui/storage/referrals'
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
-import { useCurrentVaultCoins } from '@core/ui/vault/state/currentVaultCoins'
+import {
+  useCurrentVaultChains,
+  useCurrentVaultCoins,
+} from '@core/ui/vault/state/currentVaultCoins'
+import { Chain } from '@vultisig/core-chain/Chain'
 import { areEqualCoins, extractCoinKey } from '@vultisig/core-chain/coin/Coin'
 import { vult } from '@vultisig/core-chain/coin/knownTokens'
 import { getVaultId } from '@vultisig/core-mpc/vault/Vault'
@@ -40,10 +45,16 @@ export const useHomePromoBanners = (): HomePromoBannerEntry[] => {
   const navigate = useCoreNavigate()
   const vault = useCurrentVault()
   const vaultCoins = useCurrentVaultCoins()
+  const vaultChains = useCurrentVaultChains()
+  const openKaminoEarn = useOpenKaminoEarn()
   const { mutate: createCoin } = useCreateCoinMutation()
   const { data: friendReferral } = useFriendReferralQuery(getVaultId(vault))
 
   const isVultisigBrand = currentProductBrand === 'vultisig'
+  // Kamino Earn deposits, withdraws and reads positions from the vault's own
+  // Solana address, so a vault without one - a key import with no EdDSA key -
+  // has nothing the banner could open.
+  const hasSolana = vaultChains.includes(Chain.Solana)
 
   const openSwapToVult = () => {
     const existingVultCoin = vaultCoins.find(coin => areEqualCoins(coin, vult))
@@ -150,14 +161,15 @@ export const useHomePromoBanners = (): HomePromoBannerEntry[] => {
           }),
         ]
       : []),
-    ...(isVultisigBrand
+    ...(isVultisigBrand && hasSolana
       ? [
           banner({
             id: 'kamino',
             caption: t('kamino_banner_caption'),
             title: t('kamino_banner_title'),
-            // Destination pending the Solana Kamino integration - see #4685.
-            onClick: () => {},
+            onClick: () => {
+              openKaminoEarn()
+            },
           }),
         ]
       : []),


### PR DESCRIPTION
## Description

The Kamino promo banner shipped with an intentionally empty click handler — there was no Kamino code in the repo to navigate to. The Solana Kamino Earn integration has since landed (#4692, #4695, #4697, #4698), so this points the banner at it.

Fixes #4685

## Why navigating alone wasn't enough

Both lists the Earn tab reads start out empty for the Vultisig brand: `getInitialDefiChains('vultisig')` is `[]`, so Solana isn't on the DeFi tab until the user adds it, and `getInitialDefiPositions('vultisig')` is `{}`, so the curated vaults aren't selected until something selects them. A banner that only navigated would have landed nearly every user on the "no positions selected" state.

Separately, `defiChainDetail`'s `tab?: string` state was declared but read by nothing, so there was no way to ask for a tab at all.

## Change

- **`useOpenKaminoEarn`** — seeds the DeFi selection if it has never been set up, then navigates to the Solana Earn tab. Writing the selection is best-effort (`attempt`): an Earn tab the user has to populate themselves still beats a tap that goes nowhere.

- **`resolveKaminoEarnSelection`** — the decision as a pure resolver, so the rule is testable. Positions are only ever *seeded*, never re-seeded: the trigger is whether Solana has a stored position list at all, and once it has one, whatever it says is the user's answer — including an answer of "no Kamino vaults".

  The alternative was to seed whenever no Kamino id is present, which reads the same for a vault never offered and a vault deliberately turned off, so a full opt-out would be silently undone on the next tap (raised in review, and correct). Telling those two apart properly needs persisted opt-out state; seeding once gets the same protection with no new storage. The cost is that a vault which enabled Solana for DeFi *before* Kamino existed lands on the Earn tab's opt-in prompt rather than straight on the vaults — a bounded cohort, since Kamino has not shipped in a release, and a worse first tap is cheaper than a wrong write.

- **Tab plumbing** — `DefiChainPageTab` moves to a leaf module (`tabs/core.ts`, mirroring the existing `protocols/core.ts`) so `CoreView` can type `tab` without pulling the tab content components into every navigational module. It is derived from a const list and paired with an `isDefiChainPageTab` guard, which also drops the `as` cast in `ManageDefiPositionsPage`. `DefiChainTabs` now opens the requested tab, ranked above the tab last left open; a tab a chain doesn't offer self-heals through the existing reset effect.

- **Gating** — the banner now requires the vault to have a Solana address. I read the issue's "gate on Solana holdings" as *has a Solana address*, not *has a non-zero SOL balance*: the curated vaults take USDC and PYUSD too, so a balance gate would hide the banner from the people it's aimed at, while a vault with no Solana key (a key import with no EdDSA key) genuinely has nothing to open.

## Not included

**The Kamino icon tile** (to-do 2 on the issue). The issue conditions it on "if one is provided", and at the time nothing in this repo, in `@vultisig/core-chain`, or in the Figma had a Kamino mark — the Figma uses a generic `circle-dollar` and we ship the Solana logo as the closer stand-in.

That changed while this was in flight: #4720 adds a `KaminoMarkIcon`. Worth doing as a follow-up once it lands, but it isn't a one-line swap — `HomePromoBannerVisuals` currently offers either a tinted glyph (`icon` + `iconColor`) or an image (`logoSrc`), and `KaminoMarkIcon` is a fixed-colour component that explicitly must not recolour, so the union needs a third variant. Kept out of here to avoid coupling this to an unmerged branch.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional context

`yarn check` clean (typecheck, lint, i18n, knip), 1156 tests pass including 7 new ones on the selection resolver, and `yarn build:extension` succeeds. Not exercised in a running extension — no test credentials on this machine and there's no e2e coverage of the home carousel, so the banner tap → Earn tab path is worth a manual pass on a vault that has never opened the DeFi tab.

No parity section: this touches navigation and DeFi selection only — no keysign, broadcast or fee computation. The banner set itself is tracked across platforms on the parent ticket #4680.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #4685
- **Confidence**: high
- **Needs human review for**: the seeding side effect — a banner tap writes to `defiChains` and `defiPositions` when Solana has never been set up for DeFi. It mirrors what toggling a DeFi chain on already does, and never removes or overwrites an existing selection, but it is a product call worth confirming.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Kamino Earn flow for eligible Solana vaults.
  * Selecting the Kamino promotion prepares missing Solana and Kamino selections, then opens the Earn tab.
  * Added support for requesting a specific DeFi tab when opening chain details.
* **Bug Fixes**
  * Existing Solana selections are now preserved when opening Kamino Earn.
  * Kamino promotions appear only for eligible Vultisig vaults containing Solana.
* **Tests**
  * Added coverage for default, existing, partial, empty, and migration selection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->