### PR TITLE
fix(extension): fail loudly on unsignable EIP-712 payloads, add signTypedData aliases

### DIFF
--- a/clients/extension/src/inpage/providers/ethereum/handlers.ts
+++ b/clients/extension/src/inpage/providers/ethereum/handlers.ts
@@ -30,6 +30,12 @@ import { watchAsset } from './resolvers/wallet_watchAsset'
 
 export { processSignature } from './utils'
 
+/**
+ * EIP-1193 request handlers keyed by method name. `eth_signTypedData` and
+ * `eth_signTypedData_v3` alias the v4 resolver for MetaMask parity: EIP-712
+ * hashing is identical for v3-compatible payloads, and V1 array payloads are
+ * rejected there with a descriptive error instead of `UnsupportedMethod`.
+ */
 export const ethereumHandlers = {
   eth_chainId: getEthChainId,
   eth_accounts: getEthAccounts,
@@ -57,6 +63,8 @@ export const ethereumHandlers = {
   eth_call: callEth,
   eth_getTransactionReceipt: getEthTransactionReceipt,
   eth_getTransactionByHash: getEthTransactionByHash,
+  eth_signTypedData: signEthTypedDataV4,
+  eth_signTypedData_v3: signEthTypedDataV4,
   eth_signTypedData_v4: signEthTypedDataV4,
   personal_sign: personalSign,
   eth_sendTransaction: sendEthTransaction,

--- a/clients/extension/src/inpage/providers/ethereum/resolvers/eth_signTypedData_v4.ts
+++ b/clients/extension/src/inpage/providers/ethereum/resolvers/eth_signTypedData_v4.ts
@@ -1,4 +1,3 @@
-import { EIP1193Error } from '@clients/extension/src/background/handlers/errorHandler'
 import { callPopup } from '@core/inpage-provider/popup'
 import { getEip712PayloadIssue } from '@core/inpage-provider/popup/eip712'
 import {
@@ -7,6 +6,7 @@ import {
 } from '@core/inpage-provider/popup/interface'
 import { attempt, withFallback } from '@vultisig/lib-utils/attempt'
 
+import { EIP1193Error } from '../../../../background/handlers/errorHandler'
 import { getChain, processSignature } from '../utils'
 
 const evmAddressPattern = /^0x[0-9a-fA-F]{40}$/

--- a/clients/extension/src/inpage/providers/ethereum/resolvers/eth_signTypedData_v4.ts
+++ b/clients/extension/src/inpage/providers/ethereum/resolvers/eth_signTypedData_v4.ts
@@ -1,21 +1,76 @@
+import { EIP1193Error } from '@clients/extension/src/background/handlers/errorHandler'
 import { callPopup } from '@core/inpage-provider/popup'
+import { getEip712PayloadIssue } from '@core/inpage-provider/popup/eip712'
 import {
   Eip712V4Payload,
   isEip712V4Payload,
 } from '@core/inpage-provider/popup/interface'
+import { attempt, withFallback } from '@vultisig/lib-utils/attempt'
 
 import { getChain, processSignature } from '../utils'
 
-export const signEthTypedDataV4 = async ([account, input]: [
-  string,
+const evmAddressPattern = /^0x[0-9a-fA-F]{40}$/
+
+const isEvmAddress = (value: unknown): value is string =>
+  typeof value === 'string' && evmAddressPattern.test(value)
+
+/**
+ * Serves `eth_signTypedData_v4` and its `eth_signTypedData` /
+ * `eth_signTypedData_v3` aliases — v3-compatible payloads hash identically
+ * under EIP-712, so one pipeline covers all three. Params arrive as
+ * `[account, payload]` or `[payload, account]` depending on the dApp
+ * (MetaMask accepts both), so the account is detected by shape — a JSON
+ * payload can never look like an address. The payload is hash-checked up
+ * front so a malformed message (e.g. an empty string in a bytes field)
+ * rejects with a descriptive `InvalidParams` error at request time instead
+ * of failing mid-keysign after the user has approved.
+ */
+export const signEthTypedDataV4 = async ([first, second]: [
+  string | Eip712V4Payload,
   string | Eip712V4Payload,
 ]): Promise<string> => {
-  const chain = await getChain()
+  const [account, input] = isEvmAddress(first)
+    ? [first, second]
+    : [second, first]
 
-  const parsed = typeof input === 'string' ? JSON.parse(input) : input
-  if (!isEip712V4Payload(parsed)) {
-    throw new Error('Invalid eth_signTypedData_v4 payload')
+  if (!isEvmAddress(account)) {
+    throw new EIP1193Error(
+      'InvalidParams',
+      'eth_signTypedData params must include the signer address'
+    )
   }
+
+  const parsed =
+    typeof input === 'string'
+      ? withFallback(
+          attempt((): unknown => JSON.parse(input)),
+          undefined
+        )
+      : input
+
+  if (Array.isArray(parsed)) {
+    throw new EIP1193Error(
+      'InvalidParams',
+      'eth_signTypedData V1 array payloads are not supported; pass an EIP-712 object with domain, types, primaryType, and message'
+    )
+  }
+
+  if (!isEip712V4Payload(parsed)) {
+    throw new EIP1193Error(
+      'InvalidParams',
+      'Invalid eth_signTypedData_v4 payload'
+    )
+  }
+
+  const issue = getEip712PayloadIssue(parsed)
+  if (issue) {
+    throw new EIP1193Error(
+      'InvalidParams',
+      `Cannot sign EIP-712 payload: ${issue}`
+    )
+  }
+
+  const chain = await getChain()
 
   const result = await callPopup(
     {

--- a/clients/extension/tests/unit/ethereum-handlers.test.ts
+++ b/clients/extension/tests/unit/ethereum-handlers.test.ts
@@ -122,6 +122,8 @@ describe('ethereumHandlers map', () => {
     'eth_call',
     'eth_getTransactionReceipt',
     'eth_getTransactionByHash',
+    'eth_signTypedData',
+    'eth_signTypedData_v3',
     'eth_signTypedData_v4',
     'personal_sign',
     'eth_sendTransaction',
@@ -135,6 +137,15 @@ describe('ethereumHandlers map', () => {
 
   it('has exactly the expected number of methods (no extras)', () => {
     expect(Object.keys(ethereumHandlers)).toHaveLength(expectedMethods.length)
+  })
+
+  it('serves the signTypedData aliases with the v4 handler', () => {
+    expect(ethereumHandlers.eth_signTypedData).toBe(
+      ethereumHandlers.eth_signTypedData_v4
+    )
+    expect(ethereumHandlers.eth_signTypedData_v3).toBe(
+      ethereumHandlers.eth_signTypedData_v4
+    )
   })
 
   it('all handlers are functions', () => {

--- a/core/inpage-provider/popup/eip712.test.ts
+++ b/core/inpage-provider/popup/eip712.test.ts
@@ -64,6 +64,18 @@ describe('getEip712PayloadIssue', () => {
     expect(getEip712PayloadIssue(payload)).toContain('domain.salt')
   })
 
+  it('does not blame empty bytes for invalid bytesN widths', () => {
+    const payload = makePayload({
+      types: {
+        Order: [{ name: 'salt', type: 'bytes33' }],
+      },
+      message: { salt: '' },
+    })
+    const issue = getEip712PayloadIssue(payload)
+    expect(issue).toContain('invalid bytes width')
+    expect(issue).not.toContain('empty string in bytes field')
+  })
+
   it('falls back to the ethers message for non-bytes problems', () => {
     const payload = makePayload({
       types: {

--- a/core/inpage-provider/popup/eip712.test.ts
+++ b/core/inpage-provider/popup/eip712.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+
+import { findEmptyEip712BytesFields, getEip712PayloadIssue } from './eip712'
+import { Eip712V4Payload } from './interface'
+
+const makePayload = (
+  overrides: Partial<Eip712V4Payload> = {}
+): Eip712V4Payload => ({
+  primaryType: 'Order',
+  domain: {
+    name: 'Test',
+    version: '1',
+    chainId: 8453,
+    verifyingContract: `0x${'11'.repeat(20)}`,
+  },
+  types: {
+    Order: [
+      { name: 'maker', type: 'address' },
+      { name: 'salt', type: 'bytes32' },
+      { name: 'payload', type: 'bytes' },
+      { name: 'items', type: 'Item[]' },
+    ],
+    Item: [{ name: 'id', type: 'bytes32' }],
+  },
+  message: {
+    maker: `0x${'22'.repeat(20)}`,
+    salt: `0x${'00'.repeat(32)}`,
+    payload: '0x',
+    items: [{ id: `0x${'01'.repeat(32)}` }],
+  },
+  ...overrides,
+})
+
+const withMessage = (message: Record<string, unknown>) =>
+  makePayload({ message: { ...makePayload().message, ...message } })
+
+describe('getEip712PayloadIssue', () => {
+  it('accepts a signable payload, including "0x" for empty dynamic bytes', () => {
+    expect(getEip712PayloadIssue(makePayload())).toBeUndefined()
+  })
+
+  it('names a fixed-width bytes field holding an empty string', () => {
+    const issue = getEip712PayloadIssue(withMessage({ salt: '' }))
+    expect(issue).toContain('message.salt')
+    expect(issue).toContain('"0x"')
+  })
+
+  it('names a dynamic bytes field holding an empty string', () => {
+    expect(getEip712PayloadIssue(withMessage({ payload: '' }))).toContain(
+      'message.payload'
+    )
+  })
+
+  it('names an empty bytes field nested in a struct array', () => {
+    expect(
+      getEip712PayloadIssue(withMessage({ items: [{ id: '' }] }))
+    ).toContain('message.items[0].id')
+  })
+
+  it('names an empty domain salt', () => {
+    const payload = makePayload({
+      domain: { ...makePayload().domain, salt: '' },
+    })
+    expect(getEip712PayloadIssue(payload)).toContain('domain.salt')
+  })
+
+  it('falls back to the ethers message for non-bytes problems', () => {
+    const payload = makePayload({
+      types: {
+        Order: [{ name: 'amount', type: 'uint256' }],
+      },
+      message: { amount: '' },
+    })
+    const issue = getEip712PayloadIssue(payload)
+    expect(issue).toBeDefined()
+    expect(issue).not.toContain('bytes field')
+  })
+})
+
+describe('findEmptyEip712BytesFields', () => {
+  it('collects every empty bytes field across the payload', () => {
+    const payload = makePayload({
+      domain: { ...makePayload().domain, salt: '' },
+      message: {
+        maker: `0x${'22'.repeat(20)}`,
+        salt: '',
+        payload: '',
+        items: [{ id: `0x${'01'.repeat(32)}` }, { id: '' }],
+      },
+    })
+    expect(findEmptyEip712BytesFields(payload)).toEqual([
+      'message.salt',
+      'message.payload',
+      'message.items[1].id',
+      'domain.salt',
+    ])
+  })
+
+  it('returns nothing for a well-formed payload', () => {
+    expect(findEmptyEip712BytesFields(makePayload())).toEqual([])
+  })
+})

--- a/core/inpage-provider/popup/eip712.ts
+++ b/core/inpage-provider/popup/eip712.ts
@@ -5,7 +5,7 @@ import { TypedDataEncoder } from 'ethers'
 
 import { Eip712V4Payload } from './interface'
 
-const bytesTypePattern = /^bytes\d*$/
+const bytesTypePattern = /^bytes(?:[1-9]|[12]\d|3[0-2])?$/
 const arrayTypePattern = /^(.*)\[\d*\]$/
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -26,13 +26,19 @@ export const findEmptyEip712BytesFields = ({
 }: Eip712V4Payload): string[] => {
   const result: string[] = []
 
-  const visit = (type: string, value: unknown, path: string) => {
+  type VisitInput = {
+    type: string
+    value: unknown
+    path: string
+  }
+
+  const visit = ({ type, value, path }: VisitInput) => {
     const arrayMatch = type.match(arrayTypePattern)
     if (arrayMatch) {
       if (Array.isArray(value)) {
-        value.forEach((item, index) =>
-          visit(arrayMatch[1], item, `${path}[${index}]`)
-        )
+        for (const [index, item] of value.entries()) {
+          visit({ type: arrayMatch[1], value: item, path: `${path}[${index}]` })
+        }
       }
       return
     }
@@ -46,13 +52,13 @@ export const findEmptyEip712BytesFields = ({
 
     const fields = types[type]
     if (fields && isRecord(value)) {
-      fields.forEach(({ name, type: fieldType }) =>
-        visit(fieldType, value[name], `${path}.${name}`)
-      )
+      for (const { name, type: fieldType } of fields) {
+        visit({ type: fieldType, value: value[name], path: `${path}.${name}` })
+      }
     }
   }
 
-  visit(primaryType, message, 'message')
+  visit({ type: primaryType, value: message, path: 'message' })
 
   if (domain.salt === '') {
     result.push('domain.salt')

--- a/core/inpage-provider/popup/eip712.ts
+++ b/core/inpage-provider/popup/eip712.ts
@@ -1,0 +1,91 @@
+import { attempt } from '@vultisig/lib-utils/attempt'
+import { extractErrorMsg } from '@vultisig/lib-utils/error/extractErrorMsg'
+import { omit } from '@vultisig/lib-utils/record/omit'
+import { TypedDataEncoder } from 'ethers'
+
+import { Eip712V4Payload } from './interface'
+
+const bytesTypePattern = /^bytes\d*$/
+const arrayTypePattern = /^(.*)\[\d*\]$/
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+/**
+ * Dotted paths (rooted at `message`) of `bytes`/`bytesN` fields whose value
+ * is an empty string, plus `domain.salt` when it is one. MetaMask's signer
+ * tolerates `""` in bytes fields but ethers' `TypedDataEncoder` rejects it
+ * with a cryptic `invalid BytesLike value` error, so these fields are the
+ * usual reason a payload that works in other wallets cannot be hashed here.
+ */
+export const findEmptyEip712BytesFields = ({
+  primaryType,
+  domain,
+  types,
+  message,
+}: Eip712V4Payload): string[] => {
+  const result: string[] = []
+
+  const visit = (type: string, value: unknown, path: string) => {
+    const arrayMatch = type.match(arrayTypePattern)
+    if (arrayMatch) {
+      if (Array.isArray(value)) {
+        value.forEach((item, index) =>
+          visit(arrayMatch[1], item, `${path}[${index}]`)
+        )
+      }
+      return
+    }
+
+    if (bytesTypePattern.test(type)) {
+      if (value === '') {
+        result.push(path)
+      }
+      return
+    }
+
+    const fields = types[type]
+    if (fields && isRecord(value)) {
+      fields.forEach(({ name, type: fieldType }) =>
+        visit(fieldType, value[name], `${path}.${name}`)
+      )
+    }
+  }
+
+  visit(primaryType, message, 'message')
+
+  if (domain.salt === '') {
+    result.push('domain.salt')
+  }
+
+  return result
+}
+
+/**
+ * Why the payload cannot be hashed for signing, or `undefined` when it can.
+ * Runs the same ethers `TypedDataEncoder` hashing the keysign pipeline
+ * performs (see `getCustomMessageHex`), so an unsignable dApp payload is
+ * rejected at request time — with empty bytes fields called out by path —
+ * instead of failing deep in keysign after the user has already approved.
+ */
+export const getEip712PayloadIssue = (
+  payload: Eip712V4Payload
+): string | undefined => {
+  const result = attempt(() =>
+    TypedDataEncoder.hash(
+      payload.domain,
+      omit(payload.types, 'EIP712Domain'),
+      payload.message
+    )
+  )
+  if ('data' in result) {
+    return undefined
+  }
+
+  const emptyBytesFields = findEmptyEip712BytesFields(payload)
+  if (emptyBytesFields.length > 0) {
+    return `empty string in bytes field(s) ${emptyBytesFields.join(', ')}; encode empty bytes as "0x"`
+  }
+
+  return extractErrorMsg(result.error)
+}


### PR DESCRIPTION
## Description

Krystal's auto-rebalance setup fails with `invalid BytesLike value (argument="value", value="", code=INVALID_ARGUMENT, version=6.16.0)`. That error is ethers v6's `TypedDataEncoder` rejecting an EIP-712 payload that carries `""` where hex bytes are expected — exactly what our keysign pipeline runs in `getCustomMessageHex`, on exactly the ethers version we bundle (6.16.0). MetaMask's signer tolerates `""` in bytes fields, which is why such payloads only blow up on Vultisig, and today they blow up in the worst place: deep in keysign, after the user has already approved, with a cryptic message. A second wallet-specific gap with the same user-facing symptom: we only served `eth_signTypedData_v4`, so dApps calling the `eth_signTypedData` / `eth_signTypedData_v3` aliases MetaMask supports got `UnsupportedMethod`, and dApp fallback chains that swallow that rejection end up feeding an empty signature into their own ethers calls.

This PR makes the provider fail loudly and closes the parity gap:

- **`core/inpage-provider/popup/eip712.ts`** — `getEip712PayloadIssue` dry-runs the same `TypedDataEncoder` hashing keysign performs, so an unsignable payload is rejected at request time; `findEmptyEip712BytesFields` names empty `bytes`/`bytesN` fields by path (nested structs, arrays, and `domain.salt` included).
- **`eth_signTypedData_v4` resolver** — rejects unsignable payloads with EIP-1193 `InvalidParams` (-32602) and a message like `Cannot sign EIP-712 payload: empty string in bytes field(s) message.salt; encode empty bytes as "0x"`; accepts both `[account, payload]` and `[payload, account]` param orders (MetaMask parity); rejects V1 array payloads with a descriptive error.
- **`handlers.ts`** — serves `eth_signTypedData` and `eth_signTypedData_v3` as aliases of the v4 resolver (EIP-712 digests are identical for v3-compatible payloads).

An empty provider response is now impossible on every typed-data path: malformed payloads reject with a clear error before the popup opens, and valid ones go through the existing `processSignature` guard, which never returns `""`.

Fixes #4731

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

Extension dApp provider (eth_signTypedData_* request path) — none of the listed flows.

## Testing

- 8 new unit tests in `core/inpage-provider/popup/eip712.test.ts` (empty `bytes32`, empty dynamic `bytes`, nested struct-array paths, `domain.salt`, non-bytes fallback message, and the happy path incl. `"0x"` as valid empty bytes); all 53 `core/inpage-provider` tests pass.
- `yarn check` passes.
- Playground examples for manual E2E verification: vultisig/community-tools#41 adds the empty-bytes payload preset and the alias methods to the Ethereum request panel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `eth_signTypedData` and `eth_signTypedData_v3` requests.
  * Improved typed-data signing compatibility by accepting account and payload arguments in either order.
  * Added comprehensive validation for nested EIP-712 data, byte fields, arrays, and domain salts.

* **Bug Fixes**
  * Improved handling of malformed payloads, missing accounts, unsupported formats, and empty byte values.
  * Added clearer error messages and validation before network or chain lookup occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->