### PR TITLE
fix(keysign): spin the sign button through the Blockaid scan instead of playing dead

### DIFF
--- a/core/ui/chain/security/blockaid/tx/BlockaidTxScan.tsx
+++ b/core/ui/chain/security/blockaid/tx/BlockaidTxScan.tsx
@@ -1,13 +1,8 @@
-import { useAssertWalletCore } from '@core/ui/chain/providers/WalletCoreProvider'
 import { BlockaidTxScanStatus } from '@core/ui/chain/security/blockaid/tx/BlockaidTxScanStatus'
-import { getBlockaidTxValidationQuery } from '@core/ui/chain/security/blockaid/tx/queries/blockaidTxValidation'
+import { useBlockaidTxScanQuery } from '@core/ui/chain/security/blockaid/tx/queries/useBlockaidTxScanQuery'
 import { useIsBlockaidEnabled } from '@core/ui/storage/blockaid'
-import { usePotentialQuery } from '@lib/ui/query/hooks/usePotentialQuery'
-import { useTransformQueryDataAsync } from '@lib/ui/query/hooks/useTransformQueryData'
 import { Query } from '@lib/ui/query/Query'
-import { getBlockaidTxValidationInput } from '@vultisig/core-mpc/security/blockaid/tx/validation/input'
 import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
-import { useCallback } from 'react'
 
 type BlockaidTxScanProps = {
   keysignPayloadQuery: Query<KeysignPayload>
@@ -23,36 +18,11 @@ export const BlockaidTxScan = ({
   keysignPayloadQuery,
 }: BlockaidTxScanProps) => {
   const isBlockaidEnabled = useIsBlockaidEnabled()
-  const walletCore = useAssertWalletCore()
-
-  const txScanInput = useTransformQueryDataAsync(
-    keysignPayloadQuery,
-    useCallback(
-      async payload => {
-        if (!isBlockaidEnabled) {
-          return null
-        }
-
-        return getBlockaidTxValidationInput({ payload, walletCore })
-      },
-      [isBlockaidEnabled, walletCore]
-    ),
-    ['blockaidTxValidationInput', isBlockaidEnabled]
-  )
-
-  const txScanQuery = usePotentialQuery(
-    txScanInput.data || undefined,
-    getBlockaidTxValidationQuery
-  )
-  const mergedTxScanQuery = {
-    ...txScanQuery,
-    error: txScanInput.error ?? txScanQuery.error,
-    isPending: txScanInput.isPending || txScanQuery.isPending,
-  }
+  const txScanQuery = useBlockaidTxScanQuery(keysignPayloadQuery)
 
   if (!isBlockaidEnabled) {
     return null
   }
 
-  return <BlockaidTxScanStatus value={mergedTxScanQuery} />
+  return <BlockaidTxScanStatus value={txScanQuery} />
 }

--- a/core/ui/chain/security/blockaid/tx/queries/blockaidTxValidation.test.ts
+++ b/core/ui/chain/security/blockaid/tx/queries/blockaidTxValidation.test.ts
@@ -73,4 +73,13 @@ describe('getBlockaidTxValidationQuery', () => {
       description: 'Known malicious destination',
     })
   })
+
+  it('always reaches a verdict the sign button can act on', () => {
+    const { networkMode, retry } = getBlockaidTxValidationQuery(input)
+
+    // `online` would park the query in `pending` while the device reports
+    // itself offline, leaving the sign button disabled with no way out.
+    expect(networkMode).toBe('always')
+    expect(retry).toBe(1)
+  })
 })

--- a/core/ui/chain/security/blockaid/tx/queries/blockaidTxValidation.ts
+++ b/core/ui/chain/security/blockaid/tx/queries/blockaidTxValidation.ts
@@ -1,4 +1,5 @@
 import { noRefetchQueryOptions } from '@lib/ui/query/utils/options'
