### PR TITLE
fix(swap): approve a swap on one card, as the Figma overview draws it

### DIFF
--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -1943,4 +1943,6 @@ export const de = {
   kamino_earn_deposited: 'Eingezahlt: {{amount}}',
   kamino_earn_earned: 'Verdient: {{amount}}',
   kamino_earn_protocol: 'Kamino',
+  on_chain: 'auf {{chain}}',
+  max_total_fee: 'Maximale Gesamtgebühr',
 }

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -390,6 +390,7 @@ export const en = {
   error_message: 'Error message',
   est_network_fee: 'Est. Network Fee',
   expand_view: 'Expand View',
+  on_chain: 'on {{chain}}',
   open_as_side_panel: 'Open as Side Panel',
   push_notifications: 'Push Notifications',
   push_notifications_description:
@@ -652,6 +653,7 @@ export const en = {
   max: 'Max',
   max_4_characters: 'Max 4 characters',
   max_supply: 'Max Supply',
+  max_total_fee: 'Max. Total Fee',
   memo: 'Memo',
   message: 'Message',
   message_required: 'Message is required',

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -1928,4 +1928,6 @@ export const es = {
   kamino_earn_deposited: 'Depositado: {{amount}}',
   kamino_earn_earned: 'Ganado: {{amount}}',
   kamino_earn_protocol: 'Kamino',
+  on_chain: 'en {{chain}}',
+  max_total_fee: 'Tarifa total máxima',
 }

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -1898,4 +1898,6 @@ export const hr = {
   kamino_earn_deposited: 'Položeno: {{amount}}',
   kamino_earn_earned: 'Zarađeno: {{amount}}',
   kamino_earn_protocol: 'Kamino',
+  on_chain: 'na {{chain}}',
+  max_total_fee: 'Maks. ukupna naknada',
 }

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -1934,4 +1934,6 @@ export const it = {
   kamino_earn_deposited: 'Depositato: {{amount}}',
   kamino_earn_earned: 'Guadagnato: {{amount}}',
   kamino_earn_protocol: 'Kamino',
+  on_chain: 'su {{chain}}',
+  max_total_fee: 'Tariffa totale massima',
 }

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -1888,4 +1888,6 @@ export const ko = {
   kamino_earn_deposited: '예치됨: {{amount}}',
   kamino_earn_earned: '수익: {{amount}}',
   kamino_earn_protocol: 'Kamino',
+  on_chain: '{{chain}} 에서',
+  max_total_fee: '최대 총 수수료',
 }

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -1911,4 +1911,6 @@ export const nl = {
   kamino_earn_deposited: 'Gestort: {{amount}}',
   kamino_earn_earned: 'Verdiend: {{amount}}',
   kamino_earn_protocol: 'Kamino',
+  on_chain: 'op {{chain}}',
+  max_total_fee: 'Maximale totale kosten',
 }

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -1931,4 +1931,6 @@ export const pt = {
   kamino_earn_deposited: 'Depositado: {{amount}}',
   kamino_earn_earned: 'Ganho: {{amount}}',
   kamino_earn_protocol: 'Kamino',
+  on_chain: 'em {{chain}}',
+  max_total_fee: 'Taxa máxima total',
 }

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -1907,4 +1907,6 @@ export const ru = {
   kamino_earn_deposited: 'Внесено: {{amount}}',
   kamino_earn_earned: 'Заработано: {{amount}}',
   kamino_earn_protocol: 'Kamino',
+  on_chain: 'на {{chain}}',
+  max_total_fee: 'Максимальная общая сумма комиссии',
 }

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -1772,4 +1772,6 @@ export const zh = {
   kamino_earn_deposited: '已存入：{{amount}}',
   kamino_earn_earned: '已获得：{{amount}}',
   kamino_earn_protocol: 'Kamino',
+  on_chain: '在{{chain}}上',
+  max_total_fee: '最高总费用',
 }

--- a/core/ui/mpc/keysign/join/tx/JoinKeysignLimitOrderVerify.tsx
+++ b/core/ui/mpc/keysign/join/tx/JoinKeysignLimitOrderVerify.tsx
@@ -7,6 +7,7 @@ import {
   HorizontalLine,
   IconWrapper,
 } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerify.styled'
+import { SwapVerifyFiatAmount } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerifyFiatAmount'
 import { borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { ArrowDownIcon } from '@lib/ui/icons/ArrowDownIcon'
 import { ClockIcon } from '@lib/ui/icons/ClockIcon'
@@ -25,7 +26,6 @@ import { useTranslation } from 'react-i18next'
 
 import { isOwnLimitOrderDestination } from './isOwnLimitOrderDestination'
 import { JoinKeysignNetworkFeeValue } from './JoinKeysignNetworkFeeValue'
-import { JoinSwapFiatAmount } from './JoinSwapFiatAmount'
 import { getLimitOrderBuyCoin } from './limitOrderBuyCoin'
 import { getLimitOrderUnitPriceLabel } from './limitOrderUnitPrice'
 import { getThorchainAssetTicker } from './thorchainAssetTicker'
@@ -55,7 +55,7 @@ const Leg = ({ coin, amount, ticker }: LegProps) => (
           {ticker}
         </Text>
       </Text>
-      {coin ? <JoinSwapFiatAmount coin={coin} amount={amount} /> : null}
+      {coin ? <SwapVerifyFiatAmount coin={coin} amount={amount} /> : null}
     </VStack>
   </HStack>
 )

--- a/core/ui/mpc/keysign/join/tx/JoinKeysignSwapVerify.tsx
+++ b/core/ui/mpc/keysign/join/tx/JoinKeysignSwapVerify.tsx
@@ -1,6 +1,5 @@
 import { ChainEntityIcon } from '@core/ui/chain/coin/icon/ChainEntityIcon'
 import { getSwapProviderLogoSrc } from '@core/ui/chain/metadata/getSwapProviderLogoSrc'
-import { KeysignFeeAmount } from '@core/ui/mpc/keysign/tx/FeeAmount'
 import { getSwapFeeFromPayload } from '@core/ui/mpc/keysign/tx/swap/getSwapFeeFromPayload'
 import { SwapFeeFiatValue } from '@core/ui/vault/swap/form/info/SwapTotalFeeFiatValue'
 import { getSwapToAmountLimit } from '@core/ui/vault/swap/keysignPayload/getSwapToAmountLimit'
@@ -24,6 +23,7 @@ import { formatAmount } from '@vultisig/lib-utils/formatAmount'
 import { getRecordUnionValue } from '@vultisig/lib-utils/record/union/getRecordUnionValue'
 import { useTranslation } from 'react-i18next'
 
+import { JoinKeysignNetworkFeeValue } from './JoinKeysignNetworkFeeValue'
 import { JoinKeysignSwapTotalFee } from './JoinKeysignSwapTotalFee'
 
 const logoSize = 14
@@ -113,7 +113,7 @@ export const JoinKeysignSwapVerify = ({ value }: ValueProp<KeysignPayload>) => {
         />
         <SwapVerifyRow
           label={t('network_fee')}
-          value={<KeysignFeeAmount keysignPayload={value} />}
+          value={<JoinKeysignNetworkFeeValue value={value} />}
         />
         {swapFee && (
           <>

--- a/core/ui/mpc/keysign/join/tx/JoinKeysignSwapVerify.tsx
+++ b/core/ui/mpc/keysign/join/tx/JoinKeysignSwapVerify.tsx
@@ -1,22 +1,17 @@
 import { ChainEntityIcon } from '@core/ui/chain/coin/icon/ChainEntityIcon'
-import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { getSwapProviderLogoSrc } from '@core/ui/chain/metadata/getSwapProviderLogoSrc'
 import { KeysignFeeAmount } from '@core/ui/mpc/keysign/tx/FeeAmount'
 import { getSwapFeeFromPayload } from '@core/ui/mpc/keysign/tx/swap/getSwapFeeFromPayload'
-import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { SwapFeeFiatValue } from '@core/ui/vault/swap/form/info/SwapTotalFeeFiatValue'
 import { getSwapToAmountLimit } from '@core/ui/vault/swap/keysignPayload/getSwapToAmountLimit'
-import {
-  ContainerWrapper,
-  HorizontalLine,
-  IconWrapper,
-} from '@core/ui/vault/swap/verify/SwapVerify/SwapVerify.styled'
+import { SwapVerifyAmount } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerifyAmount'
+import { SwapVerifyCard } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerifyCard'
+import { SwapVerifyChainChip } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerifyChainChip'
 import { SwapVerifyRecipient } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerifyRecipient'
-import { borderRadiusPx } from '@lib/ui/css/borderRadius'
-import { ArrowDownIcon } from '@lib/ui/icons/ArrowDownIcon'
+import { SwapVerifyRow } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerifyRow'
+import { SwapVerifyToDivider } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerifyToDivider'
+import { SwapVerifyVaultRow } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerifyVaultRow'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
-import { List } from '@lib/ui/list'
-import { ListItem } from '@lib/ui/list/item'
 import { ValueProp } from '@lib/ui/props'
 import { Text } from '@lib/ui/text'
 import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
@@ -26,12 +21,12 @@ import { fromCommCoin } from '@vultisig/core-mpc/types/utils/commCoin'
 import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { formatAmount } from '@vultisig/lib-utils/formatAmount'
-import { formatWalletAddress } from '@vultisig/lib-utils/formatWalletAddress'
 import { getRecordUnionValue } from '@vultisig/lib-utils/record/union/getRecordUnionValue'
 import { useTranslation } from 'react-i18next'
 
 import { JoinKeysignSwapTotalFee } from './JoinKeysignSwapTotalFee'
-import { JoinSwapFiatAmount } from './JoinSwapFiatAmount'
+
+const logoSize = 14
 
 /**
  * Joiner verify view for a swap. Carries the same cost breakdown and signing
@@ -45,7 +40,6 @@ import { JoinSwapFiatAmount } from './JoinSwapFiatAmount'
  */
 export const JoinKeysignSwapVerify = ({ value }: ValueProp<KeysignPayload>) => {
   const { t } = useTranslation()
-  const vault = useCurrentVault()
 
   const swapPayload = shouldBePresent(
     getKeysignSwapPayload(value),
@@ -77,124 +71,68 @@ export const JoinKeysignSwapVerify = ({ value }: ValueProp<KeysignPayload>) => {
 
   return (
     <>
-      <ContainerWrapper radius={borderRadiusPx.lg}>
-        <VStack
-          bgColor="foreground"
-          gap={24}
-          padding={24}
-          radius={borderRadiusPx.lg}
-        >
+      <SwapVerifyCard>
+        <VStack gap={24} padding={24}>
           <Text color="supporting" size={15}>
             {t('youre_swapping')}
           </Text>
           <VStack gap={16}>
-            <HStack gap={12} alignItems="center">
-              <CoinIcon coin={fromCoin} style={{ fontSize: 32 }} />
-              <VStack gap={2}>
-                <Text weight="500" size={17} color="contrast">
-                  {formatAmount(fromAmountDecimal, fromCoin)}
-                </Text>
-                <JoinSwapFiatAmount
-                  coin={fromCoin}
-                  amount={fromAmountDecimal}
-                />
-              </VStack>
-            </HStack>
-            <HStack alignItems="center" gap={10}>
-              <IconWrapper>
-                <ArrowDownIcon />
-              </IconWrapper>
-              {t('swap_expected_payout')}
-              <HorizontalLine />
-            </HStack>
+            <SwapVerifyAmount coin={fromCoin} amount={fromAmountDecimal} />
+            <SwapVerifyToDivider />
             {toCoin && (
-              <HStack gap={12} alignItems="center">
-                <CoinIcon coin={toCoin} style={{ fontSize: 32 }} />
-                <VStack gap={2}>
-                  <Text weight="500" size={17} color="contrast">
-                    {formatAmount(toAmount, toCoin)}
-                  </Text>
-                  <JoinSwapFiatAmount coin={toCoin} amount={toAmount} />
-                  {toAmountLimit !== null && (
-                    <Text size={13} color="shy">
-                      {`${t('to_min_payout')}: ${formatAmount(
+              <SwapVerifyAmount
+                coin={toCoin}
+                amount={toAmount}
+                caption={
+                  toAmountLimit === null
+                    ? undefined
+                    : `${t('to_min_payout')}: ${formatAmount(
                         toAmountLimit,
                         toCoin
-                      )}`}
-                    </Text>
-                  )}
-                </VStack>
-              </HStack>
+                      )}`
+                }
+                extra={<SwapVerifyChainChip value={toCoin.chain} />}
+              />
             )}
           </VStack>
         </VStack>
-      </ContainerWrapper>
-      <VStack
-        bgColor="foreground"
-        gap={12}
-        padding={12}
-        radius={borderRadiusPx.lg}
-      >
-        <List>
-          <ListItem
-            hoverable={false}
-            title={t('provider')}
-            extra={
-              <HStack alignItems="center" gap={6}>
-                {providerLogoSrc ? (
-                  <ChainEntityIcon
-                    value={providerLogoSrc}
-                    style={{ fontSize: 16 }}
-                  />
-                ) : null}
-                <Text color="shy">{provider}</Text>
-              </HStack>
-            }
-          />
-          <ListItem
-            hoverable={false}
-            title={t('network_fee')}
-            extra={<KeysignFeeAmount keysignPayload={value} />}
-          />
-          {swapFee && (
-            <>
-              <ListItem
-                hoverable={false}
-                title={t('swap_fee')}
-                extra={
-                  <Text color="shy">
-                    <SwapFeeFiatValue value={[swapFee]} />
-                  </Text>
-                }
-              />
-              <ListItem
-                hoverable={false}
-                title={t('total_fee')}
-                extra={
-                  <Text color="supporting">
-                    <JoinKeysignSwapTotalFee
-                      keysignPayload={value}
-                      swapFee={swapFee}
-                    />
-                  </Text>
-                }
-              />
-            </>
-          )}
-          <ListItem
-            hoverable={false}
-            title={t('vault')}
-            extra={
-              <Text color="contrast">
-                {vault.name}{' '}
-                <Text as="span" color="shy">
-                  ({formatWalletAddress(fromCoin.address)})
-                </Text>
-              </Text>
-            }
-          />
-        </List>
-      </VStack>
+        <SwapVerifyVaultRow value={fromCoin.address} />
+        <SwapVerifyRow
+          label={t('provider')}
+          value={
+            <HStack alignItems="center" gap={6} justifyContent="end">
+              {providerLogoSrc ? (
+                <ChainEntityIcon
+                  value={providerLogoSrc}
+                  style={{ fontSize: logoSize }}
+                />
+              ) : null}
+              <Text cropped>{provider}</Text>
+            </HStack>
+          }
+        />
+        <SwapVerifyRow
+          label={t('network_fee')}
+          value={<KeysignFeeAmount keysignPayload={value} />}
+        />
+        {swapFee && (
+          <>
+            <SwapVerifyRow
+              label={t('swap_fee')}
+              value={<SwapFeeFiatValue value={[swapFee]} />}
+            />
+            <SwapVerifyRow
+              label={t('max_total_fee')}
+              value={
+                <JoinKeysignSwapTotalFee
+                  keysignPayload={value}
+                  swapFee={swapFee}
+                />
+              }
+            />
+          </>
+        )}
+      </SwapVerifyCard>
       <SwapVerifyRecipient keysignPayload={value} />
     </>
   )

--- a/core/ui/vault/swap/form/info/SwapNetworkFeeRow.tsx
+++ b/core/ui/vault/swap/form/info/SwapNetworkFeeRow.tsx
@@ -40,11 +40,11 @@ export const SwapNetworkFeeRow = ({
         value:
           layout === 'stacked' ? (
             <VStack alignItems="end" gap={2}>
-              <Text color="contrast" weight="500">
+              <Text color="contrast" size={14}>
                 {amount}
               </Text>
-              <Text color="shy">
-                ~<SwapFeeFiatValue value={[fee]} />
+              <Text color="shy" size={13}>
+                <SwapFeeFiatValue value={[fee]} />
               </Text>
             </VStack>
           ) : (

--- a/core/ui/vault/swap/form/info/SwapNetworkFeeRow.tsx
+++ b/core/ui/vault/swap/form/info/SwapNetworkFeeRow.tsx
@@ -1,3 +1,4 @@
+import { VStack } from '@lib/ui/layout/Stack'
 import { Text } from '@lib/ui/text'
 import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
@@ -11,33 +12,52 @@ import { SwapFeeFiatValue } from './SwapTotalFeeFiatValue'
 type SwapNetworkFeeRowProps = {
   renderRow: SwapFeeRowRenderer
   fee: SwapFee
+  /**
+   * `stacked` puts the fiat estimate on its own line under the gas amount, for
+   * the roomier rows of the approval card. The form's collapsed breakdown has
+   * no such room and keeps both on one line.
+   */
+  layout?: 'inline' | 'stacked'
 }
 
 /** Source-chain gas, shown in the fee coin alongside its fiat estimate. */
 export const SwapNetworkFeeRow = ({
   renderRow,
   fee,
+  layout = 'inline',
 }: SwapNetworkFeeRowProps) => {
   const { t } = useTranslation()
   const { ticker } = chainFeeCoin[fee.chain]
+
+  const amount = formatAmount(fromChainAmount(fee.amount, fee.decimals), {
+    ticker,
+  })
 
   return (
     <>
       {renderRow({
         label: t('network_fee'),
-        value: (
-          <>
-            <Text as="span" color="regular" weight="500">
-              {formatAmount(fromChainAmount(fee.amount, fee.decimals), {
-                ticker,
-              })}
-            </Text>{' '}
-            <Text as="span" color="shy">
-              (~
-              <SwapFeeFiatValue value={[fee]} />)
-            </Text>
-          </>
-        ),
+        value:
+          layout === 'stacked' ? (
+            <VStack alignItems="end" gap={2}>
+              <Text color="contrast" weight="500">
+                {amount}
+              </Text>
+              <Text color="shy">
+                ~<SwapFeeFiatValue value={[fee]} />
+              </Text>
+            </VStack>
+          ) : (
+            <>
+              <Text as="span" color="regular" weight="500">
+                {amount}
+              </Text>{' '}
+              <Text as="span" color="shy">
+                (~
+                <SwapFeeFiatValue value={[fee]} />)
+              </Text>
+            </>
+          ),
       })}
     </>
   )

--- a/core/ui/vault/swap/form/info/VerifySwapFees.tsx
+++ b/core/ui/vault/swap/form/info/VerifySwapFees.tsx
@@ -1,18 +1,18 @@
 import { ChainEntityIcon } from '@core/ui/chain/coin/icon/ChainEntityIcon'
 import { getSwapProviderLogoSrc } from '@core/ui/chain/metadata/getSwapProviderLogoSrc'
-import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { getSwapQuoteAffiliateBps } from '@core/ui/vault/swap/affiliate/affiliateBps'
 import { SwapDiscountInfo } from '@core/ui/vault/swap/form/info/SwapDiscountInfo'
-import { SwapFeeRowRenderer } from '@core/ui/vault/swap/form/info/swapFeeRow'
 import { SwapNetworkFeeRow } from '@core/ui/vault/swap/form/info/SwapNetworkFeeRow'
 import { SwapPriceImpactRow } from '@core/ui/vault/swap/form/info/SwapPriceImpactRow'
 import { SwapProviderFeeRows } from '@core/ui/vault/swap/form/info/SwapProviderFeeRows'
 import { SwapFeeFiatValue } from '@core/ui/vault/swap/form/info/SwapTotalFeeFiatValue'
 import { getSwapFeeEntries } from '@core/ui/vault/swap/queries/resolveSwapFees'
 import { useSwapFeesQuery } from '@core/ui/vault/swap/queries/useSwapFeesQuery'
+import {
+  renderSwapVerifyRow,
+  SwapVerifyRow,
+} from '@core/ui/vault/swap/verify/SwapVerify/SwapVerifyRow'
 import { HStack } from '@lib/ui/layout/Stack'
-import { List } from '@lib/ui/list'
-import { ListItem } from '@lib/ui/list/item'
 import { Skeleton } from '@lib/ui/loaders/Skeleton'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
 import { Text } from '@lib/ui/text'
@@ -29,72 +29,63 @@ type VerifySwapFeesProps = {
   swapQuote: SwapQuote
 }
 
-const renderRow: SwapFeeRowRenderer = ({ label, value }) => (
-  <ListItem
-    extra={<Text color="shy">{value}</Text>}
-    hoverable={false}
-    title={label}
-  />
-)
-
 /**
- * Cost breakdown shown at the moment of approval, in the order iOS uses:
- * provider, network, the product's own cut, protocol, discounts, price impact,
- * total, then the vault the swap signs from.
+ * Cost breakdown shown at the moment of approval: provider, network, the
+ * product's own cut, protocol, discounts, price impact, then the total. The
+ * vault that pays is rendered by the card above it, since a joiner carries no
+ * quote to derive these rows from but still names the same signing vault.
  */
 export const VerifySwapFees: FC<VerifySwapFeesProps> = ({ swapQuote }) => {
   const { t } = useTranslation()
-  const vault = useCurrentVault()
   const query = useSwapFeesQuery(swapQuote)
   const affiliateBps = getSwapQuoteAffiliateBps(swapQuote.discounts)
   const provider = getSwapQuoteProviderName(swapQuote)
   const providerLogoSrc = getSwapProviderLogoSrc(provider)
 
   return (
-    <List>
-      <ListItem
-        extra={
-          <HStack alignItems="center" gap={6}>
+    <>
+      <SwapVerifyRow
+        label={t('provider')}
+        value={
+          <HStack alignItems="center" gap={6} justifyContent="end">
             {providerLogoSrc ? (
               <ChainEntityIcon
                 value={providerLogoSrc}
                 style={{ fontSize: logoSize }}
               />
             ) : null}
-            <Text color="shy" cropped>
-              {provider}
-            </Text>
+            <Text cropped>{provider}</Text>
           </HStack>
         }
-        hoverable={false}
-        title={t('provider')}
       />
       <MatchQuery
         value={query}
         pending={() => (
-          <ListItem
-            extra={<Skeleton width="48px" height="12px" />}
-            hoverable={false}
-            title={t('network_fee')}
+          <SwapVerifyRow
+            label={t('network_fee')}
+            value={<Skeleton width="48px" height="12px" />}
           />
         )}
         error={() => (
-          <ListItem
-            extra={<Text color="danger">{t('failed_to_load')}</Text>}
-            hoverable={false}
-            title={t('network_fee')}
+          <SwapVerifyRow
+            label={t('network_fee')}
+            value={<Text color="danger">{t('failed_to_load')}</Text>}
           />
         )}
         success={fees => (
           <>
-            <SwapNetworkFeeRow renderRow={renderRow} fee={fees.network} />
+            <SwapNetworkFeeRow
+              renderRow={renderSwapVerifyRow}
+              fee={fees.network}
+              layout="stacked"
+            />
             <SwapProviderFeeRows
-              renderRow={renderRow}
+              renderRow={renderSwapVerifyRow}
               fees={fees}
               affiliateBps={affiliateBps}
             />
             <SwapDiscountInfo
-              renderRow={renderRow}
+              renderRow={renderSwapVerifyRow}
               discounts={swapQuote.discounts}
               affiliate={fees.affiliate}
               notional={fees.affiliateNotional}
@@ -103,28 +94,23 @@ export const VerifySwapFees: FC<VerifySwapFeesProps> = ({ swapQuote }) => {
           </>
         )}
       />
-      <SwapPriceImpactRow renderRow={renderRow} quote={swapQuote.quote} />
-      <ListItem
-        extra={
+      <SwapPriceImpactRow
+        renderRow={renderSwapVerifyRow}
+        quote={swapQuote.quote}
+      />
+      <SwapVerifyRow
+        label={t('max_total_fee')}
+        value={
           <MatchQuery
             value={query}
             pending={() => <Skeleton width="88px" height="12px" />}
             error={() => <Text color="danger">{t('failed_to_load')}</Text>}
             success={value => (
-              <Text color="supporting">
-                <SwapFeeFiatValue value={getSwapFeeEntries(value)} />
-              </Text>
+              <SwapFeeFiatValue value={getSwapFeeEntries(value)} />
             )}
           />
         }
-        hoverable={false}
-        title={t('total_fee')}
       />
-      <ListItem
-        extra={<Text color="shy">{vault.name}</Text>}
-        hoverable={false}
-        title={t('vault')}
-      />
-    </List>
+    </>
   )
 }

--- a/core/ui/vault/swap/verify/SwapVerify/SwapVerifyAmount.tsx
+++ b/core/ui/vault/swap/verify/SwapVerify/SwapVerifyAmount.tsx
@@ -1,0 +1,47 @@
+import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
+import { SwapVerifyFiatAmount } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerifyFiatAmount'
+import { HStack, VStack } from '@lib/ui/layout/Stack'
+import { Text } from '@lib/ui/text'
+import { Coin } from '@vultisig/core-chain/coin/Coin'
+import { formatAmount } from '@vultisig/lib-utils/formatAmount'
+import { ReactNode } from 'react'
+
+/** Coin icon size of a trade side, shared so a placeholder row lines up with it. */
+export const swapVerifyCoinIconSize = 32
+
+type SwapVerifyAmountProps = {
+  coin: Coin
+  amount: number
+  /**
+   * Qualifier printed above the amount — the guaranteed floor a native swap
+   * carries. It sits above rather than below because it conditions the number
+   * it precedes, and a signer who has already read past the amount has read
+   * past the only figure the trade actually guarantees.
+   */
+  caption?: ReactNode
+  extra?: ReactNode
+}
+
+/** One side of the trade: coin, amount, and its fiat estimate. */
+export const SwapVerifyAmount = ({
+  coin,
+  amount,
+  caption,
+  extra,
+}: SwapVerifyAmountProps) => (
+  <HStack gap={12} alignItems="center" fullWidth>
+    <CoinIcon coin={coin} style={{ fontSize: swapVerifyCoinIconSize }} />
+    <VStack gap={2} flexGrow>
+      {caption && (
+        <Text color="shy" size={13}>
+          {caption}
+        </Text>
+      )}
+      <Text weight="500" size={17} color="contrast">
+        {formatAmount(amount, coin)}
+      </Text>
+      <SwapVerifyFiatAmount coin={coin} amount={amount} />
+    </VStack>
+    {extra}
+  </HStack>
+)

--- a/core/ui/vault/swap/verify/SwapVerify/SwapVerifyCard.tsx
+++ b/core/ui/vault/swap/verify/SwapVerify/SwapVerifyCard.tsx
@@ -1,0 +1,18 @@
+import { borderRadiusPx } from '@lib/ui/css/borderRadius'
+import { VStack } from '@lib/ui/layout/Stack'
+import { ChildrenProp } from '@lib/ui/props'
+
+import { ContainerWrapper } from './SwapVerify.styled'
+
+/**
+ * The single surface a swap is approved on. The amounts and every cost row
+ * share one card, so a signer reads what the swap pays in the same frame as
+ * what it returns rather than pairing two cards to price the trade.
+ */
+export const SwapVerifyCard = ({ children }: ChildrenProp) => (
+  <ContainerWrapper radius={borderRadiusPx.lg}>
+    <VStack bgColor="foreground" radius={borderRadiusPx.lg}>
+      {children}
+    </VStack>
+  </ContainerWrapper>
+)

--- a/core/ui/vault/swap/verify/SwapVerify/SwapVerifyChainChip.tsx
+++ b/core/ui/vault/swap/verify/SwapVerify/SwapVerifyChainChip.tsx
@@ -1,0 +1,30 @@
+import { ChainEntityIcon } from '@core/ui/chain/coin/icon/ChainEntityIcon'
+import { getChainLogoSrc } from '@core/ui/chain/metadata/getChainLogoSrc'
+import { HStack } from '@lib/ui/layout/Stack'
+import { ValueProp } from '@lib/ui/props'
+import { Text } from '@lib/ui/text'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { useTranslation } from 'react-i18next'
+
+const logoSize = 20
+
+/**
+ * Names the network a swap amount settles on. A ticker alone does not say which
+ * chain the asset lives on, and a payout that lands on the wrong one is not
+ * recoverable — so the destination states its chain at the point of approval.
+ */
+export const SwapVerifyChainChip = ({ value }: ValueProp<Chain>) => {
+  const { t } = useTranslation()
+
+  return (
+    <HStack alignItems="center" gap={6}>
+      <ChainEntityIcon
+        value={getChainLogoSrc(value)}
+        style={{ fontSize: logoSize }}
+      />
+      <Text color="shy" size={13} cropped>
+        {t('on_chain', { chain: value })}
+      </Text>
+    </HStack>
+  )
+}

--- a/core/ui/vault/swap/verify/SwapVerify/SwapVerifyFiatAmount.tsx
+++ b/core/ui/vault/swap/verify/SwapVerify/SwapVerifyFiatAmount.tsx
@@ -6,7 +6,7 @@ import { text } from '@lib/ui/text'
 import { Coin } from '@vultisig/core-chain/coin/Coin'
 import styled from 'styled-components'
 
-type JoinSwapFiatAmountProps = {
+type SwapVerifyFiatAmountProps = {
   coin: Coin
   amount: number
 }
@@ -18,10 +18,16 @@ const Container = styled.span`
   })}
 `
 
-export const JoinSwapFiatAmount = ({
+/**
+ * Fiat estimate shown under a swap amount on the approval card. Prices the coin
+ * it is handed rather than looking one up in the vault, so the joiner — who
+ * holds only the payload's coins — renders through the same component as the
+ * initiator.
+ */
+export const SwapVerifyFiatAmount = ({
   coin,
   amount,
-}: JoinSwapFiatAmountProps) => {
+}: SwapVerifyFiatAmountProps) => {
   const query = useCoinPriceQuery({ coin })
   const formatFiatAmount = useFormatFiatAmount()
 

--- a/core/ui/vault/swap/verify/SwapVerify/SwapVerifyRow.tsx
+++ b/core/ui/vault/swap/verify/SwapVerify/SwapVerifyRow.tsx
@@ -1,0 +1,45 @@
+import { SwapFeeRowRenderer } from '@core/ui/vault/swap/form/info/swapFeeRow'
+import { HStack } from '@lib/ui/layout/Stack'
+import { Text } from '@lib/ui/text'
+import { getColor } from '@lib/ui/theme/getters'
+import { ReactNode } from 'react'
+import styled from 'styled-components'
+
+const Container = styled(HStack)`
+  align-items: center;
+  border-top: 1px solid ${getColor('foregroundExtra')};
+  gap: 16px;
+  justify-content: space-between;
+  min-height: 56px;
+  padding: 12px 24px;
+`
+
+const Value = styled(Text)`
+  text-align: right;
+`
+
+type SwapVerifyRowProps = {
+  label: ReactNode
+  value: ReactNode
+}
+
+/**
+ * One label/value line of the swap approval card. Separated by a hairline
+ * rather than boxed, so the cost rows read as part of the card the amounts sit
+ * in instead of as a list stacked beneath it.
+ */
+export const SwapVerifyRow = ({ label, value }: SwapVerifyRowProps) => (
+  <Container>
+    <Text color="shy" size={14}>
+      {label}
+    </Text>
+    <Value as="div" color="contrast" size={14} weight="500">
+      {value}
+    </Value>
+  </Container>
+)
+
+/** {@link SwapVerifyRow} in the shape the shared swap fee rows render through. */
+export const renderSwapVerifyRow: SwapFeeRowRenderer = ({ label, value }) => (
+  <SwapVerifyRow label={label} value={value} />
+)

--- a/core/ui/vault/swap/verify/SwapVerify/SwapVerifyToDivider.tsx
+++ b/core/ui/vault/swap/verify/SwapVerify/SwapVerifyToDivider.tsx
@@ -1,0 +1,25 @@
+import {
+  HorizontalLine,
+  IconWrapper,
+} from '@core/ui/vault/swap/verify/SwapVerify/SwapVerify.styled'
+import { ArrowDownIcon } from '@lib/ui/icons/ArrowDownIcon'
+import { HStack } from '@lib/ui/layout/Stack'
+import { Text } from '@lib/ui/text'
+import { useTranslation } from 'react-i18next'
+
+/** Separates the two sides of the trade and names the receiving side. */
+export const SwapVerifyToDivider = () => {
+  const { t } = useTranslation()
+
+  return (
+    <HStack alignItems="center" gap={10}>
+      <IconWrapper>
+        <ArrowDownIcon />
+      </IconWrapper>
+      <Text color="shy" size={14}>
+        {t('to')}
+      </Text>
+      <HorizontalLine />
+    </HStack>
+  )
+}

--- a/core/ui/vault/swap/verify/SwapVerify/SwapVerifyVaultRow.tsx
+++ b/core/ui/vault/swap/verify/SwapVerify/SwapVerifyVaultRow.tsx
@@ -1,0 +1,30 @@
+import { useCurrentVault } from '@core/ui/vault/state/currentVault'
+import { SwapVerifyRow } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerifyRow'
+import { ValueProp } from '@lib/ui/props'
+import { Text } from '@lib/ui/text'
+import { formatWalletAddress } from '@vultisig/lib-utils/formatWalletAddress'
+import { useTranslation } from 'react-i18next'
+
+/**
+ * The vault the swap signs from, named and addressed. Takes the sending
+ * address rather than deriving one, so the row states the account the funds
+ * actually leave instead of a vault-level default.
+ */
+export const SwapVerifyVaultRow = ({ value }: ValueProp<string>) => {
+  const { t } = useTranslation()
+  const { name } = useCurrentVault()
+
+  return (
+    <SwapVerifyRow
+      label={t('vault')}
+      value={
+        <>
+          {name}{' '}
+          <Text as="span" color="shy">
+            ({formatWalletAddress(value)})
+          </Text>
+        </>
+      }
+    />
+  )
+}

--- a/core/ui/vault/swap/verify/SwapVerify/index.tsx
+++ b/core/ui/vault/swap/verify/SwapVerify/index.tsx
@@ -2,7 +2,6 @@ import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { VerifyKeysignStart } from '@core/ui/mpc/keysign/start/VerifyKeysignStart'
 import { useCurrentVaultCoin } from '@core/ui/vault/state/currentVaultCoins'
-import { SwapFiatAmount } from '@core/ui/vault/swap/form/amount/SwapFiatAmount'
 import { VerifySwapFees } from '@core/ui/vault/swap/form/info/VerifySwapFees'
 import { getSwapToAmountLimit } from '@core/ui/vault/swap/keysignPayload/getSwapToAmountLimit'
 import { useSwapKeysignPayloadQuery } from '@core/ui/vault/swap/keysignPayload/query'
@@ -10,13 +9,14 @@ import { useFromAmount } from '@core/ui/vault/swap/state/fromAmount'
 import { useSwapFromCoin } from '@core/ui/vault/swap/state/fromCoin'
 import { useSwapToCoin } from '@core/ui/vault/swap/state/toCoin'
 import {
-  ContainerWrapper,
-  HorizontalLine,
-  IconWrapper,
-} from '@core/ui/vault/swap/verify/SwapVerify/SwapVerify.styled'
+  SwapVerifyAmount,
+  swapVerifyCoinIconSize,
+} from '@core/ui/vault/swap/verify/SwapVerify/SwapVerifyAmount'
+import { SwapVerifyCard } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerifyCard'
+import { SwapVerifyChainChip } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerifyChainChip'
 import { SwapVerifyRecipient } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerifyRecipient'
-import { borderRadiusPx } from '@lib/ui/css/borderRadius'
-import { ArrowDownIcon } from '@lib/ui/icons/ArrowDownIcon'
+import { SwapVerifyToDivider } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerifyToDivider'
+import { SwapVerifyVaultRow } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerifyVaultRow'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { PageHeader } from '@lib/ui/page/PageHeader'
 import { OnBackProp } from '@lib/ui/props'
@@ -47,6 +47,22 @@ export const SwapVerify = ({ swapQuote, onBack }: SwapVerifyProps) => {
 
   const translatedTerms = swapTerms.map(term => t(`swap_terms.${term}`))
 
+  const fromAmountDecimal = fromChainAmount(
+    shouldBePresent(fromAmount, 'fromAmount'),
+    fromCoin.decimals
+  )
+
+  // Keeps the payout coin on screen while its amount is still resolving, so
+  // the card does not collapse to a bare line and shift everything under it.
+  const renderToPlaceholder = (message: string) => (
+    <HStack gap={12} alignItems="center">
+      <CoinIcon coin={toCoin} style={{ fontSize: swapVerifyCoinIconSize }} />
+      <Text color="shy" size={15}>
+        {message}
+      </Text>
+    </HStack>
+  )
+
   return (
     <>
       <PageHeader
@@ -59,99 +75,51 @@ export const SwapVerify = ({ swapQuote, onBack }: SwapVerifyProps) => {
         terms={translatedTerms}
         swapQuote={swapQuote}
       >
-        <ContainerWrapper radius={borderRadiusPx.lg}>
-          <VStack
-            bgColor="foreground"
-            gap={24}
-            padding={24}
-            radius={borderRadiusPx.lg}
-          >
+        <SwapVerifyCard>
+          <VStack gap={24} padding={24}>
             <Text color="supporting" size={15}>
               {t('youre_swapping')}
             </Text>
             <VStack gap={16}>
-              <HStack gap={12} alignItems="center">
-                <CoinIcon coin={fromCoin} style={{ fontSize: 32 }} />
-                <VStack gap={2}>
-                  <Text weight="500" size={17} color="contrast">
-                    {formatAmount(
-                      fromChainAmount(
-                        shouldBePresent(fromAmount, 'fromAmount'),
-                        fromCoin.decimals
-                      ),
-                      fromCoin
-                    )}
-                  </Text>
-                  <SwapFiatAmount
-                    value={{
-                      ...fromCoinKey,
-                      amount: fromChainAmount(
-                        shouldBePresent(fromAmount, 'fromAmount'),
-                        fromCoin.decimals
-                      ),
-                    }}
-                  />
-                </VStack>
-              </HStack>
-              <HStack alignItems="center" gap={10}>
-                <IconWrapper>
-                  <ArrowDownIcon />
-                </IconWrapper>
-                {t('swap_expected_payout')}
-                <HorizontalLine />
-              </HStack>
-              <HStack gap={12} alignItems="center">
-                <CoinIcon coin={toCoin} style={{ fontSize: 32 }} />
-                <MatchQuery
-                  value={keysignPayloadQuery}
-                  error={() => t('failed_to_load')}
-                  pending={() => t('loading')}
-                  success={keysignPayload => {
-                    const swapPayload = shouldBePresent(
-                      getKeysignSwapPayload(keysignPayload),
-                      'swap payload'
-                    )
-                    const { toAmountDecimal } = getRecordUnionValue(swapPayload)
-                    const toAmountLimit = getSwapToAmountLimit({
-                      swapPayload,
-                      toCoin,
-                    })
+              <SwapVerifyAmount coin={fromCoin} amount={fromAmountDecimal} />
+              <SwapVerifyToDivider />
+              <MatchQuery
+                value={keysignPayloadQuery}
+                error={() => renderToPlaceholder(t('failed_to_load'))}
+                pending={() => renderToPlaceholder(t('loading'))}
+                success={keysignPayload => {
+                  const swapPayload = shouldBePresent(
+                    getKeysignSwapPayload(keysignPayload),
+                    'swap payload'
+                  )
+                  const { toAmountDecimal } = getRecordUnionValue(swapPayload)
+                  const toAmountLimit = getSwapToAmountLimit({
+                    swapPayload,
+                    toCoin,
+                  })
 
-                    return (
-                      <VStack gap={2}>
-                        <Text weight="500" size={17} color="contrast">
-                          {formatAmount(parseFloat(toAmountDecimal), toCoin)}
-                        </Text>
-                        <SwapFiatAmount
-                          value={{
-                            ...toCoin,
-                            amount: parseFloat(toAmountDecimal),
-                          }}
-                        />
-                        {toAmountLimit !== null && (
-                          <Text size={13} color="shy">
-                            {`${t('to_min_payout')}: ${formatAmount(
+                  return (
+                    <SwapVerifyAmount
+                      coin={toCoin}
+                      amount={parseFloat(toAmountDecimal)}
+                      caption={
+                        toAmountLimit === null
+                          ? undefined
+                          : `${t('to_min_payout')}: ${formatAmount(
                               toAmountLimit,
                               toCoin
-                            )}`}
-                          </Text>
-                        )}
-                      </VStack>
-                    )
-                  }}
-                />
-              </HStack>
+                            )}`
+                      }
+                      extra={<SwapVerifyChainChip value={toCoin.chain} />}
+                    />
+                  )
+                }}
+              />
             </VStack>
           </VStack>
-        </ContainerWrapper>
-        <VStack
-          bgColor="foreground"
-          gap={24}
-          padding={12}
-          radius={borderRadiusPx.lg}
-        >
+          <SwapVerifyVaultRow value={fromCoin.address} />
           <VerifySwapFees swapQuote={swapQuote} />
-        </VStack>
+        </SwapVerifyCard>
         <MatchQuery
           value={keysignPayloadQuery}
           success={keysignPayload => (


### PR DESCRIPTION
## Description

The swap approval screen split the trade across two cards — amounts in one, costs in another, with the signing vault stranded at the bottom of the second. A signer had to hold the payout in mind while reading the price of getting it, and the payout's chain was never stated at all: a ticker alone does not say which network the funds land on, and a payout that lands on the wrong one is not recoverable.

Everything now sits on one card, in the order the Figma overview linked from the issue reads: what is spent, what comes back and on which chain, then the vault that pays and each cost down to the total.

- `expected payout` → `To` (reuses the existing `to` key rather than adding one)
- min. payout moves **above** the amount it qualifies instead of trailing it
- an `on <chain>` chip on the payout, so the receiving network is stated at the point of approval
- rows reordered to Vault → Provider → Network Fee → fees → total, with the vault now carrying its sending address
- `Total Fees` → `Max. Total Fee` — it is a ceiling, not a settled figure
- network fee stacks its fiat estimate under the gas amount on both screens

The joiner's view is rebuilt from the same components, so a co-signer reads the swap in the shape the initiator approved it in. Seven small shared pieces (`SwapVerifyCard`, `SwapVerifyRow`, `SwapVerifyAmount`, `SwapVerifyChainChip`, `SwapVerifyToDivider`, `SwapVerifyVaultRow`, `SwapVerifyFiatAmount`) now back both screens, and a duplicated fiat-amount component was folded into one.

Fixes #4700

### Two deliberate deviations from the mock

**The itemized fee rows stay.** The mock shows a single `Swap Fee`; the screen keeps the product's own cut with its percentage, plus protocol, referral, discount and price-impact rows. Those render conditionally, so most routes look like the mock — but dropping them would be a real regression in cost disclosure, and the product-named row was named that way on purpose (see `SwapProviderFeeRows`).

**The joiner's fee row keeps a neutral name.** The initiator says `Vultisig Swap Fee (0.5%)`; the joiner says `Swap Fee`. On a native swap the payload carries `fees.total` — the protocol's cut and ours together — so borrowing the brand-named label would claim money we do not take. This is the conflation `resolveSwapFees` documents as a past bug.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [x] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

No tx link: nothing about transaction construction, fee computation or the keysign payload changed — the diff is presentation only, and no swap was signed to produce one.

## Parity

Presentation-only alignment to the shared Figma; no behaviour, payload or fee arithmetic changed, so there is nothing for a sibling platform to reimplement. The issue reports the divergence as desktop/extension-specific.

- iOS: n/a — brings desktop/extension to the design the shared Figma already specifies
- Android: n/a — same
- SDK: n/a — no SDK surface touched

> Note: the sibling repos were not reachable from the environment this PR was prepared in, so these verdicts rest on the issue's framing rather than a check of the other codebases. Worth a second look before merge.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

`yarn check` clean (typecheck, lint, knip, i18n integrity) and `yarn test` green at 1163 tests. No tests added: the change is layout and wording on two screens with no rendering coverage in this repo, and a snapshot of a card is not evidence it matches a design.

## Screenshots (if applicable):

Not attached — the change was verified by reading the composition and by an extension build loaded locally; no screenshot tooling was available in the session that wrote it. Compare against the Figma frame linked in #4700.

## Additional context

New i18n keys `max_total_fee` and `on_chain`, propagated to all nine locales with `yarn translate`.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #4700
- **Confidence**: high on structure, wording and row order; medium on pixel-level spacing, which was not visually diffed against Figma
- **Needs human review for**: the visual match against the Figma frame, and the two deviations called out above

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved swap verification with clearer cards, amount details, chain labels, vault information, and fee breakdowns.
  * Added support for displaying network fees, swap fees, discounts, price impact, and maximum total fees.
  * Added stacked layouts for fee details where needed.
* **Localization**
  * Added translations for on-chain labels and maximum total fees across supported languages.
* **UI Improvements**
  * Standardized swap and join verification displays for a more consistent experience.
  * Improved loading and error-state presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->