### PR TITLE
fix(defi): open THORChain Staked from the Ruji home banner

### DIFF
--- a/core/ui/defi/chain/thorchain/stakedSelection.test.ts
+++ b/core/ui/defi/chain/thorchain/stakedSelection.test.ts
@@ -1,0 +1,86 @@
+import { getDefaultStakePositionIds } from '@core/ui/storage/defiPositions'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { describe, expect, it } from 'vitest'
+
+import { resolveThorchainStakedSelection } from './stakedSelection'
+
+const thorStakePositionIds = getDefaultStakePositionIds(Chain.THORChain)
+
+describe('resolveThorchainStakedSelection', () => {
+  it('adds THORChain and its stake positions to an untouched selection', () => {
+    expect(
+      resolveThorchainStakedSelection({ defiChains: [], defiPositions: {} })
+    ).toEqual({
+      defiChains: [Chain.THORChain],
+      defiPositions: { [Chain.THORChain]: thorStakePositionIds },
+    })
+  })
+
+  it('seeds the RUJI and TCY stake positions but never bond', () => {
+    const { defiPositions } = resolveThorchainStakedSelection({
+      defiChains: [],
+      defiPositions: {},
+    })
+
+    expect(defiPositions?.[Chain.THORChain]).toEqual(
+      expect.arrayContaining(['thor-stake-ruji', 'thor-stake-tcy'])
+    )
+    expect(defiPositions?.[Chain.THORChain]).not.toContain('thor-bond-rune')
+  })
+
+  it('keeps the chains and positions of other chains', () => {
+    const { defiChains, defiPositions } = resolveThorchainStakedSelection({
+      defiChains: [Chain.Solana],
+      defiPositions: { [Chain.Solana]: ['solana-stake-sol'] },
+    })
+
+    expect(defiChains).toEqual([Chain.Solana, Chain.THORChain])
+    expect(defiPositions?.[Chain.Solana]).toEqual(['solana-stake-sol'])
+  })
+
+  it('writes nothing once THORChain and its stake positions are selected', () => {
+    expect(
+      resolveThorchainStakedSelection({
+        defiChains: [Chain.THORChain],
+        defiPositions: { [Chain.THORChain]: thorStakePositionIds },
+      })
+    ).toEqual({ defiChains: undefined, defiPositions: undefined })
+  })
+
+  it('leaves a partial position selection alone rather than re-adding what was turned off', () => {
+    expect(
+      resolveThorchainStakedSelection({
+        defiChains: [Chain.THORChain],
+        defiPositions: { [Chain.THORChain]: ['thor-stake-tcy'] },
+      }).defiPositions
+    ).toBeUndefined()
+  })
+
+  it('honours a THORChain selection that deliberately holds no stake position', () => {
+    expect(
+      resolveThorchainStakedSelection({
+        defiChains: [Chain.THORChain],
+        defiPositions: { [Chain.THORChain]: ['thor-bond-rune'] },
+      }).defiPositions
+    ).toBeUndefined()
+  })
+
+  it('honours a THORChain selection emptied of every position', () => {
+    expect(
+      resolveThorchainStakedSelection({
+        defiChains: [Chain.THORChain],
+        defiPositions: { [Chain.THORChain]: [] },
+      }).defiPositions
+    ).toBeUndefined()
+  })
+
+  it('still adds THORChain to the chain list when its positions are already set', () => {
+    const { defiChains, defiPositions } = resolveThorchainStakedSelection({
+      defiChains: [],
+      defiPositions: { [Chain.THORChain]: ['thor-stake-ruji'] },
+    })
+
+    expect(defiChains).toEqual([Chain.THORChain])
+    expect(defiPositions).toBeUndefined()
+  })
+})

