### PR TITLE
fix(swap): read secured-asset tickers in limit order details

### DIFF
--- a/core/ui/mpc/keysign/join/tx/limitOrderBuyCoin.test.ts
+++ b/core/ui/mpc/keysign/join/tx/limitOrderBuyCoin.test.ts
@@ -1,69 +1,83 @@
-import { Chain } from '@vultisig/core-chain/Chain'
 import { describe, expect, it } from 'vitest'
 
 import { getLimitOrderBuyCoin } from './limitOrderBuyCoin'
 
+const usdcContract = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+
 describe('getLimitOrderBuyCoin', () => {
   it.each([
-    ['THOR.RUNE', Chain.THORChain, 'RUNE'],
-    ['BTC.BTC', Chain.Bitcoin, 'BTC'],
-    ['ETH.ETH', Chain.Ethereum, 'ETH'],
-  ])('resolves the gas asset %s', (targetAsset, targetChain, ticker) => {
-    expect(getLimitOrderBuyCoin({ targetAsset, targetChain })?.ticker).toBe(
-      ticker
-    )
+    ['THOR.RUNE', 'RUNE'],
+    ['BTC.BTC', 'BTC'],
+    ['ETH.ETH', 'ETH'],
+  ])('resolves the gas asset %s', (targetAsset, ticker) => {
+    expect(getLimitOrderBuyCoin({ targetAsset })?.ticker).toBe(ticker)
   })
 
   // The memo abbreviates the contract to its last six characters, so resolving
   // it back is a suffix match against the real address.
   it('resolves an L1 token from its abbreviated contract', () => {
-    const coin = getLimitOrderBuyCoin({
-      targetAsset: 'ETH.USDC-06EB48',
-      targetChain: Chain.Ethereum,
-    })
+    const coin = getLimitOrderBuyCoin({ targetAsset: 'ETH.USDC-06EB48' })
 
     expect(coin?.ticker).toBe('USDC')
-    expect(coin?.id?.toLowerCase()).toBe(
-      '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
-    )
+    expect(coin?.id?.toLowerCase()).toBe(usdcContract)
   })
 
   it('matches the abbreviation case-insensitively', () => {
     expect(
-      getLimitOrderBuyCoin({
-        targetAsset: 'ETH.USDC-06eb48',
-        targetChain: Chain.Ethereum,
-      })?.ticker
+      getLimitOrderBuyCoin({ targetAsset: 'ETH.USDC-06eb48' })?.ticker
     ).toBe('USDC')
+  })
+
+  // A secured asset separates its chain with `-` and carries the whole contract
+  // address, so both the chain prefix and the contract have to be read from a
+  // shape dotted notation never produces.
+  it('resolves a secured token from its full contract', () => {
+    const coin = getLimitOrderBuyCoin({
+      targetAsset: `ETH-USDC-${usdcContract}`,
+    })
+
+    expect(coin?.ticker).toBe('USDC')
+    expect(coin?.id?.toLowerCase()).toBe(usdcContract)
+  })
+
+  it.each([
+    ['XRP-XRP', 'XRP'],
+    ['BTC-BTC', 'BTC'],
+    // THORChain spells its own bank denoms in lower case.
+    ['eth-eth', 'ETH'],
+  ])('resolves the secured gas asset %s', (targetAsset, ticker) => {
+    expect(getLimitOrderBuyCoin({ targetAsset })?.ticker).toBe(ticker)
+  })
+
+  it.each([
+    ['a synth', 'BTC/BTC', 'BTC'],
+    ['a trade asset', 'ETH~ETH', 'ETH'],
+  ])('resolves %s', (_label, targetAsset, ticker) => {
+    expect(getLimitOrderBuyCoin({ targetAsset })?.ticker).toBe(ticker)
   })
 
   // Showing the wrong coin's logo and price on a signing review is worse than
   // showing none, so anything unresolved must come back undefined.
   it.each([
-    ['an unroutable prefix', 'XYZ.XYZ', undefined],
+    ['an unroutable prefix', 'XYZ.XYZ'],
+    ['an unroutable secured prefix', 'XYZ-XYZ'],
+    ['a contract that matches no known token', 'ETH.USDC-FFFFFF'],
     [
-      'a contract that matches no known token',
-      'ETH.USDC-FFFFFF',
-      Chain.Ethereum,
+      'a full contract that matches no known token',
+      `ETH-USDC-0x${'f'.repeat(40)}`,
     ],
-    [
-      'a ticker that is neither gas asset nor known token',
-      'ETH.NOTACOIN',
-      Chain.Ethereum,
-    ],
-    ['asset notation with no symbol', 'ETH', Chain.Ethereum],
-  ])('returns undefined for %s', (_label, targetAsset, targetChain) => {
-    expect(getLimitOrderBuyCoin({ targetAsset, targetChain })).toBeUndefined()
+    ['a ticker that is neither gas asset nor known token', 'ETH.NOTACOIN'],
+    ['asset notation with no symbol', 'ETH'],
+    ['a chain prefix with nothing after it', 'ETH.'],
+  ])('returns undefined for %s', (_label, targetAsset) => {
+    expect(getLimitOrderBuyCoin({ targetAsset })).toBeUndefined()
   })
 
   // A suffix that matches a different token's address must not resolve just
   // because the tail happens to line up.
   it('requires the ticker to agree with the contract match', () => {
     expect(
-      getLimitOrderBuyCoin({
-        targetAsset: 'ETH.WBTC-06EB48',
-        targetChain: Chain.Ethereum,
-      })
+      getLimitOrderBuyCoin({ targetAsset: 'ETH.WBTC-06EB48' })
     ).toBeUndefined()
   })
 })

