### PR TITLE
fix(qbtc): show the claim banner to secure vaults

### DIFF
--- a/core/ui/qbtc/claim/components/QbtcClaimBanner.styles.tsx
+++ b/core/ui/qbtc/claim/components/QbtcClaimBanner.styles.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@lib/ui/buttons/Button'
+import { IconButton } from '@lib/ui/buttons/IconButton'
 import { borderRadius } from '@lib/ui/css/borderRadius'
 import { vStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
@@ -12,7 +13,6 @@ export const BannerRoot = styled.div`
   position: relative;
   width: 100%;
   min-height: 156px;
-  margin-bottom: 32px;
   box-sizing: border-box;
   padding: 24px;
   ${borderRadius.md};
@@ -131,4 +131,26 @@ export const BannerCta = styled(Button).attrs({ size: 'xs' })`
   align-self: center;
   white-space: nowrap;
   z-index: 2;
+`
+
+/**
+ * The dismiss affordance, floated over the top-right coin artwork. It carries a
+ * scrim of the banner's own base colour rather than the usual white `mist`,
+ * which would wash out against the gold coin instead of holding the glyph.
+ */
+export const BannerDismissButton = styled(IconButton).attrs({ size: 'md' })`
+  position: absolute;
+  z-index: 3;
+  top: 8px;
+  right: 8px;
+  border: none;
+  color: ${getColor('contrast')};
+  background: ${({ theme }) =>
+    theme.colors.background.withAlpha(0.6).toCssValue()};
+  backdrop-filter: blur(8px);
+
+  &:hover {
+    background: ${({ theme }) =>
+      theme.colors.background.withAlpha(0.8).toCssValue()};
+  }
 `

--- a/core/ui/qbtc/claim/components/QbtcClaimBanner.tsx
+++ b/core/ui/qbtc/claim/components/QbtcClaimBanner.tsx
@@ -1,8 +1,5 @@
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
-import {
-  useCurrentVault,
-  useCurrentVaultSecurityType,
-} from '@core/ui/vault/state/currentVault'
+import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { useCurrentVaultAddress } from '@core/ui/vault/state/currentVaultCoins'
 import { Text } from '@lib/ui/text'
 import { Chain } from '@vultisig/core-chain/Chain'
@@ -25,25 +22,24 @@ import {
 } from './QbtcClaimBanner.styles'
 
 /** Promotional banner shown on the BTC chain detail page that takes the user
- * into the QBTC claim flow. Visible only for Fast Vaults with an MLDSA key,
- * at least one claimable UTXO, and where ClaimWithProof is not globally
- * disabled. */
+ * into the QBTC claim flow. Visible for any vault holding an MLDSA key with at
+ * least one claimable UTXO, where ClaimWithProof is not globally disabled - the
+ * flow itself co-signs with the server or a second device depending on the
+ * vault, so neither kind is excluded here. */
 export const QbtcClaimBanner = () => {
   const { t } = useTranslation()
   const navigate = useCoreNavigate()
   const vault = useCurrentVault()
-  const securityType = useCurrentVaultSecurityType()
   const btcAddress = useCurrentVaultAddress(Chain.Bitcoin)
 
   const utxosQuery = useClaimableUtxosQuery({ btcAddress })
   const disabledQuery = useClaimWithProofDisabledQuery()
 
   const hasMldsaKey = Boolean(vault.publicKeyMldsa)
-  const isFastVault = securityType === 'fast'
   const claimEnabled = disabledQuery.data === false
   const hasClaimableUtxos = (utxosQuery.data?.length ?? 0) > 0
 
-  if (!hasMldsaKey || !isFastVault || !claimEnabled || !hasClaimableUtxos) {
+  if (!hasMldsaKey || !claimEnabled || !hasClaimableUtxos) {
     return null
   }
 

--- a/core/ui/qbtc/claim/components/QbtcClaimBanner.tsx
+++ b/core/ui/qbtc/claim/components/QbtcClaimBanner.tsx
@@ -1,6 +1,11 @@
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
+import {
+  useDismissBanner,
+  useDismissedBanners,
+} from '@core/ui/storage/dismissedBanners'
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
 import { useCurrentVaultAddress } from '@core/ui/vault/state/currentVaultCoins'
+import { CrossIcon } from '@lib/ui/icons/CrossIcon'
 import { Text } from '@lib/ui/text'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { useTranslation } from 'react-i18next'
@@ -9,6 +14,7 @@ import { useClaimableUtxosQuery } from '../hooks/useClaimableUtxosQuery'
 import { useClaimWithProofDisabledQuery } from '../hooks/useClaimWithProofDisabledQuery'
 import {
   BannerCta,
+  BannerDismissButton,
   BannerEllipseGlass,
   BannerEllipseGlow,
   BannerEllipseOuter,
@@ -25,12 +31,15 @@ import {
  * into the QBTC claim flow. Visible for any vault holding an MLDSA key with at
  * least one claimable UTXO, where ClaimWithProof is not globally disabled - the
  * flow itself co-signs with the server or a second device depending on the
- * vault, so neither kind is excluded here. */
+ * vault, so neither kind is excluded here. Dismissing it hides it for the
+ * cooldown its entry sets in the shared per-banner dismiss registry. */
 export const QbtcClaimBanner = () => {
   const { t } = useTranslation()
   const navigate = useCoreNavigate()
   const vault = useCurrentVault()
   const btcAddress = useCurrentVaultAddress(Chain.Bitcoin)
+  const { hasLoaded, isBannerDismissed } = useDismissedBanners()
+  const dismissBanner = useDismissBanner()
 
   const utxosQuery = useClaimableUtxosQuery({ btcAddress })
   const disabledQuery = useClaimWithProofDisabledQuery()
@@ -40,6 +49,12 @@ export const QbtcClaimBanner = () => {
   const hasClaimableUtxos = (utxosQuery.data?.length ?? 0) > 0
 
   if (!hasMldsaKey || !claimEnabled || !hasClaimableUtxos) {
+    return null
+  }
+
+  // Held back until storage answers so a previously dismissed banner never
+  // flashes in and then disappears.
+  if (!hasLoaded || isBannerDismissed('qbtcClaim')) {
     return null
   }
 
@@ -53,6 +68,13 @@ export const QbtcClaimBanner = () => {
       <BtcStickerBottomLeft aria-hidden />
       <BtcStickerTopRight aria-hidden />
       <BtcStickerMidRight aria-hidden />
+      <BannerDismissButton
+        aria-label={t('close')}
+        data-testid="qbtc-claim-banner-dismiss"
+        onClick={() => dismissBanner('qbtcClaim')}
+      >
+        <CrossIcon />
+      </BannerDismissButton>
       <BannerTextStack>
         <Text variant="caption" color="shy">
           {t('qbtc_claim_banner_title')}

--- a/core/ui/storage/dismissedBanners.test.ts
+++ b/core/ui/storage/dismissedBanners.test.ts
@@ -62,6 +62,14 @@ describe('isBannerDismissed', () => {
     ).toBe(false)
   })
 
+  it('resurfaces the QBTC claim banner once its cooldown elapses', () => {
+    const banners: DismissedBanners = {
+      qbtcClaim: { dismissedAt: now - bannerDismissalTtl.qbtcClaim },
+    }
+
+    expect(isBannerDismissed({ banners, id: 'qbtcClaim', now })).toBe(false)
+  })
+
   it('applies a per-banner TTL: buyVultPromo resurfaces before other banners', () => {
     const dismissedAt = now - convertDuration(10, 'd', 'ms')
     const banners: DismissedBanners = {

--- a/core/ui/storage/dismissedBanners.tsx
+++ b/core/ui/storage/dismissedBanners.tsx
@@ -15,6 +15,7 @@ export const bannerIds = [
   'vaultBackup',
   'referralCode',
   'kamino',
+  'qbtcClaim',
 ] as const
 
 export type BannerId = (typeof bannerIds)[number]
@@ -48,6 +49,11 @@ export const bannerDismissalTtl: Record<BannerId, number> = {
   vaultBackup: convertDuration(7, 'd', 'ms'),
   referralCode: convertDuration(7, 'd', 'ms'),
   kamino: convertDuration(7, 'd', 'ms'),
+  // Deliberately a TTL rather than a permanent dismissal: this banner is gated
+  // on the current vault, but the dismissal is stored per profile (#4769), so a
+  // dismissal on a vault with nothing to claim would otherwise hide the banner
+  // for good on a vault that does have claimable UTXOs.
+  qbtcClaim: convertDuration(7, 'd', 'ms'),
 }
 
 /**

--- a/core/ui/vault/chain/VaultChainPage.tsx
+++ b/core/ui/vault/chain/VaultChainPage.tsx
@@ -54,9 +54,9 @@ export const VaultChainPage = () => {
         />
         <StyledPageContent scrollable gap={32} flexGrow>
           <VaultChainOverview />
+          {chain === Chain.Bitcoin && <QbtcClaimBanner />}
           {chain === Chain.Tron && <TronResourcesSection />}
           <VaultChainTabs />
-          {chain === Chain.Bitcoin && <QbtcClaimBanner />}
         </StyledPageContent>
         {chain === Chain.QBTC && (
           <BottomCtaArea>

--- a/core/ui/vault/page/banners/homePromoBanners.tsx
+++ b/core/ui/vault/page/banners/homePromoBanners.tsx
@@ -7,6 +7,16 @@ import { ThemeColor } from '@lib/ui/theme/ThemeColors'
 import { ComponentType } from 'react'
 
 /**
+ * The banners the home carousel actually renders. Banners that live on their
+ * own surface - the agent coachmark, the QBTC claim promo on the Bitcoin page -
+ * share the dismissal registry but not the carousel's presentation.
+ */
+export type HomePromoBannerId = Exclude<
+  BannerId,
+  'agentNavigationCoachmark' | 'qbtcClaim'
+>
+
+/**
  * Static presentation for each home promo banner: the artwork, the accent hue
  * behind it, and what fills the icon tile. Copy lives in i18n and the tap
  * destination lives with the carousel, so this record stays free of both.
@@ -25,7 +35,7 @@ export type HomePromoBannerVisuals = {
 const artSrc = (name: string) => `/core/images/banner-art-${name}.png`
 
 export const homePromoBannerVisuals: Record<
-  Exclude<BannerId, 'agentNavigationCoachmark'>,
+  HomePromoBannerId,
   HomePromoBannerVisuals
 > = {
   migrate: {

--- a/core/ui/vault/page/banners/useHomePromoBanners.tsx
+++ b/core/ui/vault/page/banners/useHomePromoBanners.tsx
@@ -18,7 +18,7 @@ import { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { currentProductBrand } from '../../../product/brand'
-import { homePromoBannerVisuals } from './homePromoBanners'
+import { HomePromoBannerId, homePromoBannerVisuals } from './homePromoBanners'
 import { HomePromoBanner } from './shared/HomePromoBanner'
 import { HomePromoBannerIcon } from './shared/HomePromoBannerIcon'
 
@@ -28,7 +28,7 @@ type HomePromoBannerEntry = {
 }
 
 type BannerInput = {
-  id: Exclude<BannerId, 'agentNavigationCoachmark'>
+  id: HomePromoBannerId
   /** The small line above the title. */
   caption: string
   /** The emphasised line the banner leads with. */


### PR DESCRIPTION
Closes #4767

## What

`QbtcClaimBanner` gated its own visibility on `securityType === 'fast'`, so a Secure Vault never saw the "Claim your QBTC" banner on the Bitcoin chain detail page — even with an MLDSA key and claimable UTXOs.

## Why it's stale, not deliberate

```
2026-05-25  #3978  banner added, with `isFastVault` in its visibility check
2026-06-24  #4195  "feat(qbtc): support secure vaults for QBTC claim"
```

#4195 taught the whole pipeline to co-sign with a second device — `QbtcClaimPage`, `ClaimRunner`, `ClaimSignRound`, plus a `JoinKeysignQbtcClaimVerify` screen for the co-signer — but never touched the banner, so the gate outlived its reason by a month.

Nothing else in the product agrees with it. `QbtcClaimSection`, the `Claim` CTA on the QBTC chain detail page, has **no** vault-type gate: a Secure Vault user could already reach the claim flow and complete it there. Only the banner advertising it was hidden from them.

And the destination branches on vault type on purpose:

```ts
// Fast vaults co-sign with the server and need the password up front.
// Secure vaults co-sign with a second device, so go straight to signing.
if (securityType === 'fast') {
  setPendingUtxos(utxos)
} else {
  setStep({ claiming: { utxos } })
}
```

## What stays

`hasMldsaKey`. The claim signs with the post-quantum key, so a vault without one genuinely cannot claim regardless of type — a Secure Vault created before QBTC onboarding may not have one. The claimable-UTXO and `ClaimWithProofDisabled` gates are untouched.

## Testing

- `yarn typecheck`, `yarn lint`, `yarn knip` — clean
- `yarn validate-public` fails on `thor.svg` / `vthor.svg`, pre-existing on `main` from 8b576170c, unrelated

Needs a Secure Vault with an MLDSA key and claimable UTXOs to verify end-to-end, which I can't drive alone — the claim needs a second-device co-sign.

## Stack

This is the base of a two-PR stack. #4765 (#4727 — dismissable + Figma placement) sits on top of it and will retarget to `main` once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded QBTC claim banner availability beyond Fast Vaults.
  - The banner now appears for eligible vaults with an MLDSA key, claimable UTXOs, and Claim With Proof enabled.
  - Added a dismiss option for the banner, which remains hidden for seven days after dismissal.
  - Positioned the QBTC claim banner more prominently within the vault view.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->