### PR TITLE
fix(keysign): add back navigation from tx details to the receipt

### DIFF
--- a/core/ui/mpc/keysign/KeysignSigningStep.tsx
+++ b/core/ui/mpc/keysign/KeysignSigningStep.tsx
@@ -1,4 +1,5 @@
 import { DappRequestBanner } from '@core/ui/dapp/DappRequestBanner'
+import { FlowPageHeader } from '@core/ui/flow/FlowPageHeader'
 import { FullPageFlowErrorState } from '@core/ui/flow/FullPageFlowErrorState'
 import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { useKeysignMutation } from '@core/ui/mpc/keysign/action/mutations/useKeysignMutation'
@@ -85,7 +86,6 @@ export const KeysignSigningStep = ({
       value={mutationStatus}
       success={result => (
         <>
-          <PageHeader title={t('done')} hasBorder />
           <MatchRecordUnion
             value={payload}
             handlers={{
@@ -96,6 +96,7 @@ export const KeysignSigningStep = ({
                 if (payload.isQbtcClaim) {
                   return (
                     <>
+                      <PageHeader title={t('done')} hasBorder />
                       <PageContent alignItems="center" scrollable>
                         <VStack gap={16} maxWidth={576} fullWidth>
                           <Panel>
@@ -119,25 +120,29 @@ export const KeysignSigningStep = ({
                 return (
                   <TxHashProvider value={getLastItem(txs).hash}>
                     {isSwapTx ? (
-                      <PageContent alignItems="center" scrollable>
-                        <AnimatedVisibility
-                          animationConfig="bottomToTop"
-                          overlayStyles={{
-                            display: 'flex',
-                            justifyContent: 'center',
-                            width: '100%',
-                          }}
-                        >
-                          <SwapKeysignTxOverview
-                            txHashes={txs.map(tx => tx.hash)}
-                            value={payload}
-                          />
-                        </AnimatedVisibility>
-                      </PageContent>
+                      <>
+                        <PageHeader title={t('done')} hasBorder />
+                        <PageContent alignItems="center" scrollable>
+                          <AnimatedVisibility
+                            animationConfig="bottomToTop"
+                            overlayStyles={{
+                              display: 'flex',
+                              justifyContent: 'center',
+                              width: '100%',
+                            }}
+                          >
+                            <SwapKeysignTxOverview
+                              txHashes={txs.map(tx => tx.hash)}
+                              value={payload}
+                            />
+                          </AnimatedVisibility>
+                        </PageContent>
+                      </>
                     ) : (
                       <StepTransition
                         from={({ onFinish: onSeeTxDetails }) => (
                           <>
+                            <PageHeader title={t('done')} hasBorder />
                             <PageContent alignItems="center" scrollable>
                               <AnimatedVisibility
                                 animationConfig="bottomToTop"
@@ -196,8 +201,12 @@ export const KeysignSigningStep = ({
                             </PageFooter>
                           </>
                         )}
-                        to={() => (
+                        to={({ onBack: onBackToReceipt }) => (
                           <>
+                            <FlowPageHeader
+                              title={t('transaction_details')}
+                              onBack={onBackToReceipt}
+                            />
                             <PageContent alignItems="center" scrollable>
                               <VStack gap={16} maxWidth={576} fullWidth>
                                 <DappRequestBanner
@@ -227,6 +236,7 @@ export const KeysignSigningStep = ({
 
                 return (
                   <>
+                    <PageHeader title={t('done')} hasBorder />
                     <PageContent alignItems="center" scrollable>
                       <VStack gap={16} maxWidth={576} fullWidth>
                         <Panel>


### PR DESCRIPTION
## Description

Opening **Transaction details** from the post-send receipt was a one-way door: the details step had no back control, so the only exit was **Complete**, which drops the user home. This is worst in the extension, where the popup is a fixed-size box with no browser chrome or back gesture to fall back on.

The cause is a single dropped argument. [`StepTransition`](https://github.com/vultisig/vultisig-windows/blob/main/lib/ui/base/StepTransition.tsx) always supplies `onBack` to its `to` branch, and `KeysignSigningStep` was the only one of thirteen call sites that discarded it:

```diff
-to={() => (
+to={({ onBack: onBackToReceipt }) => (
```

It is now wired into a `FlowPageHeader`, so the details step gets the standard header back button. The title reads **Transaction Details** rather than **Done**, since it is a step the user can leave rather than the end of the flow. `transaction_details` was already translated into all 10 locales, so no new i18n key and no `yarn translate` run were needed.

To let the header differ per step it moved out of the shared success wrapper into each branch. For the swap, custom-message and QBTC-claim branches that is a pure refactor — they render exactly as before. In every branch it stays a flex sibling of `PageContent`/`PageFooter`, so the layout is unchanged.

### Scope

Only the non-swap receipt is affected. A payload carrying a `swapPayload` renders `SwapKeysignTxOverview` with no `StepTransition`, so **market swaps have no details step and no dead end to fix**.

Send is the reported case. Deposit/stake/bond, dApp send, referral, Kamino, Circle, QBTC vote and the matching join-keysign flows share the same step and are fixed with it. Limit orders land on either side: the builder attaches a `swapPayload` only for ERC20 sources, so RUNE and native-gas-asset orders go through this step as plain deposits and are fixed too.

Because `KeysignSigningStep` is shared, this covers **both the extension and desktop** — the second half of the issue ("check the desktop build for the same dead-end") needed no separate change.

Fixes #4730

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [x] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

> Presentation-only change to the post-send Done screen. No keysign, broadcast, payload or fee logic is touched, so there is no new tx to link — the fix is visible on any existing send receipt.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

**On tests:** no automated coverage was added. The existing e2e page object (`KeysignProgress.po.ts`) only targets the receipt step — `tx-success`, `tx-hash`, `tx-success-done` — and no test navigates into the details view, so nothing regressed and nothing covers this. A test would need a full keysign ceremony to reach the screen. Happy to add one if reviewers want it.

Validation run: `yarn typecheck` clean, `yarn lint` clean, `yarn test` 1251 passed across 180 files.

`yarn check` fails at the asset-validation step on unexpected `thor.svg` / `vthor.svg`. That reproduces on a clean `main` (verified via `git stash`) and comes from 8b576170c — unrelated to this PR. Since that check runs first and short-circuits, typecheck and lint were run directly.

## Screenshots (if applicable):

Not captured — verifying in the running app requires completing a real keysign ceremony. **Manual QA request:** on a Fast Vault in the extension, send a transaction, open *Transaction details* from the receipt, and confirm the header back button returns you to the receipt with the tx hash intact.

## Additional context

Every other `StepTransition` in the codebase already destructures `onBack`, so this reads as an oversight at one call site rather than a deliberate one-way step.

## Agent Metadata (if applicable)
- **Agent**: Claude Code (Opus 5)
- **Issue**: #4730
- **Confidence**: high — one-line root cause, mechanical fix, typecheck/lint/tests green
- **Needs human review for**: manual QA in the extension popup (no screenshots), and the unverified iOS/Android parity above


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved completion screens in the keysigning flow with clearer, context-specific headers.
  * Added back navigation to transaction detail results.
  * Preserved dedicated confirmation messaging for QBTC claim completions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
