### PR TITLE
fix: refresh wallet balances automatically

### DIFF
--- a/clients/extension/tests/e2e/helpers/tx-confirmation.ts
+++ b/clients/extension/tests/e2e/helpers/tx-confirmation.ts
@@ -25,7 +25,7 @@ type ChainFamily = 'evm' | 'utxo' | 'cosmos' | 'solana'
  */
 const RPC_ENDPOINTS: Record<string, string> = {
   // EVM chains
-  ethereum: 'https://eth.llamarpc.com',
+  ethereum: 'https://ethereum-rpc.publicnode.com',
   bsc: 'https://bsc-dataseed.binance.org',
   polygon: 'https://polygon-rpc.com',
   arbitrum: 'https://arb1.arbitrum.io/rpc',
@@ -50,7 +50,15 @@ const RPC_ENDPOINTS: Record<string, string> = {
  * Determine chain family from chain name
  */
 function getChainFamily(chain: string): ChainFamily {
-  const evmChains = ['ethereum', 'bsc', 'polygon', 'arbitrum', 'optimism', 'avalanche', 'base']
+  const evmChains = [
+    'ethereum',
+    'bsc',
+    'polygon',
+    'arbitrum',
+    'optimism',
+    'avalanche',
+    'base',
+  ]
   const utxoChains = ['bitcoin', 'litecoin', 'dogecoin', 'dash', 'zcash']
   const cosmosChains = ['cosmos', 'thorchain', 'osmosis', 'kava', 'terra']
 
@@ -108,7 +116,7 @@ async function pollEvmTx(
       console.warn('EVM poll error:', error)
     }
 
-    await new Promise((r) => setTimeout(r, pollInterval))
+    await new Promise(r => setTimeout(r, pollInterval))
   }
 
   return {
@@ -121,7 +129,7 @@ async function pollEvmTx(
 
 /**
  * Poll for UTXO transaction in mempool (Bitcoin, Litecoin, etc.)
- * 
+ *
  * For E2E tests, we only verify the tx is BROADCAST (seen in mempool).
  * We don't wait for block confirmation since UTXO chains can take 10+ minutes.
  * "Broadcast successful" = tx exists in mempool = confirmed: true
@@ -140,18 +148,20 @@ async function pollUtxoTx(
       if (chain === 'bitcoin' || chain === 'litecoin') {
         // Mempool.space API - check if tx EXISTS (in mempool OR confirmed)
         const response = await fetch(`${apiUrl}/tx/${txHash}`)
-        
+
         if (response.ok) {
           const data = await response.json()
-          
+
           // Tx exists! Could be in mempool (unconfirmed) or in a block (confirmed)
           // Either way, broadcast was successful - that's all we need for E2E
           const inMempool = data.txid === txHash
           const inBlock = data.status?.confirmed === true
-          
+
           if (inMempool || inBlock) {
             const blockNumber = inBlock ? data.status.block_height : null
-            console.log(`✅ ${chain} tx ${txHash.slice(0, 16)}... found in ${inBlock ? 'block ' + blockNumber : 'mempool'}`)
+            console.log(
+              `✅ ${chain} tx ${txHash.slice(0, 16)}... found in ${inBlock ? 'block ' + blockNumber : 'mempool'}`
+            )
             return {
               confirmed: true, // "confirmed" means "broadcast successful" for E2E
               blockNumber,
@@ -162,10 +172,10 @@ async function pollUtxoTx(
       } else if (chain === 'dogecoin') {
         // Dogechain API
         const response = await fetch(`${apiUrl}/transaction/${txHash}`)
-        
+
         if (response.ok) {
           const data = await response.json()
-          
+
           if (data.transaction) {
             // Tx exists - broadcast successful
             const blockNumber = data.transaction.block_height || null
@@ -182,7 +192,7 @@ async function pollUtxoTx(
       console.warn('UTXO poll error:', error)
     }
 
-    await new Promise((r) => setTimeout(r, pollInterval))
+    await new Promise(r => setTimeout(r, pollInterval))
   }
 
   return {
@@ -229,7 +239,7 @@ async function pollCosmosTx(
       console.warn('Cosmos poll error:', error)
     }
 
-    await new Promise((r) => setTimeout(r, pollInterval))
+    await new Promise(r => setTimeout(r, pollInterval))
   }
 
   return {
@@ -269,7 +279,10 @@ async function pollSolanaTx(
       if (data.result?.value?.[0]) {
         const status = data.result.value[0]
 
-        if (status.confirmationStatus === 'finalized' || status.confirmationStatus === 'confirmed') {
+        if (
+          status.confirmationStatus === 'finalized' ||
+          status.confirmationStatus === 'confirmed'
+        ) {
           return {
             confirmed: status.err === null,
             blockNumber: status.slot,
@@ -282,7 +295,7 @@ async function pollSolanaTx(
       console.warn('Solana poll error:', error)
     }
 
-    await new Promise((r) => setTimeout(r, pollInterval))
+    await new Promise(r => setTimeout(r, pollInterval))
   }
 
   return {
@@ -328,7 +341,12 @@ export async function waitForTxConfirmation(
 
     case 'utxo':
       // Shorter timeout for UTXO since we're just checking mempool, not block confirmation
-      return pollUtxoTx(endpoint, txHash, Math.min(timeoutMs, 30_000), chainLower)
+      return pollUtxoTx(
+        endpoint,
+        txHash,
+        Math.min(timeoutMs, 30_000),
+        chainLower
+      )
 
     case 'cosmos':
       return pollCosmosTx(endpoint, txHash, timeoutMs)
@@ -349,7 +367,10 @@ export async function waitForTxConfirmation(
 /**
  * Check if a transaction is already confirmed (single check, no polling)
  */
-export async function isTxConfirmed(chain: string, txHash: string): Promise<boolean> {
+export async function isTxConfirmed(
+  chain: string,
+  txHash: string
+): Promise<boolean> {
   const result = await waitForTxConfirmation(chain, txHash, 5000)
   return result.confirmed
 }

--- a/clients/extension/tests/e2e/page-objects/SwapFlow.po.ts
+++ b/clients/extension/tests/e2e/page-objects/SwapFlow.po.ts
@@ -209,7 +209,7 @@ export class SwapFlow extends BasePage {
 
     const currentCoin = await this.swapForm
       .locator('[data-testid="swap-from-coin-selector"]')
-      .textContent()
+      .innerText()
       .catch(() => '')
     if (currentCoin?.toUpperCase().includes(coin.toUpperCase())) {
       console.log(`From coin ${coin} already selected`)
@@ -222,6 +222,10 @@ export class SwapFlow extends BasePage {
     const chainOption = this.getExplorerChainOption(chainName)
     if (await chainOption.isVisible({ timeout: 3000 }).catch(() => false)) {
       await chainOption.click({ force: true })
+      await waitForLoadingComplete(this.page)
+      const nativeCoinOption = this.getCoinOption(coin).first()
+      await nativeCoinOption.waitFor({ state: 'visible', timeout: 10_000 })
+      await nativeCoinOption.click({ force: true })
       await this.page.waitForTimeout(500)
       console.log(`Selected ${chainName} from explorer carousel`)
       return
@@ -246,7 +250,7 @@ export class SwapFlow extends BasePage {
 
     const currentCoin = await this.swapForm
       .locator('[data-testid="swap-to-coin-selector"]')
-      .textContent()
+      .innerText()
       .catch(() => '')
     if (currentCoin?.toUpperCase().includes(coin.toUpperCase())) {
       console.log(`To coin ${coin} already selected`)
@@ -259,6 +263,10 @@ export class SwapFlow extends BasePage {
     const chainOption = this.getExplorerChainOption(chainName)
     if (await chainOption.isVisible({ timeout: 3000 }).catch(() => false)) {
       await chainOption.click({ force: true })
+      await waitForLoadingComplete(this.page)
+      const nativeCoinOption = this.getCoinOption(coin).first()
+      await nativeCoinOption.waitFor({ state: 'visible', timeout: 10_000 })
+      await nativeCoinOption.click({ force: true })
       await this.page.waitForTimeout(500)
       console.log(`Selected ${chainName} from explorer carousel (to)`)
       return
@@ -389,7 +397,7 @@ export class SwapFlow extends BasePage {
   // Fast vaults open a password modal after "Fast Sign".
   async sign(): Promise<void> {
     await waitForLoadingComplete(this.page)
-    await robustClick(this.signButton)
+    await robustClick(this.signButton, { timeout: 60_000 })
     await this.page.waitForTimeout(500)
 
     if (
@@ -454,6 +462,35 @@ export class SwapFlow extends BasePage {
     return this.continueButton.isEnabled()
   }
 
+  async waitForContinueEnabled(timeout = 30_000): Promise<boolean> {
+    // A missing Continue control is a structural regression and must fail the
+    // funded test. Only a confirmed visible-but-disabled control is a valid
+    // insufficient-balance/validation outcome for callers to skip.
+    await this.continueButton.waitFor({ state: 'visible', timeout })
+    try {
+      await expect(this.continueButton).toBeEnabled({ timeout })
+      return true
+    } catch (error) {
+      const stillVisible = await this.continueButton
+        .isVisible()
+        .catch(() => false)
+      if (!stillVisible) throw error
+
+      const enabledAfterTimeout = await this.continueButton
+        .isEnabled()
+        .catch(() => false)
+      return enabledAfterTimeout
+    }
+  }
+
+  async getValidationError(): Promise<string | null> {
+    const tooltip = this.page.getByRole('tooltip')
+    if (!(await tooltip.isVisible().catch(() => false))) return null
+
+    const text = (await tooltip.innerText()).trim()
+    return text || null
+  }
+
   /**
    * Pre-broadcast safety gate. Reads the visible from/to coin selectors and
    * confirms they match the intended symbols. Throws if mismatch so callers
@@ -484,11 +521,9 @@ export class SwapFlow extends BasePage {
     toSymbol,
   }: AssertSelectionMatchesInput): Promise<void> {
     const fromText = (
-      (await this.fromCoinSelector.textContent()) || ''
+      (await this.fromCoinSelector.innerText()) || ''
     ).toUpperCase()
-    const toText = (
-      (await this.toCoinSelector.textContent()) || ''
-    ).toUpperCase()
+    const toText = ((await this.toCoinSelector.innerText()) || '').toUpperCase()
 
     const fromOk = this.hasSelectedSymbol(fromText, fromSymbol)
     const toOk = this.hasSelectedSymbol(toText, toSymbol)
@@ -560,9 +595,9 @@ export class SwapFlow extends BasePage {
     await this.page.waitForTimeout(500)
 
     const currentFromText =
-      (await this.fromCoinSelector.textContent().catch(() => '')) || ''
+      (await this.fromCoinSelector.innerText().catch(() => '')) || ''
     const currentToText =
-      (await this.toCoinSelector.textContent().catch(() => '')) || ''
+      (await this.toCoinSelector.innerText().catch(() => '')) || ''
     console.log(`Current selection: ${currentFromText} → ${currentToText}`)
 
     if (
@@ -577,7 +612,7 @@ export class SwapFlow extends BasePage {
     }
 
     const updatedToText =
-      (await this.toCoinSelector.textContent().catch(() => '')) || ''
+      (await this.toCoinSelector.innerText().catch(() => '')) || ''
     if (!this.hasSelectedSymbol(updatedToText, toSymbol)) {
       await this.selectToCoin(toSymbol)
     }

--- a/clients/extension/tests/e2e/specs/send-flow.spec.ts
+++ b/clients/extension/tests/e2e/specs/send-flow.spec.ts
@@ -213,10 +213,11 @@ async function waitForSendTxConfirmation(
   }
 
   const startedAt = Date.now()
+  const normalizedHash = txHash.trim().replace(/^0x/i, '')
   while (Date.now() - startedAt < timeoutMs) {
     try {
       const response = await fetch(
-        `https://gateway.liquify.com/chain/thorchain_rpc/tx?hash=0x${txHash}&prove=false`
+        `https://gateway.liquify.com/chain/thorchain_rpc/tx?hash=0x${normalizedHash}&prove=false`
       )
       if (response.ok) {
         const data = await response.json()
@@ -544,10 +545,16 @@ test.describe('Send Flow', () => {
           ) {
             await expect
               .poll(
-                async () =>
-                  (
-                    await readPersistedBalance(context, balanceQueryInput!)
-                  )?.toString() ?? null,
+                async () => {
+                  const persistedBalance = await readPersistedBalance(
+                    context,
+                    balanceQueryInput!
+                  )
+                  return (
+                    persistedBalance?.toString() ??
+                    initialNativeBalance.toString()
+                  )
+                },
                 {
                   message: `${chainInfo.symbol} native balance query should auto-update without the refresh button`,
                   timeout: 180_000,

--- a/clients/extension/tests/e2e/specs/send-flow.spec.ts
+++ b/clients/extension/tests/e2e/specs/send-flow.spec.ts
@@ -13,6 +13,8 @@
  * - Tests skip gracefully if chain has insufficient funds
  */
 
+import type { BrowserContext, Page } from '@playwright/test'
+
 import { expect, test } from '../fixtures/extension-loader'
 import {
   type ChainId,
@@ -24,6 +26,7 @@ import {
   readChromeStorage,
   writeChromeStorage,
 } from '../helpers/chrome-storage'
+import { CHAIN_UI_LABELS } from '../helpers/enable-chains'
 import { waitForTxConfirmation } from '../helpers/tx-confirmation'
 import {
   getAddressForChain,
@@ -39,6 +42,202 @@ import { VaultPage } from '../page-objects/VaultPage.po'
 
 // Skip if fund-dependent tests not enabled
 const enableTxTests = process.env.ENABLE_TX_SIGNING_TESTS === 'true'
+const assertBalanceAutoRefresh =
+  process.env.VULTISIG_E2E_ASSERT_BALANCE_AUTO_REFRESH === 'true'
+const configuredSendDestination =
+  process.env.VULTISIG_E2E_SEND_DESTINATION?.trim()
+
+async function getDisplayedChainBalance(page: Page, chain: string) {
+  const chainRow = getChainRow(page, chain)
+  await chainRow.waitFor({ state: 'visible' })
+
+  const text = await chainRow.textContent()
+  const tokenAmount = text?.match(/[\d.,]+\s*[A-Z]{3,}/)
+  const fiatAmount = text?.match(/[$€£]\s*[\d.,]+/)
+
+  return tokenAmount?.[0] || fiatAmount?.[0] || '0'
+}
+
+const getChainRow = (page: Page, chain: string) =>
+  page
+    .locator('[data-testid="VaultChainItem-Panel"]')
+    .filter({ hasText: new RegExp(chain, 'i') })
+
+const captureChainRow = async (page: Page, chain: string, path: string) => {
+  const row = getChainRow(page, chain)
+  await row.evaluate(element =>
+    element.scrollIntoView({ block: 'center', inline: 'nearest' })
+  )
+  await page.waitForTimeout(250)
+  await row.screenshot({ path })
+}
+
+type BalanceQueryInput = {
+  chain: string
+  id?: string
+  address: string
+}
+
+type PersistedQuery = {
+  queryKey?: [string, BalanceQueryInput]
+  state?: {
+    data?: Record<string, bigint>
+    dataUpdatedAt?: number
+  }
+}
+
+type PersistedQueryClient = {
+  timestamp: number
+  clientState?: { queries?: PersistedQuery[] }
+}
+
+const parsePersistedQueryClient = (value: string): PersistedQueryClient =>
+  JSON.parse(value, (_, item) => {
+    if (typeof item === 'string' && /^-?\d+n$/.test(item)) {
+      return BigInt(item.slice(0, -1))
+    }
+    return item
+  })
+
+const serializePersistedQueryClient = (value: PersistedQueryClient) =>
+  JSON.stringify(value, (_, item) =>
+    typeof item === 'bigint' ? `${item}n` : item
+  )
+
+const findBalanceQuery = (
+  client: PersistedQueryClient,
+  input: BalanceQueryInput
+) =>
+  client.clientState?.queries?.find(query => {
+    const [category, candidate] = query.queryKey ?? []
+    return (
+      category === 'coinBalance' &&
+      candidate?.chain === input.chain &&
+      candidate.address === input.address &&
+      candidate.id === input.id
+    )
+  })
+
+async function getNativeBalanceQueryInput(
+  context: BrowserContext,
+  chain: ChainId,
+  address: string,
+  ticker: string
+): Promise<BalanceQueryInput> {
+  const currentVaultId = await readChromeStorage<string>(
+    context,
+    'currentVaultId'
+  )
+  const vaultsCoins = await readChromeStorage<
+    Record<string, Array<BalanceQueryInput & { ticker?: string }>>
+  >(context, 'vaultsCoins')
+  const expectedChain = CHAIN_UI_LABELS[chain]
+  expect(
+    expectedChain,
+    `Stored-chain mapping should exist for ${chain}`
+  ).toBeTruthy()
+  const coin = vaultsCoins?.[currentVaultId ?? '']?.find(
+    item =>
+      item.chain === expectedChain &&
+      item.address === address &&
+      item.ticker === ticker &&
+      item.id == null
+  )
+
+  expect(
+    coin,
+    `Native ${ticker} coin on ${expectedChain} should exist in vault storage`
+  ).toBeTruthy()
+  return { chain: coin!.chain, address: coin!.address }
+}
+
+async function readPersistedBalance(
+  context: BrowserContext,
+  input: BalanceQueryInput
+) {
+  return (await readPersistedBalanceSnapshot(context, input))?.amount ?? null
+}
+
+async function readPersistedBalanceSnapshot(
+  context: BrowserContext,
+  input: BalanceQueryInput
+) {
+  const raw = await readChromeStorage<string>(context, 'queriesPersister')
+  if (!raw) return null
+
+  const query = findBalanceQuery(parsePersistedQueryClient(raw), input)
+  const amount = Object.values(query?.state?.data ?? {})[0]
+  if (typeof amount !== 'bigint') return null
+
+  return {
+    amount,
+    dataUpdatedAt: query?.state?.dataUpdatedAt ?? 0,
+  }
+}
+
+async function replacePersistedBalance(
+  context: BrowserContext,
+  input: BalanceQueryInput,
+  amount: bigint
+) {
+  const raw = await readChromeStorage<string>(context, 'queriesPersister')
+  expect(raw, 'Persisted query client should exist').toBeTruthy()
+
+  const client = parsePersistedQueryClient(raw!)
+  const query = findBalanceQuery(client, input)
+  expect(
+    query?.state?.data,
+    'Native balance query should be persisted'
+  ).toBeTruthy()
+
+  query!.state!.data = Object.fromEntries(
+    Object.keys(query!.state!.data!).map(key => [key, amount])
+  )
+  query!.state!.dataUpdatedAt = Date.now()
+  client.timestamp = Date.now()
+
+  await writeChromeStorage(
+    context,
+    'queriesPersister',
+    serializePersistedQueryClient(client)
+  )
+}
+
+async function waitForSendTxConfirmation(
+  chain: ChainId,
+  txHash: string,
+  timeoutMs: number
+) {
+  if (chain !== 'thorchain') {
+    return waitForTxConfirmation(chain, txHash, timeoutMs)
+  }
+
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const response = await fetch(
+        `https://gateway.liquify.com/chain/thorchain_rpc/tx?hash=0x${txHash}&prove=false`
+      )
+      if (response.ok) {
+        const data = await response.json()
+        const txResult = data.result?.tx_result
+        if (txResult) {
+          const confirmed = Number(txResult.code ?? 0) === 0
+          return {
+            confirmed,
+            error: confirmed ? undefined : txResult.log,
+          }
+        }
+      }
+    } catch (error) {
+      console.warn('THORChain RPC confirmation error:', error)
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 5_000))
+  }
+
+  return { confirmed: false, error: 'Timeout waiting for confirmation' }
+}
 
 function isChainId(value: string): value is ChainId {
   return Object.hasOwn(SUPPORTED_CHAINS, value)
@@ -117,8 +316,11 @@ test.describe('Send Flow', () => {
   test('send native token on chain 1 - broadcasts and confirms', async ({
     context,
     extensionId,
-  }) => {
+  }, testInfo) => {
     test.skip(!enableTxTests, 'TX signing tests disabled')
+    if (assertBalanceAutoRefresh) {
+      test.setTimeout(600_000)
+    }
 
     const chain = selectedChains[0]
     if (!chain) {
@@ -141,16 +343,81 @@ test.describe('Send Flow', () => {
       return
     }
     const sendAmount = getSendAmount(chain)
+    const sendDestination = configuredSendDestination || ownAddress
     console.log(
-      `Self-send on ${chain}: ${ownAddress} (amount: ${sendAmount} ${chainInfo.symbol})`
+      `${configuredSendDestination ? 'Designated-vault transfer' : 'Self-send'} on ${chain}: ${sendDestination} (amount: ${sendAmount} ${chainInfo.symbol})`
     )
 
     const page = await context.newPage()
     const vaultPage = new VaultPage(page, extensionId)
     const sendFlow = new SendFlow(page, extensionId)
     const keysignProgress = new KeysignProgress(page, extensionId)
+    const monitorPage = assertBalanceAutoRefresh
+      ? await context.newPage()
+      : null
+    const monitorVaultPage = monitorPage
+      ? new VaultPage(monitorPage, extensionId)
+      : null
+    let initialMonitoredBalance: string | null = null
+    let balanceQueryInput: BalanceQueryInput | null = null
+    let initialNativeBalance: bigint | null = null
+    let initialRowText: string | null = null
+    let autoUpdatedRowText: string | null = null
+    let reopenedRowText: string | null = null
 
     try {
+      if (monitorPage && monitorVaultPage) {
+        const monitorOpenedAt = Date.now()
+        await monitorVaultPage.goto()
+        await monitorVaultPage.waitForView(15_000)
+        balanceQueryInput = await getNativeBalanceQueryInput(
+          context,
+          chain,
+          ownAddress,
+          chainInfo.symbol
+        )
+        await expect
+          .poll(
+            async () =>
+              (await readPersistedBalanceSnapshot(context, balanceQueryInput!))
+                ?.dataUpdatedAt ?? 0,
+            {
+              message: `${chainInfo.symbol} monitor mount refetch should finish before the send baseline`,
+              timeout: 60_000,
+              intervals: [2_000],
+            }
+          )
+          .toBeGreaterThan(monitorOpenedAt)
+        initialNativeBalance = await readPersistedBalance(
+          context,
+          balanceQueryInput
+        )
+        expect(initialNativeBalance).not.toBeNull()
+
+        await expect
+          .poll(() => getDisplayedChainBalance(monitorPage, chain), {
+            message: `${chainInfo.symbol} monitor balance should finish loading before the send`,
+            timeout: 60_000,
+            intervals: [2_000],
+          })
+          .not.toBe('0')
+        initialMonitoredBalance = await getDisplayedChainBalance(
+          monitorPage,
+          chain
+        )
+        initialRowText = (
+          await getChainRow(monitorPage, chain).innerText()
+        ).trim()
+        const initialRowScreenshot = testInfo.outputPath(
+          `balance-before-send-${chain}.png`
+        )
+        await captureChainRow(monitorPage, chain, initialRowScreenshot)
+        await testInfo.attach('balance row before send', {
+          path: initialRowScreenshot,
+          contentType: 'image/png',
+        })
+      }
+
       await vaultPage.goto()
       await vaultPage.waitForView(15_000)
 
@@ -158,9 +425,10 @@ test.describe('Send Flow', () => {
       await navigateToSend(page)
       await sendFlow.waitForView()
 
-      // Fill send form (SELF-SEND: sending to own address)
+      // Default to a self-send; the opt-in balance-refresh proof may target a
+      // second designated QA vault so the visible fiat row changes materially.
       await sendFlow.selectCoin(chainInfo.symbol)
-      await sendFlow.fillAddress(ownAddress)
+      await sendFlow.fillAddress(sendDestination)
       await sendFlow.fillAmount(sendAmount)
 
       // Wait for fee estimation and balance to load
@@ -261,12 +529,155 @@ test.describe('Send Flow', () => {
 
         if (txHash) {
           console.log(`✅ ${chain} send tx: ${txHash}`)
-          const confirmation = await waitForTxConfirmation(
+          const confirmationPromise = waitForSendTxConfirmation(
             chain,
             txHash,
-            120_000
+            180_000
           )
-          expect(confirmation.confirmed).toBe(true)
+
+          if (
+            monitorPage &&
+            monitorVaultPage &&
+            initialMonitoredBalance &&
+            balanceQueryInput &&
+            initialNativeBalance !== null
+          ) {
+            await expect
+              .poll(
+                async () =>
+                  (
+                    await readPersistedBalance(context, balanceQueryInput!)
+                  )?.toString() ?? null,
+                {
+                  message: `${chainInfo.symbol} native balance query should auto-update without the refresh button`,
+                  timeout: 180_000,
+                  intervals: [5_000],
+                }
+              )
+              .not.toBe(initialNativeBalance.toString())
+
+            const autoUpdatedNativeBalance = await readPersistedBalance(
+              context,
+              balanceQueryInput
+            )
+            expect(autoUpdatedNativeBalance).not.toBeNull()
+
+            await expect
+              .poll(() => getDisplayedChainBalance(monitorPage, chain), {
+                message: `${chainInfo.symbol} balance should auto-update without the refresh button`,
+                timeout: 180_000,
+                intervals: [5_000],
+              })
+              .not.toBe(initialMonitoredBalance)
+
+            autoUpdatedRowText = (
+              await getChainRow(monitorPage, chain).innerText()
+            ).trim()
+
+            const openPopupScreenshot = testInfo.outputPath(
+              `balance-auto-updated-open-${chain}.png`
+            )
+            await captureChainRow(monitorPage, chain, openPopupScreenshot)
+            await testInfo.attach(
+              'balance auto-updated while popup stayed open',
+              {
+                path: openPopupScreenshot,
+                contentType: 'image/png',
+              }
+            )
+
+            await monitorPage.close()
+            await page.close()
+
+            const bogusFreshBalance = autoUpdatedNativeBalance! + 123_456_789n
+            await replacePersistedBalance(
+              context,
+              balanceQueryInput,
+              bogusFreshBalance
+            )
+
+            const reopenedPage = await context.newPage()
+            const reopenedVaultPage = new VaultPage(reopenedPage, extensionId)
+            try {
+              await reopenedPage.bringToFront()
+              await reopenedVaultPage.goto()
+              await reopenedVaultPage.waitForView(15_000)
+              await expect
+                .poll(
+                  async () =>
+                    (
+                      await readPersistedBalance(context, balanceQueryInput!)
+                    )?.toString() ?? null,
+                  {
+                    message: `${chainInfo.symbol} fresh persisted balance should refetch after reopening the popup`,
+                    timeout: 60_000,
+                    intervals: [2_000],
+                  }
+                )
+                .toBe(autoUpdatedNativeBalance!.toString())
+
+              await expect
+                .poll(() => getDisplayedChainBalance(reopenedPage, chain), {
+                  message: `${chainInfo.symbol} balance should render after reopening the popup`,
+                  timeout: 30_000,
+                  intervals: [2_000],
+                })
+                .not.toBe('0')
+
+              await expect(
+                reopenedVaultPage.totalBalanceContainer
+              ).toBeVisible()
+              await reopenedPage.waitForTimeout(3_000)
+
+              reopenedRowText = (
+                await getChainRow(reopenedPage, chain).innerText()
+              ).trim()
+
+              const reopenedScreenshot = testInfo.outputPath(
+                `balance-current-after-reopen-${chain}.png`
+              )
+              await captureChainRow(reopenedPage, chain, reopenedScreenshot)
+              await testInfo.attach('balance current after popup reopen', {
+                path: reopenedScreenshot,
+                contentType: 'image/png',
+              })
+
+              await testInfo.attach('balance auto-refresh receipt', {
+                body: Buffer.from(
+                  JSON.stringify(
+                    {
+                      revision:
+                        process.env.VULTISIG_E2E_PROOF_REVISION ?? 'unknown',
+                      chain,
+                      ticker: chainInfo.symbol,
+                      transactionHash: txHash,
+                      initialPersistedBalance: initialNativeBalance.toString(),
+                      autoUpdatedPersistedBalance:
+                        autoUpdatedNativeBalance!.toString(),
+                      injectedFreshBalance: bogusFreshBalance.toString(),
+                      reopenedPersistedBalance:
+                        (
+                          await readPersistedBalance(context, balanceQueryInput)
+                        )?.toString() ?? null,
+                      initialRowText,
+                      autoUpdatedRowText,
+                      reopenedRowText,
+                      refreshControlInvoked: false,
+                    },
+                    null,
+                    2
+                  )
+                ),
+                contentType: 'application/json',
+              })
+            } finally {
+              await reopenedPage.close()
+            }
+          }
+
+          const confirmation = await confirmationPromise
+          expect(confirmation.confirmed, confirmation.error).toBe(true)
+
           updateStaleness([chain], true)
         }
       } else {
@@ -278,7 +689,12 @@ test.describe('Send Flow', () => {
         }
       }
     } finally {
-      await page.close()
+      if (monitorPage && !monitorPage.isClosed()) {
+        await monitorPage.close()
+      }
+      if (!page.isClosed()) {
+        await page.close()
+      }
     }
   })
 

--- a/clients/extension/tests/e2e/specs/swap-flow.spec.ts
+++ b/clients/extension/tests/e2e/specs/swap-flow.spec.ts
@@ -408,10 +408,12 @@ test.describe('Swap Flow', () => {
 
       await expect
         .poll(
-          async () =>
-            (
+          async () => {
+            const persistedBalance = (
               await readPersistedBalance(context, sourceInput)
-            ).amount?.toString(),
+            ).amount
+            return persistedBalance?.toString() ?? initialBalance!.toString()
+          },
           { timeout: 180_000, intervals: [5_000] }
         )
         .not.toBe(initialBalance!.toString())

--- a/clients/extension/tests/e2e/specs/swap-flow.spec.ts
+++ b/clients/extension/tests/e2e/specs/swap-flow.spec.ts
@@ -21,12 +21,15 @@
  * - Only swap fees + gas are consumed
  */
 
+import type { BrowserContext, Page } from '@playwright/test'
+
 import { expect, test } from '../fixtures/extension-loader'
 import {
   type ChainId,
   SUPPORTED_CHAINS,
   updateStaleness,
 } from '../helpers/chain-rotation'
+import { readChromeStorage } from '../helpers/chrome-storage'
 import {
   canSwap,
   CHAIN_SYMBOLS,
@@ -44,6 +47,102 @@ import { SwapFlow } from '../page-objects/SwapFlow.po'
 import { VaultPage } from '../page-objects/VaultPage.po'
 
 const ENABLE_TX_TESTS = process.env.ENABLE_TX_SIGNING_TESTS === 'true'
+const ASSERT_BALANCE_AUTO_REFRESH =
+  process.env.VULTISIG_E2E_ASSERT_SWAP_BALANCE_AUTO_REFRESH === 'true'
+
+type BalanceQueryInput = {
+  chain: string
+  id?: string
+  address: string
+}
+
+type PersistedBalanceQuery = {
+  queryKey?: [string, BalanceQueryInput]
+  state?: {
+    data?: Record<string, bigint>
+    dataUpdatedAt?: number
+  }
+}
+
+const parsePersistedQueryClient = (value: string) =>
+  JSON.parse(value, (_, item) => {
+    if (typeof item === 'string' && /^-?\d+n$/.test(item)) {
+      return BigInt(item.slice(0, -1))
+    }
+    return item
+  }) as { clientState?: { queries?: PersistedBalanceQuery[] } }
+
+const findPersistedBalanceQuery = async (
+  context: BrowserContext,
+  input: BalanceQueryInput
+) => {
+  const raw = await readChromeStorage<string>(context, 'queriesPersister')
+  if (!raw) return null
+
+  return (
+    parsePersistedQueryClient(raw).clientState?.queries?.find(query => {
+      const [category, candidate] = query.queryKey ?? []
+      return (
+        category === 'coinBalance' &&
+        candidate?.chain === input.chain &&
+        candidate.address === input.address &&
+        candidate.id === input.id
+      )
+    }) ?? null
+  )
+}
+
+const readPersistedBalance = async (
+  context: BrowserContext,
+  input: BalanceQueryInput
+) => {
+  const query = await findPersistedBalanceQuery(context, input)
+  const amount = Object.values(query?.state?.data ?? {})[0]
+
+  return {
+    amount: typeof amount === 'bigint' ? amount : null,
+    dataUpdatedAt: query?.state?.dataUpdatedAt ?? 0,
+  }
+}
+
+const getStoredCoin = async (
+  context: BrowserContext,
+  ticker: string
+): Promise<BalanceQueryInput> => {
+  const currentVaultId = await readChromeStorage<string>(
+    context,
+    'currentVaultId'
+  )
+  const vaultsCoins = await readChromeStorage<
+    Record<string, Array<BalanceQueryInput & { ticker?: string }>>
+  >(context, 'vaultsCoins')
+  const coin = vaultsCoins?.[currentVaultId ?? '']?.find(
+    item => item.ticker === ticker
+  )
+
+  expect(coin, `${ticker} should exist in the designated QA vault`).toBeTruthy()
+  return { chain: coin!.chain, id: coin!.id, address: coin!.address }
+}
+
+const getChainRowText = async (page: Page, chain: string) => {
+  const row = getChainRow(page, chain)
+  await row.waitFor({ state: 'visible' })
+  return (await row.innerText()).trim()
+}
+
+const getChainRow = (page: Page, chain: string) =>
+  page
+    .locator('[data-testid="VaultChainItem-Panel"]')
+    .filter({ hasText: new RegExp(chain, 'i') })
+
+const captureChainRow = async (page: Page, chain: string, path: string) => {
+  const row = getChainRow(page, chain)
+  await row.evaluate(element =>
+    element.scrollIntoView({ block: 'center', inline: 'nearest' })
+  )
+  await page.waitForTimeout(250)
+  await row.screenshot({ path })
+}
 
 const parseVisibleAmount = (value: string) => {
   const normalized = value.replace(/,/g, '')
@@ -60,16 +159,12 @@ const getDifferentAmount = (amount: string) => {
 }
 
 type PasteAmountInput = {
-  page: import('@playwright/test').Page,
+  page: import('@playwright/test').Page
   swapFlow: SwapFlow
   amount: string
 }
 
-const pasteAmount = async ({
-  page,
-  swapFlow,
-  amount,
-}: PasteAmountInput) => {
+const pasteAmount = async ({ page, swapFlow, amount }: PasteAmountInput) => {
   await swapFlow.fromAmountInput.click({ force: true })
   await page.evaluate(async value => {
     await navigator.clipboard.writeText(value)
@@ -156,9 +251,11 @@ test.describe('Swap Flow', () => {
         `Quote: ${swapConfig.amount} ${swapConfig.fromSymbol} → ${expectedOutput} ${swapConfig.toSymbol}`
       )
 
-      const canContinue = await swapFlow.isContinueEnabled()
+      const canContinue = await swapFlow.waitForContinueEnabled()
       if (!canContinue) {
+        const validationError = await swapFlow.getValidationError()
         console.log('⚠️ Continue button disabled - amount may be too small')
+        console.log(`Swap validation error: ${validationError ?? 'unknown'}`)
         test.skip()
         return
       }
@@ -212,6 +309,155 @@ test.describe('Swap Flow', () => {
         }
       }
     } finally {
+      await page.close()
+    }
+  })
+
+  test('funded swap updates the source balance without manual refresh', async ({
+    context,
+    extensionId,
+  }, testInfo) => {
+    test.skip(!ENABLE_TX_TESTS, 'TX signing tests disabled')
+    test.skip(
+      !ASSERT_BALANCE_AUTO_REFRESH,
+      'Funded swap balance auto-refresh proof disabled'
+    )
+    test.setTimeout(600_000)
+
+    const sourceTicker = 'VULT'
+    const destinationTicker = 'ETH'
+    const sourceInput = await getStoredCoin(context, sourceTicker)
+    const page = await context.newPage()
+    const monitorPage = await context.newPage()
+    const vaultPage = new VaultPage(page, extensionId)
+    const monitorVaultPage = new VaultPage(monitorPage, extensionId)
+    const swapFlow = new SwapFlow(page, extensionId)
+    const keysignProgress = new KeysignProgress(page, extensionId)
+
+    try {
+      const monitorOpenedAt = Date.now()
+      await monitorVaultPage.goto()
+      await monitorVaultPage.waitForView(15_000)
+      await expect
+        .poll(
+          async () =>
+            (await readPersistedBalance(context, sourceInput)).dataUpdatedAt,
+          { timeout: 60_000, intervals: [2_000] }
+        )
+        .toBeGreaterThan(monitorOpenedAt)
+
+      const initialBalance = (await readPersistedBalance(context, sourceInput))
+        .amount
+      expect(initialBalance).not.toBeNull()
+      expect(initialBalance!).toBeGreaterThan(0n)
+      const initialChainRow = await getChainRowText(
+        monitorPage,
+        sourceInput.chain
+      )
+      const initialRowProof = testInfo.outputPath(
+        'swap-balance-before-transaction.png'
+      )
+      await captureChainRow(monitorPage, sourceInput.chain, initialRowProof)
+      await testInfo.attach('swap balance row before transaction', {
+        path: initialRowProof,
+        contentType: 'image/png',
+      })
+
+      await vaultPage.goto()
+      await vaultPage.waitForView(15_000)
+      await navigateToSwap(page)
+      await swapFlow.waitForView()
+
+      // Switch to the funded Ethereum chain first, then choose its VULT token.
+      await swapFlow.selectFromCoin('ETH')
+      await swapFlow.selectFromCoin(sourceTicker)
+      await swapFlow.selectToCoin(destinationTicker)
+      await swapFlow.clickPercentage(25)
+      await swapFlow.waitForQuote()
+
+      const expectedOutput = await swapFlow.getExpectedOutput()
+      console.log(
+        `Balance auto-refresh swap quote: ${sourceTicker}>${destinationTicker} output=${expectedOutput}; validation=${(await swapFlow.getValidationError()) ?? 'none'}`
+      )
+      expect(expectedOutput).not.toBe('')
+      expect(expectedOutput).not.toBe('0')
+      expect(
+        await swapFlow.waitForContinueEnabled(60_000),
+        (await swapFlow.getValidationError()) ??
+          'swap validation did not settle'
+      ).toBe(true)
+      await swapFlow.assertSelectionMatches({
+        fromSymbol: sourceTicker,
+        toSymbol: destinationTicker,
+      })
+
+      await swapFlow.continue()
+      await swapFlow.acceptTerms()
+      await swapFlow.sign()
+      await keysignProgress.waitForView(30_000)
+      expect(await keysignProgress.waitForComplete(180_000)).toBe('success')
+
+      const txHash = await keysignProgress.getTxHash()
+      expect(txHash).toBeTruthy()
+      const confirmation = await waitForTxConfirmation(
+        'ethereum',
+        txHash,
+        180_000
+      )
+      expect(confirmation.confirmed, confirmation.error).toBe(true)
+
+      await expect
+        .poll(
+          async () =>
+            (
+              await readPersistedBalance(context, sourceInput)
+            ).amount?.toString(),
+          { timeout: 180_000, intervals: [5_000] }
+        )
+        .not.toBe(initialBalance!.toString())
+
+      await expect
+        .poll(() => getChainRowText(monitorPage, sourceInput.chain), {
+          timeout: 180_000,
+          intervals: [5_000],
+        })
+        .not.toBe(initialChainRow)
+
+      const finalBalance = (await readPersistedBalance(context, sourceInput))
+        .amount
+      const finalChainRow = await getChainRowText(
+        monitorPage,
+        sourceInput.chain
+      )
+
+      const proof = testInfo.outputPath('swap-balance-auto-updated.png')
+      await captureChainRow(monitorPage, sourceInput.chain, proof)
+      await testInfo.attach('swap balance auto-updated without refresh', {
+        path: proof,
+        contentType: 'image/png',
+      })
+      await testInfo.attach('swap balance auto-refresh receipt', {
+        body: Buffer.from(
+          JSON.stringify(
+            {
+              revision: process.env.VULTISIG_E2E_PROOF_REVISION ?? 'unknown',
+              route: `${sourceTicker}>${destinationTicker}`,
+              transactionHash: txHash,
+              initialPersistedBalance: initialBalance!.toString(),
+              autoUpdatedPersistedBalance: finalBalance?.toString() ?? null,
+              initialRowText: initialChainRow,
+              autoUpdatedRowText: finalChainRow,
+              refreshControlInvoked: false,
+            },
+            null,
+            2
+          )
+        ),
+        contentType: 'application/json',
+      })
+      console.log(`✅ ${sourceTicker}>${destinationTicker} swap tx: ${txHash}`)
+    } finally {
+      await monitorPage.close()
       await page.close()
     }
   })
@@ -418,10 +664,11 @@ test.describe('Swap Flow', () => {
           `Quote: ${amount} ${fromSymbol} → ${expectedOutput} ${toSymbol}`
         )
 
-        const canContinue = await swapFlow.isContinueEnabled()
+        const canContinue = await swapFlow.waitForContinueEnabled()
         if (!canContinue) {
+          const validationError = await swapFlow.getValidationError()
           console.log(
-            '⚠️ Continue disabled - quote present but blocked (likely balance or min)'
+            `⚠️ Continue disabled - quote present but blocked: ${validationError ?? 'unknown validation error'}`
           )
           test.skip()
           return

--- a/core/ui/chain/coin/queries/useBalanceAutoRefresh.test.ts
+++ b/core/ui/chain/coin/queries/useBalanceAutoRefresh.test.ts
@@ -1,0 +1,37 @@
+import { QueryClient, QueryObserver } from '@tanstack/react-query'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getLiveBalanceQueryOptions } from './useBalancesQuery'
+
+const input = {
+  chain: Chain.Bitcoin,
+  address: 'bc1qvault',
+} as const
+
+describe('live persisted balance refresh', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('refetches even a fresh hydrated balance when the popup remounts', async () => {
+    const queryClient = new QueryClient()
+    const options = getLiveBalanceQueryOptions(input)
+    queryClient.setQueryData(options.queryKey, { balance: 1n })
+    const queryFn = vi.fn().mockResolvedValue({ balance: 2n })
+    const observer = new QueryObserver(queryClient, { ...options, queryFn })
+
+    const unsubscribe = observer.subscribe(() => undefined)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(queryFn).toHaveBeenCalledTimes(1)
+    expect(observer.getCurrentResult().data).toEqual({ balance: 2n })
+
+    unsubscribe()
+    queryClient.clear()
+  })
+})

--- a/core/ui/chain/coin/queries/useBalancesQuery.test.ts
+++ b/core/ui/chain/coin/queries/useBalancesQuery.test.ts
@@ -11,8 +11,11 @@ import { getEvmChainBalances } from '@vultisig/core-chain/coin/balance/getEvmCha
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  balanceQueryKey,
   getBalanceQueryOptions,
   getCoinBalanceQueryAmount,
+  getLiveBalanceQueryOptions,
+  invalidateBalanceQueries,
 } from './useBalancesQuery'
 
 vi.mock('@vultisig/core-chain/coin/balance', () => ({
@@ -150,6 +153,30 @@ describe('getBalanceQueryOptions', () => {
       [accountCoinKeyToString(ethInput)]: 44n,
     })
     expect(options.queryKey).toEqual(['coinBalance', ethInput])
+    expect(options.queryKey.slice(0, balanceQueryKey.length)).toEqual(
+      balanceQueryKey
+    )
+    expect(options).toMatchObject({
+      meta: { shouldPersist: true },
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      staleTime: 30_000,
+    })
+    expect(options.refetchInterval).toBeUndefined()
+    expect(options.refetchIntervalInBackground).toBeUndefined()
+  })
+
+  it('adds mount verification and polling only for live wallet observers', () => {
+    expect(getLiveBalanceQueryOptions(ethInput)).toMatchObject({
+      meta: { shouldPersist: true },
+      refetchOnMount: 'always',
+      refetchOnWindowFocus: true,
+      refetchOnReconnect: true,
+      staleTime: 30_000,
+      refetchInterval: 30_000,
+      refetchIntervalInBackground: false,
+    })
   })
 
   it('surfaces a failed EVM batch read as a query error', async () => {
@@ -209,5 +236,26 @@ describe('getBalanceQueryOptions', () => {
       [accountCoinKeyToString(ethInput)]: 77n,
     })
     expect(getEvmChainBalances).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('invalidateBalanceQueries', () => {
+  it('invalidates every balance without touching unrelated query families', async () => {
+    const queryClient = new QueryClient()
+    const ethKey = getBalanceQueryOptions(ethInput).queryKey
+    const runeKey = getBalanceQueryOptions(runeInput).queryKey
+    const priceKey = ['coinPrices', { coins: ['ETH'] }]
+
+    queryClient.setQueryData(ethKey, { eth: 1n })
+    queryClient.setQueryData(runeKey, { rune: 2n })
+    queryClient.setQueryData(priceKey, { eth: 3 })
+
+    await invalidateBalanceQueries(queryClient)
+
+    expect(queryClient.getQueryState(ethKey)?.isInvalidated).toBe(true)
+    expect(queryClient.getQueryState(runeKey)?.isInvalidated).toBe(true)
+    expect(queryClient.getQueryState(priceKey)?.isInvalidated).toBe(false)
+
+    queryClient.clear()
   })
 })

--- a/core/ui/chain/coin/queries/useBalancesQuery.ts
+++ b/core/ui/chain/coin/queries/useBalancesQuery.ts
@@ -1,6 +1,9 @@
 import { useCombineQueries } from '@lib/ui/query/hooks/useCombineQueries'
-import { persistQueryOptions } from '@lib/ui/query/utils/options'
-import { useQueries } from '@tanstack/react-query'
+import {
+  liveBalanceQueryOptions,
+  persistQueryOptions,
+} from '@lib/ui/query/utils/options'
+import { QueryClient, useQueries } from '@tanstack/react-query'
 import { EvmChain } from '@vultisig/core-chain/Chain'
 import { isChainOfKind } from '@vultisig/core-chain/ChainKind'
 import { accountCoinKeyToString } from '@vultisig/core-chain/coin/AccountCoin'
@@ -99,8 +102,13 @@ export const getCoinBalanceQueryAmount = (input: CoinBalanceResolverInput) => {
 export function getBalanceQueryKey<T extends CoinBalanceResolverInput>(
   input: Exact<CoinBalanceResolverInput, T>
 ): [string, CoinBalanceResolverInput] {
-  return ['coinBalance', input]
+  return [...balanceQueryKey, input]
 }
+
+export const balanceQueryKey = ['coinBalance'] as const
+
+export const invalidateBalanceQueries = (queryClient: QueryClient) =>
+  queryClient.invalidateQueries({ queryKey: balanceQueryKey })
 
 export const getBalanceQueryOptions = <T extends CoinBalanceResolverInput>(
   input: Exact<CoinBalanceResolverInput, T>
@@ -115,11 +123,25 @@ export const getBalanceQueryOptions = <T extends CoinBalanceResolverInput>(
   ...persistQueryOptions,
 })
 
+export const getLiveBalanceQueryOptions = <T extends CoinBalanceResolverInput>(
+  input: Exact<CoinBalanceResolverInput, T>
+) => ({
+  ...getBalanceQueryOptions(input),
+  ...liveBalanceQueryOptions,
+})
+
+type UseBalancesQueryOptions = {
+  live?: boolean
+}
+
 export const useBalancesQuery = <T extends CoinBalanceResolverInput>(
-  inputs: Exact<CoinBalanceResolverInput, T>[]
+  inputs: Exact<CoinBalanceResolverInput, T>[],
+  { live = true }: UseBalancesQueryOptions = {}
 ) => {
   const queries = useQueries({
-    queries: inputs.map(input => getBalanceQueryOptions(input)),
+    queries: inputs.map(input =>
+      live ? getLiveBalanceQueryOptions(input) : getBalanceQueryOptions(input)
+    ),
   })
 
   return useCombineQueries({

--- a/core/ui/transaction-history/record/TransactionRecorderProvider.tsx
+++ b/core/ui/transaction-history/record/TransactionRecorderProvider.tsx
@@ -1,4 +1,4 @@
-import { getBalanceQueryKey } from '@core/ui/chain/coin/queries/useBalancesQuery'
+import { invalidateBalanceQueries } from '@core/ui/chain/coin/queries/useBalancesQuery'
 import {
   KeysignMutationListenerProvider,
   useKeysignMutationListener,
@@ -11,9 +11,7 @@ import {
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { ChildrenProp } from '@lib/ui/props'
 import { useQueryClient } from '@tanstack/react-query'
-import { extractAccountCoinKey } from '@vultisig/core-chain/coin/AccountCoin'
 import { isCancelLimitSwapMemo } from '@vultisig/core-chain/swap/native/limitSwapCancelMemo'
-import { getKeysignCoin } from '@vultisig/core-mpc/keysign/utils/getKeysignCoin'
 import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
 import { getVaultId } from '@vultisig/core-mpc/vault/Vault'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
@@ -109,12 +107,11 @@ export const TransactionRecorderProvider = ({ children }: ChildrenProp) => {
             console.error('Failed to record a broadcast transaction', error)
           })
 
-          if (!keysignPayload.coin) return
-
-          const coin = getKeysignCoin(keysignPayload)
-          void queryClient.invalidateQueries({
-            queryKey: getBalanceQueryKey(extractAccountCoinKey(coin)),
-          })
+          // A broadcast can change more than the selected coin: fees touch the
+          // native asset and swaps also affect their destination asset. Mark
+          // the whole balance family stale so active queries refetch now and
+          // inactive persisted queries refresh when the wallet remounts.
+          void invalidateBalanceQueries(queryClient)
         },
       }}
     >

--- a/core/ui/vault/import/seedphrase/queries/useScanChainsWithBalanceQuery.ts
+++ b/core/ui/vault/import/seedphrase/queries/useScanChainsWithBalanceQuery.ts
@@ -41,7 +41,9 @@ export const useScanChainsWithBalanceQuery =
       [trustWalletInputs, phantomSolanaInput]
     )
 
-    const balancesQuery = useBalancesQuery(allInputs)
+    // Import discovery is a bounded one-shot scan, not a live wallet surface.
+    // Polling every derived chain would keep an unnecessary RPC fanout alive.
+    const balancesQuery = useBalancesQuery(allInputs, { live: false })
 
     return useMemo(() => {
       const { isPending, errors, data: balances } = balancesQuery

--- a/core/ui/vault/send/queries/useSendBalanceQuery.test.ts
+++ b/core/ui/vault/send/queries/useSendBalanceQuery.test.ts
@@ -19,9 +19,11 @@ describe('getSendBalanceQueryOptions', () => {
     expect(getSendBalanceQueryOptions(input)).toMatchObject({
       meta: { shouldPersist: true },
       refetchOnMount: 'always',
-      refetchOnWindowFocus: false,
-      refetchOnReconnect: false,
+      refetchOnWindowFocus: true,
+      refetchOnReconnect: true,
       staleTime: 0,
+      refetchInterval: 30_000,
+      refetchIntervalInBackground: false,
     })
   })
 })

--- a/core/ui/vault/send/queries/useSendBalanceQuery.ts
+++ b/core/ui/vault/send/queries/useSendBalanceQuery.ts
@@ -8,12 +8,12 @@ import { CoinBalanceResolverInput } from '@vultisig/core-chain/coin/balance/reso
 import { Exact } from '@vultisig/lib-utils/types/Exact'
 import { useMemo, useRef } from 'react'
 
-import { getBalanceQueryOptions } from '../../../chain/coin/queries/useBalancesQuery'
+import { getLiveBalanceQueryOptions } from '../../../chain/coin/queries/useBalancesQuery'
 
 export const getSendBalanceQueryOptions = <T extends CoinBalanceResolverInput>(
   input: Exact<CoinBalanceResolverInput, T>
 ) => ({
-  ...getBalanceQueryOptions(input),
+  ...getLiveBalanceQueryOptions(input),
   refetchOnMount: 'always' as const,
   staleTime: 0,
 })

--- a/lib/ui/query/utils/options.test.ts
+++ b/lib/ui/query/utils/options.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  liveBalanceQueryOptions,
+  liveBalanceQueryRefetchInterval,
   persistQueryOptions,
   persistQueryStaleTime,
   pricePersistQueryOptions,
@@ -18,6 +20,20 @@ describe('persistQueryOptions', () => {
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
       staleTime: persistQueryStaleTime,
+    })
+  })
+})
+
+describe('liveBalanceQueryOptions', () => {
+  it('always verifies reopened balances and polls only live wallet observers', () => {
+    expect(liveBalanceQueryRefetchInterval).toBe(30_000)
+    expect(liveBalanceQueryOptions).toMatchObject({
+      refetchOnMount: 'always',
+      refetchOnWindowFocus: true,
+      refetchOnReconnect: true,
+      staleTime: persistQueryStaleTime,
+      refetchInterval: liveBalanceQueryRefetchInterval,
+      refetchIntervalInBackground: false,
     })
   })
 })

--- a/lib/ui/query/utils/options.ts
+++ b/lib/ui/query/utils/options.ts
@@ -40,6 +40,23 @@ export const persistQueryOptions: UseQueryGenericOptions = {
   staleTime: persistQueryStaleTime,
 }
 
+export const liveBalanceQueryRefetchInterval = convertDuration(30, 's', 'ms')
+
+/**
+ * Options layered onto persisted balance queries shown on a live wallet
+ * surface. The cached value renders immediately, every mount verifies it, and
+ * a bounded foreground interval follows incoming or settling transactions.
+ * One-shot import scans deliberately do not use these options.
+ */
+export const liveBalanceQueryOptions: UseQueryGenericOptions = {
+  refetchOnMount: 'always',
+  refetchOnWindowFocus: true,
+  refetchOnReconnect: true,
+  staleTime: persistQueryStaleTime,
+  refetchInterval: liveBalanceQueryRefetchInterval,
+  refetchIntervalInBackground: false,
+}
+
 export const priceQueryStaleTime = convertDuration(1, 'min', 'ms')
 
 export const priceQueryRefetchInterval = convertDuration(5, 'min', 'ms')


### PR DESCRIPTION
## Summary

- Refresh live wallet balances on mount, focus, reconnect, and every 30 seconds while the app is active.
- Invalidate the full balance-query family after successful sends and swaps.
- Keep seedphrase bulk scans non-live while applying the shared refresh behavior to extension and desktop wallet surfaces.

## Verification

- Full repository check suite passed: root 1,062 tests, extension 598 tests, desktop 26 tests, and auxiliary gates.
- Production extension build and brand assertion passed.
- Funded THORChain send and VULT-to-ETH swap flows refreshed balances without manual action; reopening also replaced a deliberately stale persisted value.
- A foreground native desktop run independently refreshed the THORChain row without using either refresh control.

![THORChain balance after automatic refresh](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/4690-auto-refresh-extension-balances/screenshot-1-20260823T1701.png)

Closes #4690

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added live balance updates that refresh automatically when accounts are viewed, focused, reconnected, or after transactions.
  - Send and swap flows now reflect confirmed balance changes without requiring manual refresh.
  - Improved validation feedback and loading behavior during coin selection and swaps.

- **Bug Fixes**
  - Improved balance consistency across supported chains after broadcasts.
  - Seed phrase chain discovery now completes as a one-time scan, avoiding unnecessary ongoing updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->