### PR TITLE
Recover passcode-protected vaults after proof loss

### DIFF
--- a/clients/extension/tests/e2e/helpers/chrome-storage.ts
+++ b/clients/extension/tests/e2e/helpers/chrome-storage.ts
@@ -23,10 +23,14 @@ export const StorageKey = {
 /**
  * Get the service worker for chrome.storage access
  */
-export async function getServiceWorker(context: BrowserContext): Promise<Worker> {
+export async function getServiceWorker(
+  context: BrowserContext
+): Promise<Worker> {
   let [background] = context.serviceWorkers()
   if (!background) {
-    background = await context.waitForEvent('serviceworker', { timeout: 30_000 })
+    background = await context.waitForEvent('serviceworker', {
+      timeout: 30_000,
+    })
   }
   return background
 }
@@ -41,8 +45,8 @@ export async function readChromeStorage<T = unknown>(
   const worker = await getServiceWorker(context)
 
   const result = await worker.evaluate(async (storageKey: string) => {
-    return new Promise((resolve) => {
-      chrome.storage.local.get([storageKey], (result) => {
+    return new Promise(resolve => {
+      chrome.storage.local.get([storageKey], result => {
         resolve(result[storageKey])
       })
     })
@@ -61,9 +65,34 @@ export async function writeChromeStorage(
 ): Promise<void> {
   const worker = await getServiceWorker(context)
 
-  await worker.evaluate(async ({ key, value }: { key: string; value: unknown }) => {
+  await worker.evaluate(
+    async ({ key, value }: { key: string; value: unknown }) => {
+      return new Promise<void>((resolve, reject) => {
+        chrome.storage.local.set({ [key]: value }, () => {
+          if (chrome.runtime.lastError) {
+            reject(new Error(chrome.runtime.lastError.message))
+          } else {
+            resolve()
+          }
+        })
+      })
+    },
+    { key, value }
+  )
+}
+
+/**
+ * Remove one value from chrome.storage.local.
+ */
+export async function removeChromeStorage(
+  context: BrowserContext,
+  key: string
+): Promise<void> {
+  const worker = await getServiceWorker(context)
+
+  await worker.evaluate(async (storageKey: string) => {
     return new Promise<void>((resolve, reject) => {
-      chrome.storage.local.set({ [key]: value }, () => {
+      chrome.storage.local.remove(storageKey, () => {
         if (chrome.runtime.lastError) {
           reject(new Error(chrome.runtime.lastError.message))
         } else {
@@ -71,7 +100,49 @@ export async function writeChromeStorage(
         }
       })
     })
-  }, { key, value })
+  }, key)
+}
+
+/**
+ * Read one value from chrome.storage.session.
+ */
+export async function readChromeSessionStorage<T = unknown>(
+  context: BrowserContext,
+  key: string
+): Promise<T | undefined> {
+  const worker = await getServiceWorker(context)
+
+  const result = await worker.evaluate(async (storageKey: string) => {
+    return new Promise(resolve => {
+      chrome.storage.session.get([storageKey], result => {
+        resolve(result[storageKey])
+      })
+    })
+  }, key)
+
+  return result as T | undefined
+}
+
+/**
+ * Remove one value from chrome.storage.session.
+ */
+export async function removeChromeSessionStorage(
+  context: BrowserContext,
+  key: string
+): Promise<void> {
+  const worker = await getServiceWorker(context)
+
+  await worker.evaluate(async (storageKey: string) => {
+    return new Promise<void>((resolve, reject) => {
+      chrome.storage.session.remove(storageKey, () => {
+        if (chrome.runtime.lastError) {
+          reject(new Error(chrome.runtime.lastError.message))
+        } else {
+          resolve()
+        }
+      })
+    })
+  }, key)
 }
 
 /**
@@ -99,7 +170,9 @@ export async function writeChromeStorageMultiple(
 /**
  * Clear all chrome.storage.local data
  */
-export async function clearChromeStorage(context: BrowserContext): Promise<void> {
+export async function clearChromeStorage(
+  context: BrowserContext
+): Promise<void> {
   const worker = await getServiceWorker(context)
 
   await worker.evaluate(async () => {
@@ -124,8 +197,8 @@ export async function readAllChromeStorage(
   const worker = await getServiceWorker(context)
 
   const result = await worker.evaluate(async () => {
-    return new Promise((resolve) => {
-      chrome.storage.local.get(null, (result) => {
+    return new Promise(resolve => {
+      chrome.storage.local.get(null, result => {
         resolve(result)
       })
     })

--- a/clients/extension/tests/e2e/specs/passcode-lock-layering.spec.ts
+++ b/clients/extension/tests/e2e/specs/passcode-lock-layering.spec.ts
@@ -24,8 +24,17 @@
  */
 
 import type { Locator, Page } from '@playwright/test'
+import type { Vault } from '@vultisig/core-mpc/vault/Vault'
+import fs from 'fs'
+import path from 'path'
 
 import { expect, test } from '../fixtures/extension-loader'
+import {
+  readChromeSessionStorage,
+  readChromeStorage,
+  removeChromeSessionStorage,
+  removeChromeStorage,
+} from '../helpers/chrome-storage'
 import {
   ensureVaultExists,
   getVaultConfigFromEnv,
@@ -38,6 +47,23 @@ const autoLockMinutes = 1
 // `topLayerTextAt` compares raw textContent, so the casing has to be right.
 const modalMarker = 'Select chain'
 const gateMarker = 'App Locked'
+const passcodeEncryptionStorageKey = 'passcodeEncryption'
+const vaultsStorageKey = 'vaults'
+const qaArtifactDirectory = process.env.PASSCODE_RECOVERY_QA_DIR
+// Matches the production-only chrome.storage.session key. The value remains
+// sealed; the E2E needs only presence/absence for the restoration boundary.
+const passcodeUnlockSessionChromeStorageKey = 'extensionPasscodeUnlockSession'
+
+const captureQaArtifact = async (page: Page, name: string) => {
+  if (!qaArtifactDirectory) {
+    return
+  }
+
+  fs.mkdirSync(qaArtifactDirectory, { recursive: true })
+  await page.screenshot({
+    path: path.join(qaArtifactDirectory, name),
+  })
+}
 
 /**
  * Returns the text of the top-level layer that owns the centre of the viewport.
@@ -114,6 +140,94 @@ const enablePasscode = async (page: Page) => {
   await expect(page.getByText('ON', { exact: true })).toBeVisible({
     timeout: 30_000,
   })
+}
+
+const enterPasscode = async (page: Page, value: string) => {
+  const digitBoxes = page.locator('input[type="password"]')
+  await expect(digitBoxes).toHaveCount(6)
+  await digitBoxes.first().click()
+  await page.keyboard.type(value)
+}
+
+const waitForUnlockSession = (
+  context: Parameters<typeof readChromeSessionStorage>[0]
+) =>
+  expect
+    .poll(() =>
+      readChromeSessionStorage(context, passcodeUnlockSessionChromeStorageKey)
+    )
+    .not.toBeUndefined()
+
+const openVaultPage = async (
+  context: Parameters<typeof readChromeStorage>[0],
+  extensionId: string
+) => {
+  const page = await context.newPage()
+  await page.setViewportSize({ width: 480, height: 600 })
+  const vaultPage = new VaultPage(page, extensionId)
+  await vaultPage.goto()
+
+  return { page, vaultPage }
+}
+
+const interruptPasscodeChange = async ({
+  context,
+  page,
+  toPasscode,
+}: {
+  context: Parameters<typeof readChromeStorage>[0]
+  page: Page
+  toPasscode: string
+}) => {
+  const before = await readChromeStorage<Vault[]>(context, vaultsStorageKey)
+  const beforeKeyShares = JSON.stringify(
+    before?.map(({ chainKeyShares, keyShareMldsa, keyShares }) => ({
+      chainKeyShares,
+      keyShareMldsa,
+      keyShares,
+    }))
+  )
+
+  await page.evaluate(() => {
+    const originalSet = chrome.storage.local.set
+
+    chrome.storage.local.set = async items => {
+      await originalSet.call(chrome.storage.local, items)
+
+      if ('vaults' in items) {
+        throw new Error('popup destroyed after vault write')
+      }
+    }
+  })
+
+  await page.getByRole('button', { name: /change passcode/i }).click()
+
+  const digitBoxes = page.locator('input[type="password"]')
+  await expect(digitBoxes).toHaveCount(18)
+  await digitBoxes.first().click()
+  await page.keyboard.type(passcode)
+  await digitBoxes.nth(6).click()
+  await page.keyboard.type(toPasscode)
+  await digitBoxes.nth(12).click()
+  await page.keyboard.type(toPasscode)
+  await page.getByRole('button', { name: 'Save', exact: true }).click()
+
+  await expect
+    .poll(async () => {
+      const current = await readChromeStorage<Vault[]>(
+        context,
+        vaultsStorageKey
+      )
+
+      return JSON.stringify(
+        current?.map(({ chainKeyShares, keyShareMldsa, keyShares }) => ({
+          chainKeyShares,
+          keyShareMldsa,
+          keyShares,
+        }))
+      )
+    })
+    .not.toBe(beforeKeyShares)
 }
 
 /**
@@ -231,6 +345,154 @@ test.describe('Passcode lock layering', () => {
       await expect(page.getByText(modalMarker)).toBeVisible()
     } finally {
       await page.close()
+    }
+  })
+
+  test('recovers after proof loss, preserves throttling, and repairs restart state', async ({
+    context,
+    extensionId,
+  }) => {
+    test.slow()
+
+    const { page, vaultPage } = await openVaultPage(context, extensionId)
+
+    try {
+      await vaultPage.waitForView()
+      await vaultPage.dismissPromptSheets()
+      await page.locator('[data-testid="settings-button"]').click()
+      await expect(
+        page.getByText('Security', { exact: true }).first()
+      ).toBeVisible()
+      await enablePasscode(page)
+      await waitForUnlockSession(context)
+
+      await removeChromeStorage(context, passcodeEncryptionStorageKey)
+      await removeChromeSessionStorage(
+        context,
+        passcodeUnlockSessionChromeStorageKey
+      )
+    } finally {
+      await page.close()
+    }
+
+    const recovery = await openVaultPage(context, extensionId)
+
+    try {
+      await expect(recovery.page.getByText(gateMarker)).toBeVisible()
+      await expect(recovery.page.locator('input[type="password"]')).toHaveCount(
+        6
+      )
+
+      await enterPasscode(recovery.page, '246801')
+      await expect(recovery.page.getByText('Invalid passcode')).toBeVisible({
+        timeout: 15_000,
+      })
+
+      const throttled = await readChromeStorage<{
+        encryptedSample: null
+        attemptState: { failedAttempts: number }
+      }>(context, passcodeEncryptionStorageKey)
+
+      expect(throttled).toMatchObject({
+        encryptedSample: null,
+        attemptState: { failedAttempts: 1 },
+      })
+
+      await captureQaArtifact(recovery.page, 'proof-loss-invalid-passcode.png')
+
+      await enterPasscode(recovery.page, passcode)
+      await expect(recovery.page.getByText(gateMarker)).toBeHidden({
+        timeout: 15_000,
+      })
+
+      await expect
+        .poll(
+          () =>
+            readChromeStorage<{
+              encryptedSample: string | null
+              passcodeLength?: number
+              attemptState?: unknown
+            }>(context, passcodeEncryptionStorageKey),
+          { timeout: 15_000 }
+        )
+        .toMatchObject({
+          encryptedSample: expect.any(String),
+          passcodeLength: 6,
+        })
+    } finally {
+      await recovery.page.close()
+    }
+
+    const restarted = await openVaultPage(context, extensionId)
+
+    try {
+      await restarted.vaultPage.waitForView()
+      await expect(restarted.page.getByText(gateMarker)).toBeHidden()
+    } finally {
+      await restarted.page.close()
+    }
+  })
+
+  test('rejects a stale restored session before accepting the shares passcode', async ({
+    context,
+    extensionId,
+  }) => {
+    test.slow()
+
+    const newPasscode = '246801'
+    const { page, vaultPage } = await openVaultPage(context, extensionId)
+
+    try {
+      await vaultPage.waitForView()
+      await vaultPage.dismissPromptSheets()
+      await page.locator('[data-testid="settings-button"]').click()
+      await expect(
+        page.getByText('Security', { exact: true }).first()
+      ).toBeVisible()
+      await enablePasscode(page)
+      await waitForUnlockSession(context)
+      await interruptPasscodeChange({
+        context,
+        page,
+        toPasscode: newPasscode,
+      })
+    } finally {
+      await page.close()
+    }
+
+    const recovery = await openVaultPage(context, extensionId)
+
+    try {
+      await expect(recovery.page.getByText(gateMarker)).toBeVisible({
+        timeout: 15_000,
+      })
+      await expect
+        .poll(() =>
+          readChromeSessionStorage(
+            context,
+            passcodeUnlockSessionChromeStorageKey
+          )
+        )
+        .toBeUndefined()
+
+      await captureQaArtifact(recovery.page, 'stale-session-rejected.png')
+
+      await enterPasscode(recovery.page, newPasscode)
+      await expect(recovery.page.getByText(gateMarker)).toBeHidden({
+        timeout: 15_000,
+      })
+      await waitForUnlockSession(context)
+    } finally {
+      await recovery.page.close()
+    }
+
+    const restarted = await openVaultPage(context, extensionId)
+
+    try {
+      await restarted.vaultPage.waitForView()
+      await expect(restarted.page.getByText(gateMarker)).toBeHidden()
+    } finally {
+      await restarted.page.close()
     }
   })
 })

--- a/clients/extension/tests/unit/EnterPasscodeRecovery.test.tsx
+++ b/clients/extension/tests/unit/EnterPasscodeRecovery.test.tsx
@@ -1,0 +1,217 @@
+// @vitest-environment happy-dom
+
+import { passcodeEncryptionStorage } from '@core/extension/storage/passcodeEncryption'
+import { vaultsStorage } from '@core/extension/storage/vaults'
+import { encryptSample } from '@core/ui/passcodeEncryption/core/sample'
+import { encryptVaultAllKeyShares } from '@core/ui/passcodeEncryption/core/vaultKeyShares'
+import { EnterPasscode } from '@core/ui/passcodeEncryption/guard/EnterPasscode'
+import {
+  PasscodeProvider,
+  usePasscode,
+} from '@core/ui/passcodeEncryption/state/passcode'
+import { StorageKey } from '@core/ui/storage/StorageKey'
+import { darkTheme } from '@lib/ui/theme/darkTheme'
+import { ThemeProvider } from '@lib/ui/theme/ThemeProvider'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { Vault } from '@vultisig/core-mpc/vault/Vault'
+import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
+import { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('lottie-react', () => ({ default: () => null }))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    i18n: { language: 'en', resolvedLanguage: 'en' },
+    t: (key: string) => key,
+  }),
+  Trans: ({ children }: { children?: ReactNode }) => children ?? null,
+}))
+
+vi.mock('@core/ui/passcodeEncryption/manage/PasscodeInput', () => ({
+  PasscodeInput: ({
+    length,
+    onChange,
+    validation,
+    value,
+  }: {
+    length: number
+    onChange: (value: string | null) => void
+    validation?: string
+    value: string | null
+  }) => (
+    <input
+      data-testid="passcode-input"
+      data-length={length}
+      data-validation={validation ?? ''}
+      onChange={event => onChange(event.target.value || null)}
+      value={value ?? ''}
+    />
+  ),
+}))
+
+const coreHolder: { value: Record<string, unknown> | undefined } = vi.hoisted(
+  () => ({ value: undefined })
+)
+
+vi.mock('@core/ui/state/core', () => ({
+  useCore: () => shouldBePresent(coreHolder.value),
+}))
+
+coreHolder.value = {
+  ...vaultsStorage,
+  ...passcodeEncryptionStorage,
+}
+
+const baseVault: Omit<Vault, 'keyShares'> = {
+  name: 'Recovery Vault',
+  publicKeys: { ecdsa: 'ecdsa-public-key', eddsa: 'eddsa-public-key' },
+  signers: ['device-1'],
+  hexChainCode: 'chain-code',
+  localPartyId: 'device-1',
+  libType: 'DKLS',
+  isBackedUp: true,
+  order: 0,
+}
+
+const PasscodeProbe = () => {
+  const [passcode] = usePasscode()
+
+  return <span data-testid="passcode-probe">{passcode ?? ''}</span>
+}
+
+const renderProofLossRecovery = async (
+  passcode: string,
+  { preserveProof = false }: { preserveProof?: boolean } = {}
+) => {
+  const encrypted = await encryptVaultAllKeyShares({
+    keyShares: {
+      ecdsa: 'ecdsa-share',
+      eddsa: 'eddsa-share',
+    },
+    key: passcode,
+  })
+
+  await chrome.storage.local.set({
+    [StorageKey.vaults]: [
+      {
+        ...baseVault,
+        keyShares: encrypted.keyShares,
+      },
+    ],
+  })
+  const passcodeEncryption = preserveProof
+    ? {
+        encryptedSample: await encryptSample({
+          key: passcode,
+          value: 'sample',
+        }),
+        passcodeLength: passcode.length,
+      }
+    : null
+
+  if (passcodeEncryption) {
+    await passcodeEncryptionStorage.setPasscodeEncryption(passcodeEncryption)
+  } else {
+    await chrome.storage.local.remove(StorageKey.passcodeEncryption)
+  }
+
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  queryClient.setQueryData([StorageKey.passcodeEncryption], passcodeEncryption)
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={darkTheme}>
+        <PasscodeProvider initialValue={null}>
+          <EnterPasscode />
+          <PasscodeProbe />
+        </PasscodeProvider>
+      </ThemeProvider>
+    </QueryClientProvider>
+  )
+
+  return screen.getByTestId<HTMLInputElement>('passcode-input')
+}
+
+const validationOf = (input: HTMLInputElement) =>
+  input.getAttribute('data-validation')
+
+describe('EnterPasscode proof-loss recovery', () => {
+  it('waits for the full six-digit recovery code before verifying', async () => {
+    const passcode = '135790'
+    const input = await renderProofLossRecovery(passcode)
+
+    expect(input.getAttribute('data-length')).toBe('6')
+
+    fireEvent.change(input, { target: { value: passcode.slice(0, -1) } })
+    expect(validationOf(input)).toBe('')
+
+    fireEvent.change(input, { target: { value: passcode } })
+
+    await waitFor(
+      () =>
+        expect(screen.getByTestId('passcode-probe').textContent).toBe(passcode),
+      { timeout: 5_000 }
+    )
+  })
+
+  it('charges the completed six-digit failure and persists throttling without a proof', async () => {
+    const input = await renderProofLossRecovery('135790')
+
+    fireEvent.change(input, { target: { value: '24680' } })
+    expect(validationOf(input)).toBe('')
+
+    expect(await passcodeEncryptionStorage.getPasscodeEncryption()).toBeNull()
+
+    fireEvent.change(input, { target: { value: '246801' } })
+
+    await waitFor(() => expect(validationOf(input)).toBe('invalid'), {
+      timeout: 5_000,
+    })
+
+    expect(await passcodeEncryptionStorage.getPasscodeEncryption()).toEqual({
+      encryptedSample: null,
+      attemptState: {
+        failedAttempts: 1,
+        lastFailedAt: expect.any(Number),
+      },
+    })
+  })
+
+  it('unlocks a proofless legacy five-digit vault only after explicit submission', async () => {
+    const passcode = '13579'
+    const input = await renderProofLossRecovery(passcode)
+
+    expect(input.getAttribute('data-length')).toBe('6')
+    fireEvent.change(input, { target: { value: passcode } })
+    expect(screen.getByTestId('passcode-probe').textContent).toBe('')
+    fireEvent.click(screen.getByRole('button', { name: 'continue' }))
+
+    await waitFor(
+      () =>
+        expect(screen.getByTestId('passcode-probe').textContent).toBe(passcode),
+      { timeout: 5_000 }
+    )
+  })
+
+  it('charges a failed explicit legacy recovery attempt', async () => {
+    const input = await renderProofLossRecovery('13579')
+
+    fireEvent.change(input, { target: { value: '54321' } })
+    fireEvent.click(screen.getByRole('button', { name: 'continue' }))
+
+    await waitFor(() => expect(validationOf(input)).toBe('invalid'), {
+      timeout: 5_000,
+    })
+    expect(await passcodeEncryptionStorage.getPasscodeEncryption()).toEqual({
+      encryptedSample: null,
+      attemptState: {
+        failedAttempts: 1,
+        lastFailedAt: expect.any(Number),
+      },
+    })
+  })
+})

--- a/clients/extension/tests/unit/passcodeCrashRecovery.test.tsx
+++ b/clients/extension/tests/unit/passcodeCrashRecovery.test.tsx
@@ -417,7 +417,15 @@ describe('passcode set/change survives a popup teardown', () => {
     // a WebView2 profile reset wipes one and leaves the other.
     await chrome.storage.local.remove(StorageKey.passcodeEncryption)
 
+    expect(await openVaultOnNextLaunch([newPasscode])).toEqual({
+      ecdsaShare: null,
+      servedCiphertext: false,
+    })
     expect(await openVaultOnNextLaunch([passcode])).toEqual(healthyVault)
+
+    await reconcileAfterUnlock(passcode)
+
+    expect(await proofOpensWith([passcode, newPasscode])).toEqual([passcode])
   })
 
   // Change-passcode runs to completion in both of these, so the new passcode is

--- a/clients/extension/tests/unit/usePasscodeUnlockSession.test.ts
+++ b/clients/extension/tests/unit/usePasscodeUnlockSession.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 
 import { usePasscodeUnlockSession } from '@core/ui/passcodeEncryption/autoLock/usePasscodeUnlockSession'
+import { withPasscodeOperationLock } from '@core/ui/passcodeEncryption/core/passcodeAttemptThrottle'
 import { verifyPasscode } from '@core/ui/passcodeEncryption/core/passcodeLock'
 import { usePasscode } from '@core/ui/passcodeEncryption/state/passcode'
 import { useCore } from '@core/ui/state/core'
@@ -24,6 +25,10 @@ describe('usePasscodeUnlockSession', () => {
     vi.mocked(useCore).mockReset()
     vi.mocked(usePasscode).mockReset()
     vi.mocked(verifyPasscode).mockReset()
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: undefined,
+    })
   })
 
   it('when persistence is disabled: no pending restore and no storage calls', () => {
@@ -229,6 +234,66 @@ describe('usePasscodeUnlockSession', () => {
     })
 
     expect(setPasscode).not.toHaveBeenCalled()
+  })
+
+  it('serializes failed-restore clearing ahead of a concurrent session write', async () => {
+    let tail = Promise.resolve<unknown>(undefined)
+    const request = vi.fn(
+      (_name: string, operation: () => Promise<unknown>) => {
+        const result = tail.then(operation)
+        tail = result.catch(() => undefined)
+        return result
+      }
+    )
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: { request },
+    })
+
+    let finishClear!: () => void
+    const clearPending = new Promise<void>(resolve => {
+      finishClear = resolve
+    })
+    const getPasscodeUnlockSession = vi.fn(async () => {
+      throw new Error('restore failed')
+    })
+    const setPasscodeUnlockSession = vi.fn(async () => {})
+    const clearPasscodeUnlockSession = vi.fn(() => clearPending)
+
+    vi.mocked(useCore).mockReturnValue({
+      canPersistPasscodeUnlockSession: true,
+      getPasscodeUnlockSession,
+      setPasscodeUnlockSession,
+      clearPasscodeUnlockSession,
+    } as ReturnType<typeof useCore>)
+    vi.mocked(usePasscode).mockReturnValue([null, vi.fn()])
+
+    const { unmount } = renderHook(() =>
+      usePasscodeUnlockSession({
+        hasPasscodeEncryption: true,
+        passcodeAutoLock: null,
+      })
+    )
+
+    await waitFor(() => {
+      expect(clearPasscodeUnlockSession).toHaveBeenCalledTimes(1)
+    })
+    unmount()
+
+    const concurrentWrite = withPasscodeOperationLock(() =>
+      setPasscodeUnlockSession({ passcode: 'new-session', expiresAt: null })
+    )
+
+    expect(setPasscodeUnlockSession).not.toHaveBeenCalled()
+
+    finishClear()
+    await concurrentWrite
+
+    expect(setPasscodeUnlockSession).toHaveBeenCalledWith({
+      passcode: 'new-session',
+      expiresAt: null,
+    })
+    expect(request).toHaveBeenCalledTimes(2)
   })
 
   it('disabling passcode encryption clears persisted session', async () => {

--- a/clients/extension/tests/unit/usePasscodeUnlockSession.test.ts
+++ b/clients/extension/tests/unit/usePasscodeUnlockSession.test.ts
@@ -1,11 +1,11 @@
 // @vitest-environment happy-dom
 
+import { usePasscodeUnlockSession } from '@core/ui/passcodeEncryption/autoLock/usePasscodeUnlockSession'
+import { verifyPasscode } from '@core/ui/passcodeEncryption/core/passcodeLock'
+import { usePasscode } from '@core/ui/passcodeEncryption/state/passcode'
+import { useCore } from '@core/ui/state/core'
 import { renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-
-import { usePasscodeUnlockSession } from '@core/ui/passcodeEncryption/autoLock/usePasscodeUnlockSession'
-import { useCore } from '@core/ui/state/core'
-import { usePasscode } from '@core/ui/passcodeEncryption/state/passcode'
 
 vi.mock('@core/ui/state/core', () => ({
   useCore: vi.fn(),
@@ -15,10 +15,15 @@ vi.mock('@core/ui/passcodeEncryption/state/passcode', () => ({
   usePasscode: vi.fn(),
 }))
 
+vi.mock('@core/ui/passcodeEncryption/core/passcodeLock', () => ({
+  verifyPasscode: vi.fn(),
+}))
+
 describe('usePasscodeUnlockSession', () => {
   beforeEach(() => {
     vi.mocked(useCore).mockReset()
     vi.mocked(usePasscode).mockReset()
+    vi.mocked(verifyPasscode).mockReset()
   })
 
   it('when persistence is disabled: no pending restore and no storage calls', () => {
@@ -50,10 +55,13 @@ describe('usePasscodeUnlockSession', () => {
   })
 
   it('while restore is pending: no set/clear; after null restore: clears storage', async () => {
-    let resolveGet!: (value: { passcode: string; expiresAt: number | null } | null) => void
-    const restorePromise = new Promise<
-      { passcode: string; expiresAt: number | null } | null
-    >(resolve => {
+    let resolveGet!: (
+      value: { passcode: string; expiresAt: number | null } | null
+    ) => void
+    const restorePromise = new Promise<{
+      passcode: string
+      expiresAt: number | null
+    } | null>(resolve => {
       resolveGet = resolve
     })
 
@@ -100,20 +108,27 @@ describe('usePasscodeUnlockSession', () => {
     expect(setPasscodeUnlockSession).not.toHaveBeenCalled()
   })
 
-  it('after session restore: applies stored passcode', async () => {
+  it('after a valid session restore: applies stored passcode', async () => {
     const getPasscodeUnlockSession = vi.fn(async () => ({
       passcode: 'from-session',
       expiresAt: null as number | null,
     }))
     const setPasscodeUnlockSession = vi.fn(async () => {})
     const clearPasscodeUnlockSession = vi.fn(async () => {})
+    const getPasscodeEncryption = vi.fn(async () => ({
+      encryptedSample: 'current-proof',
+    }))
+    const getVaults = vi.fn(async () => [])
 
     vi.mocked(useCore).mockReturnValue({
       canPersistPasscodeUnlockSession: true,
       getPasscodeUnlockSession,
       setPasscodeUnlockSession,
       clearPasscodeUnlockSession,
+      getPasscodeEncryption,
+      getVaults,
     } as ReturnType<typeof useCore>)
+    vi.mocked(verifyPasscode).mockResolvedValue(true)
 
     const setPasscode = vi.fn()
     vi.mocked(usePasscode).mockReturnValue([null, setPasscode])
@@ -130,6 +145,58 @@ describe('usePasscodeUnlockSession', () => {
     })
 
     expect(setPasscode).toHaveBeenCalledWith('from-session')
+    expect(verifyPasscode).toHaveBeenCalledWith({
+      vaults: [],
+      encryptedSample: 'current-proof',
+      passcode: 'from-session',
+    })
+  })
+
+  it('clears and rejects a session that cannot decrypt the current shares', async () => {
+    const getPasscodeUnlockSession = vi.fn(async () => ({
+      passcode: 'stale-session',
+      expiresAt: null as number | null,
+    }))
+    const setPasscodeUnlockSession = vi.fn(async () => {})
+    const clearPasscodeUnlockSession = vi.fn(async () => {})
+    const getPasscodeEncryption = vi.fn(async () => ({
+      encryptedSample: 'stale-proof',
+    }))
+    const getVaults = vi.fn(async () => [
+      { keyShares: { ecdsa: 'current-encrypted-share' } },
+    ])
+
+    vi.mocked(useCore).mockReturnValue({
+      canPersistPasscodeUnlockSession: true,
+      getPasscodeUnlockSession,
+      setPasscodeUnlockSession,
+      clearPasscodeUnlockSession,
+      getPasscodeEncryption,
+      getVaults,
+    } as ReturnType<typeof useCore>)
+    vi.mocked(verifyPasscode).mockResolvedValue(false)
+
+    const setPasscode = vi.fn()
+    vi.mocked(usePasscode).mockReturnValue([null, setPasscode])
+
+    const { result } = renderHook(() =>
+      usePasscodeUnlockSession({
+        hasPasscodeEncryption: true,
+        passcodeAutoLock: null,
+      })
+    )
+
+    await waitFor(() => {
+      expect(result.current.restoreComplete).toBe(true)
+      expect(clearPasscodeUnlockSession).toHaveBeenCalled()
+    })
+
+    expect(setPasscode).not.toHaveBeenCalled()
+    expect(verifyPasscode).toHaveBeenCalledWith({
+      vaults: [{ keyShares: { ecdsa: 'current-encrypted-share' } }],
+      encryptedSample: 'stale-proof',
+      passcode: 'stale-session',
+    })
   })
 
   it('rejected restore finishes pending without applying passcode', async () => {

--- a/clients/extension/vite.config.ts
+++ b/clients/extension/vite.config.ts
@@ -27,6 +27,26 @@ const extensionNodePolyfills = (isFirefoxBuild = false) =>
   })
 const extensionVultisigSdk = () => vultisigSdk({ browserGlobals: false })
 
+// `define-data-property` declares itself side-effect-free, but its exported
+// function performs the property writes used by `globalthis`. When the SDK
+// pulls xstream into the app chunk, Rollup can otherwise remove those calls
+// and the extension crashes before React mounts (`getPolyfill is not a
+// function`). Keep only this module's body intact instead of disabling tree
+// shaking for the whole extension.
+const preserveDefineDataProperty = (): PluginOption => ({
+  name: 'vultisig:preserve-define-data-property',
+  enforce: 'pre',
+  async resolveId(source, importer) {
+    if (source !== 'define-data-property') return null
+
+    const resolved = await this.resolve(source, importer, { skipSelf: true })
+
+    return resolved
+      ? { ...resolved, moduleSideEffects: 'no-treeshake' }
+      : resolved
+  },
+})
+
 /** One physical copy of MPC entry + types across chunks (vultisig-windows#3831 / #3777). */
 const vultisigMpcDedupe: readonly string[] = [
   '@vultisig/sdk',
@@ -143,6 +163,7 @@ export default defineConfig(async ({ mode }) => {
       define: defines,
       resolve: { dedupe: [...vultisigMpcDedupe] },
       plugins: [
+        preserveDefineDataProperty(),
         extensionVultisigSdk(),
         tsconfigPaths({ root: rootDir }),
         extensionBrandVitePlugin({
@@ -186,6 +207,7 @@ export default defineConfig(async ({ mode }) => {
       define: defines,
       resolve: { dedupe: [...vultisigMpcDedupe] },
       plugins: [
+        preserveDefineDataProperty(),
         tsconfigPaths({ root: rootDir }),
         ...getCommonPlugins({
           nodePolyfills: extensionNodePolyfills(isFirefoxBuild),

--- a/core/ui/passcodeEncryption/autoLock/PasscodeAutoLock.tsx
+++ b/core/ui/passcodeEncryption/autoLock/PasscodeAutoLock.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useCore } from '../../state/core'
 import { usePasscodeAutoLock } from '../../storage/passcodeAutoLock'
 import { computePasscodeUnlockSessionExpiresAt } from '../../storage/passcodeUnlockSession'
+import { withPasscodeOperationLock } from '../core/passcodeAttemptThrottle'
 import { usePasscode } from '../state/passcode'
 import { usePasscodeAutoLockHolds } from './passcodeAutoLockHolds'
 
@@ -87,10 +88,12 @@ export const PasscodeAutoLock = () => {
       setPasscode(null)
     }, lockDelayMs)
 
-    void setPasscodeUnlockSession({
-      passcode,
-      expiresAt: computePasscodeUnlockSessionExpiresAt(passcodeAutoLock),
-    })
+    void withPasscodeOperationLock(() =>
+      setPasscodeUnlockSession({
+        passcode,
+        expiresAt: computePasscodeUnlockSessionExpiresAt(passcodeAutoLock),
+      })
+    )
 
     return () => {
       if (timeoutRef.current) {

--- a/core/ui/passcodeEncryption/autoLock/usePasscodeUnlockSession.ts
+++ b/core/ui/passcodeEncryption/autoLock/usePasscodeUnlockSession.ts
@@ -82,8 +82,8 @@ export const usePasscodeUnlockSession = ({
     let cancelled = false
 
     const restorePasscodeUnlockSession = async () => {
-      try {
-        await withPasscodeOperationLock(async () => {
+      await withPasscodeOperationLock(async () => {
+        try {
           const session = await getPasscodeUnlockSession()
 
           if (cancelled || session === null) {
@@ -114,12 +114,12 @@ export const usePasscodeUnlockSession = ({
           } else {
             await clearPasscodeUnlockSession()
           }
-        })
-      } catch {
-        if (!cancelled) {
-          await clearPasscodeUnlockSession().catch(() => {})
+        } catch {
+          if (!cancelled) {
+            await clearPasscodeUnlockSession().catch(() => {})
+          }
         }
-      } finally {
+      }).finally(() => {
         if (!cancelled) {
           setRestoreState({
             hasPasscodeEncryption,
@@ -127,7 +127,7 @@ export const usePasscodeUnlockSession = ({
             complete: true,
           })
         }
-      }
+      })
     }
 
     void restorePasscodeUnlockSession()
@@ -150,24 +150,26 @@ export const usePasscodeUnlockSession = ({
       return
     }
 
-    if (!hasPasscodeEncryption) {
-      void clearPasscodeUnlockSession()
+    if (hasPasscodeEncryption && !restoreComplete) {
       return
     }
 
-    if (!restoreComplete) {
-      return
-    }
-
-    if (passcode) {
-      const session: PasscodeUnlockSession = {
-        passcode,
-        expiresAt: computePasscodeUnlockSessionExpiresAt(passcodeAutoLock),
+    void withPasscodeOperationLock(async () => {
+      if (!hasPasscodeEncryption) {
+        await clearPasscodeUnlockSession()
+        return
       }
-      void setPasscodeUnlockSession(session)
-    } else {
-      void clearPasscodeUnlockSession()
-    }
+
+      if (passcode) {
+        const session: PasscodeUnlockSession = {
+          passcode,
+          expiresAt: computePasscodeUnlockSessionExpiresAt(passcodeAutoLock),
+        }
+        await setPasscodeUnlockSession(session)
+      } else {
+        await clearPasscodeUnlockSession()
+      }
+    })
   }, [
     hasPasscodeEncryption,
     passcode,

--- a/core/ui/passcodeEncryption/autoLock/usePasscodeUnlockSession.ts
+++ b/core/ui/passcodeEncryption/autoLock/usePasscodeUnlockSession.ts
@@ -6,6 +6,8 @@ import {
   computePasscodeUnlockSessionExpiresAt,
   PasscodeUnlockSession,
 } from '../../storage/passcodeUnlockSession'
+import { withPasscodeOperationLock } from '../core/passcodeAttemptThrottle'
+import { verifyPasscode } from '../core/passcodeLock'
 import { usePasscode } from '../state/passcode'
 
 type UsePasscodeUnlockSessionInput = {
@@ -29,6 +31,8 @@ export const usePasscodeUnlockSession = ({
     getPasscodeUnlockSession,
     setPasscodeUnlockSession,
     clearPasscodeUnlockSession,
+    getPasscodeEncryption,
+    getVaults,
   } = useCore()
 
   const [restoreState, setRestoreState] = useState<RestoreState>(() => {
@@ -77,33 +81,56 @@ export const usePasscodeUnlockSession = ({
 
     let cancelled = false
 
-    getPasscodeUnlockSession()
-      .then(session => {
-        if (cancelled) {
-          return
-        }
+    const restorePasscodeUnlockSession = async () => {
+      try {
+        await withPasscodeOperationLock(async () => {
+          const session = await getPasscodeUnlockSession()
 
-        if (session !== null) {
-          setPasscode(session.passcode)
-        }
+          if (cancelled || session === null) {
+            return
+          }
 
-        setRestoreState({
-          hasPasscodeEncryption,
-          canPersistPasscodeUnlockSession,
-          complete: true,
+          const [passcodeEncryption, vaults] = await Promise.all([
+            getPasscodeEncryption(),
+            getVaults(),
+          ])
+
+          if (cancelled) {
+            return
+          }
+
+          const isValid = await verifyPasscode({
+            vaults,
+            encryptedSample: passcodeEncryption?.encryptedSample ?? null,
+            passcode: session.passcode,
+          })
+
+          if (cancelled) {
+            return
+          }
+
+          if (isValid) {
+            setPasscode(session.passcode)
+          } else {
+            await clearPasscodeUnlockSession()
+          }
         })
-      })
-      .catch(() => {
-        if (cancelled) {
-          return
+      } catch {
+        if (!cancelled) {
+          await clearPasscodeUnlockSession().catch(() => {})
         }
+      } finally {
+        if (!cancelled) {
+          setRestoreState({
+            hasPasscodeEncryption,
+            canPersistPasscodeUnlockSession,
+            complete: true,
+          })
+        }
+      }
+    }
 
-        setRestoreState({
-          hasPasscodeEncryption,
-          canPersistPasscodeUnlockSession,
-          complete: true,
-        })
-      })
+    void restorePasscodeUnlockSession()
 
     return () => {
       cancelled = true
@@ -111,7 +138,10 @@ export const usePasscodeUnlockSession = ({
   }, [
     hasPasscodeEncryption,
     canPersistPasscodeUnlockSession,
+    clearPasscodeUnlockSession,
+    getPasscodeEncryption,
     getPasscodeUnlockSession,
+    getVaults,
     setPasscode,
   ])
 

--- a/core/ui/passcodeEncryption/core/passcodeLock.test.ts
+++ b/core/ui/passcodeEncryption/core/passcodeLock.test.ts
@@ -7,10 +7,12 @@ import {
 import { beforeAll, describe, expect, it } from 'vitest'
 
 import {
+  getPasscodeEntryLength,
   isPasscodeRequired,
   mayNeedPasscodeSampleRewrite,
   needsPasscodeSampleRewrite,
   verifyPasscode,
+  verifyPasscodeEntry,
 } from './passcodeLock'
 import { encryptSample } from './sample'
 import { encryptVaultAllKeyShares } from './vaultKeyShares'
@@ -133,6 +135,110 @@ describe('verifyPasscode', () => {
         passcode,
       })
     ).resolves.toBe(false)
+  })
+})
+
+describe('passcode entry recovery', () => {
+  it('shows the current six-digit input when the proof is missing', () => {
+    expect(
+      getPasscodeEntryLength({
+        encryptedSample: null,
+        storedPasscodeLength: undefined,
+      })
+    ).toBe(6)
+  })
+
+  it('accepts a proof-declared legacy five-digit passcode', async () => {
+    const legacyPasscode = '13579'
+    const legacySealedShares = await encryptVaultAllKeyShares({
+      ...plainShares,
+      key: legacyPasscode,
+    })
+    const legacyPasscodeSample = await encryptSample({
+      key: legacyPasscode,
+      value: 'sample',
+    })
+
+    await expect(
+      verifyPasscodeEntry({
+        vaults: [legacySealedShares],
+        encryptedSample: legacyPasscodeSample,
+        passcode: legacyPasscode,
+        storedPasscodeLength: 5,
+      })
+    ).resolves.toBe('valid')
+  })
+
+  it('accepts a proofless legacy passcode only when explicitly submitted', async () => {
+    const legacyPasscode = '13579'
+    const legacySealedShares = await encryptVaultAllKeyShares({
+      ...plainShares,
+      key: legacyPasscode,
+    })
+    const input = {
+      vaults: [legacySealedShares],
+      encryptedSample: null,
+      passcode: legacyPasscode,
+    }
+
+    await expect(verifyPasscodeEntry(input)).resolves.toBe('incomplete')
+    await expect(
+      verifyPasscodeEntry({ ...input, allowProoflessLegacy: true })
+    ).resolves.toBe('valid')
+  })
+
+  it('rejects an incorrect explicitly submitted proofless legacy passcode', async () => {
+    await expect(
+      verifyPasscodeEntry({
+        vaults: [sealedShares],
+        encryptedSample: null,
+        passcode: '54321',
+        allowProoflessLegacy: true,
+      })
+    ).resolves.toBe('invalid')
+  })
+
+  it('does not submit a five-digit prefix when proof recovery requires six digits', async () => {
+    await expect(
+      verifyPasscodeEntry({
+        vaults: [sealedShares],
+        encryptedSample: null,
+        passcode: passcode.slice(0, -1),
+      })
+    ).resolves.toBe('incomplete')
+
+    await expect(
+      verifyPasscodeEntry({
+        vaults: [sealedShares],
+        encryptedSample: null,
+        passcode,
+      })
+    ).resolves.toBe('valid')
+  })
+
+  it('rejects an incorrect six-digit recovery code', async () => {
+    await expect(
+      verifyPasscodeEntry({
+        vaults: [sealedShares],
+        encryptedSample: null,
+        passcode: otherPasscode,
+      })
+    ).resolves.toBe('invalid')
+  })
+
+  it('preserves the stored length when a proof is present', () => {
+    expect(
+      getPasscodeEntryLength({
+        encryptedSample: sample,
+        storedPasscodeLength: 5,
+      })
+    ).toBe(5)
+    expect(
+      getPasscodeEntryLength({
+        encryptedSample: sample,
+        storedPasscodeLength: 6,
+      })
+    ).toBe(6)
   })
 })
 

--- a/core/ui/passcodeEncryption/core/passcodeLock.ts
+++ b/core/ui/passcodeEncryption/core/passcodeLock.ts
@@ -1,6 +1,8 @@
 import { VaultAllKeyShares } from '@vultisig/core-mpc/vault/Vault'
 import { attempt } from '@vultisig/lib-utils/attempt'
 
+import { passcodeEncryptionConfig } from './config'
+import { getStoredPasscodeLength } from './passcodePolicy'
 import { decryptSample } from './sample'
 import {
   decryptVaultAllKeyShares,
@@ -51,6 +53,55 @@ type VerifyPasscodeInput = PasscodeLockState & {
   passcode: string
 }
 
+type PasscodeEntryInput = VerifyPasscodeInput & {
+  allowProoflessLegacy?: boolean
+  storedPasscodeLength?: number
+}
+
+type PasscodeEntryVerification = 'incomplete' | 'invalid' | 'valid'
+
+/**
+ * Number of input slots to show on the lock screen.
+ *
+ * A stored proof carries enough metadata to preserve the passcode length used
+ * when it was written. When that proof is gone, encrypted shares prove that a
+ * passcode still exists but cannot reveal its length, so recovery shows the
+ * current six-digit policy. A legacy five-digit passcode can still be submitted
+ * explicitly, but is never probed automatically while the sixth digit is being
+ * entered.
+ */
+export const getPasscodeEntryLength = ({
+  encryptedSample,
+  storedPasscodeLength,
+}: Pick<PasscodeEntryInput, 'encryptedSample' | 'storedPasscodeLength'>) =>
+  encryptedSample === null
+    ? passcodeEncryptionConfig.passcodeLength
+    : getStoredPasscodeLength(storedPasscodeLength)
+
+export const isPasscodeEntryCandidate = ({
+  allowProoflessLegacy = false,
+  encryptedSample,
+  passcode,
+  storedPasscodeLength,
+}: Pick<
+  PasscodeEntryInput,
+  | 'allowProoflessLegacy'
+  | 'encryptedSample'
+  | 'passcode'
+  | 'storedPasscodeLength'
+>): boolean => {
+  const isExplicitLegacyRecovery =
+    allowProoflessLegacy &&
+    encryptedSample === null &&
+    passcode.length === passcodeEncryptionConfig.legacyPasscodeLength
+
+  return (
+    isExplicitLegacyRecovery ||
+    passcode.length ===
+      getPasscodeEntryLength({ encryptedSample, storedPasscodeLength })
+  )
+}
+
 /**
  * Whether a passcode opens what is actually stored.
  *
@@ -92,6 +143,31 @@ export const verifyPasscode = async ({
   )
 
   return 'data' in result
+}
+
+/**
+ * Verify one complete lock-screen candidate.
+ *
+ * Only the proof-declared length, the current six-digit recovery length, or an
+ * explicitly submitted proofless legacy value reaches the expensive verifier.
+ * This keeps every failed verification inside the normal attempt throttle.
+ */
+export const verifyPasscodeEntry = async ({
+  storedPasscodeLength,
+  ...input
+}: PasscodeEntryInput): Promise<PasscodeEntryVerification> => {
+  if (
+    !isPasscodeEntryCandidate({
+      allowProoflessLegacy: input.allowProoflessLegacy,
+      encryptedSample: input.encryptedSample,
+      passcode: input.passcode,
+      storedPasscodeLength,
+    })
+  ) {
+    return 'incomplete'
+  }
+
+  return (await verifyPasscode(input)) ? 'valid' : 'invalid'
 }
 
 type NeedsPasscodeSampleRewriteInput = PasscodeLockState & {

--- a/core/ui/passcodeEncryption/core/passcodeLock.ts
+++ b/core/ui/passcodeEncryption/core/passcodeLock.ts
@@ -78,6 +78,13 @@ export const getPasscodeEntryLength = ({
     ? passcodeEncryptionConfig.passcodeLength
     : getStoredPasscodeLength(storedPasscodeLength)
 
+/**
+ * Whether the entered passcode is complete enough to verify.
+ *
+ * Proof-backed candidates use the stored passcode length. Proofless recovery
+ * uses the current length unless the user explicitly submits a legacy-length
+ * candidate through `allowProoflessLegacy`.
+ */
 export const isPasscodeEntryCandidate = ({
   allowProoflessLegacy = false,
   encryptedSample,

--- a/core/ui/passcodeEncryption/guard/EnterPasscode.tsx
+++ b/core/ui/passcodeEncryption/guard/EnterPasscode.tsx
@@ -1,23 +1,27 @@
+import { passcodeEncryptionConfig } from '@core/ui/passcodeEncryption/core/config'
 import {
   getPasscodeAttemptDelayMs,
   recordFailedPasscodeAttempt,
   withPasscodeOperationLock,
 } from '@core/ui/passcodeEncryption/core/passcodeAttemptThrottle'
-import { verifyPasscode } from '@core/ui/passcodeEncryption/core/passcodeLock'
-import { getStoredPasscodeLength } from '@core/ui/passcodeEncryption/core/passcodePolicy'
+import {
+  getPasscodeEntryLength,
+  isPasscodeEntryCandidate,
+  verifyPasscodeEntry,
+} from '@core/ui/passcodeEncryption/core/passcodeLock'
 import { PasscodeInput } from '@core/ui/passcodeEncryption/manage/PasscodeInput'
 import { usePasscode } from '@core/ui/passcodeEncryption/state/passcode'
 import { useCore } from '@core/ui/state/core'
 import { usePasscodeEncryption } from '@core/ui/storage/passcodeEncryption'
 import { StorageKey } from '@core/ui/storage/StorageKey'
+import { Button } from '@lib/ui/buttons/Button'
 import { takeWholeSpace } from '@lib/ui/css/takeWholeSpace'
 import { VStack, vStack } from '@lib/ui/layout/Stack'
 import { panel } from '@lib/ui/panel/Panel'
 import { useRefetchQueries } from '@lib/ui/query/hooks/useRefetchQueries'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
-import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
@@ -63,19 +67,30 @@ export const EnterPasscode = () => {
   const [, setPasscode] = usePasscode()
   const [isInvalid, setIsInvalid] = useState(false)
   const [isVerifying, setIsVerifying] = useState(false)
-  const isVerifyingRef = useRef(false)
+  const [legacyRecoverySubmission, setLegacyRecoverySubmission] = useState<
+    string | null
+  >(null)
   const [attemptState, setAttemptState] = useState(
     passcodeEncryption?.attemptState
   )
   const [now, setNow] = useState(Date.now)
 
-  const passcodeLength = getStoredPasscodeLength(
-    passcodeEncryption?.passcodeLength
-  )
+  const encryptedSample = passcodeEncryption?.encryptedSample ?? null
+  const passcodeLength = getPasscodeEntryLength({
+    encryptedSample,
+    storedPasscodeLength: passcodeEncryption?.passcodeLength,
+  })
   const retryDelayMs = getPasscodeAttemptDelayMs({ state: attemptState, now })
   const isLockedOut = retryDelayMs > 0
 
-  const isComplete = !!inputValue && inputValue.length === passcodeLength
+  const isComplete =
+    !!inputValue &&
+    (legacyRecoverySubmission === inputValue ||
+      isPasscodeEntryCandidate({
+        encryptedSample,
+        passcode: inputValue,
+        storedPasscodeLength: passcodeEncryption?.passcodeLength,
+      }))
 
   useEffect(() => {
     setAttemptState(passcodeEncryption?.attemptState)
@@ -96,26 +111,25 @@ export const EnterPasscode = () => {
   // on every keystroke would block the UI. On success the passcode unlocks the
   // app.
   useEffect(() => {
-    if (!isComplete || isLockedOut || isVerifyingRef.current) {
+    if (!isComplete || isLockedOut) {
       return
     }
 
     let cancelled = false
 
     const verifyEnteredPasscode = async () => {
-      isVerifyingRef.current = true
       setIsVerifying(true)
 
       await withPasscodeOperationLock(async () => {
         const [current, currentVaults] = await Promise.all([
-          getPasscodeEncryption().then(shouldBePresent),
+          getPasscodeEncryption(),
           getVaults(),
         ])
         const activeAttemptState =
           (attemptState?.failedAttempts ?? 0) >
-          (current.attemptState?.failedAttempts ?? 0)
+          (current?.attemptState?.failedAttempts ?? 0)
             ? attemptState
-            : current.attemptState
+            : current?.attemptState
         const currentDelay = getPasscodeAttemptDelayMs({
           state: activeAttemptState,
           now: Date.now(),
@@ -130,13 +144,19 @@ export const EnterPasscode = () => {
           return
         }
 
-        const isValid = await verifyPasscode({
+        const verification = await verifyPasscodeEntry({
+          allowProoflessLegacy: legacyRecoverySubmission === inputValue,
           vaults: currentVaults,
-          encryptedSample: current.encryptedSample,
+          encryptedSample: current?.encryptedSample ?? null,
           passcode: inputValue,
+          storedPasscodeLength: current?.passcodeLength,
         })
 
-        if (!isValid) {
+        if (verification === 'incomplete') {
+          return
+        }
+
+        if (verification === 'invalid') {
           const nextAttemptState = recordFailedPasscodeAttempt({
             state: activeAttemptState,
             now: Date.now(),
@@ -144,6 +164,7 @@ export const EnterPasscode = () => {
 
           await setPasscodeEncryption({
             ...current,
+            encryptedSample: current?.encryptedSample ?? null,
             attemptState: nextAttemptState,
           })
           await refetchQueries([StorageKey.passcodeEncryption])
@@ -157,10 +178,14 @@ export const EnterPasscode = () => {
           return
         }
 
-        const cleared = { ...current }
-        delete cleared.attemptState
-        await setPasscodeEncryption(cleared)
-        await refetchQueries([StorageKey.passcodeEncryption])
+        if (current?.attemptState) {
+          const cleared = { ...current }
+          delete cleared.attemptState
+          await setPasscodeEncryption(
+            cleared.encryptedSample === null ? null : cleared
+          )
+          await refetchQueries([StorageKey.passcodeEncryption])
+        }
 
         if (!cancelled) {
           setIsInvalid(false)
@@ -177,7 +202,6 @@ export const EnterPasscode = () => {
         }
       })
       .finally(() => {
-        isVerifyingRef.current = false
         if (!cancelled) {
           setIsVerifying(false)
         }
@@ -193,6 +217,7 @@ export const EnterPasscode = () => {
     inputValue,
     isComplete,
     isLockedOut,
+    legacyRecoverySubmission,
     refetchQueries,
     setPasscode,
     setPasscodeEncryption,
@@ -230,6 +255,7 @@ export const EnterPasscode = () => {
             length={passcodeLength}
             onChange={value => {
               setInputValue(value)
+              setLegacyRecoverySubmission(null)
               setIsInvalid(false)
             }}
             validation={validation}
@@ -237,6 +263,16 @@ export const EnterPasscode = () => {
             value={inputValue}
             autoFocus
           />
+          {encryptedSample === null &&
+            inputValue?.length ===
+              passcodeEncryptionConfig.legacyPasscodeLength && (
+              <Button
+                disabled={isVerifying || isLockedOut}
+                onClick={() => setLegacyRecoverySubmission(inputValue)}
+              >
+                {t('continue')}
+              </Button>
+            )}
         </Content>
       </Container>
     </Wrapper>

--- a/core/ui/passcodeEncryption/guard/EnterPasscode.tsx
+++ b/core/ui/passcodeEncryption/guard/EnterPasscode.tsx
@@ -1,19 +1,3 @@
-import { passcodeEncryptionConfig } from '@core/ui/passcodeEncryption/core/config'
-import {
-  getPasscodeAttemptDelayMs,
-  recordFailedPasscodeAttempt,
-  withPasscodeOperationLock,
-} from '@core/ui/passcodeEncryption/core/passcodeAttemptThrottle'
-import {
-  getPasscodeEntryLength,
-  isPasscodeEntryCandidate,
-  verifyPasscodeEntry,
-} from '@core/ui/passcodeEncryption/core/passcodeLock'
-import { PasscodeInput } from '@core/ui/passcodeEncryption/manage/PasscodeInput'
-import { usePasscode } from '@core/ui/passcodeEncryption/state/passcode'
-import { useCore } from '@core/ui/state/core'
-import { usePasscodeEncryption } from '@core/ui/storage/passcodeEncryption'
-import { StorageKey } from '@core/ui/storage/StorageKey'
 import { Button } from '@lib/ui/buttons/Button'
 import { takeWholeSpace } from '@lib/ui/css/takeWholeSpace'
 import { VStack, vStack } from '@lib/ui/layout/Stack'
@@ -24,6 +8,23 @@ import { getColor } from '@lib/ui/theme/getters'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
+
+import { useCore } from '../../state/core'
+import { usePasscodeEncryption } from '../../storage/passcodeEncryption'
+import { StorageKey } from '../../storage/StorageKey'
+import { passcodeEncryptionConfig } from '../core/config'
+import {
+  getPasscodeAttemptDelayMs,
+  recordFailedPasscodeAttempt,
+  withPasscodeOperationLock,
+} from '../core/passcodeAttemptThrottle'
+import {
+  getPasscodeEntryLength,
+  isPasscodeEntryCandidate,
+  verifyPasscodeEntry,
+} from '../core/passcodeLock'
+import { PasscodeInput } from '../manage/PasscodeInput'
+import { usePasscode } from '../state/passcode'
 
 const Wrapper = styled.div`
   ${takeWholeSpace}

--- a/core/ui/storage/passcodeEncryption.tsx
+++ b/core/ui/storage/passcodeEncryption.tsx
@@ -7,7 +7,7 @@ import { useCore } from '../state/core'
 import { StorageKey } from './StorageKey'
 
 type PasscodeEncryption = {
-  encryptedSample: string
+  encryptedSample: string | null
   passcodeLength?: number
   attemptState?: PasscodeAttemptState
 }


### PR DESCRIPTION
Closes #4761
![screenshot-1](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/4761-passcode-proof-loss-recovery/screenshot-1-1787828163635.png)
![screenshot-2](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/4761-passcode-proof-loss-recovery/screenshot-2-1787828163635.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved passcode recovery when encryption proof is unavailable.
  - Added support for legacy passcode lengths with an explicit Continue action.
  - Restored unlock sessions are now validated before access is granted.

- **Bug Fixes**
  - Invalid or interrupted unlock sessions are cleared safely.
  - Failed passcode attempts remain throttled across restarts.
  - Recovery restores encryption proof and rejects stale sessions.
  - Passcode and auto-lock updates are handled more reliably.

- **Tests**
  - Expanded coverage for recovery, throttling, interruptions, and session validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->