### PR TITLE
fix(solana): fail closed when address lookup tables can't be resolved

### DIFF
--- a/core/inpage-provider/popup/view/resolvers/sendTx/core/solana/parseProgramCall/instructionParser/parseTokenInstruction.test.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/core/solana/parseProgramCall/instructionParser/parseTokenInstruction.test.ts
@@ -1,0 +1,60 @@
+import { ASSOCIATED_TOKEN_PROGRAM_ID } from '@solana/spl-token'
+import { PublicKey } from '@solana/web3.js'
+import { TW } from '@trustwallet/wallet-core'
+import { describe, expect, it } from 'vitest'
+
+import { findAtaRecipient } from './parseTokenInstruction'
+
+const publicKeyFromSeed = (seed: number) =>
+  new PublicKey(new Uint8Array(32).fill(seed))
+
+const staticKeys = [publicKeyFromSeed(1), publicKeyFromSeed(2)]
+const loadedKeys = [
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  publicKeyFromSeed(3),
+  publicKeyFromSeed(4),
+]
+const keys = [...staticKeys, ...loadedKeys]
+
+const txWithInstructions = (
+  instructions: TW.Solana.Proto.RawMessage.IInstruction[]
+): TW.Solana.Proto.RawMessage.IMessageLegacy => ({
+  accountKeys: staticKeys.map(key => key.toBase58()),
+  instructions,
+})
+
+describe('findAtaRecipient', () => {
+  it('resolves the recipient against the merged keys, not the static ones', () => {
+    const tx = txWithInstructions([
+      { programId: 2, accounts: [0, 1, 4], programData: new Uint8Array() },
+    ])
+
+    expect(findAtaRecipient({ tx, keys })?.toBase58()).toBe(
+      publicKeyFromSeed(4).toBase58()
+    )
+  })
+
+  it('returns undefined when the transaction creates no associated token account', () => {
+    const tx = txWithInstructions([
+      { programId: 1, accounts: [0, 1, 3], programData: new Uint8Array() },
+    ])
+
+    expect(findAtaRecipient({ tx, keys })).toBeUndefined()
+  })
+
+  it('fails closed when the owner index is outside the resolved keys', () => {
+    const tx = txWithInstructions([
+      { programId: 2, accounts: [0, 1, 9], programData: new Uint8Array() },
+    ])
+
+    expect(() => findAtaRecipient({ tx, keys })).toThrow()
+  })
+
+  it('fails closed when a program index is outside the resolved keys', () => {
+    const tx = txWithInstructions([
+      { programId: 9, accounts: [0, 1, 4], programData: new Uint8Array() },
+    ])
+
+    expect(() => findAtaRecipient({ tx, keys })).toThrow()
+  })
+})

--- a/core/inpage-provider/popup/view/resolvers/sendTx/core/solana/parseProgramCall/instructionParser/parseTokenInstruction.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/core/solana/parseProgramCall/instructionParser/parseTokenInstruction.ts
@@ -1,11 +1,58 @@
-import { ASSOCIATED_TOKEN_PROGRAM_ID, getAccount } from '@solana/spl-token'
+import {
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  getAccount,
+  TokenError,
+} from '@solana/spl-token'
 import { Connection, PublicKey } from '@solana/web3.js'
 import { TW } from '@trustwallet/wallet-core'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { Coin, CoinKey } from '@vultisig/core-chain/coin/Coin'
 import { rootApiUrl } from '@vultisig/core-config'
+import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 
 import { SolanaTxData } from '../../types/types'