--- a/core/ui/mpc/keysign/join/tx/limitOrderBuyCoin.ts
+++ b/core/ui/mpc/keysign/join/tx/limitOrderBuyCoin.ts
@@ -1,22 +1,31 @@
-import { Chain } from '@vultisig/core-chain/Chain'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { Coin } from '@vultisig/core-chain/coin/Coin'
 import { knownTokens } from '@vultisig/core-chain/coin/knownTokens'
+import {
+  findThorchainMemoAssetSeparatorIndex,
+  getThorchainMemoAssetChain,
+} from '@vultisig/core-chain/swap/native/thorchainMemoAsset'
 
 type GetLimitOrderBuyCoinInput = {
-  /** THORChain asset notation from the memo, e.g. `THOR.RUNE`, `ETH.USDC-06EB48`. */
+  /**
+   * THORChain asset notation from the memo — `THOR.RUNE`, `ETH.USDC-06EB48`, or
+   * a secured `ETH-USDC-0xa0b8…`.
+   */
   targetAsset: string
-  /** The decoded chain, absent when the asset prefix isn't THORChain-routable. */
-  targetChain?: Chain
 }
 
 /**
  * Resolve the buy side of a limit order to a real coin, for its icon and price.
  *
- * The memo only carries THORChain asset notation, and for L1 tokens that is an
- * *abbreviated* contract — `ETH.USDC-06EB48` is the last six characters of the
- * real address. Matching on that suffix is the inverse of how the memo was
- * built.
+ * The chain is read off the asset itself rather than taken from the caller: the
+ * prefix ends at the first separator of any flavour, and a caller that split on
+ * `.` would hand over `undefined` for every secured asset. One derivation means
+ * the coin and the ticker beside it cannot disagree about which asset this is.
+ *
+ * The contract segment is matched by suffix, which covers both spellings the
+ * memo uses: an L1 token carries only the last six characters of its address
+ * (`ETH.USDC-06EB48`), while a secured denom carries the whole thing. Matching
+ * on that tail is the inverse of how the memo was built.
  *
  * Returns `undefined` rather than guessing when the asset can't be resolved
  * confidently. This renders a co-signer review, so an unresolved asset must
@@ -26,24 +35,30 @@ type GetLimitOrderBuyCoinInput = {
  */
 export const getLimitOrderBuyCoin = ({
   targetAsset,
-  targetChain,
 }: GetLimitOrderBuyCoinInput): Coin | undefined => {
+  const separatorIndex = findThorchainMemoAssetSeparatorIndex(targetAsset)
+  if (separatorIndex === -1) {
+    return undefined
+  }
+
+  const targetChain = getThorchainMemoAssetChain(targetAsset)
   if (!targetChain) {
     return undefined
   }
 
-  const [, symbol] = targetAsset.split('.')
+  const symbol = targetAsset.slice(separatorIndex + 1)
   if (!symbol) {
     return undefined
   }
 
-  const [ticker, contractSuffix] = symbol.split('-')
+  const [ticker, ...contractSegments] = symbol.split('-')
+  const contract = contractSegments.join('-')
 
-  if (contractSuffix) {
+  if (contract) {
     return knownTokens[targetChain]?.find(
       token =>
         !!token.id &&
-        token.id.toUpperCase().endsWith(contractSuffix.toUpperCase()) &&
+        token.id.toUpperCase().endsWith(contract.toUpperCase()) &&
         token.ticker.toUpperCase() === ticker.toUpperCase()
     )
   }

--- a/core/ui/mpc/keysign/join/tx/thorchainAssetTicker.test.ts
+++ b/core/ui/mpc/keysign/join/tx/thorchainAssetTicker.test.ts
@@ -17,8 +17,31 @@ describe('getThorchainAssetTicker', () => {
     expect(getThorchainAssetTicker(asset)).toBe(ticker)
   })
 
-  it.each([['RUNE'], ['']])(
-    'falls back to the input when there is no chain prefix (%s)',
+  // Secured denoms separate the chain with `-` and carry the FULL contract
+  // address, so a dot-only split leaves the whole 40-plus character denom
+  // standing in for the ticker on every screen that renders one.
+  it.each([
+    ['XRP-XRP', 'XRP'],
+    ['BTC-BTC', 'BTC'],
+    ['ETH-USDC-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', 'USDC'],
+    ['eth-usdc-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', 'usdc'],
+  ])('reads the secured asset %s as %s', (asset, ticker) => {
+    expect(getThorchainAssetTicker(asset)).toBe(ticker)
+  })
+
+  it.each([
+    // Synths.
+    ['BTC/BTC', 'BTC'],
+    ['ETH/USDC-0X1234', 'USDC'],
+    // Trade assets.
+    ['ETH~ETH', 'ETH'],
+    ['AVAX~USDC-0X1234', 'USDC'],
+  ])('reads the THORChain-held asset %s as %s', (asset, ticker) => {
+    expect(getThorchainAssetTicker(asset)).toBe(ticker)
+  })
+
+  it.each([['RUNE'], [''], ['ETH.']])(
+    'falls back to the input when no ticker can be read (%s)',
     asset => {
       expect(getThorchainAssetTicker(asset)).toBe(asset)
     }

--- a/core/ui/mpc/keysign/join/tx/thorchainAssetTicker.ts
+++ b/core/ui/mpc/keysign/join/tx/thorchainAssetTicker.ts
@@ -1,13 +1,26 @@
+import { findThorchainMemoAssetSeparatorIndex } from '@vultisig/core-chain/swap/native/thorchainMemoAsset'
+
 /**
  * The ticker inside THORChain asset notation — `THOR.RUNE` → `RUNE`,
- * `ETH.USDC-06EB48` → `USDC`.
+ * `ETH.USDC-06EB48` → `USDC`, secured `ETH-USDC-0xa0b8…` → `USDC`.
+ *
+ * The chain prefix ends at the FIRST separator of any flavour (`.`, `/`, `~`,
+ * `-`), which is what makes secured assets readable at all: they spell the whole
+ * denom with `-`, so looking only for a dot finds no prefix and leaves the raw
+ * 40-plus character denom standing in for the ticker on every surface that
+ * renders one.
  *
  * Falls back to the whole string when the notation has no chain prefix, so an
  * asset shape this doesn't anticipate still renders something truthful to a
  * co-signer rather than an empty cell.
  */
 export const getThorchainAssetTicker = (asset: string): string => {
-  const [, symbol] = asset.split('.')
+  const separatorIndex = findThorchainMemoAssetSeparatorIndex(asset)
+  if (separatorIndex === -1) {
+    return asset
+  }
 
-  return symbol ? symbol.split('-')[0] : asset
+  const [ticker] = asset.slice(separatorIndex + 1).split('-')
+
+  return ticker || asset
 }

--- a/core/ui/storage/transactionHistory.tsx
+++ b/core/ui/storage/transactionHistory.tsx
@@ -2,6 +2,7 @@ import {
   SerializedTransactionRecord,
   TransactionRecord,
 } from '@core/ui/transaction-history/core'
+import { normalizeTransactionRecord } from '@core/ui/transaction-history/record/normalizeTransactionRecord'
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { useRefetchQueries } from '@lib/ui/query/hooks/useRefetchQueries'
 import { noRefetchQueryOptions } from '@lib/ui/query/utils/options'
@@ -41,7 +42,10 @@ const deserializeRecord = (
     throw new Error(`Failed to parse transaction data for record ${record.id}`)
   }
 
-  return { ...record, data: parsedData } as TransactionRecord
+  return normalizeTransactionRecord({
+    ...record,
+    data: parsedData,
+  } as TransactionRecord)
 }
 
 const serializeRecord = (

--- a/core/ui/transaction-history/detail/TransactionDetailPage.tsx
+++ b/core/ui/transaction-history/detail/TransactionDetailPage.tsx
@@ -46,7 +46,6 @@ import {
   CoinKey,
   coinKeyToString,
 } from '@vultisig/core-chain/coin/Coin'
-import { thorchainAssetPrefixToChain } from '@vultisig/core-chain/swap/native/thorchainMemoAsset'
 import { getBlockExplorerUrl } from '@vultisig/core-chain/utils/getBlockExplorerUrl'
 import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 import { formatAmount } from '@vultisig/lib-utils/formatAmount'
@@ -309,20 +308,20 @@ const SwapAmountDisplay = ({ record }: { record: SwapTransactionRecord }) => {
             style={{ fontSize: 36 }}
           />
         )}
-        <VStack alignItems="center" gap={2}>
-          <Text size={14} weight={500} centerHorizontally>
+        <SwapCoinCardContent>
+          <SwapCoinAmount size={14} weight={500} centerHorizontally>
             {formatCryptoDisplay(
               safeBigInt(data.fromAmount),
               data.fromDecimals
             )}{' '}
             {data.fromToken}
-          </Text>
+          </SwapCoinAmount>
           {fromFiat && (
             <Text size={12} color="supporting" centerHorizontally>
               {fromFiat}
             </Text>
           )}
-        </VStack>
+        </SwapCoinCardContent>
       </SwapCoinCard>
 
       <SwapChevronWrapper alignItems="center" justifyContent="center">
@@ -342,10 +341,10 @@ const SwapAmountDisplay = ({ record }: { record: SwapTransactionRecord }) => {
             style={{ fontSize: 36 }}
           />
         )}
-        <VStack alignItems="center" gap={2}>
-          <Text size={14} weight={500} centerHorizontally>
+        <SwapCoinCardContent>
+          <SwapCoinAmount size={14} weight={500} centerHorizontally>
             {formatAmount(toCryptoAmount, { precision: 'high' })} {data.toToken}
-          </Text>
+          </SwapCoinAmount>
           {toFiat && (
             <Text size={12} color="supporting" centerHorizontally>
               {toFiat}
@@ -358,7 +357,7 @@ const SwapAmountDisplay = ({ record }: { record: SwapTransactionRecord }) => {
               })} ${data.toToken}`}
             </Text>
           )}
-        </VStack>
+        </SwapCoinCardContent>
       </SwapCoinCard>
     </HStack>
   )
@@ -414,11 +413,7 @@ const LimitSwapAmountDisplay = ({
   // The memo only names the buy asset in THORChain notation; resolve it back to
   // a real coin for its logo. Unresolvable assets render as text, never as
   // another coin's icon.
-  const buyCoin = getLimitOrderBuyCoin({
-    targetAsset: data.targetAsset,
-    targetChain:
-      thorchainAssetPrefixToChain[data.targetAsset.split('.')[0].toUpperCase()],
-  })
+  const buyCoin = getLimitOrderBuyCoin({ targetAsset: data.targetAsset })
 
   return (
     <HStack gap={8} style={{ position: 'relative' }}>
@@ -433,15 +428,15 @@ const LimitSwapAmountDisplay = ({
             style={{ fontSize: 36 }}
           />
         )}
-        <VStack alignItems="center" gap={2}>
-          <Text size={14} weight={500} centerHorizontally>
+        <SwapCoinCardContent>
+          <SwapCoinAmount size={14} weight={500} centerHorizontally>
             {formatCryptoDisplay(
               safeBigInt(data.fromAmount),
               data.fromDecimals
             )}{' '}
             {data.fromToken}
-          </Text>
-        </VStack>
+          </SwapCoinAmount>
+        </SwapCoinCardContent>
       </SwapCoinCard>
 
       <SwapChevronWrapper alignItems="center" justifyContent="center">
@@ -452,14 +447,14 @@ const LimitSwapAmountDisplay = ({
 
       <SwapCoinCard gap={12} alignItems="center">
         {buyCoin ? <CoinIcon coin={buyCoin} style={{ fontSize: 36 }} /> : null}
-        <VStack alignItems="center" gap={2}>
-          <Text size={14} weight={500} centerHorizontally>
+        <SwapCoinCardContent>
+          <SwapCoinAmount size={14} weight={500} centerHorizontally>
             {`${data.minimumReceived} ${data.buyTicker}`}
-          </Text>
+          </SwapCoinAmount>
           <Text size={12} color="shy" centerHorizontally>
             {t('swap_limit_minimum_received')}
           </Text>
-        </VStack>
+        </SwapCoinCardContent>
       </SwapCoinCard>
     </HStack>
   )
@@ -641,7 +636,39 @@ const SwapCoinCard = styled(VStack)`
   border: 1px solid ${({ theme }) => theme.colors.foregroundExtra.toCssValue()};
   ${borderRadius.lg};
   flex: 1;
+  /* Without this a flex item refuses to shrink below its content, so one long
+     unbreakable asset string pushes both cards past the viewport and out from
+     under the absolutely-centred chevron. */
+  min-width: 0;
   padding: 24px 16px;
+`
+
+/**
+ * The text column inside a swap card. `align-items: center` alone leaves each
+ * line free to size to its own content and spill past the card's edge, so the
+ * column is pinned to the card's width and long asset strings are allowed to
+ * break mid-token — THORChain's secured denoms carry a 42-character contract
+ * address with nothing a normal line break could land on.
+ */
+const SwapCoinCardContent = styled(VStack)`
+  align-items: center;
+  gap: 2px;
+  max-width: 100%;
+  min-width: 0;
+  overflow-wrap: anywhere;
+`
+
+/**
+ * The amount-and-ticker line, clamped to two lines. An asset this screen cannot
+ * shorten to a ticker would otherwise wrap into a paragraph and push the rest of
+ * the card off-screen; two lines is enough to read an amount and still tell the
+ * user the asset is one the app didn't recognise.
+ */
+const SwapCoinAmount = styled(Text)`
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
 `
 
 const SwapChevronWrapper = styled(HStack)`

--- a/core/ui/transaction-history/progress/PendingTransactionProgressCard.tsx
+++ b/core/ui/transaction-history/progress/PendingTransactionProgressCard.tsx
@@ -20,7 +20,6 @@ import {
   CoinKey,
   coinKeyToString,
 } from '@vultisig/core-chain/coin/Coin'
-import { thorchainAssetPrefixToChain } from '@vultisig/core-chain/swap/native/thorchainMemoAsset'
 import { formatAmount } from '@vultisig/lib-utils/formatAmount'
 import { match } from '@vultisig/lib-utils/match'
 import { useTranslation } from 'react-i18next'
@@ -151,11 +150,7 @@ const LimitSwapProgressContent = ({
     { chain: data.fromChain, id: data.fromTokenId },
     fromAmount
   )
-  const buyCoin = getLimitOrderBuyCoin({
-    targetAsset: data.targetAsset,
-    targetChain:
-      thorchainAssetPrefixToChain[data.targetAsset.split('.')[0].toUpperCase()],
-  })
+  const buyCoin = getLimitOrderBuyCoin({ targetAsset: data.targetAsset })
 
   return (
     <StepperContainer>

--- a/core/ui/transaction-history/record/normalizeTransactionRecord.test.ts
+++ b/core/ui/transaction-history/record/normalizeTransactionRecord.test.ts
@@ -1,7 +1,11 @@
 import { Chain } from '@vultisig/core-chain/Chain'
 import { describe, expect, it } from 'vitest'
 
-import { LimitSwapTransactionRecord, SendTransactionRecord } from '../core'
+import {
+  LimitSwapTransactionRecord,
+  SendTransactionRecord,
+  TransactionRecord,
+} from '../core'
 import { normalizeTransactionRecord } from './normalizeTransactionRecord'
 
 const securedUsdc = 'ETH-USDC-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
@@ -35,13 +39,25 @@ const order = (
   },
 })
 
+/**
+ * A record as it comes back from storage, where `data` is JSON that carries no
+ * shape guarantee — the same value `deserializeRecord` hands the normalizer.
+ *
+ * Round-tripping through JSON reproduces damage rather than simulating it: an
+ * `undefined` field is dropped by `JSON.stringify` exactly as it would be on the
+ * way in, so the record really does come back without the key.
+ */
+const fromStorage = (data: unknown): TransactionRecord =>
+  JSON.parse(JSON.stringify({ ...order(), data }))
+
 describe('normalizeTransactionRecord', () => {
   // Orders placed before the ticker decode understood secured notation stored
   // the whole denom where the ticker belongs, and it renders on every surface.
   it('re-derives a buy ticker that was stored as the raw denom', () => {
-    const record = normalizeTransactionRecord(
-      order({ buyTicker: securedUsdc })
-    ) as LimitSwapTransactionRecord
+    const record = normalizeTransactionRecord(order({ buyTicker: securedUsdc }))
+    if (record.type !== 'limitSwap') {
+      throw new Error(`expected a limit swap record, got ${record.type}`)
+    }
 
     expect(record.data.buyTicker).toBe('USDC')
     expect(record.data.targetAsset).toBe(securedUsdc)
@@ -72,9 +88,7 @@ describe('normalizeTransactionRecord', () => {
   ])(
     'passes a limit record with %s through untouched',
     (_label, targetAsset) => {
-      const record = order({
-        targetAsset: targetAsset as unknown as string,
-      })
+      const record = fromStorage({ ...order().data, targetAsset })
 
       expect(() => normalizeTransactionRecord(record)).not.toThrow()
       expect(normalizeTransactionRecord(record)).toBe(record)

--- a/core/ui/transaction-history/record/normalizeTransactionRecord.test.ts
+++ b/core/ui/transaction-history/record/normalizeTransactionRecord.test.ts
@@ -1,0 +1,88 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { describe, expect, it } from 'vitest'
+
+import { LimitSwapTransactionRecord, SendTransactionRecord } from '../core'
+import { normalizeTransactionRecord } from './normalizeTransactionRecord'
+
+const securedUsdc = 'ETH-USDC-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+
+const order = (
+  data: Partial<LimitSwapTransactionRecord['data']> = {}
+): LimitSwapTransactionRecord => ({
+  id: 'order-1',
+  vaultId: 'vault',
+  type: 'limitSwap',
+  status: 'pending',
+  chain: Chain.THORChain,
+  timestamp: '2026-08-09T13:39:00.000Z',
+  txHash: 'ORDERHASH',
+  explorerUrl: '',
+  fiatValue: '',
+  data: {
+    fromAddress: 'rAddress',
+    fromToken: 'XRP',
+    fromTokenLogo: 'xrp',
+    fromChain: Chain.Ripple,
+    fromDecimals: 6,
+    fromAmount: '200000',
+    buyTicker: 'USDC',
+    targetAsset: securedUsdc,
+    minimumReceived: '0.20841434',
+    destinationAddress: 'thor12a9rpf9u2ulwuezxkh6uas4au7xnde8umdua5t',
+    memo: `=<:${securedUsdc}:thor12a9rpf9u2ulwuezxkh6uas4au7xnde8umdua5t:20841434/14400/0:v0:50`,
+    orderStatus: 'expired',
+    ...data,
+  },
+})
+
+describe('normalizeTransactionRecord', () => {
+  // Orders placed before the ticker decode understood secured notation stored
+  // the whole denom where the ticker belongs, and it renders on every surface.
+  it('re-derives a buy ticker that was stored as the raw denom', () => {
+    const record = normalizeTransactionRecord(
+      order({ buyTicker: securedUsdc })
+    ) as LimitSwapTransactionRecord
+
+    expect(record.data.buyTicker).toBe('USDC')
+    expect(record.data.targetAsset).toBe(securedUsdc)
+  })
+
+  it('leaves a record whose ticker already agrees untouched', () => {
+    const record = order()
+
+    expect(normalizeTransactionRecord(record)).toBe(record)
+  })
+
+  it('leaves dotted notation alone', () => {
+    const record = order({
+      buyTicker: 'USDC',
+      targetAsset: 'ETH.USDC-06EB48',
+    })
+
+    expect(normalizeTransactionRecord(record)).toBe(record)
+  })
+
+  it('passes non-limit records through untouched', () => {
+    const record: SendTransactionRecord = {
+      id: 'send-1',
+      vaultId: 'vault',
+      type: 'send',
+      status: 'confirmed',
+      chain: Chain.Ripple,
+      timestamp: '2026-08-09T13:39:00.000Z',
+      txHash: 'SENDHASH',
+      explorerUrl: '',
+      fiatValue: '',
+      data: {
+        fromAddress: 'rFrom',
+        toAddress: 'rTo',
+        amount: '200000',
+        decimals: 6,
+        token: 'XRP',
+        tokenLogo: 'xrp',
+      },
+    }
+
+    expect(normalizeTransactionRecord(record)).toBe(record)
+  })
+})

--- a/core/ui/transaction-history/record/normalizeTransactionRecord.test.ts
+++ b/core/ui/transaction-history/record/normalizeTransactionRecord.test.ts
@@ -62,6 +62,25 @@ describe('normalizeTransactionRecord', () => {
     expect(normalizeTransactionRecord(record)).toBe(record)
   })
 
+  // Storage is JSON behind an unchecked cast, so a damaged record must not take
+  // the whole history query down with it on its way out.
+  it.each([
+    ['a missing targetAsset', undefined],
+    ['a null targetAsset', null],
+    ['an empty targetAsset', ''],
+    ['a non-string targetAsset', 42],
+  ])(
+    'passes a limit record with %s through untouched',
+    (_label, targetAsset) => {
+      const record = order({
+        targetAsset: targetAsset as unknown as string,
+      })
+
+      expect(() => normalizeTransactionRecord(record)).not.toThrow()
+      expect(normalizeTransactionRecord(record)).toBe(record)
+    }
+  )
+
   it('passes non-limit records through untouched', () => {
     const record: SendTransactionRecord = {
       id: 'send-1',

--- a/core/ui/transaction-history/record/normalizeTransactionRecord.ts
+++ b/core/ui/transaction-history/record/normalizeTransactionRecord.ts
@@ -15,6 +15,13 @@ import { TransactionRecord } from '../core'
  *
  * Returns the record unchanged when nothing needed repairing, so React Query
  * consumers keep their referential identity.
+ *
+ * This runs on the far side of a `JSON.parse` and an unchecked cast, so it is
+ * the one place that cannot take its own types at face value: a record whose
+ * `targetAsset` did not survive storage is passed through untouched rather than
+ * throwing. A repair pass that dies on damaged input would take the entire
+ * history query down with it — every record, not just the bad one — which is
+ * the opposite of what it is here to do.
  */
 export const normalizeTransactionRecord = (
   record: TransactionRecord
@@ -23,7 +30,12 @@ export const normalizeTransactionRecord = (
     return record
   }
 
-  const buyTicker = getThorchainAssetTicker(record.data.targetAsset)
+  const { targetAsset } = record.data
+  if (typeof targetAsset !== 'string' || !targetAsset) {
+    return record
+  }
+
+  const buyTicker = getThorchainAssetTicker(targetAsset)
   if (buyTicker === record.data.buyTicker) {
     return record
   }

--- a/core/ui/transaction-history/record/normalizeTransactionRecord.ts
+++ b/core/ui/transaction-history/record/normalizeTransactionRecord.ts
@@ -1,0 +1,32 @@
+import { getThorchainAssetTicker } from '../../mpc/keysign/join/tx/thorchainAssetTicker'
+import { TransactionRecord } from '../core'
+
+/**
+ * Repair a record on its way out of storage, re-deriving the display fields that
+ * were denormalized off a memo at write time.
+ *
+ * A limit order's `buyTicker` is decoded from `targetAsset`, so an order placed
+ * before that decode understood secured-asset notation has the entire raw denom
+ * sitting where its ticker belongs — on the history row, the pending card, the
+ * detail screen and the cancel confirmation alike. Re-deriving on read fixes
+ * those orders without a migration: the memo the record already carries is the
+ * source of truth, so the derivation is correct whenever it runs, and it stays
+ * correct for records this bug never touched.
+ *
+ * Returns the record unchanged when nothing needed repairing, so React Query
+ * consumers keep their referential identity.
+ */
+export const normalizeTransactionRecord = (
+  record: TransactionRecord
+): TransactionRecord => {
+  if (record.type !== 'limitSwap') {
+    return record
+  }
+
+  const buyTicker = getThorchainAssetTicker(record.data.targetAsset)
+  if (buyTicker === record.data.buyTicker) {
+    return record
+  }
+
+  return { ...record, data: { ...record.data, buyTicker } }
+}


### PR DESCRIPTION
Closes #4744

## The problem

A limit order whose buy side is a THORChain **secured asset** — denom form `CHAIN-ASSET`, e.g. `ETH-USDC-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48` — renders the whole raw denom where its ticker belongs, with no coin icon, and the 47-character unbreakable string pushes the swap cards clean off the screen so the absolutely-centred chevron lands on top of the "Minimum received" caption.

Three independent defects stack into that one screenshot:

- **`getThorchainAssetTicker`** splits on `.`. A secured denom has no dot, so the "no chain prefix" fallback returns the *entire* string as the ticker.
- **`getLimitOrderBuyCoin`** also splits on `.`, and its call sites resolved `targetChain` via `thorchainAssetPrefixToChain[targetAsset.split('.')[0]]` — which passes the whole denom as the prefix, resolves nothing, and renders no icon.
- **`SwapCoinCard`** is a `flex: 1` child with no `min-width: 0`, so it cannot shrink below its content. That is what turns a long string into a viewport overflow rather than a clamp — the layout half of the bug is independent of the asset shape and would fire again on any asset the ticker helper can't shorten.

The first defect is the one that spreads: `buyTicker` is denormalized into the stored record, so the raw denom also reaches the history list row, the pending progress card, the "Filled so far" row, the cancel page, the join-keysign verify screen and the history search index.

## The fix

**Notation.** Both helpers now locate the chain prefix with the SDK's shared separator helpers (`findThorchainMemoAssetSeparatorIndex`, `getThorchainMemoAssetChain`) instead of re-implementing the parse. The prefix ends at the **first** separator of any flavour, which is the rule that makes secured denoms readable — searching from the right would land the boundary inside the token identifier. Synth (`BTC/BTC`) and trade (`ETH~ETH`) notation fall out of the same change.

`getLimitOrderBuyCoin` now derives the chain from the asset itself rather than accepting it as an argument, so the coin and the ticker rendered beside it cannot disagree about which asset this is — and the join-keysign path stops inheriting the SDK's own `split('.')` result. Its contract match by `endsWith` already covers both spellings with no branch: an L1 token carries only the last six characters of its address, a secured denom carries the whole thing. The ticker still has to agree with the contract match, so a tail that happens to line up cannot resolve the wrong coin's logo and price onto a signing review.

**Already-placed orders.** Fixing the decode only helps orders placed from here on; the order in the issue is already in storage with the raw denom in `buyTicker`. `deserializeRecord` — the single read boundary for both desktop and extension — now re-derives it from the memo's `targetAsset`. The memo the record already carries is the source of truth, so the derivation is correct whenever it runs and stays correct for records this bug never touched. That heals every render site listed above at once, with no migration.

**Layout.** `min-width: 0` on the card so a flex item can shrink, `overflow-wrap: anywhere` on the text column so a contract address has somewhere to break, and a two-line clamp on the amount line so an unrecognised asset can't wrap into a paragraph. This is deliberately independent of the notation fix: no future asset shape can break the layout again.

## Blast radius

`core/ui` display path only. No memo construction, no cancel-memo spelling, nothing that feeds signing; no `core/mpc/` or `tss/`; no SDK change; no new i18n keys. `isOwnLimitOrderDestination` is deliberately left alone — for a secured asset it still gets `targetChain: undefined` from the SDK's `getKeysignLimitSwapOrder`, which fails *visible* (shows the payout address to the co-signer) and is a signing-review decision rather than a display one.

## Verification

`yarn check:all` passes (exit 0) — lint, typecheck, 1273 unit tests, extension + desktop tests, `i18n:check`, `i18n:review-quality --strict`, knip and `quality:health`.

**Unit tests.** `thorchainAssetTicker.test.ts` covers secured (`ETH-USDC-0x…`, `XRP-XRP`, lower-cased bank denoms), synth and trade notation alongside the existing dotted cases and the no-prefix fallback. `limitOrderBuyCoin.test.ts` covers secured tokens matched on their full contract, secured gas assets, synths and trade assets, and the unresolvable cases that must stay `undefined`. New `normalizeTransactionRecord.test.ts` uses the exact record from the issue.

**Layout, measured.** Reproduced the card markup in headless Chromium at a 375px viewport:

| | sell card | buy card | buy card right edge | overflows 375px |
|---|---|---|---|---|
| before | 70px | 386px | **x=480** | yes |
| after | 168px | 168px | x=359 | no |
| after, with an unresolvable asset | 168px | 168px | x=359 | no (clamps to 2 lines) |

The "before" row reproduces the reported screenshot exactly, down to the sell card squeezing "0.2 XRP" onto two lines. After the fix the cards are equal halves with the chevron spanning x=169–207, dead centre between them — the same geometry the regular-swap card already ships.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast)
- [ ] Sending
- [ ] Swap — display only; no transaction is built, signed or broadcast by this change
- [ ] New Chain / Chain related feature

## Parity

- iOS: n/a — the raw denom leaks from `core/ui`'s own memo decode and its record denormalization, neither of which exists on iOS
- Android: n/a — limit swaps are not implemented there
- SDK: `getKeysignLimitSwapOrder` derives `targetChain` with the same `split('.')` and returns `undefined` for every secured asset. Worked around here by deriving the chain in the UI helper; worth correcting at source

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction history recovery for limit-swap records, including secured assets and legacy formats.
  * Fixed asset and ticker recognition across secured tokens, synths, trade assets, and varied notation styles.
  * Corrected handling of full contract addresses and malformed stored records.

* **UI Improvements**
  * Improved swap and limit-order amount layouts.
  * Long asset names now wrap cleanly, while amounts are constrained for readability.

* **Tests**
  * Expanded coverage for asset parsing, ticker extraction, and transaction-history normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->