### PR TITLE
Manage chains/tokens pill: pencil icon + label

### DIFF
--- a/core/ui/vault/chain/tabs/VaultChainTabsHeader.tsx
+++ b/core/ui/vault/chain/tabs/VaultChainTabsHeader.tsx
@@ -1,22 +1,25 @@
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { useCurrentVaultChain } from '@core/ui/vault/chain/useCurrentVaultChain'
-import { IconButton } from '@lib/ui/buttons/IconButton'
-import { HousePenIcon } from '@lib/ui/icons/HousePenIcon'
+import { ManagePillButton } from '@core/ui/vault/components/ManagePillButton'
+import { IconWrapper } from '@lib/ui/icons/IconWrapper'
+import { PencilIcon } from '@lib/ui/icons/PenciIcon'
 import { hStack } from '@lib/ui/layout/Stack'
 import { ChildrenProp } from '@lib/ui/props'
+import { Text } from '@lib/ui/text'
 import { knownTokens } from '@vultisig/core-chain/coin/knownTokens'
 import { chainsWithTokenMetadataDiscovery } from '@vultisig/core-chain/coin/token/metadata/chains'
 import { isOneOf } from '@vultisig/lib-utils/array/isOneOf'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useState } from 'react'
-import styled, { useTheme } from 'styled-components'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
 
 import { SearchChainToken } from './controls/SearchChainToken'
 
 export const VaultChainTabsHeader = ({ children }: ChildrenProp) => {
-  const { colors } = useTheme()
   const navigate = useCoreNavigate()
   const chain = useCurrentVaultChain()
+  const { t } = useTranslation()
   const [isSearchExpanded, setIsSearchExpanded] = useState(false)
   const hasMultipleCoinsSupport =
     knownTokens[chain].length > 0 ||
@@ -64,18 +67,19 @@ export const VaultChainTabsHeader = ({ children }: ChildrenProp) => {
               exit={{ opacity: 0, scale: 0.95 }}
               transition={{ duration: 0.2, ease: 'easeInOut' }}
             >
-              <IconButton
-                kind="secondary"
+              <ManagePillButton
+                data-testid="manage-chain-coins-button"
                 onClick={() =>
                   navigate({ id: 'manageVaultChainCoins', state: { chain } })
                 }
-                style={{
-                  color: colors.info.toCssValue(),
-                }}
-                size="lg"
               >
-                <HousePenIcon />
-              </IconButton>
+                <IconWrapper size={16}>
+                  <PencilIcon />
+                </IconWrapper>
+                <Text variant="footnote" color="supporting">
+                  {t('vaultChainTabs.tokens')}
+                </Text>
+              </ManagePillButton>
             </ManageButtonMotion>
           )}
         </AnimatePresence>

