### PR TITLE
fix(defi): lead the Solana DeFi tabs with Earn, not Staked

### DIFF
--- a/core/ui/defi/chain/tabs/DefiChainTabs.tsx
+++ b/core/ui/defi/chain/tabs/DefiChainTabs.tsx
@@ -38,7 +38,14 @@ export const DefiChainTabs = () => {
   // Solana is the only chain with curated earn vaults (Kamino Earn).
   const includeEarn = chain === Chain.Solana
 
-  const defaultTab: DefiChainPageTab = includeBonding ? 'bonded' : 'staked'
+  // Whichever tab leads in `getDefiChainTabs` is the one the screen opens on,
+  // so Solana lands on Earn rather than on the second tab — matching the design
+  // and `vultisig-android`.
+  const defaultTab: DefiChainPageTab = includeBonding
+    ? 'bonded'
+    : includeEarn
+      ? 'earn'
+      : 'staked'
   // An entry point that named a tab wins over the tab last left open: it is
   // the only one that knows what the user just asked to see. A tab this chain
   // does not offer falls through to the reset below.

--- a/core/ui/defi/chain/tabs/config.test.ts
+++ b/core/ui/defi/chain/tabs/config.test.ts
@@ -1,0 +1,37 @@
+import { TFunction } from 'i18next'
+import { describe, expect, it } from 'vitest'
+
+import { getDefiChainTabs } from './config'
+
+// The labels are irrelevant to ordering; echo the key back so a failure names
+// the tab rather than a translated string.
+const t = ((key: string) => key) as unknown as TFunction
+
+const tabValues = (...args: Parameters<typeof getDefiChainTabs>) =>
+  getDefiChainTabs(...args).map(tab => tab.value)
+
+describe('getDefiChainTabs', () => {
+  it('leads with Earn where the chain has one, per the design', () => {
+    // Solana's gating: no bonding, no LPs, no governance, earn.
+    expect(
+      tabValues(t, {
+        includeBonded: false,
+        includeLps: false,
+        includeEarn: true,
+      })
+    ).toStrictEqual(['earn', 'staked'])
+  })
+
+  it('keeps Bonded leading on the chains that have it', () => {
+    // THORChain / MayaChain have no earn segment, so Staked stays second.
+    expect(
+      tabValues(t, { includeBonded: true, includeLps: false })
+    ).toStrictEqual(['bonded', 'staked'])
+  })
+
+  it('falls back to Staked alone for a chain with neither', () => {
+    expect(
+      tabValues(t, { includeBonded: false, includeLps: false })
+    ).toStrictEqual(['staked'])
+  })
+})

--- a/core/ui/defi/chain/tabs/config.test.ts
+++ b/core/ui/defi/chain/tabs/config.test.ts
@@ -1,11 +1,15 @@
-import { TFunction } from 'i18next'
+import { createInstance } from 'i18next'
 import { describe, expect, it } from 'vitest'
 
 import { getDefiChainTabs } from './config'
 
-// The labels are irrelevant to ordering; echo the key back so a failure names
-// the tab rather than a translated string.
-const t = ((key: string) => key) as unknown as TFunction
+// A real i18next instance with no resources: t(key) returns the key verbatim,
+// giving an identity translator with a genuine TFunction type (no casts). The
+// labels are irrelevant to ordering, and echoing the key back means a failure
+// names the tab rather than a translated string.
+const i18n = createInstance()
+void i18n.init({ lng: 'en', resources: {} })
+const t = i18n.t
 
 const tabValues = (...args: Parameters<typeof getDefiChainTabs>) =>
   getDefiChainTabs(...args).map(tab => tab.value)

--- a/core/ui/defi/chain/tabs/config.tsx
+++ b/core/ui/defi/chain/tabs/config.tsx
@@ -21,11 +21,20 @@ type DefiChainTabsOptions = {
   includeGovernance?: boolean
   /**
    * Solana-only Earn segment (Kamino Earn vaults). Other chains have no
-   * curated earn vaults, so the tab would render empty for them.
+   * curated earn vaults, so the tab would render empty for them. Where it is
+   * present it leads `staked` — see the ordering note on `getDefiChainTabs`.
    */
   includeEarn?: boolean
 }
 
+/**
+ * Tabs for the DeFi chain page, in render order.
+ *
+ * `earn` deliberately precedes `staked`: yield is the reason most users open
+ * this screen, so the design leads with it, and `vultisig-android` orders its
+ * Solana tabs the same way. `bonded` still leads where it is present
+ * (THORChain / MayaChain), which have no earn segment.
+ */
 export const getDefiChainTabs = (
   t: TFunction,
   {
@@ -44,11 +53,6 @@ export const getDefiChainTabs = (
         },
       ]
     : []),
-  {
-    value: 'staked' as const,
-    label: t('defiChainTabs.staked'),
-    renderContent: StakedPositions,
-  },
   ...(includeEarn
     ? [
         {
@@ -58,6 +62,11 @@ export const getDefiChainTabs = (
         },
       ]
     : []),
+  {
+    value: 'staked' as const,
+    label: t('defiChainTabs.staked'),
+    renderContent: StakedPositions,
+  },
   ...(featureFlags.defiLpsTab && includeLps
     ? [
         {


### PR DESCRIPTION
Closes #4725

### Problem

The Solana DeFi screen rendered its segments as **`Staked` | `Earn`**, opening on `Staked`. Per the design they should read **`Earn` | `Staked`**, opening on `Earn`.

Figma: https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=80871-73789&t=elxSoZ5NPdfW86xr-0

`vultisig-android` already implements exactly this, so desktop/extension was the odd platform out:

```kotlin
// SolanaStakingPositionsScreen.kt
/** Earn leads, matching the design: yield is the reason most users open this tab. */
private val SOLANA_DEFI_TABS = listOf(DeFiTab.EARN, DeFiTab.STAKED)
...
var selectedTab by rememberSaveable { mutableStateOf(DeFiTab.EARN) }
```

### Change

- **`config.tsx`** — the `earn` block now precedes `staked` in `getDefiChainTabs`, with a doc comment recording *why* the order is what it is so it doesn't get tidied back.
- **`DefiChainTabs.tsx`** — `defaultTab` follows whichever segment leads, so Solana opens on `Earn` instead of landing on the second tab. Without this the screen would render `Earn` first but underline `Staked`.
- **`config.test.ts`** (new) — pins the order for the three gating shapes.

### Blast radius

Solana only. `includeEarn` is Solana-gated, so every other chain's tab list is byte-for-byte unchanged, and `bonded` still leads on THORChain / MayaChain. The `Earn` tab already has its own empty state (`DefiPositionEmptyState returnTab="earn"`), so a vault with no Kamino vaults enabled lands on a proper empty surface rather than a blank one.

Two behaviours worth calling out for review:

- Switching from a chain whose active tab Solana doesn't offer (e.g. `bonded`) now resets to `earn` rather than `staked`, via the existing `tabs[0]` fallback.
- An entry point that names a tab explicitly (`requestedTab`) and the last-left-open tab both still win over the default, so this only changes the first-open case.

### Verification

```
yarn typecheck                  # exit 0
npx eslint core/ui/defi/chain/tabs/   # exit 0
npx vitest run core/ui/defi     # 13 files, 71 tests passed
```

### Note for the reviewer

I could not open the Figma node programmatically — the API returns `403 File not exportable` for this file, so the order here is taken from the reported design and corroborated by the Android implementation quoted above. Worth a quick eyeball against the frame before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated DeFi chain tabs to show **Earn** first for Solana and other chains offering Earn.
  * Preserved the existing default tab behavior for bonding and staking chains.
  * Improved tab ordering for a more consistent experience.

* **Tests**
  * Added coverage to verify tab ordering across supported chain configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->