### PR TITLE
fix(defi): open Solana on Earn to match iOS and Android

### DIFF
--- a/core/ui/defi/chain/tabs/DefiChainTabs.tsx
+++ b/core/ui/defi/chain/tabs/DefiChainTabs.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next'
 import styled, { css, useTheme } from 'styled-components'
 
 import { useCurrentDefiChain } from '../useCurrentDefiChain'
-import { DefiChainPageTab, getDefiChainTabs } from './config'
+import { defaultDefiChainTab, getDefiChainTabs } from './config'
 import { getLastDefiChainTab, setLastDefiChainTab } from './lastTab'
 
 export const DefiChainTabs = () => {
@@ -26,8 +26,11 @@ export const DefiChainTabs = () => {
   // Solana is the only chain with curated earn vaults (Kamino Earn).
   const includeEarn = chain === Chain.Solana
 
-  const defaultTab: DefiChainPageTab = includeBonding ? 'bonded' : 'staked'
-  const [activeTab, setActiveTab] = useState<DefiChainPageTab>(
+  const defaultTab = defaultDefiChainTab({
+    includeEarn,
+    includeBonded: includeBonding,
+  })
+  const [activeTab, setActiveTab] = useState(
     getLastDefiChainTab(chain) ?? defaultTab
   )
   const { colors } = useTheme()

--- a/core/ui/defi/chain/tabs/config.test.ts
+++ b/core/ui/defi/chain/tabs/config.test.ts
@@ -1,0 +1,45 @@
+import { TFunction } from 'i18next'
+import { describe, expect, it } from 'vitest'
+
+import { defaultDefiChainTab, getDefiChainTabs } from './config'
+
+const t = ((key: string) => key) as TFunction
+
+const tabValues = (options: Parameters<typeof getDefiChainTabs>[1]): string[] =>
+  getDefiChainTabs(t, options).map(tab => tab.value)
+
+describe('defaultDefiChainTab', () => {
+  it('opens Solana on Earn, matching iOS and Android', () => {
+    expect(defaultDefiChainTab({ includeEarn: true })).toBe('earn')
+  })
+
+  it('opens bonding chains on Bonded', () => {
+    expect(defaultDefiChainTab({ includeBonded: true })).toBe('bonded')
+  })
+
+  it('falls back to Staked when neither Earn nor Bonded is present', () => {
+    expect(defaultDefiChainTab()).toBe('staked')
+  })
+})
+
+describe('getDefiChainTabs', () => {
+  it('leads Solana with Earn then Staked', () => {
+    expect(
+      tabValues({
+        includeEarn: true,
+        includeBonded: false,
+        includeLps: false,
+      })
+    ).toEqual(['earn', 'staked'])
+  })
+
+  it('does not insert Earn on a bonding chain', () => {
+    expect(
+      tabValues({
+        includeBonded: true,
+        includeLps: false,
+        includeEarn: false,
+      })
+    ).toEqual(['bonded', 'staked'])
+  })
+})

--- a/core/ui/defi/chain/tabs/config.tsx
+++ b/core/ui/defi/chain/tabs/config.tsx
@@ -32,6 +32,18 @@ type DefiChainTabsOptions = {
   includeEarn?: boolean
 }
 
+export const defaultDefiChainTab = ({
+  includeEarn = false,
+  includeBonded = false,
+}: Pick<
+  DefiChainTabsOptions,
+  'includeEarn' | 'includeBonded'
+> = {}): DefiChainPageTab => {
+  if (includeEarn) return 'earn'
+  if (includeBonded) return 'bonded'
+  return 'staked'
+}
+
 export const getDefiChainTabs = (
   t: TFunction,
   {
@@ -41,6 +53,15 @@ export const getDefiChainTabs = (
     includeEarn = false,
   }: DefiChainTabsOptions = {}
 ): Tab<DefiChainPageTab>[] => [
+  ...(includeEarn
+    ? [
+        {
+          value: 'earn' as const,
+          label: t('defiChainTabs.earn'),
+          renderContent: EarnPositions,
+        },
+      ]
+    : []),
   ...(includeBonded
     ? [
         {
@@ -55,15 +76,6 @@ export const getDefiChainTabs = (
     label: t('defiChainTabs.staked'),
     renderContent: StakedPositions,
   },
-  ...(includeEarn
-    ? [
-        {
-          value: 'earn' as const,
-          label: t('defiChainTabs.earn'),
-          renderContent: EarnPositions,
-        },
-      ]
-    : []),
   ...(featureFlags.defiLpsTab && includeLps
     ? [
         {


### PR DESCRIPTION
## Summary
- Solana DeFi now leads with Earn and selects it on first visit, matching iOS and Android.
- Bonding chains still open on Bonded; last-tab session memory is unchanged.

## Changes
| File | Change |
|------|--------|
| `core/ui/defi/chain/tabs/config.tsx` | Earn is first when `includeEarn`; `defaultDefiChainTab` picks Earn / Bonded / Staked. |
| `core/ui/defi/chain/tabs/DefiChainTabs.tsx` | First visit uses `defaultDefiChainTab` instead of always Staked. |
| `core/ui/defi/chain/tabs/config.test.ts` | Pins Solana order earn then staked, default earn, bonding default bonded. |

## Context
QA screenshot had Staked underlined and first on Solana. iOS already returns earn then stake and selects the first type; Android lists Earn then Staked with Earn selected. This is the same shared UI for desktop and the extension.

No open duplicate (`gh pr list --search "solana earn"` — #4721 is the Kamino home-banner destination, not tab order).

## Test plan
- [x] `yarn test core/ui/defi/chain/tabs/config.test.ts` (5/5)
- [x] `yarn typecheck` + eslint on the three files
- [ ] Reload the extension and open Solana DeFi on a fresh session (Earn first and selected)
- [ ] Tap Staked, leave and return in the same session (last-tab still restores Staked)

## receipts

```
$ yarn test core/ui/defi/chain/tabs/config.test.ts

 RUN  v4.1.10 /Users/paaaotc/Documents/Vultisig/GitHub/vultisig-windows

 ✓ core/ui/defi/chain/tabs/config.test.ts (5 tests) 2ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
   Duration  2.65s
```

Live extension screenshot not captured (popup was not running). Visual check is the unchecked item above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved default tab selection for DeFi chain pages, prioritizing Earn, then Bonded, and finally Staked.
  * Updated tab ordering to display Earn before Bonded when available.
  * Preserved existing LP and governance tab behavior.

* **Tests**
  * Added coverage for default tab selection and chain-specific tab ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->