--- a/core/ui/vault/chain/tabs/VaultChainTabsHeader.tsx
+++ b/core/ui/vault/chain/tabs/VaultChainTabsHeader.tsx
@@ -76,7 +76,7 @@ export const VaultChainTabsHeader = ({ children }: ChildrenProp) => {
                 <IconWrapper size={16}>
                   <PencilIcon />
                 </IconWrapper>
-                <Text variant="footnote" color="supporting">
+                <Text variant="footnote" color="contrast">
                   {t('vaultChainTabs.tokens')}
                 </Text>
               </ManagePillButton>

--- a/core/ui/vault/components/ManagePillButton.tsx
+++ b/core/ui/vault/components/ManagePillButton.tsx
@@ -1,0 +1,18 @@
+import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
+import { borderRadius } from '@lib/ui/css/borderRadius'
+import { hStack } from '@lib/ui/layout/Stack'
+import { getColor } from '@lib/ui/theme/getters'
+import styled from 'styled-components'
+
+/**
+ * Pill-shaped trigger (icon + label) used for chain/token management buttons.
+ */
+export const ManagePillButton = styled(UnstyledButton)`
+  ${hStack({ alignItems: 'center', gap: 8 })};
+  ${borderRadius.pill};
+  height: 40px;
+  padding: 12px;
+  color: ${getColor('contrast')};
+  background: ${getColor('foreground')};
+  box-shadow: inset 0 0 8px rgba(240, 244, 252, 0.03);
+`

--- a/core/ui/vault/page/components/VaultTabs/VaultTabsHeader.tsx
+++ b/core/ui/vault/page/components/VaultTabs/VaultTabsHeader.tsx
@@ -1,31 +1,24 @@
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
-import { useCore } from '@core/ui/state/core'
+import { ManagePillButton } from '@core/ui/vault/components/ManagePillButton'
 import { useCurrentVault } from '@core/ui/vault/state/currentVault'
-import { IconButton } from '@lib/ui/buttons/IconButton'
-import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
-import { borderRadius } from '@lib/ui/css/borderRadius'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
-import { StationPenIcon } from '@lib/ui/icons/StationFigmaIcons'
+import { PencilIcon } from '@lib/ui/icons/PenciIcon'
 import { hStack } from '@lib/ui/layout/Stack'
 import { ChildrenProp } from '@lib/ui/props'
 import { Text } from '@lib/ui/text'
-import { getColor } from '@lib/ui/theme/getters'
 import { isKeyImportVault } from '@vultisig/core-mpc/vault/Vault'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import styled, { css, useTheme } from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import { SearchChain } from './controls/SearchChain'
 
 export const VaultTabsHeader = ({ children }: ChildrenProp) => {
-  const { client } = useCore()
-  const { colors } = useTheme()
   const vault = useCurrentVault()
   const navigate = useCoreNavigate()
   const { t } = useTranslation()
   const [isSearchExpanded, setIsSearchExpanded] = useState(false)
-  const isExtension = client === 'extension'
 
   return (
     <Wrapper>
@@ -69,29 +62,17 @@ export const VaultTabsHeader = ({ children }: ChildrenProp) => {
               exit={{ opacity: 0, scale: 0.95 }}
               transition={{ duration: 0.2, ease: 'easeInOut' }}
             >
-              {isExtension ? (
-                <ManageChainsButton
-                  data-testid="manage-chains-button"
-                  onClick={() => navigate({ id: 'manageVaultChains' })}
-                >
-                  <IconWrapper size={16}>
-                    <StationPenIcon />
-                  </IconWrapper>
-                  <Text variant="footnote" color="supporting">
-                    {t('chains')}
-                  </Text>
-                </ManageChainsButton>
-              ) : (
-                <IconButton
-                  data-testid="manage-chains-button"
-                  kind="secondary"
-                  onClick={() => navigate({ id: 'manageVaultChains' })}
-                  style={{ color: colors.info.toCssValue() }}
-                  size="lg"
-                >
-                  <HousePenIcon />
-                </IconButton>
-              )}
+              <ManagePillButton
+                data-testid="manage-chains-button"
+                onClick={() => navigate({ id: 'manageVaultChains' })}
+              >
+                <IconWrapper size={16}>
+                  <PencilIcon />
+                </IconWrapper>
+                <Text variant="footnote" color="supporting">
+                  {t('chains')}
+                </Text>
+              </ManagePillButton>
             </ManageButtonMotion>
           )}
         </AnimatePresence>
@@ -155,14 +136,3 @@ const SearchArea = styled(motion.div)`
 const ManageButtonMotion = styled(motion.div)`
   display: flex;
 `
-
-const ManageChainsButton = styled(UnstyledButton)`
-  ${hStack({ alignItems: 'center', gap: 8 })};
-  ${borderRadius.pill};
-  height: 40px;
-  padding: 12px;
-  color: ${getColor('contrast')};
-  background: ${getColor('foreground')};
-  box-shadow: inset 0 0 8px rgba(240, 244, 252, 0.03);
-`
-import { HousePenIcon } from '@lib/ui/icons/HousePenIcon'

--- a/core/ui/vault/page/components/VaultTabs/VaultTabsHeader.tsx
+++ b/core/ui/vault/page/components/VaultTabs/VaultTabsHeader.tsx
@@ -69,7 +69,7 @@ export const VaultTabsHeader = ({ children }: ChildrenProp) => {
                 <IconWrapper size={16}>
                   <PencilIcon />
                 </IconWrapper>
-                <Text variant="footnote" color="supporting">
+                <Text variant="footnote" color="contrast">
                   {t('chains')}
                 </Text>
               </ManagePillButton>

--- a/lib/ui/icons/StationFigmaIcons.tsx
+++ b/lib/ui/icons/StationFigmaIcons.tsx
@@ -13,18 +13,6 @@ export const StationSecureVaultIcon: FC<SvgProps> = props => (
   </svg>
 )
 
-export const StationPenIcon: FC<SvgProps> = props => (
-  <svg viewBox="0 0 16 16" fill="none" width="1em" height="1em" {...props}>
-    <path
-      d="M2.39974 13.6002L3.19974 9.60019L9.93094 2.86899C10.5557 2.24419 11.5685 2.24419 12.1933 2.86899L13.1309 3.80659C13.7557 4.43139 13.7557 5.44419 13.1309 6.06899L6.39974 12.8002L2.39974 13.6002Z"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </svg>
-)
-
 export const StationArrowsRotateCenterIcon: FC<SvgProps> = props => (
   <svg viewBox="0 0 20 20" fill="none" width="1em" height="1em" {...props}>
     <path


### PR DESCRIPTION
## Summary
- Replaced the icon-only manage-chains circle button with a pill (icon + label), matching the existing extension pattern, for both desktop and extension
- Applied the same pill treatment to the chain-detail manage-tokens header, labeled "Tokens"
- Extracted the shared pill styling into `ManagePillButton`
- Swapped the icon to the existing pencil icon (`PencilIcon`)

## Issue
Closes #4679

## Test Plan
- [x] `yarn check` passes (typecheck, lint, i18n, knip)
- [ ] Manual check against Figma frames (no Figma MCP access this session — verify spacing/colors visually)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated vault management controls with a consistent pill-shaped design.
  * Added pencil icons and clearer “Manage chains” labels.
  * Improved contrast, spacing, sizing, and visual alignment across vault headers.
* **Accessibility**
  * Replaced icon-only controls with buttons that include descriptive text.
* **Internationalization**
  * Updated header labels to use translated text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->