### PR TITLE
fix(errors): add a back button to the root error screen

### DIFF
--- a/core/ui/errors/RootErrorFallback.tsx
+++ b/core/ui/errors/RootErrorFallback.tsx
@@ -1,4 +1,5 @@
 import { reportBugUrl } from '@core/ui/errors/constants'
+import { PageHeaderBackButton } from '@core/ui/flow/PageHeaderBackButton'
 import { useCore } from '@core/ui/state/core'
 import { Button } from '@lib/ui/buttons/Button'
 import { borderRadius } from '@lib/ui/css/borderRadius'
@@ -40,7 +41,17 @@ export const RootErrorFallback = ({
 
   return (
     <VStack fullSize>
-      <PageHeader title={t('something_went_wrong')} />
+      <PageHeader
+        primaryControls={
+          <PageHeaderBackButton
+            onClick={() => {
+              goBack()
+              clearError()
+            }}
+          />
+        }
+        title={t('something_went_wrong')}
+      />
       <PageContent gap={20}>
         <VStack flexGrow gap={40} alignItems="center" justifyContent="center">
           <FilledAlertIcon style={{ fontSize: 66 }} />
@@ -60,14 +71,7 @@ export const RootErrorFallback = ({
           <Button kind="secondary" onClick={() => openUrl(reportBugUrl)}>
             {t('report_error')}
           </Button>
-          <Button
-            onClick={() => {
-              goBack()
-              clearError()
-            }}
-          >
-            {t('try_again')}
-          </Button>
+          <Button onClick={clearError}>{t('try_again')}</Button>
         </UniformColumnGrid>
       </PageContent>
     </VStack>


### PR DESCRIPTION
## Summary

`RootErrorFallback` rendered a `PageHeader` with no `primaryControls`, so the error screen was the one place in the app without the back chevron every other screen shows. Any render error anywhere in the app dropped the user onto a header-less "Something went wrong" page with no familiar way back.

The only escape was **Try Again**, which called `goBack()` before `clearError()` — collapsing two distinct intents ("retry this view" and "leave this view") into one control at the bottom of the page.

## Changes

- `PageHeader` now gets `primaryControls={<PageHeaderBackButton … />}` that calls `goBack()` **and** `clearError()`. `clearError()` is required here — without it the boundary stays in its error state and the destination screen renders the fallback again.
- **Try Again** now calls only `clearError()`, making it a true in-place retry. This resolves the open question the issue raised, so the two controls have distinct meanings: back leaves, retry re-renders.

```diff
-      <PageHeader title={t('something_went_wrong')} />
+      <PageHeader
+        primaryControls={
+          <PageHeaderBackButton
+            onClick={() => {
+              goBack()
+              clearError()
+            }}
+          />
+        }
+        title={t('something_went_wrong')}
+      />
```

```diff
-          <Button
-            onClick={() => {
-              goBack()
-              clearError()
-            }}
-          >
-            {t('try_again')}
-          </Button>
+          <Button onClick={clearError}>{t('try_again')}</Button>
```

## Scope

`RootErrorFallback` is shared, so this affects both desktop and extension. One file, no new strings, no API changes.

## Testing

- `yarn eslint core/ui/errors/RootErrorFallback.tsx` — clean.
- `yarn typecheck` reports 5 errors, all in `core/ui/chain/metadata/getSwapProviderLogoSrc.ts` and `core/ui/vault/swap/queries/resolveSwapFees*`. I verified these are **pre-existing on a clean `origin/main`** (stashed the change and re-ran — identical output); none are in the touched file and none are introduced here.

Closes #4775

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added a back button to the error page for easier navigation.
  - Updated “Try again” to only clear the current error, while back navigation is handled separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->