--- a/core/ui/defi/chain/thorchain/stakedSelection.ts
+++ b/core/ui/defi/chain/thorchain/stakedSelection.ts
@@ -1,0 +1,51 @@
+import { getDefaultStakePositionIds } from '@core/ui/storage/defiPositions'
+import { Chain } from '@vultisig/core-chain/Chain'
+
+type ResolveThorchainStakedSelectionInput = {
+  /** The chain list the DeFi tab shows rows for. */
+  defiChains: Chain[]
+  /** The selected DeFi positions, keyed by chain. */
+  defiPositions: Record<string, string[]>
+}
+
+/**
+ * What has to be written before the THORChain Staked tab can show anything. A
+ * list is `undefined` when the stored one already works, so a caller writes
+ * only what it has to.
+ */
+type ThorchainStakedSelection = {
+  defiChains?: Chain[]
+  defiPositions?: Record<string, string[]>
+}
+
+/**
+ * Seeds the DeFi selection so the THORChain Staked tab has something to show:
+ * THORChain is appended to the chain list, and its stake positions (RUJI, TCY
+ * and the rest) become THORChain's positions. Bond stays unseeded - a staking
+ * entry point should not opt the user into node bonding.
+ *
+ * Positions are only ever seeded, never re-seeded. A position the user turned
+ * off is indistinguishable from one never offered, so the trigger is whether
+ * THORChain has a stored position list at all - once it has one, whatever it
+ * says is the user's answer, including an answer of "no stake positions". A
+ * user who opted out that way lands on the Staked tab's own opt-in prompt
+ * instead of having the positions quietly put back.
+ */
+export const resolveThorchainStakedSelection = ({
+  defiChains,
+  defiPositions,
+}: ResolveThorchainStakedSelectionInput): ThorchainStakedSelection => {
+  const hasThorchainPositions = defiPositions[Chain.THORChain] !== undefined
+
+  return {
+    defiChains: defiChains.includes(Chain.THORChain)
+      ? undefined
+      : [...defiChains, Chain.THORChain],
+    defiPositions: hasThorchainPositions
+      ? undefined
+      : {
+          ...defiPositions,
+          [Chain.THORChain]: getDefaultStakePositionIds(Chain.THORChain),
+        },
+  }
+}

--- a/core/ui/defi/chain/thorchain/useOpenThorchainStaked.ts
+++ b/core/ui/defi/chain/thorchain/useOpenThorchainStaked.ts
@@ -1,0 +1,52 @@
+import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
+import { useCore } from '@core/ui/state/core'
+import { StorageKey } from '@core/ui/storage/StorageKey'
+import { useRefetchQueries } from '@lib/ui/query/hooks/useRefetchQueries'
+import { Chain } from '@vultisig/core-chain/Chain'
+import { attempt } from '@vultisig/lib-utils/attempt'
+
+import { resolveThorchainStakedSelection } from './stakedSelection'
+
+/**
+ * Opens the THORChain Staked tab from outside the DeFi tab, where neither of
+ * the lists the tab reads can be assumed: THORChain is not on the DeFi tab
+ * until the user adds it, and its stake positions are not selected until
+ * something selects them. An entry point that only navigated would land on the
+ * "no positions selected" state, so the selection is seeded first - see
+ * {@link resolveThorchainStakedSelection} for what counts as unseeded.
+ *
+ * Writing the selection is best-effort - a Staked tab the user has to populate
+ * themselves still beats a tap that goes nowhere.
+ */
+export const useOpenThorchainStaked = () => {
+  const navigate = useCoreNavigate()
+  const { getDefiChains, setDefiChains, getDefiPositions, setDefiPositions } =
+    useCore()
+  const refetchQueries = useRefetchQueries()
+
+  const selectThorchainStaked = async () => {
+    const selection = resolveThorchainStakedSelection({
+      defiChains: await getDefiChains(),
+      defiPositions: await getDefiPositions(),
+    })
+
+    if (selection.defiChains) {
+      await setDefiChains(selection.defiChains)
+      await refetchQueries([StorageKey.defiChains])
+    }
+
+    if (selection.defiPositions) {
+      await setDefiPositions(selection.defiPositions)
+      await refetchQueries([StorageKey.defiPositions])
+    }
+  }
+
+  return async () => {
+    await attempt(selectThorchainStaked)
+
+    navigate({
+      id: 'defiChainDetail',
+      state: { chain: Chain.THORChain, tab: 'staked' },
+    })
+  }
+}