+import { UseQueryOptions } from '@tanstack/react-query'
 import { RiskLevel } from '@vultisig/core-chain/security/blockaid/core/riskLevel'
 import { getTxBlockaidValidation } from '@vultisig/core-chain/security/blockaid/tx/validation'
 import {
@@ -36,6 +37,18 @@ const getValidationDescription = ({
   )
 }
 
+// The sign button waits on this scan, so it has to reach a verdict. The
+// default `online` network mode parks the query in `pending` for as long as the
+// device reports itself offline, which leaves that button disabled with no way
+// out; `always` turns the same situation into the failure the banner already
+// covers — "transaction not scanned". One retry keeps a transient failure
+// recoverable without stacking four of the SDK's 20s request deadlines onto the
+// wait (#4738).
+const settlingOptions: Pick<UseQueryOptions, 'networkMode' | 'retry'> = {
+  networkMode: 'always',
+  retry: 1,
+}
+
 export const getBlockaidTxValidationQuery = (
   input: BlockaidTxValidationInput
 ) => ({
@@ -56,4 +69,5 @@ export const getBlockaidTxValidationQuery = (
     return { ...result, description: getValidationDescription(validation) }
   },
   ...noRefetchQueryOptions,
+  ...settlingOptions,
 })

--- a/core/ui/chain/security/blockaid/tx/queries/useBlockaidTxScanQuery.ts
+++ b/core/ui/chain/security/blockaid/tx/queries/useBlockaidTxScanQuery.ts
@@ -1,0 +1,63 @@
+import { useAssertWalletCore } from '@core/ui/chain/providers/WalletCoreProvider'
+import { useIsBlockaidEnabled } from '@core/ui/storage/blockaid'
+import { usePotentialQuery } from '@lib/ui/query/hooks/usePotentialQuery'
+import { useTransformQueryDataAsync } from '@lib/ui/query/hooks/useTransformQueryData'
+import { Query } from '@lib/ui/query/Query'
+import { getBlockaidTxValidationInput } from '@vultisig/core-mpc/security/blockaid/tx/validation/input'
+import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+
+import {
+  BlockaidTxScanResult,
+  getBlockaidTxValidationQuery,
+} from './blockaidTxValidation'
+
+type BlockaidTxScanQuery = Query<BlockaidTxScanResult | undefined> & {
+  /**
+   * The scan itself is in flight. Narrower than `isPending`, which also covers
+   * the keysign payload still being built — that wait belongs to the payload
+   * query, and reporting it as a scan tells the user the wrong thing.
+   */
+  isScanning: boolean
+}
+
+/**
+ * Blockaid transaction scan for a keysign payload, as a single query.
+ *
+ * Shared by the scan banner and by the screens that gate signing on it, so the
+ * initiator and the joiner can never disagree about a transaction's verdict.
+ * With Blockaid disabled — or on a chain it does not cover — the query settles
+ * inactive rather than pending, and nothing is scanned.
+ */
+export const useBlockaidTxScanQuery = (
+  keysignPayloadQuery: Query<KeysignPayload>
+): BlockaidTxScanQuery => {
+  const isBlockaidEnabled = useIsBlockaidEnabled()
+  const walletCore = useAssertWalletCore()
+
+  const txScanInput = useTransformQueryDataAsync(
+    keysignPayloadQuery,
+    async payload => {
+      if (!isBlockaidEnabled) {
+        return null
+      }
+
+      return getBlockaidTxValidationInput({ payload, walletCore })
+    },
+    ['blockaidTxValidationInput', isBlockaidEnabled]
+  )
+
+  const txScanQuery = usePotentialQuery(
+    txScanInput.data || undefined,
+    getBlockaidTxValidationQuery
+  )
+
+  const isPending = txScanInput.isPending || txScanQuery.isPending
+
+  return {
+    ...txScanQuery,
+    error: txScanInput.error ?? txScanQuery.error,
+    isPending,
+    isScanning:
+      isBlockaidEnabled && !keysignPayloadQuery.isPending && isPending,
+  }
+}

--- a/core/ui/mpc/keysign/prompt/FastVaultStartKeysignPrompt.tsx
+++ b/core/ui/mpc/keysign/prompt/FastVaultStartKeysignPrompt.tsx
@@ -28,7 +28,7 @@ export const FastVaultStartKeysignPrompt = (props: StartKeysignPromptProps) => {
   const navigate = useCoreNavigate()
   const [showModal, setShowModal] = useState(false)
 
-  const { onBeforeStart, ...navigationProps } = props
+  const { onBeforeStart, isLoading, ...navigationProps } = props
   const keysignPayload =
     'keysignPayload' in navigationProps
       ? navigationProps.keysignPayload
@@ -81,19 +81,17 @@ export const FastVaultStartKeysignPrompt = (props: StartKeysignPromptProps) => {
     })
   }
 
