### PR TITLE
fix(keysign): show the full recipient address on the verify screen

### DIFF
--- a/core/ui/mpc/keysign/verify/VerifyTransactionOverview.tsx
+++ b/core/ui/mpc/keysign/verify/VerifyTransactionOverview.tsx
@@ -8,6 +8,7 @@ import {
 import { getVerifyTransactionTitleKey } from '@core/ui/mpc/keysign/transaction-decoding/presentation'
 import { KeysignFeeAmount } from '@core/ui/mpc/keysign/tx/FeeAmount'
 import {
+  TransactionOverviewAddress,
   TransactionOverviewAmount,
   TransactionOverviewItem,
 } from '@core/ui/mpc/keysign/verify/components'
@@ -18,12 +19,10 @@ import { Spinner } from '@lib/ui/loaders/Spinner'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
 import { Query } from '@lib/ui/query/Query'
 import { Text } from '@lib/ui/text'
-import { MiddleTruncate } from '@lib/ui/truncate'
 import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { CoinKey, CoinMetadata } from '@vultisig/core-chain/coin/Coin'
 import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
-import { formatWalletAddress } from '@vultisig/lib-utils/formatWalletAddress'
 import { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -107,27 +106,8 @@ export const VerifyTransactionOverview = ({
     />
   )
 
-  const receiverDisplay: ReactNode = (() => {
-    if (typeof receiver !== 'string') return receiver
-
-    const label =
-      receiverVaultName ?? receiverAddressBookName ?? receiverAddressLabel
-
-    if (label !== undefined) {
-      return (
-        <HStack alignItems="center" gap={8}>
-          <Text as="span" size={14} weight={500}>
-            {label}
-          </Text>
-          <Text as="span" color="shy" size={14} weight={500}>
-            ({formatWalletAddress(receiver)})
-          </Text>
-        </HStack>
-      )
-    }
-
-    return <MiddleTruncate size={14} text={receiver} weight={500} width={200} />
-  })()
+  const receiverName =
+    receiverVaultName ?? receiverAddressBookName ?? receiverAddressLabel
 
   return (
     <List border="gradient" radius={borderRadiusPx.lg}>
@@ -146,20 +126,20 @@ export const VerifyTransactionOverview = ({
           )
         }}
       />
-      <TransactionOverviewItem
+      <TransactionOverviewAddress
         label={t('from')}
-        value={
-          <HStack alignItems="center" gap={8}>
-            <Text as="span" size={14} weight={500}>
-              {senderName}
-            </Text>
-            <Text as="span" color="shy" size={14} weight={500}>
-              ({formatWalletAddress(senderAddress)})
-            </Text>
-          </HStack>
-        }
+        address={senderAddress}
+        name={senderName}
       />
-      <TransactionOverviewItem label={t('to')} value={receiverDisplay} />
+      {typeof receiver === 'string' ? (
+        <TransactionOverviewAddress
+          label={t('to')}
+          address={receiver}
+          name={receiverName}
+        />
+      ) : (
+        <TransactionOverviewItem label={t('to')} value={receiver} />
+      )}
       <TransactionOverviewItem
         label={t('network')}
         value={

--- a/core/ui/mpc/keysign/verify/components/TransactionOverviewAddress.tsx
+++ b/core/ui/mpc/keysign/verify/components/TransactionOverviewAddress.tsx
@@ -1,0 +1,61 @@
+import { VStack } from '@lib/ui/layout/Stack'
+import { Text } from '@lib/ui/text'
+import { getColor } from '@lib/ui/theme/getters'
+import { ReactNode } from 'react'
+import styled from 'styled-components'
+
+const AddressRow = styled.div`
+  align-items: flex-start;
+  background-color: ${getColor('foreground')};
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-height: 58px;
+  padding: 12px 16px;
+`
+
+type TransactionOverviewAddressProps = {
+  label: ReactNode
+  address: string
+  /**
+   * Human-readable name for the address (vault name, address book entry, or
+   * name-service label). Rendered above the address rather than beside it, so
+   * it never competes with the address for horizontal space.
+   */
+  name?: string
+}
+
+/**
+ * Renders an address on a keysign review screen in full, wrapping across lines
+ * instead of middle-truncating. This is the last checkpoint before signing, so
+ * the entire string has to be readable: a truncated address hides exactly the
+ * characters an address-poisoning lookalike differs in.
+ */
+export const TransactionOverviewAddress = ({
+  label,
+  address,
+  name,
+}: TransactionOverviewAddressProps) => (
+  <AddressRow>
+    <Text as="span" color="shy" size={14} weight={500}>
+      {label}
+    </Text>
+    <VStack gap={2} fullWidth>
+      {name !== undefined && (
+        <Text as="span" size={14} weight={500}>
+          {name}
+        </Text>
+      )}
+      <Text
+        as="span"
+        color={name === undefined ? 'regular' : 'shy'}
+        family="mono"
+        size={13}
+        weight={500}
+        style={{ overflowWrap: 'anywhere', width: '100%' }}
+      >
+        {address}
+      </Text>
+    </VStack>
+  </AddressRow>
+)

--- a/core/ui/mpc/keysign/verify/components/index.ts
+++ b/core/ui/mpc/keysign/verify/components/index.ts
@@ -1,2 +1,3 @@
+export { TransactionOverviewAddress } from './TransactionOverviewAddress'
 export { TransactionOverviewAmount } from './TransactionOverviewAmount'
 export { TransactionOverviewItem } from './TransactionOverviewItem'


### PR DESCRIPTION
Closes #4751

## Problem

The final review screen before signing never showed the recipient in full. `VerifyTransactionOverview` rendered the address two ways, both truncated:

- With a label (vault name, address book entry, or name-service label): `Name (thor1...fhekt)` via `formatWalletAddress` — 5 prefix + 4 suffix characters.
- Without one: `MiddleTruncate` at a fixed `width={200}`.

Neither had a tooltip, copy button, or expand affordance, so the middle of the address was unreadable and unrecoverable from the UI. That middle is exactly where an address-poisoning lookalike differs — an attacker generating a vanity address matching the first 5 and last 4 characters is indistinguishable at the one screen where it matters most.

The labelled case was the worse of the two: the label and the address shared a single line, so the address was squeezed hardest precisely when the user had most reason to trust the row.

## Change

Adds `TransactionOverviewAddress`, which renders the address in full, wrapped across lines in a mono font, and places any label *above* the address instead of beside it so the two never compete for horizontal space. Wired into both the `from` and `to` rows.

`overflow-wrap: anywhere` means long addresses wrap rather than forcing horizontal scroll, so this holds in the extension's 480px popup as well as a wide desktop window — the mobile/desktop parity the issue asked to settle before implementation.

## Scope

`VerifyTransactionOverview` is shared, so one change covers every final review screen — satisfying the issue's "for every signer" requirement:

- `SendVerify` — the initiator's send verify
- `JoinKeysignTxOverview` — the co-signer's join-keysign overview
- `CircleWithdrawVerify`

Desktop and extension both, since they share `core/ui`.

## Deliberately out of scope

- `KeysignTxOverview` (`MiddleTruncate width={80}`) — the **post-sign** screen. The transaction is already broadcast; there is no verification decision left.
- `DownloadKeysignQrCode` — a label baked into an exported QR image, not a review step.

The issue specifies "at the last review step", so both were left alone.

## Testing

- `yarn typecheck` — clean
- `yarn test` — 1312 passed / 184 files
- `npx eslint core/ui/mpc/keysign/verify/` — clean
- `yarn build:extension` and `yarn build:desktop` — both succeed
- Manually verified in the extension build: a 63-character THORChain address now renders in full on Send Overview, in both the labelled and unlabelled cases

## Cross-platform note

While scoping this I checked the iOS and Android clients. Both have the same gap — iOS via `.lineLimit(1)` + `.truncationMode(.middle)` in `SendCryptoVerifySummaryView`, Android via `maxLines = 1` + `TextOverflow.MiddleEllipsis` in `VerifyCardDetails` — and neither offers an expand or copy affordance either. In all three platforms the truncation is purely presentational; the full string already reaches the view. Worth tracking separately if we want real parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated transaction review screens to display complete sender and receiver addresses without truncation.
  * Added clearer address formatting with monospaced text and line wrapping for improved readability.
  * Receiver names now prioritize vault names, address book names, and custom labels in that order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->