+import { accountKeyAt } from '../../utils'
+
+const senderAccountIndex = 0
+const receiverAccountIndex = 2
+const ataOwnerAccountIndex = 2
+
+const debugPrefix = '[parseTokenInstruction]'
+
+type FindAtaRecipientInput = {
+  tx: TW.Solana.Proto.RawMessage.IMessageLegacy
+  keys: PublicKey[]
+}
+
+/**
+ * Finds the wallet an associated-token-account creation instruction opens an
+ * account for, which is the recipient when the destination token account does
+ * not exist on chain yet. Account indices are read against the merged
+ * static-plus-lookup key list, so a v0 transaction that loads the recipient
+ * from an address lookup table resolves to the right account instead of
+ * whatever happens to sit at that index among the static keys.
+ */
+export const findAtaRecipient = ({
+  tx,
+  keys,
+}: FindAtaRecipientInput): PublicKey | undefined => {
+  const ataInstruction = (tx.instructions ?? []).find(
+    instruction =>
+      accountKeyAt(keys, shouldBePresent(instruction.programId)).toBase58() ===
+      ASSOCIATED_TOKEN_PROGRAM_ID.toBase58()
+  )
+
+  if (!ataInstruction) {
+    return undefined
+  }
+
+  const accounts = shouldBePresent(
+    ataInstruction.accounts,
+    'ataInstruction.accounts'
+  )
+
+  return accountKeyAt(keys, shouldBePresent(accounts[ataOwnerAccountIndex]))
+}
 
 type Input = {
   tx: TW.Solana.Proto.RawMessage.IMessageLegacy
@@ -13,56 +60,60 @@ type Input = {
   keys: PublicKey[]
   getCoin: (coinKey: CoinKey) => Promise<Coin>
 }
+
+/**
+ * Parses an SPL token transfer into the approval view's transfer shape. The
+ * ATA fallback runs only when the destination token account genuinely does not
+ * exist yet; any other failure propagates, so a transient RPC error can never
+ * be presented to the user as a recipient address.
+ */
 export const parseTokenInstruction = async ({
   tx,
   instruction,
   keys,
   getCoin,
 }: Input): Promise<SolanaTxData> => {
-  const debugPrefix = '[parseTokenInstruction]'
-  if (!instruction.accounts || !tx.instructions || !tx.accountKeys)
-    throw new Error('invalid token instruction')
+  const accounts = shouldBePresent(instruction.accounts, 'instruction.accounts')
+
   const connection = new Connection(`${rootApiUrl}/solana/`)
   const senderTokenAccountInfo = await getAccount(
     connection,
-    keys[instruction.accounts[0]]
+    accountKeyAt(keys, shouldBePresent(accounts[senderAccountIndex]))
   )
 
   let recipient: string
   try {
-    // Try fetching receiver account
     const receiverTokenAccountInfo = await getAccount(
       connection,
-      keys[instruction.accounts[2]]
+      accountKeyAt(keys, shouldBePresent(accounts[receiverAccountIndex]))
     )
-    recipient = receiverTokenAccountInfo.owner.toString()
-  } catch {
+    recipient = receiverTokenAccountInfo.owner.toBase58()
+  } catch (error) {
+    if (!(error instanceof TokenError)) {
+      throw error
+    }
+
     console.warn(
       debugPrefix,
       'receiver token account not found. Checking for ATA...'
     )
-    const ataInstruction = tx.instructions.find(
-      instr =>
-        tx.accountKeys![instr.programId!] ===
-        ASSOCIATED_TOKEN_PROGRAM_ID.toBase58()
-    )
-    if (ataInstruction) {
-      // The recipient should be in the ATA instruction's keys[0] (payer) or keys[2] (owner)
-      if (!ataInstruction.accounts) {
-        throw new Error('ATA instruction accounts are missing.')
-      }
-      recipient = tx.accountKeys[ataInstruction.accounts[2]]
-    } else {
+
+    const ataRecipient = findAtaRecipient({ tx, keys })
+    if (!ataRecipient) {
       console.warn(debugPrefix, 'no ATA instruction found in tx.instructions')
       throw new Error(
         'Unable to determine recipient address. No direct token account or ATA instruction found.'
       )
     }
+
+    recipient = ataRecipient.toBase58()
   }
-  if (!instruction.programData) {
-    throw new Error('Program data is missing.')
-  }
-  const amountBytes = instruction.programData.slice(1, 9)
+
+  const programData = shouldBePresent(
+    instruction.programData,
+    'instruction.programData'
+  )
+  const amountBytes = programData.slice(1, 9)
 
   const amount = new DataView(Uint8Array.from(amountBytes).buffer).getBigUint64(
     0,

--- a/core/inpage-provider/popup/view/resolvers/sendTx/core/solana/parser.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/core/solana/parser.ts
@@ -167,11 +167,11 @@ export const parseSolanaTx = async ({
   if (parsedSimulation) {
     return parsedSimulation
   }
-  const resolvedKeys = await attempt(
+  const addressTableLookups = decodedTx.transaction.v0?.addressTableLookups
+
+  const resolvedKeys = await attempt(async () =>
     resolveAddressTableKeys({
-      lookups: toAddressTableLookups(
-        decodedTx.transaction.v0?.addressTableLookups
-      ),
+      lookups: toAddressTableLookups(addressTableLookups),
       connection: new Connection(solanaRpcUrl),
     })
   )

--- a/core/inpage-provider/popup/view/resolvers/sendTx/core/solana/parser.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/core/solana/parser.ts
@@ -50,7 +50,6 @@ export const parseSolanaTx = async ({
   }
 
   const buffer = getSerializedSolanaTxBuffer(data)
-  const connection = new Connection(solanaRpcUrl)
   const encodedTx = walletCore.TransactionDecoder.decode(
     walletCore.CoinType.solana,
     buffer
@@ -63,16 +62,6 @@ export const parseSolanaTx = async ({
   const tx = decodedTx.transaction?.v0 ?? decodedTx.transaction?.legacy
   if (!tx)
     throw new Error('Invalid Solana transaction: missing v0 transaction data')
-
-  const staticKeys = (tx.accountKeys ?? []).map(k => new PublicKey(k))
-
-  const resolvedKeys = await resolveAddressTableKeys(
-    ('addressTableLookups' in tx
-      ? tx.addressTableLookups
-      : []) as AddressTableLookup[],
-    connection
-  )
-  const keys = mergedKeys(staticKeys, resolvedKeys)
 
   const { data: parsedSimulation } = await attempt(async () => {
     const keysignPayload = create(KeysignPayloadSchema, {
@@ -165,6 +154,26 @@ export const parseSolanaTx = async ({
   if (parsedSimulation) {
     return parsedSimulation
   }
+  const resolvedKeys = await attempt(
+    resolveAddressTableKeys(
+      ('addressTableLookups' in tx
+        ? tx.addressTableLookups
+        : []) as AddressTableLookup[],
+      new Connection(solanaRpcUrl)
+    )
+  )
+
+  if ('error' in resolvedKeys) {
+    console.warn(
+      'could not resolve Solana address lookup tables, returning raw fallback',
+      resolvedKeys.error
+    )
+    return getSolanaRawTxFallback(data)
+  }
+
+  const staticKeys = (tx.accountKeys ?? []).map(k => new PublicKey(k))
+  const keys = mergedKeys(staticKeys, resolvedKeys.data)
+
   const { data: parsedTx } = await attempt(
     parseProgramCall({
       tx,

--- a/core/inpage-provider/popup/view/resolvers/sendTx/core/solana/parser.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/core/solana/parser.ts
@@ -17,6 +17,7 @@ import {
 } from '@vultisig/core-mpc/types/vultisig/keysign/v1/1inch_swap_payload_pb'
 import { Coin as CommCoin } from '@vultisig/core-mpc/types/vultisig/keysign/v1/coin_pb'
 import { KeysignPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { attempt } from '@vultisig/lib-utils/attempt'
 import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
 
@@ -36,6 +37,18 @@ type ParseSolanaTxInput = {
   getCoin: (coinKey: CoinKey) => Promise<Coin>
   swapProvider: string
 }
+
+const toAddressTableLookups = (
+  lookups:
+    | TW.Solana.Proto.RawMessage.IMessageAddressTableLookup[]
+    | null
+    | undefined
+): AddressTableLookup[] =>
+  (lookups ?? []).map(({ accountKey, writableIndexes, readonlyIndexes }) => ({
+    accountKey: shouldBePresent(accountKey, 'addressTableLookup.accountKey'),
+    writableIndexes: writableIndexes ?? [],
+    readonlyIndexes: readonlyIndexes ?? [],
+  }))
 
 export const parseSolanaTx = async ({
   fromCoin,
@@ -155,12 +168,12 @@ export const parseSolanaTx = async ({
     return parsedSimulation
   }
   const resolvedKeys = await attempt(
-    resolveAddressTableKeys(
-      ('addressTableLookups' in tx
-        ? tx.addressTableLookups
-        : []) as AddressTableLookup[],
-      new Connection(solanaRpcUrl)
-    )
+    resolveAddressTableKeys({
+      lookups: toAddressTableLookups(
+        decodedTx.transaction.v0?.addressTableLookups
+      ),
+      connection: new Connection(solanaRpcUrl),
+    })
   )
 
   if ('error' in resolvedKeys) {

--- a/core/inpage-provider/popup/view/resolvers/sendTx/core/solana/utils/index.test.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/core/solana/utils/index.test.ts
@@ -1,0 +1,93 @@
+import {
+  AddressLookupTableAccount,
+  Connection,
+  PublicKey,
+} from '@solana/web3.js'
+import { describe, expect, it } from 'vitest'
+
+import { AddressTableLookup } from '../types/types'
+import { resolveAddressTableKeys } from '.'
+
+const publicKeyFromSeed = (seed: number) =>
+  new PublicKey(new Uint8Array(32).fill(seed))
+
+const tableAccount = (addresses: PublicKey[]) =>
+  new AddressLookupTableAccount({
+    key: publicKeyFromSeed(1),
+    state: {
+      deactivationSlot: BigInt(0),
+      lastExtendedSlot: 0,
+      lastExtendedSlotStartIndex: 0,
+      addresses,
+    },
+  })
+
+const connectionThatReturns = (
+  value: AddressLookupTableAccount | null
+): Pick<Connection, 'getAddressLookupTable'> => ({
+  getAddressLookupTable: async () => ({ context: { slot: 0 }, value }),
+})
+
+const connectionThatFails = (): Pick<Connection, 'getAddressLookupTable'> => ({
+  getAddressLookupTable: async () => {
+    throw new Error('rpc unavailable')
+  },
+})
+
+const lookup = (
+  writableIndexes: number[],
+  readonlyIndexes: number[]
+): AddressTableLookup => ({
+  accountKey: publicKeyFromSeed(1).toBase58(),
+  writableIndexes,
+  readonlyIndexes,
+})
+
+describe('resolveAddressTableKeys', () => {
+  it('resolves writable indexes before readonly ones', async () => {
+    const addresses = [
+      publicKeyFromSeed(10),
+      publicKeyFromSeed(11),
+      publicKeyFromSeed(12),
+    ]
+
+    const keys = await resolveAddressTableKeys(
+      [lookup([2], [0, 1])],
+      connectionThatReturns(tableAccount(addresses))
+    )
+
+    expect(keys.map(key => key.toBase58())).toEqual([
+      addresses[2].toBase58(),
+      addresses[0].toBase58(),
+      addresses[1].toBase58(),
+    ])
+  })
+
+  it('fails closed when the lookup table account is missing', async () => {
+    await expect(
+      resolveAddressTableKeys([lookup([0], [1])], connectionThatReturns(null))
+    ).rejects.toThrow()
+  })
+
+  it('fails closed when the lookup table fetch errors', async () => {
+    await expect(
+      resolveAddressTableKeys([lookup([0], [1])], connectionThatFails())
+    ).rejects.toThrow()
+  })
+
+  it('fails closed when a writable index is outside the fetched table', async () => {
+    const table = tableAccount([publicKeyFromSeed(10), publicKeyFromSeed(11)])
+
+    await expect(
+      resolveAddressTableKeys([lookup([5], [])], connectionThatReturns(table))
+    ).rejects.toThrow()
+  })
+
+  it('fails closed when a readonly index is outside the fetched table', async () => {
+    const table = tableAccount([publicKeyFromSeed(10), publicKeyFromSeed(11)])
+
+    await expect(
+      resolveAddressTableKeys([lookup([], [2])], connectionThatReturns(table))
+    ).rejects.toThrow()
+  })
+})

--- a/core/inpage-provider/popup/view/resolvers/sendTx/core/solana/utils/index.test.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/core/solana/utils/index.test.ts
@@ -6,7 +6,7 @@ import {
 import { describe, expect, it } from 'vitest'
 
 import { AddressTableLookup } from '../types/types'
-import { resolveAddressTableKeys } from '.'
+import { accountKeyAt, resolveAddressTableKeys } from '.'
 
 const publicKeyFromSeed = (seed: number) =>
   new PublicKey(new Uint8Array(32).fill(seed))
@@ -137,5 +137,45 @@ describe('resolveAddressTableKeys', () => {
       publicKeyFromSeed(11).toBase58(),
       publicKeyFromSeed(21).toBase58(),
     ])
+  })
+  it('fetches every lookup table concurrently', async () => {
+    const firstTable = tableAccount([publicKeyFromSeed(10)], 1)
+    const secondTable = tableAccount([publicKeyFromSeed(20)], 2)
+    const tables = {
+      [firstTable.key.toBase58()]: firstTable,
+      [secondTable.key.toBase58()]: secondTable,
+    }
+
+    let inFlight = 0
+    let peakInFlight = 0
+
+    await resolveAddressTableKeys({
+      lookups: [lookup([0], [], 1), lookup([0], [], 2)],
+      connection: {
+        getAddressLookupTable: async key => {
+          inFlight += 1
+          peakInFlight = Math.max(peakInFlight, inFlight)
+          await Promise.resolve()
+          inFlight -= 1
+          return { context: { slot: 0 }, value: tables[key.toBase58()] ?? null }
+        },
+      },
+    })
+
+    expect(peakInFlight).toBe(2)
+  })
+})
+
+describe('accountKeyAt', () => {
+  it('reads the account the transaction addresses by index', () => {
+    const keys = [publicKeyFromSeed(1), publicKeyFromSeed(2)]
+
+    expect(accountKeyAt(keys, 1).toBase58()).toBe(
+      publicKeyFromSeed(2).toBase58()
+    )
+  })
+
+  it('fails closed instead of handing back an undefined account', () => {
+    expect(() => accountKeyAt([publicKeyFromSeed(1)], 3)).toThrow()
   })
 })

--- a/core/inpage-provider/popup/view/resolvers/sendTx/core/solana/utils/index.test.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/core/solana/utils/index.test.ts
@@ -11,9 +11,9 @@ import { resolveAddressTableKeys } from '.'
 const publicKeyFromSeed = (seed: number) =>
   new PublicKey(new Uint8Array(32).fill(seed))
 
-const tableAccount = (addresses: PublicKey[]) =>
+const tableAccount = (addresses: PublicKey[], keySeed = 1) =>
   new AddressLookupTableAccount({
-    key: publicKeyFromSeed(1),
+    key: publicKeyFromSeed(keySeed),
     state: {
       deactivationSlot: BigInt(0),
       lastExtendedSlot: 0,
@@ -28,6 +28,15 @@ const connectionThatReturns = (
   getAddressLookupTable: async () => ({ context: { slot: 0 }, value }),
 })
 
+const connectionThatServes = (
+  tables: Record<string, AddressLookupTableAccount>
+): Pick<Connection, 'getAddressLookupTable'> => ({
+  getAddressLookupTable: async key => ({
+    context: { slot: 0 },
+    value: tables[key.toBase58()] ?? null,
+  }),
+})
+
 const connectionThatFails = (): Pick<Connection, 'getAddressLookupTable'> => ({
   getAddressLookupTable: async () => {
     throw new Error('rpc unavailable')
@@ -36,9 +45,10 @@ const connectionThatFails = (): Pick<Connection, 'getAddressLookupTable'> => ({
 
 const lookup = (
   writableIndexes: number[],
-  readonlyIndexes: number[]
+  readonlyIndexes: number[],
+  tableSeed = 1
 ): AddressTableLookup => ({
-  accountKey: publicKeyFromSeed(1).toBase58(),
+  accountKey: publicKeyFromSeed(tableSeed).toBase58(),
   writableIndexes,
   readonlyIndexes,
 })
@@ -51,10 +61,10 @@ describe('resolveAddressTableKeys', () => {
       publicKeyFromSeed(12),
     ]
 
-    const keys = await resolveAddressTableKeys(
-      [lookup([2], [0, 1])],
-      connectionThatReturns(tableAccount(addresses))
-    )
+    const keys = await resolveAddressTableKeys({
+      lookups: [lookup([2], [0, 1])],
+      connection: connectionThatReturns(tableAccount(addresses)),
+    })
 
     expect(keys.map(key => key.toBase58())).toEqual([
       addresses[2].toBase58(),
@@ -65,13 +75,19 @@ describe('resolveAddressTableKeys', () => {
 
   it('fails closed when the lookup table account is missing', async () => {
     await expect(
-      resolveAddressTableKeys([lookup([0], [1])], connectionThatReturns(null))
+      resolveAddressTableKeys({
+        lookups: [lookup([0], [1])],
+        connection: connectionThatReturns(null),
+      })
     ).rejects.toThrow()
   })
 
   it('fails closed when the lookup table fetch errors', async () => {
     await expect(
-      resolveAddressTableKeys([lookup([0], [1])], connectionThatFails())
+      resolveAddressTableKeys({
+        lookups: [lookup([0], [1])],
+        connection: connectionThatFails(),
+      })
     ).rejects.toThrow()
   })
 
@@ -79,7 +95,10 @@ describe('resolveAddressTableKeys', () => {
     const table = tableAccount([publicKeyFromSeed(10), publicKeyFromSeed(11)])
 
     await expect(
-      resolveAddressTableKeys([lookup([5], [])], connectionThatReturns(table))
+      resolveAddressTableKeys({
+        lookups: [lookup([5], [])],
+        connection: connectionThatReturns(table),
+      })
     ).rejects.toThrow()
   })
 
@@ -87,7 +106,36 @@ describe('resolveAddressTableKeys', () => {
     const table = tableAccount([publicKeyFromSeed(10), publicKeyFromSeed(11)])
 
     await expect(
-      resolveAddressTableKeys([lookup([], [2])], connectionThatReturns(table))
+      resolveAddressTableKeys({
+        lookups: [lookup([], [2])],
+        connection: connectionThatReturns(table),
+      })
     ).rejects.toThrow()
+  })
+
+  it('orders every writable entry before any readonly entry across tables', async () => {
+    const firstTable = tableAccount(
+      [publicKeyFromSeed(10), publicKeyFromSeed(11)],
+      1
+    )
+    const secondTable = tableAccount(
+      [publicKeyFromSeed(20), publicKeyFromSeed(21)],
+      2
+    )
+
+    const keys = await resolveAddressTableKeys({
+      lookups: [lookup([0], [1], 1), lookup([0], [1], 2)],
+      connection: connectionThatServes({
+        [firstTable.key.toBase58()]: firstTable,
+        [secondTable.key.toBase58()]: secondTable,
+      }),
+    })
+
+    expect(keys.map(key => key.toBase58())).toEqual([
+      publicKeyFromSeed(10).toBase58(),
+      publicKeyFromSeed(20).toBase58(),
+      publicKeyFromSeed(11).toBase58(),
+      publicKeyFromSeed(21).toBase58(),
+    ])
   })
 })

--- a/core/inpage-provider/popup/view/resolvers/sendTx/core/solana/utils/index.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/core/solana/utils/index.ts
@@ -8,19 +8,44 @@ export const readU64LE = (buf: Buffer, off: number) => {
   return (hi << 32n) | lo
 }
 
+/** The slice of `Connection` needed to read address lookup tables. */
+type AddressLookupTableReader = Pick<Connection, 'getAddressLookupTable'>
+
+/**
+ * Resolves the account keys a v0 transaction loads from on-chain address
+ * lookup tables, writable entries first. Fails closed: an unreadable table or
+ * an index outside it throws instead of yielding undefined keys, so callers
+ * can never present a partially decoded transaction as a complete one.
+ */
 export const resolveAddressTableKeys = async (
   lookups: AddressTableLookup[],
-  connection: Connection
+  connection: AddressLookupTableReader
 ): Promise<PublicKey[]> => {
   const out: PublicKey[] = []
-  for (const l of lookups ?? []) {
-    const res = await connection.getAddressLookupTable(
-      new PublicKey(l.accountKey)
+  for (const lookup of lookups) {
+    const { value } = await connection.getAddressLookupTable(
+      new PublicKey(lookup.accountKey)
     )
-    const table = res.value?.state.addresses ?? []
+    if (!value) {
+      throw new Error(
+        `Address lookup table ${lookup.accountKey} could not be read`
+      )
+    }
+
+    const addresses = value.state.addresses
+    const resolveIndex = (index: number) => {
+      const address = addresses[index]
+      if (!address) {
+        throw new Error(
+          `Address lookup table ${lookup.accountKey} has no entry at index ${index}`
+        )
+      }
+      return address
+    }
+
     out.push(
-      ...l.writableIndexes.map(i => table[i]),
-      ...l.readonlyIndexes.map(i => table[i])
+      ...lookup.writableIndexes.map(resolveIndex),
+      ...lookup.readonlyIndexes.map(resolveIndex)
     )
   }
   return out

--- a/core/inpage-provider/popup/view/resolvers/sendTx/core/solana/utils/index.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/core/solana/utils/index.ts
@@ -11,17 +11,25 @@ export const readU64LE = (buf: Buffer, off: number) => {
 /** The slice of `Connection` needed to read address lookup tables. */
 type AddressLookupTableReader = Pick<Connection, 'getAddressLookupTable'>
 
+type ResolveAddressTableKeysInput = {
+  lookups: AddressTableLookup[]
+  connection: AddressLookupTableReader
+}
+
 /**
  * Resolves the account keys a v0 transaction loads from on-chain address
- * lookup tables, writable entries first. Fails closed: an unreadable table or
- * an index outside it throws instead of yielding undefined keys, so callers
- * can never present a partially decoded transaction as a complete one.
+ * lookup tables. Writable entries from every table come before readonly ones,
+ * matching how Solana orders loaded addresses. Fails closed: an unreadable
+ * table or an index outside it throws instead of yielding undefined keys, so
+ * callers can never present a partially decoded transaction as a complete one.
  */
-export const resolveAddressTableKeys = async (
-  lookups: AddressTableLookup[],
-  connection: AddressLookupTableReader
-): Promise<PublicKey[]> => {
-  const out: PublicKey[] = []
+export const resolveAddressTableKeys = async ({
+  lookups,
+  connection,
+}: ResolveAddressTableKeysInput): Promise<PublicKey[]> => {
+  const writable: PublicKey[] = []
+  const readonly: PublicKey[] = []
+
   for (const lookup of lookups) {
     const { value } = await connection.getAddressLookupTable(
       new PublicKey(lookup.accountKey)
@@ -43,12 +51,11 @@ export const resolveAddressTableKeys = async (
       return address
     }
 
-    out.push(
-      ...lookup.writableIndexes.map(resolveIndex),
-      ...lookup.readonlyIndexes.map(resolveIndex)
-    )
+    writable.push(...lookup.writableIndexes.map(resolveIndex))
+    readonly.push(...lookup.readonlyIndexes.map(resolveIndex))
   }
-  return out
+
+  return [...writable, ...readonly]
 }
 export const mergedKeys = (staticKeys: PublicKey[], loaded: PublicKey[]) => {
   return [...staticKeys, ...loaded]

--- a/core/inpage-provider/popup/view/resolvers/sendTx/core/solana/utils/index.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/core/solana/utils/index.ts
@@ -18,45 +18,67 @@ type ResolveAddressTableKeysInput = {
 
 /**
  * Resolves the account keys a v0 transaction loads from on-chain address
- * lookup tables. Writable entries from every table come before readonly ones,
- * matching how Solana orders loaded addresses. Fails closed: an unreadable
- * table or an index outside it throws instead of yielding undefined keys, so
- * callers can never present a partially decoded transaction as a complete one.
+ * lookup tables. Every table is fetched concurrently, but writable entries
+ * from all tables still come before readonly ones, matching how Solana orders
+ * loaded addresses. Fails closed: an unreadable table or an index outside it
+ * throws instead of yielding undefined keys, so callers can never present a
+ * partially decoded transaction as a complete one.
  */
 export const resolveAddressTableKeys = async ({
   lookups,
   connection,
 }: ResolveAddressTableKeysInput): Promise<PublicKey[]> => {
-  const writable: PublicKey[] = []
-  const readonly: PublicKey[] = []
-
-  for (const lookup of lookups) {
-    const { value } = await connection.getAddressLookupTable(
-      new PublicKey(lookup.accountKey)
-    )
-    if (!value) {
-      throw new Error(
-        `Address lookup table ${lookup.accountKey} could not be read`
+  const resolved = await Promise.all(
+    lookups.map(async lookup => {
+      const { value } = await connection.getAddressLookupTable(
+        new PublicKey(lookup.accountKey)
       )
-    }
-
-    const addresses = value.state.addresses
-    const resolveIndex = (index: number) => {
-      const address = addresses[index]
-      if (!address) {
+      if (!value) {
         throw new Error(
-          `Address lookup table ${lookup.accountKey} has no entry at index ${index}`
+          `Address lookup table ${lookup.accountKey} could not be read`
         )
       }
-      return address
-    }
 
-    writable.push(...lookup.writableIndexes.map(resolveIndex))
-    readonly.push(...lookup.readonlyIndexes.map(resolveIndex))
-  }
+      const { addresses } = value.state
+      const resolveIndex = (index: number) => {
+        const address = addresses[index]
+        if (!address) {
+          throw new Error(
+            `Address lookup table ${lookup.accountKey} has no entry at index ${index}`
+          )
+        }
+        return address
+      }
 
-  return [...writable, ...readonly]
+      return {
+        writable: lookup.writableIndexes.map(resolveIndex),
+        readonly: lookup.readonlyIndexes.map(resolveIndex),
+      }
+    })
+  )
+
+  return [
+    ...resolved.flatMap(({ writable }) => writable),
+    ...resolved.flatMap(({ readonly }) => readonly),
+  ]
 }
+
+/**
+ * Reads the account a transaction addresses by index, against the merged
+ * static-plus-lookup key list. Throws rather than returning undefined, since
+ * an index past the resolved keys means the transaction was only partially
+ * decoded and any account read from it would be a guess.
+ */
+export const accountKeyAt = (keys: PublicKey[], index: number): PublicKey => {
+  const key = keys[index]
+  if (!key) {
+    throw new Error(
+      `Transaction references account index ${index}, outside the ${keys.length} resolved account keys`
+    )
+  }
+  return key
+}
+
 export const mergedKeys = (staticKeys: PublicKey[], loaded: PublicKey[]) => {
   return [...staticKeys, ...loaded]
 }


### PR DESCRIPTION
Fixes #4734

## The problem

A Solana v0 transaction doesn't list most of its accounts inline. It references them by index into an on-chain **address lookup table**, so the extension has to read those tables before it can show what a dApp transaction actually does.

That resolution failed open in two ways:

```ts
const table = res.value?.state.addresses ?? []   // unreadable table → pretend it's empty
...l.writableIndexes.map(i => table[i])          // no bounds check → undefined
```

Both paths produce `undefined` account keys, which the approval parser then goes on to trust. So the approval card could present a wrong or incomplete picture of a transaction *precisely when* the lookup data was missing.

This isn't only theoretical. In `parseTokenInstruction`, an `undefined` recipient key makes the account fetch throw, a local `catch` swallows it, and the recipient is then guessed from a different source — so the user can be shown a **wrong recipient address**, with no warning.

## The fix

Two layers, deliberately separate:

**`resolveAddressTableKeys` now fails closed.** An unreadable table or an out-of-range index throws instead of yielding `undefined`, matching the SDK's `assertSafeSolanaSwapInstructions`, which already throws on an unresolved account index.

**`parseSolanaTx` catches that and returns the raw review fallback** with a warning. Without this second layer the throw would propagate all the way to the approval screen, replacing a confident lie with a hard error — which is not an improvement for the user. A missing table now degrades to "we can't decode this", which is the honest answer.

Also narrowed the resolver's connection parameter to `Pick<Connection, 'getAddressLookupTable'>` — the only method it uses. That made the tests injectable with a plain object, with no `as` cast and no `vi.mock`.

## One change beyond the minimum

Lookup table reads moved to *below* the Blockaid simulation. Blockaid works from the raw transaction and never needed our locally resolved keys, so a transient RPC failure was costing the user a correct server-side result for no reason. As a side effect the happy path now makes one fewer network call.

## Tests

`core/inpage-provider/.../solana/utils/index.test.ts` — written before the fix, and confirmed to actually catch the bug. Against the old code:

```text
✓ resolves writable indexes before readonly ones
× fails closed when the lookup table account is missing
  → promise resolved "[ undefined, undefined ]" instead of rejecting
✓ fails closed when the lookup table fetch errors
× fails closed when a writable index is outside the fetched table
  → promise resolved "[ undefined ]" instead of rejecting
× fails closed when a readonly index is outside the fetched table
  → promise resolved "[ undefined ]" instead of rejecting

Tests  3 failed | 2 passed (5)
```

That `[ undefined ]` is what reached the approval card. All five pass against this branch.

The two cases that pass in *both* states are there on purpose: they show the happy path still works and that the suite isn't simply asserting that everything throws.

Sibling of vultisig-sdk#2182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Solana transaction handling when address lookup tables are unavailable, invalid, or cannot be fetched.
  - Transactions now fall back to raw transaction processing instead of failing during parsing.
  - Improved account resolution for program calls by correctly combining static and lookup-table accounts.
  - Blockaid simulation is completed before address lookup tables are resolved, reducing unnecessary lookup errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->