### PR TITLE
Show DKLS malicious party keysign error

### DIFF
--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -901,6 +901,9 @@ export const de = {
   signed_signature: 'Unterschrift',
   signing_address: 'Unterschriftsadresse',
   signing_error: 'Signierfehler. Bitte versuchen Sie es erneut.',
+  keysign_malicious_party_error: 'Bösartiger Signierer erkannt',
+  keysign_malicious_party_error_description:
+    'Keysign wurde gestoppt, weil sich ein Signierer bösartig verhalten hat. Verwenden Sie diesen Signierer nicht erneut für Keysign.',
   signing_method: 'Signaturverfahren',
   silver: 'Silber',
   site: 'Website',

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -1104,6 +1104,9 @@ export const en = {
   signing_error: 'Signing Error. Please try again.',
   signing_error_description:
     "One of your devices didn't respond in time. Check your connection and try again.",
+  keysign_malicious_party_error: 'Malicious signer detected',
+  keysign_malicious_party_error_description:
+    'Keysign was stopped because one signer behaved maliciously. Do not use that signer for keysign again.',
   signing_method: 'Signing Method',
   silver: 'Silver',
   site: 'Site',

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -896,6 +896,9 @@ export const es = {
   signed_signature: 'Firma firmada',
   signing_address: 'Dirección de firma',
   signing_error: 'Error de firma. Inténtalo de nuevo.',
+  keysign_malicious_party_error: 'Firmante malicioso detectado',
+  keysign_malicious_party_error_description:
+    'Keysign se detuvo porque un firmante se comportó de forma maliciosa. No vuelvas a usar ese firmante para Keysign.',
   signing_method: 'Método de firma',
   silver: 'Plata',
   site: 'Sitio',

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -889,6 +889,9 @@ export const hr = {
   signed_signature: 'Potpis',
   signing_address: 'Adresa za potpisivanje',
   signing_error: 'Pogreška pri potpisivanju. Pokušajte ponovno.',
+  keysign_malicious_party_error: 'Otkriven je zlonamjerni potpisnik',
+  keysign_malicious_party_error_description:
+    'Keysign je zaustavljen jer se jedan potpisnik ponašao zlonamjerno. Nemojte ponovno koristiti tog potpisnika za Keysign.',
   signing_method: 'Metoda potpisivanja',
   silver: 'Srebro',
   site: 'Stranica',

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -897,6 +897,9 @@ export const it = {
   signed_signature: 'Firma firmata',
   signing_address: 'Indirizzo di firma',
   signing_error: 'Errore di firma. Riprova.',
+  keysign_malicious_party_error: 'Firmatario malevolo rilevato',
+  keysign_malicious_party_error_description:
+    'Keysign è stato interrotto perché un firmatario si è comportato in modo malevolo. Non usare di nuovo quel firmatario per Keysign.',
   signing_method: 'Metodo di firma',
   silver: 'Argento',
   site: 'Sito',

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -877,6 +877,9 @@ export const ko = {
   signed_signature: '서명',
   signing_address: '서명 주소',
   signing_error: '서명 오류입니다. 다시 시도해 주세요.',
+  keysign_malicious_party_error: '악의적인 서명자가 감지되었습니다',
+  keysign_malicious_party_error_description:
+    '서명자 중 하나가 악의적으로 동작하여 Keysign이 중지되었습니다. 해당 서명자를 Keysign에 다시 사용하지 마세요.',
   signing_method: '서명 방식',
   silver: '은',
   site: '대지',

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -884,6 +884,9 @@ export const nl = {
   signed_signature: 'Ondertekende handtekening',
   signing_address: 'Ondertekenadres',
   signing_error: 'Ondertekenfout. Probeer opnieuw.',
+  keysign_malicious_party_error: 'Kwaadwillende ondertekenaar gedetecteerd',
+  keysign_malicious_party_error_description:
+    'Keysign is gestopt omdat een ondertekenaar zich kwaadwillend gedroeg. Gebruik die ondertekenaar niet opnieuw voor Keysign.',
   signing_method: 'Ondertekenmethode',
   silver: 'Zilver',
   site: 'Site',

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -894,6 +894,9 @@ export const pt = {
   signed_signature: 'Assinatura assinada',
   signing_address: 'Endereço de assinatura',
   signing_error: 'Erro ao assinar. Tente novamente.',
+  keysign_malicious_party_error: 'Signatário malicioso detectado',
+  keysign_malicious_party_error_description:
+    'O Keysign foi interrompido porque um signatário se comportou de forma maliciosa. Não use esse signatário novamente para Keysign.',
   signing_method: 'Método de assinatura',
   silver: 'Prata',
   site: 'Site',

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -882,6 +882,9 @@ export const ru = {
   signed_signature: 'Подписанная подпись',
   signing_address: 'Адрес подписи',
   signing_error: 'Ошибка подписи. Попробуйте ещё раз.',
+  keysign_malicious_party_error: 'Обнаружен вредоносный подписант',
+  keysign_malicious_party_error_description:
+    'Keysign остановлен, потому что один из подписантов вел себя вредоносно. Не используйте этого подписанта для Keysign снова.',
   signing_method: 'Метод подписи',
   silver: 'Серебро',
   site: 'Сайт',

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -827,6 +827,9 @@ export const zh = {
   signed_signature: '签名',
   signing_address: '签名地址',
   signing_error: '签名错误，请重试。',
+  keysign_malicious_party_error: '检测到恶意签名方',
+  keysign_malicious_party_error_description:
+    'Keysign 已停止，因为一名签名方存在恶意行为。请勿再次使用该签名方进行 Keysign。',
   signing_method: '签名方法',
   silver: '银',
   site: '地点',

--- a/core/ui/mpc/keysign/KeysignSigningStep.tsx
+++ b/core/ui/mpc/keysign/KeysignSigningStep.tsx
@@ -49,6 +49,14 @@ type KeysignSigningStepProps = Partial<OnBackProp> & {
   toAddressLabel?: string
 }
 
+const isDklsMaliciousPartyError = (error: unknown) => {
+  if (error instanceof Error && error.name === 'DklsMaliciousPartyError') {
+    return true
+  }
+
+  return extractErrorMsg(error).includes('DKLS keysign aborted because party')
+}
+
 export const KeysignSigningStep = ({
   onBack,
   onSettled,
@@ -280,6 +288,17 @@ export const KeysignSigningStep = ({
               error={error}
               title={t('broadcast_error')}
               description={t('broadcast_error_description')}
+            />
+          )
+        }
+
+        if (isDklsMaliciousPartyError(error)) {
+          return (
+            <FullPageFlowErrorState
+              variant="error"
+              error={error}
+              title={t('keysign_malicious_party_error')}
+              description={t('keysign_malicious_party_error_description')}
             />
           )
         }


### PR DESCRIPTION
## Summary
- detect the SDK's DklsMaliciousPartyError in the keysign signing step
- show a dedicated malicious signer warning instead of the generic signing timeout copy
- add localized strings for the new error branch

## Validation
- yarn check
- yarn prettier --config .prettierrc --check core/ui/mpc/keysign/KeysignSigningStep.tsx core/ui/i18n/locales/en.ts core/ui/i18n/locales/de.ts core/ui/i18n/locales/es.ts core/ui/i18n/locales/hr.ts core/ui/i18n/locales/it.ts core/ui/i18n/locales/ko.ts core/ui/i18n/locales/nl.ts core/ui/i18n/locales/pt.ts core/ui/i18n/locales/ru.ts core/ui/i18n/locales/zh.ts

## Dependency
- Requires SDK support from vultisig/vultisig-sdk#2224 to surface DklsMaliciousPartyError from DKLS keysign abort-and-ban codes.

Closes #4686