-  const buttonProps = {
-    disabled: keysignPayload
-      ? false
-      : 'disabledMessage' in props
-        ? props.disabledMessage
-        : true,
-  }
+  const disabled = keysignPayload
+    ? false
+    : 'disabledMessage' in props
+      ? props.disabledMessage
+      : true
 
   return (
     <>
       <HStack gap={12} fullWidth>
         <PairedButton
-          {...buttonProps}
+          disabled={disabled}
           kind="secondary"
           icon={<DevicesIcon />}
           onClick={() => executeNavigation('secure')}
@@ -101,7 +99,8 @@ export const FastVaultStartKeysignPrompt = (props: StartKeysignPromptProps) => {
           {t('paired')}
         </PairedButton>
         <FastSignButton
-          {...buttonProps}
+          disabled={disabled}
+          loading={isLoading}
           onClick={() => executeNavigation('fast')}
         >
           {t('fast_sign')}

--- a/core/ui/mpc/keysign/prompt/SecureVaultStartKeysignPrompt.tsx
+++ b/core/ui/mpc/keysign/prompt/SecureVaultStartKeysignPrompt.tsx
@@ -12,7 +12,7 @@ export const SecureVaultStartKeysignPrompt = (
   const navigate = useCoreNavigate()
 
   const buttonProps = useMemo(() => {
-    const { onBeforeStart, ...navigationProps } = props
+    const { onBeforeStart, isLoading, ...navigationProps } = props
     const keysignPayload =
       'keysignPayload' in navigationProps
         ? navigationProps.keysignPayload
@@ -21,6 +21,7 @@ export const SecureVaultStartKeysignPrompt = (
     if (!keysignPayload) {
       return {
         disabled: 'disabledMessage' in props ? props.disabledMessage : true,
+        loading: isLoading,
       }
     }
 

--- a/core/ui/mpc/keysign/prompt/StartKeysignPromptProps.tsx
+++ b/core/ui/mpc/keysign/prompt/StartKeysignPromptProps.tsx
@@ -13,6 +13,12 @@ export type StartKeysignPromptProps = BaseStartKeysignPromptProps & {
   /** Why the button is disabled, when it is. */
   disabledMessage?: string
   /**
+   * The button is waiting on work that is under way — the payload build, the
+   * security scan — rather than on the user. Renders the button's loading
+   * state, so the wait is visible without hovering for the tooltip.
+   */
+  isLoading?: boolean
+  /**
    * Rebuilds the payload at the moment signing starts, so the builder's
    * fail-closed gates run now rather than when the verify screen mounted.
    * Resolves to the payload to sign, or `null` when the rebuild failed — in

--- a/core/ui/mpc/keysign/start/VerifyKeysignStart.tsx
+++ b/core/ui/mpc/keysign/start/VerifyKeysignStart.tsx
@@ -1,29 +1,21 @@
-import { getBlockaidTxValidationQuery } from '@core/ui/chain/security/blockaid/tx/queries/blockaidTxValidation'
-import { StartKeysignPromptProps } from '@core/ui/mpc/keysign/prompt/StartKeysignPromptProps'
-import { useIsBlockaidEnabled } from '@core/ui/storage/blockaid'
+import { useBlockaidTxScanQuery } from '@core/ui/chain/security/blockaid/tx/queries/useBlockaidTxScanQuery'
 import { verticalPadding } from '@lib/ui/css/verticalPadding'
 import { Checkbox } from '@lib/ui/inputs/checkbox/Checkbox'
 import { VStack } from '@lib/ui/layout/Stack'
 import { PageContent } from '@lib/ui/page/PageContent'
 import { PageFooter } from '@lib/ui/page/PageFooter'
-import { usePotentialQuery } from '@lib/ui/query/hooks/usePotentialQuery'
-import { useTransformQueryDataAsync } from '@lib/ui/query/hooks/useTransformQueryData'
 import { Query } from '@lib/ui/query/Query'
 import { Text } from '@lib/ui/text'
 import { SwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
-import { BuildKeysignPayloadError } from '@vultisig/core-mpc/keysign/error'
-import { getBlockaidTxValidationInput } from '@vultisig/core-mpc/security/blockaid/tx/validation/input'
 import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
 import { updateAtIndex } from '@vultisig/lib-utils/array/updateAtIndex'
-import { extractErrorMsg } from '@vultisig/lib-utils/error/extractErrorMsg'
-import { match } from '@vultisig/lib-utils/match'
-import { ReactNode, useCallback, useMemo, useState } from 'react'
+import { ReactNode, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
-import { useAssertWalletCore } from '../../../chain/providers/WalletCoreProvider'
-import { BlockaidTxScanStatus } from '../../../chain/security/blockaid/tx/BlockaidTxScanStatus'
+import { BlockaidTxScan } from '../../../chain/security/blockaid/tx/BlockaidTxScan'
 import { RefetchableKeysignPayloadQuery } from './refreshKeysignPayload'
+import { resolveStartKeysignPromptProps } from './resolveStartKeysignPromptProps'
 import { StartKeysignPromptWithRefresh } from './StartKeysignPromptWithRefresh'
 
 type VerifyKeysignStartInput = {
@@ -65,121 +57,28 @@ export const VerifyKeysignStart = ({
   swapQuote,
 }: VerifyKeysignStartInput) => {
   const { t } = useTranslation()
-  const isBlockaidEnabled = useIsBlockaidEnabled()
 
   const [termsAccepted, setTermsAccepted] = useState<boolean[]>(
     new Array(terms.length).fill(false)
   )
 
-  const walletCore = useAssertWalletCore()
+  const { isScanning } = useBlockaidTxScanQuery(keysignPayloadQuery)
 
-  const txScanInput = useTransformQueryDataAsync(
-    keysignPayloadQuery,
-    useCallback(
-      async payload => {
-        if (!isBlockaidEnabled) {
-          return null
-        }
-
-        return getBlockaidTxValidationInput({
-          payload,
-          walletCore,
-        })
-      },
-      [isBlockaidEnabled, walletCore]
-    ),
-    ['keysignStartBlockaidTxValidationInput', isBlockaidEnabled]
-  )
-
-  const txScanQueryBase = usePotentialQuery(
-    txScanInput.data || undefined,
-    getBlockaidTxValidationQuery
-  )
-  const txScanQuery = {
-    ...txScanQueryBase,
-    error: txScanInput.error ?? txScanQueryBase.error,
-    isPending: txScanInput.isPending || txScanQueryBase.isPending,
-  }
-
-  const startKeysignPromptProps: StartKeysignPromptProps = useMemo(() => {
-    if (termsAccepted.some(term => !term)) {
-      return {
-        disabledMessage: t('terms_required'),
-      }
-    }
-
-    if (txScanQuery.isPending) {
-      return {
-        disabledMessage: t('scanning'),
-      }
-    }
-
-    if (keysignPayloadQuery.isPending) {
-      return {
-        disabledMessage: t('loading'),
-      }
-    }
-
-    if (extraPendingMessage) {
-      return {
-        disabledMessage: extraPendingMessage,
-      }
-    }
-
-    if (keysignPayloadQuery.error) {
-      if (keysignPayloadQuery.error instanceof BuildKeysignPayloadError) {
-        return {
-          disabledMessage: match(keysignPayloadQuery.error.type, {
-            'not-enough-funds': () => t('not_enough_funds'),
-            'ripple-destination-tag-invalid': () =>
-              extractErrorMsg(keysignPayloadQuery.error),
-            'ripple-destination-tag-required': () =>
-              t('ripple_destination_tag_required'),
-          }),
-        }
-      }
-      return {
-        disabledMessage: extractErrorMsg(keysignPayloadQuery.error),
-      }
-    }
-
-    const keysign = keysignPayloadQuery.data
-
-    if (!keysign) {
-      if (keysignPayloadQuery.isPending) {
-        return {
-          disabledMessage: t('loading'),
-        }
-      }
-      return {}
-    }
-
-    if (disabledMessage) {
-      return { disabledMessage }
-    }
-
-    return {
-      keysignPayload: { keysign },
-      ...(toAddressLabel ? { toAddressLabel } : {}),
-      ...(swapQuote ? { swapQuote } : {}),
-    }
-  }, [
-    disabledMessage,
-    extraPendingMessage,
-    keysignPayloadQuery.data,
-    keysignPayloadQuery.error,
-    keysignPayloadQuery.isPending,
-    swapQuote,
+  const startKeysignPromptProps = resolveStartKeysignPromptProps({
     t,
     termsAccepted,
+    keysignPayloadQuery,
+    isScanning,
+    extraPendingMessage,
+    disabledMessage,
     toAddressLabel,
-    txScanQuery.isPending,
-  ])
+    swapQuote,
+  })
 
   return (
     <>
       <PageContent gap={12} scrollable>
-        {isBlockaidEnabled && <BlockaidTxScanStatus value={txScanQuery} />}
+        <BlockaidTxScan keysignPayloadQuery={keysignPayloadQuery} />
 
         {children}
 

--- a/core/ui/mpc/keysign/start/resolveStartKeysignPromptProps.test.ts
+++ b/core/ui/mpc/keysign/start/resolveStartKeysignPromptProps.test.ts
@@ -1,0 +1,90 @@
+import { create } from '@bufbuild/protobuf'
+import { Query } from '@lib/ui/query/Query'
+import { BuildKeysignPayloadError } from '@vultisig/core-mpc/keysign/error'
+import {
+  KeysignPayload,
+  KeysignPayloadSchema,
+} from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { createInstance } from 'i18next'
+import { describe, expect, it } from 'vitest'
+
+import { resolveStartKeysignPromptProps } from './resolveStartKeysignPromptProps'
+
+// A real i18next instance with no resources: t(key) returns the key verbatim,
+// giving an identity translator with a genuine TFunction type (no casts). The
+// wording is irrelevant here — which key is chosen is the whole point.
+const i18n = createInstance()
+void i18n.init({ lng: 'en', resources: {} })
+const t = i18n.t
+
+const keysign = create(KeysignPayloadSchema, { memo: 'synthetic-payload' })
+
+const pendingPayload: Query<KeysignPayload> = {
+  data: undefined,
+  error: null,
+  isPending: true,
+}
+
+const resolvedPayload: Query<KeysignPayload> = {
+  data: keysign,
+  error: null,
+  isPending: false,
+}
+
+const resolve = (
+  input: Partial<Parameters<typeof resolveStartKeysignPromptProps>[0]> = {}
+) =>
+  resolveStartKeysignPromptProps({
+    t,
+    termsAccepted: [true],
+    keysignPayloadQuery: resolvedPayload,
+    isScanning: false,
+    ...input,
+  })
+
+describe('resolveStartKeysignPromptProps', () => {
+  it('waits on the user first, without a spinner', () => {
+    expect(resolve({ termsAccepted: [true, false] })).toStrictEqual({
+      disabledMessage: 'terms_required',
+    })
+  })
+
+  it('reports a payload still being built as loading, never as scanning', () => {
+    expect(resolve({ keysignPayloadQuery: pendingPayload })).toStrictEqual({
+      disabledMessage: 'loading',
+      isLoading: true,
+    })
+  })
+
+  it('keeps the payload wait ahead of the scan wait', () => {
+    expect(
+      resolve({ keysignPayloadQuery: pendingPayload, isScanning: true })
+    ).toStrictEqual({
+      disabledMessage: 'loading',
+      isLoading: true,
+    })
+  })
+
+  it('spins the button while the security scan is in flight', () => {
+    expect(resolve({ isScanning: true })).toStrictEqual({
+      disabledMessage: 'scanning',
+      isLoading: true,
+    })
+  })
+
+  it('hands over the payload once every wait has settled', () => {
+    expect(resolve()).toStrictEqual({ keysignPayload: { keysign } })
+  })
+
+  it('surfaces a build failure as the reason, without a spinner', () => {
+    expect(
+      resolve({
+        keysignPayloadQuery: {
+          data: undefined,
+          error: new BuildKeysignPayloadError('not-enough-funds'),
+          isPending: false,
+        },
+      })
+    ).toStrictEqual({ disabledMessage: 'not_enough_funds' })
+  })
+})

--- a/core/ui/mpc/keysign/start/resolveStartKeysignPromptProps.ts
+++ b/core/ui/mpc/keysign/start/resolveStartKeysignPromptProps.ts
@@ -1,0 +1,99 @@
+import { Query } from '@lib/ui/query/Query'
+import { SwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
+import { BuildKeysignPayloadError } from '@vultisig/core-mpc/keysign/error'
+import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { extractErrorMsg } from '@vultisig/lib-utils/error/extractErrorMsg'
+import { match } from '@vultisig/lib-utils/match'
+import { TFunction } from 'i18next'
+
+import { StartKeysignPromptProps } from '../prompt/StartKeysignPromptProps'
+
+type ResolveStartKeysignPromptPropsInput = {
+  t: TFunction
+  termsAccepted: boolean[]
+  keysignPayloadQuery: Query<KeysignPayload>
+  /** The Blockaid scan is in flight — see `useBlockaidTxScanQuery`. */
+  isScanning: boolean
+  extraPendingMessage?: string
+  disabledMessage?: string
+  toAddressLabel?: string
+  swapQuote?: SwapQuote
+}
+
+/**
+ * Decides whether the start-keysign button signs or stays disabled, and why.
+ *
+ * Order matters: the payload build is reported before the security scan, so a
+ * transaction that is still being built never claims to be scanning. Both are
+ * waits the user has to sit through, so both mark the button as loading — a
+ * disabled button whose only explanation is a hover tooltip reads as broken.
+ */
+export const resolveStartKeysignPromptProps = ({
+  t,
+  termsAccepted,
+  keysignPayloadQuery,
+  isScanning,
+  extraPendingMessage,
+  disabledMessage,
+  toAddressLabel,
+  swapQuote,
+}: ResolveStartKeysignPromptPropsInput): StartKeysignPromptProps => {
+  if (termsAccepted.some(term => !term)) {
+    return {
+      disabledMessage: t('terms_required'),
+    }
+  }
+
+  if (keysignPayloadQuery.isPending) {
+    return {
+      disabledMessage: t('loading'),
+      isLoading: true,
+    }
+  }
+
+  if (isScanning) {
+    return {
+      disabledMessage: t('scanning'),
+      isLoading: true,
+    }
+  }
+
+  if (extraPendingMessage) {
+    return {
+      disabledMessage: extraPendingMessage,
+    }
+  }
+
+  if (keysignPayloadQuery.error) {
+    if (keysignPayloadQuery.error instanceof BuildKeysignPayloadError) {
+      return {
+        disabledMessage: match(keysignPayloadQuery.error.type, {
+          'not-enough-funds': () => t('not_enough_funds'),
+          'ripple-destination-tag-invalid': () =>
+            extractErrorMsg(keysignPayloadQuery.error),
+          'ripple-destination-tag-required': () =>
+            t('ripple_destination_tag_required'),
+        }),
+      }
+    }
+    return {
+      disabledMessage: extractErrorMsg(keysignPayloadQuery.error),
+    }
+  }
+
+  const keysign = keysignPayloadQuery.data
+
+  if (!keysign) {
+    return {}
+  }
+
+  if (disabledMessage) {
+    return { disabledMessage }
+  }
+
+  return {
+    keysignPayload: { keysign },
+    ...(toAddressLabel ? { toAddressLabel } : {}),
+    ...(swapQuote ? { swapQuote } : {}),
+  }
+}


### PR DESCRIPTION
Closes #4738

## The bug

On the swap (and send / dApp sign) overview, after both confirmation terms are ticked, the sign button could sit greyed out with no visible reason. The only explanation was a hover tooltip reading `scanning...`, while the spinning Blockaid banner sat at the top of a scrollable page — out of view exactly where the user was looking. It reads as a broken screen.

Three separate things fed it.

**One label for three different waits.** `txScanQuery.isPending` ORed together the keysign-payload build, the validation-input transform and the Blockaid request, and the `scanning` branch was tested *before* the `loading` branch — so a payload that was still being built claimed to be scanning.

**The pending state was not guaranteed to end.** On top of the SDK's 20s per-request deadline the query inherited the client default of three retries (~90s worst case), and React Query's default `networkMode: 'online'` *parks* a query in `pending` for as long as the device reports itself offline — an indefinitely dead button.

**A pending gate rendered as a dead button.** `disabled: string` renders hover-only through `Tooltip`; nothing on the button said work was in progress, even though `Button` already has a `loading` prop with a spinner used throughout the app.

## The fix

No new time-based gate: the button re-enables on exactly the condition that enabled it before — the scan query reaching a verdict, success or error — and a failed scan still lands on the already-designed "transaction not scanned" banner.

- `useBlockaidTxScanQuery` reports `isScanning` separately from the payload's own wait, and `resolveStartKeysignPromptProps` puts the payload build ahead of the scan, so a pending payload says `loading` and never `scanning`.
- Waits set `isLoading`, which drives `Button`'s existing loading state on the primary action. Nothing new was designed and no new i18n key was added; the secondary "Paired" button stays plainly disabled so two spinners don't sit side by side.
- `networkMode: 'always'` plus `retry: 1` on the scan query turn the offline/stalled case into the failure the UI already covers, and cut the worst-case wait from ~90s to ~40s.
- The scan wiring duplicated between `VerifyKeysignStart` and `BlockaidTxScan` moves into the shared hook, on one query key — initiator and joiner can no longer drift, and the scan runs once instead of twice.

The gate itself is unchanged in strength: while the scan is genuinely in flight the button is still not clickable, so nothing can be signed ahead of a Blockaid verdict.

## Blast radius

`VerifyKeysignStart` backs six screens — send, swap, limit-order review, limit-order cancel, Circle withdraw, and the extension's dApp sign request — and all six get the same behavior. No MPC/TSS code is touched, and no SDK change is needed.

## Verification

- `yarn check` clean (typecheck, lint, i18n, knip)
- `yarn test` — 1170 passed; extension 603 passed; desktop 26 passed
- Six new tests: gate ordering / loading state in `resolveStartKeysignPromptProps.test.ts`, and the settling options in `blockaidTxValidation.test.ts`
- `yarn build:extension` succeeds

Manual check worth doing on review: with the network cut after the swap overview opens, the button should show the spinner and then re-enable behind the "transaction not scanned" banner, rather than staying dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clear loading indicators while transaction details are prepared or security scans are running.
  - Improved keysign prompts with consistent status, error, address, and swap information.

- **Bug Fixes**
  - Security validation now handles offline conditions decisively and retries once after transient failures.
  - Improved error messaging and state handling throughout the keysign start flow.

- **Tests**
  - Added coverage for loading priorities, scan states, terms acceptance, successful handoff, and validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->