--- a/core/ui/storage/defiPositions.tsx
+++ b/core/ui/storage/defiPositions.tsx
@@ -185,6 +185,16 @@ const getAvailablePositionsForChain = (chain: Chain): DefiPosition[] => {
 export const getDefaultDefiPositionIds = (chain: Chain): string[] =>
   getAvailablePositionsForChain(chain).map(p => p.id)
 
+/**
+ * IDs of a chain's static stake positions only. A staking entry point seeds
+ * these instead of the full default set, so bond and LP tiles stay something
+ * the user opts into.
+ */
+export const getDefaultStakePositionIds = (chain: Chain): string[] =>
+  getAvailablePositionsForChain(chain)
+    .filter(({ type }) => type === 'stake')
+    .map(({ id }) => id)
+
 type DefiPositionsRecord = Record<string, string[]> // chain -> position ids
 
 export const getInitialDefiPositions = (

--- a/core/ui/vault/page/banners/useHomePromoBanners.tsx
+++ b/core/ui/vault/page/banners/useHomePromoBanners.tsx
@@ -1,4 +1,5 @@
 import { useOpenKaminoEarn } from '@core/ui/defi/chain/solana/kamino/useOpenKaminoEarn'
+import { useOpenThorchainStaked } from '@core/ui/defi/chain/thorchain/useOpenThorchainStaked'
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { vultisigTwitterUrl } from '@core/ui/settings/constants'
 import { useCreateCoinMutation } from '@core/ui/storage/coins'
@@ -47,6 +48,7 @@ export const useHomePromoBanners = (): HomePromoBannerEntry[] => {
   const vaultCoins = useCurrentVaultCoins()
   const vaultChains = useCurrentVaultChains()
   const openKaminoEarn = useOpenKaminoEarn()
+  const openThorchainStaked = useOpenThorchainStaked()
   const { mutate: createCoin } = useCreateCoinMutation()
   const { data: friendReferral } = useFriendReferralQuery(getVaultId(vault))
 
@@ -55,6 +57,10 @@ export const useHomePromoBanners = (): HomePromoBannerEntry[] => {
   // Solana address, so a vault without one - a key import with no EdDSA key -
   // has nothing the banner could open.
   const hasSolana = vaultChains.includes(Chain.Solana)
+  // The Staked tab reads positions from the vault's own THORChain address, so
+  // a vault without one - a key import with no ECDSA THORChain key - has
+  // nothing the Ruji banner could open.
+  const hasThorchain = vaultChains.includes(Chain.THORChain)
 
   const openSwapToVult = () => {
     const existingVultCoin = vaultCoins.find(coin => areEqualCoins(coin, vult))
@@ -110,13 +116,15 @@ export const useHomePromoBanners = (): HomePromoBannerEntry[] => {
           }),
         ]
       : []),
-    ...(isVultisigBrand
+    ...(isVultisigBrand && hasThorchain
       ? [
           banner({
             id: 'rujiraStaking',
             caption: t('rujira_banner_caption'),
             title: t('rujira_banner_title'),
-            onClick: () => navigate({ id: 'defi', state: {} }),
+            onClick: () => {
+              openThorchainStaked()
+            },
           }),
         ]
       : []),


### PR DESCRIPTION
## Description

The Ruji promo banner navigated to the generic DeFi home (`id: 'defi'`). For the Vultisig brand that home starts with zero chains selected (`getInitialDefiChains('vultisig')` is `[]`), so the tap landed on an empty page instead of the staking it advertises.

Closes #4724

## Change

Mirrors the Kamino Earn entry point (#4721) for THORChain staking:

- **`resolveThorchainStakedSelection`** — a pure resolver that seeds THORChain onto the DeFi chain list and its stake positions (RUJI, TCY, yRUNE, yTCY, sTCY, bRUNE) onto the selection. Same seed-once rule as `resolveKaminoEarnSelection`: the trigger is whether THORChain has a stored position list at all, so a user who opted out of these positions is never quietly opted back in. Bond stays unseeded — a staking promo should not enrol anyone in node bonding.

- **`useOpenThorchainStaked`** — seeds best-effort (`attempt`), then navigates to `defiChainDetail` with `{ chain: THORChain, tab: 'staked' }`. The requested tab wins over the tab last left open and over THORChain's Bonded default, via the existing `requestedTab` plumbing from #4721.

- **`getDefaultStakePositionIds`** — stake-only variant of `getDefaultDefiPositionIds`, so the seed list tracks `staticDefiPositions` instead of being hardcoded.

- **Gating** — the banner now requires the vault to have a THORChain address, matching how the Kamino banner is gated on Solana: a key import with no ECDSA THORChain key has nothing the banner could open.

## Kamino retest

Per the issue, the Kamino side needed a retest rather than new code, and it holds on current main: the banner is gated on a Solana address, `useOpenKaminoEarn` seeds and requests the Earn tab, and `DefiChainTabs` still honours `requestedTab`. The flagged merge hazard is moot — #4722 was closed unmerged (superseded by #4726, which kept the `requestedTab` handling).

## Testing

- `resolveThorchainStakedSelection` unit tests, same shape as `earnSelection.test.ts`: fresh seed, cross-chain preservation, no re-seed of partial/emptied/opt-out selections, and never seeding bond.
- `yarn check:all` passes; the extension's own `tsc -b` build passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a direct navigation flow to THORChain staking.
  * Automatically selects THORChain staking options when no previous selection exists.
  * Preserves custom or empty staking selections and excludes node bonding from defaults.
  * Updated the Ruji staking promotion to appear in eligible Vultisig vaults and open THORChain staking directly.
* **Tests**
  * Added coverage for default selections, preserved preferences, supported positions, and repeated selection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->