### PR TITLE
fix(swap): block submission on an expired quote and stop the countdown lying

### DIFF
--- a/core/ui/i18n/locales/de.ts
+++ b/core/ui/i18n/locales/de.ts
@@ -1962,4 +1962,6 @@ export const de = {
   swap_limit_chart_last_traded: 'Zuletzt gehandelt hier: {{when}}',
   swap_limit_chart_not_reached:
     'In diesem Zeitfenster nicht gehandelt — das Hoch lag bei {{price}}',
+  swap_quote_expired:
+    'Dieses Angebot ist abgelaufen. Aktualisieren Sie die Seite, um einen aktuellen Preis zu erhalten.',
 }

--- a/core/ui/i18n/locales/en.ts
+++ b/core/ui/i18n/locales/en.ts
@@ -1301,6 +1301,7 @@ export const en = {
   swap_mode_limit: 'Limit',
   swap_mode_market: 'Market',
   swap_overview: 'Swap overview',
+  swap_quote_expired: 'This quote has expired. Refresh to get a current price.',
   swap_same_asset: 'Cannot swap between the same asset',
   swap_all_providers_failed:
     'Swap providers are temporarily unavailable. Please try again in a moment.',

--- a/core/ui/i18n/locales/es.ts
+++ b/core/ui/i18n/locales/es.ts
@@ -1947,4 +1947,6 @@ export const es = {
   swap_limit_chart_last_traded: 'Última transacción realizada aquí: {{when}}',
   swap_limit_chart_not_reached:
     'No ha cotizado aquí en este período; el máximo fue {{price}}',
+  swap_quote_expired:
+    'Esta cotización ha caducado. Actualiza la página para ver el precio actual.',
 }

--- a/core/ui/i18n/locales/hr.ts
+++ b/core/ui/i18n/locales/hr.ts
@@ -1916,4 +1916,6 @@ export const hr = {
   swap_limit_chart_last_traded: 'Zadnje trgovanje ovdje {{when}}',
   swap_limit_chart_not_reached:
     'Nije trgovao ovdje u ovom prozoru — najviša cijena je bila {{price}}',
+  swap_quote_expired:
+    'Ova ponuda je istekla. Osvježite stranicu da biste dobili trenutnu cijenu.',
 }

--- a/core/ui/i18n/locales/it.ts
+++ b/core/ui/i18n/locales/it.ts
@@ -1953,4 +1953,6 @@ export const it = {
   swap_limit_chart_last_traded: 'Ultimo scambio qui {{when}}',
   swap_limit_chart_not_reached:
     'Non è stato scambiato qui in questa finestra — il massimo è stato {{price}}',
+  swap_quote_expired:
+    'Questo preventivo è scaduto. Aggiorna la pagina per visualizzare il prezzo attuale.',
 }

--- a/core/ui/i18n/locales/ko.ts
+++ b/core/ui/i18n/locales/ko.ts
@@ -1907,4 +1907,6 @@ export const ko = {
   swap_limit_chart_last_traded: '여기서 마지막 거래: {{when}}',
   swap_limit_chart_not_reached:
     '이 기간 동안에는 거래되지 않았습니다. 최고가는 {{price}} 였습니다.',
+  swap_quote_expired:
+    '이 견적은 만료되었습니다. 최신 가격을 확인하려면 페이지를 새로고침하세요.',
 }

--- a/core/ui/i18n/locales/nl.ts
+++ b/core/ui/i18n/locales/nl.ts
@@ -1931,4 +1931,6 @@ export const nl = {
   swap_limit_chart_last_traded: 'Laatst verhandeld hier: {{when}}',
   swap_limit_chart_not_reached:
     'Er is hier in dit tijdsvenster niet in gehandeld — de hoogste koers was {{price}}',
+  swap_quote_expired:
+    'Deze prijsopgave is verlopen. Vernieuw de pagina voor de actuele prijs.',
 }

--- a/core/ui/i18n/locales/pt.ts
+++ b/core/ui/i18n/locales/pt.ts
@@ -1950,4 +1950,6 @@ export const pt = {
   swap_limit_chart_last_traded: 'Última negociação aqui: {{when}}',
   swap_limit_chart_not_reached:
     'Não houve negociações aqui neste período — a máxima foi {{price}}',
+  swap_quote_expired:
+    'Esta cotação expirou. Atualize a página para ver o preço atual.',
 }

--- a/core/ui/i18n/locales/ru.ts
+++ b/core/ui/i18n/locales/ru.ts
@@ -1925,4 +1925,6 @@ export const ru = {
   swap_limit_chart_last_traded: 'Последняя сделка здесь: {{when}}',
   swap_limit_chart_not_reached:
     'В этот период здесь ничего не торговалось — максимум был {{price}}',
+  swap_quote_expired:
+    'Срок действия этого предложения истек. Обновите страницу, чтобы узнать актуальную цену.',
 }

--- a/core/ui/i18n/locales/zh.ts
+++ b/core/ui/i18n/locales/zh.ts
@@ -1789,4 +1789,5 @@ export const zh = {
   swap_limit_chart_fills_immediately: '此价格会立即成交',
   swap_limit_chart_last_traded: '此处最后交易记录为{{when}}',
   swap_limit_chart_not_reached: '本窗口期内未在此交易——最高价为{{price}}',
+  swap_quote_expired: '此报价已过期，请刷新页面查看最新价格。',
 }

--- a/core/ui/vault/swap/form/hooks/useRefreshSwapQuoteInterval.test.ts
+++ b/core/ui/vault/swap/form/hooks/useRefreshSwapQuoteInterval.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { getDisplayedSwapQuoteCountdown } from './useRefreshSwapQuoteInterval'
+
+const now = 1_000_000
+
+describe('getDisplayedSwapQuoteCountdown', () => {
+  it('shows the refresh interval while the quote outlives it', () => {
+    expect(
+      getDisplayedSwapQuoteCountdown({
+        timeLeft: 60,
+        expiresAt: now + 300_000,
+        now,
+      })
+    ).toBe(60)
+  })
+
+  it('counts the interval down normally', () => {
+    expect(
+      getDisplayedSwapQuoteCountdown({
+        timeLeft: 42,
+        expiresAt: now + 300_000,
+        now,
+      })
+    ).toBe(42)
+  })
+
+  it('shows the quote validity once it is shorter than the interval', () => {
+    expect(
+      getDisplayedSwapQuoteCountdown({
+        timeLeft: 60,
+        expiresAt: now + 20_000,
+        now,
+      })
+    ).toBe(20)
+  })
+
+  it('shows zero for an expired quote rather than a full interval', () => {
+    expect(
+      getDisplayedSwapQuoteCountdown({
+        timeLeft: 60,
+        expiresAt: now - 5_000,
+        now,
+      })
+    ).toBe(0)
+  })
+
+  it('falls back to the interval when the quote carries no expiry', () => {
+    expect(
+      getDisplayedSwapQuoteCountdown({
+        timeLeft: 60,
+        expiresAt: undefined,
+        now,
+      })
+    ).toBe(60)
+  })
+})

--- a/core/ui/vault/swap/form/hooks/useRefreshSwapQuoteInterval.ts
+++ b/core/ui/vault/swap/form/hooks/useRefreshSwapQuoteInterval.ts
@@ -4,6 +4,32 @@ import { useEffect, useState } from 'react'
 import { useRefreshSwapQuoteMutation } from '../../mutations/useRefreshSwapQuoteMutation'
 import { useSwapQuoteQuery } from '../../queries/useSwapQuoteQuery'
 
+type GetDisplayedSwapQuoteCountdownInput = {
+  timeLeft: Seconds
+  expiresAt: number | undefined
+  now?: number
+}
+
+/**
+ * The countdown to show for the quote currently on screen: whichever runs out
+ * first, the refresh interval or the quote's own validity. A quote served from
+ * cache after a failed refetch would otherwise carry a full interval and read
+ * as freshly fetched; clamping to its remaining validity shows `0` instead.
+ */
+export const getDisplayedSwapQuoteCountdown = ({
+  timeLeft,
+  expiresAt,
+  now = Date.now(),
+}: GetDisplayedSwapQuoteCountdownInput): Seconds => {
+  if (expiresAt === undefined) {
+    return timeLeft
+  }
+
+  const secondsUntilExpiry = Math.max(Math.floor((expiresAt - now) / 1000), 0)
+
+  return Math.min(timeLeft, secondsUntilExpiry)
+}
+
 export const useRefreshSwapQuoteInterval = (countdownTime: Seconds) => {
   const [timeLeft, setTimeLeft] = useState(0)
 
@@ -30,5 +56,8 @@ export const useRefreshSwapQuoteInterval = (countdownTime: Seconds) => {
     return () => clearInterval(timer)
   }, [timeLeft, refreshQuote, countdownTime])
 
-  return timeLeft
+  return getDisplayedSwapQuoteCountdown({
+    timeLeft,
+    expiresAt: swapQuoteData?.expiresAt,
+  })
 }

--- a/core/ui/vault/swap/queries/useSwapValidationQuery.test.ts
+++ b/core/ui/vault/swap/queries/useSwapValidationQuery.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   getImmediateSwapValidationError,
   getSwapBalanceValidationError,
+  getSwapQuoteExpiryDelay,
   getSwapQuoteExpiryValidationError,
 } from './useSwapValidationQuery'
 
@@ -101,24 +102,46 @@ describe('getImmediateSwapValidationError', () => {
 })
 
 describe('getSwapQuoteExpiryValidationError', () => {
-  const quoteExpiringAt = (expiresAt: number) =>
-    ({ expiresAt }) as Parameters<typeof getSwapQuoteExpiryValidationError>[0]
-
   it('accepts a quote that is still valid', () => {
     expect(
-      getSwapQuoteExpiryValidationError(quoteExpiringAt(1_500), 1_000)
+      getSwapQuoteExpiryValidationError({
+        quote: { expiresAt: 1_500 },
+        now: 1_000,
+      })
     ).toBeNull()
   })
 
   it('rejects a quote whose expiry has passed', () => {
-    expect(getSwapQuoteExpiryValidationError(quoteExpiringAt(500), 1_000)).toBe(
-      'swap_quote_expired'
-    )
+    expect(
+      getSwapQuoteExpiryValidationError({
+        quote: { expiresAt: 500 },
+        now: 1_000,
+      })
+    ).toBe('swap_quote_expired')
   })
 
   it('rejects a quote expiring exactly now, since it can no longer be signed in time', () => {
     expect(
-      getSwapQuoteExpiryValidationError(quoteExpiringAt(1_000), 1_000)
+      getSwapQuoteExpiryValidationError({
+        quote: { expiresAt: 1_000 },
+        now: 1_000,
+      })
     ).toBe('swap_quote_expired')
+  })
+})
+
+describe('getSwapQuoteExpiryDelay', () => {
+  it('reports the wait until a live quote expires', () => {
+    expect(getSwapQuoteExpiryDelay({ expiresAt: 5_000, now: 1_000 })).toBe(
+      4_000
+    )
+  })
+
+  it('reports nothing to wait for once the quote has expired', () => {
+    expect(getSwapQuoteExpiryDelay({ expiresAt: 500, now: 1_000 })).toBeNull()
+  })
+
+  it('reports nothing to wait for at the exact expiry instant', () => {
+    expect(getSwapQuoteExpiryDelay({ expiresAt: 1_000, now: 1_000 })).toBeNull()
   })
 })

--- a/core/ui/vault/swap/queries/useSwapValidationQuery.test.ts
+++ b/core/ui/vault/swap/queries/useSwapValidationQuery.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   getImmediateSwapValidationError,
   getSwapBalanceValidationError,
+  getSwapQuoteExpiryValidationError,
 } from './useSwapValidationQuery'
 
 vi.mock('@vultisig/core-chain/utils/isValidAddress', () => ({
@@ -96,5 +97,28 @@ describe('getImmediateSwapValidationError', () => {
         walletCore: {} as never,
       })
     ).toBe(null)
+  })
+})
+
+describe('getSwapQuoteExpiryValidationError', () => {
+  const quoteExpiringAt = (expiresAt: number) =>
+    ({ expiresAt }) as Parameters<typeof getSwapQuoteExpiryValidationError>[0]
+
+  it('accepts a quote that is still valid', () => {
+    expect(
+      getSwapQuoteExpiryValidationError(quoteExpiringAt(1_500), 1_000)
+    ).toBeNull()
+  })
+
+  it('rejects a quote whose expiry has passed', () => {
+    expect(getSwapQuoteExpiryValidationError(quoteExpiringAt(500), 1_000)).toBe(
+      'swap_quote_expired'
+    )
+  })
+
+  it('rejects a quote expiring exactly now, since it can no longer be signed in time', () => {
+    expect(
+      getSwapQuoteExpiryValidationError(quoteExpiringAt(1_000), 1_000)
+    ).toBe('swap_quote_expired')
   })
 })

--- a/core/ui/vault/swap/queries/useSwapValidationQuery.ts
+++ b/core/ui/vault/swap/queries/useSwapValidationQuery.ts
@@ -2,6 +2,7 @@ import { useCombineQueries } from '@lib/ui/query/hooks/useCombineQueries'
 import { WalletCore } from '@trustwallet/wallet-core'
 import { extractAccountCoinKey } from '@vultisig/core-chain/coin/AccountCoin'
 import { areEqualCoins } from '@vultisig/core-chain/coin/Coin'
+import { BoundSwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
 import { isValidAddress } from '@vultisig/core-chain/utils/isValidAddress'
 import { t } from 'i18next'
 
@@ -39,6 +40,18 @@ export const getSwapBalanceValidationError = ({
 
   return null
 }
+
+/**
+ * Rejects a quote whose absolute expiry has already passed. React Query keeps a
+ * quote for a day and retains it when a refetch fails, so a cached one can be
+ * displayed long after it was fetched — returning to an unchanged pair and
+ * amount while offline is enough. Nothing else in the swap flow compares a
+ * quote against the clock, so without this the user can submit a stale price.
+ */
+export const getSwapQuoteExpiryValidationError = (
+  quote: BoundSwapQuote,
+  now: number = Date.now()
+): string | null => (quote.expiresAt <= now ? t('swap_quote_expired') : null)
 
 /** Input for swap validation that does not depend on async quote or balance data. */
 type GetImmediateSwapValidationErrorInput = {
@@ -89,8 +102,11 @@ export const useSwapValidationQuery = () => {
       balance: balanceQuery,
       swapQuote: firmSwapQuoteQuery,
     },
-    joinData: ({ balance }) => {
-      return getSwapBalanceValidationError({ amount, balance })
+    joinData: ({ balance, swapQuote }) => {
+      return (
+        getSwapBalanceValidationError({ amount, balance }) ??
+        getSwapQuoteExpiryValidationError(swapQuote)
+      )
     },
     eager: false,
   })

--- a/core/ui/vault/swap/queries/useSwapValidationQuery.ts
+++ b/core/ui/vault/swap/queries/useSwapValidationQuery.ts
@@ -5,6 +5,7 @@ import { areEqualCoins } from '@vultisig/core-chain/coin/Coin'
 import { BoundSwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
 import { isValidAddress } from '@vultisig/core-chain/utils/isValidAddress'
 import { t } from 'i18next'
+import { useEffect, useState } from 'react'
 
 import { useBalanceQuery } from '../../../chain/coin/queries/useBalanceQuery'
 import { useAssertWalletCore } from '../../../chain/providers/WalletCoreProvider'
@@ -41,6 +42,11 @@ export const getSwapBalanceValidationError = ({
   return null
 }
 
+type GetSwapQuoteExpiryValidationErrorInput = {
+  quote: Pick<BoundSwapQuote, 'expiresAt'>
+  now: number
+}
+
 /**
  * Rejects a quote whose absolute expiry has already passed. React Query keeps a
  * quote for a day and retains it when a refetch fails, so a cached one can be
@@ -48,10 +54,57 @@ export const getSwapBalanceValidationError = ({
  * amount while offline is enough. Nothing else in the swap flow compares a
  * quote against the clock, so without this the user can submit a stale price.
  */
-export const getSwapQuoteExpiryValidationError = (
-  quote: BoundSwapQuote,
-  now: number = Date.now()
-): string | null => (quote.expiresAt <= now ? t('swap_quote_expired') : null)
+export const getSwapQuoteExpiryValidationError = ({
+  quote,
+  now,
+}: GetSwapQuoteExpiryValidationErrorInput): string | null =>
+  quote.expiresAt <= now ? t('swap_quote_expired') : null
+
+type GetSwapQuoteExpiryDelayInput = {
+  expiresAt: number
+  now: number
+}
+
+/**
+ * How long until the quote expires, or `null` when it already has. Drives the
+ * single timer below, and is separated from it so the scheduling decision can
+ * be tested without fake timers.
+ */
+export const getSwapQuoteExpiryDelay = ({
+  expiresAt,
+  now,
+}: GetSwapQuoteExpiryDelayInput): number | null =>
+  expiresAt > now ? expiresAt - now : null
+
+/**
+ * A clock that advances exactly when the current quote expires.
+ *
+ * Validation is memoized on query data, and a quote sitting past its expiry
+ * produces no new data — so without a value that changes at that moment, the
+ * last "valid" verdict would stand indefinitely and Continue would stay
+ * enabled. One timer per quote rather than a poll: the only interesting
+ * instant is known in advance.
+ */
+const useSwapQuoteExpiryClock = (expiresAt: number | undefined) => {
+  const [now, setNow] = useState(() => Date.now())
+
+  useEffect(() => {
+    if (expiresAt === undefined) {
+      return
+    }
+
+    const delay = getSwapQuoteExpiryDelay({ expiresAt, now: Date.now() })
+    if (delay === null) {
+      return
+    }
+
+    const timer = setTimeout(() => setNow(Date.now()), delay)
+
+    return () => clearTimeout(timer)
+  }, [expiresAt])
+
+  return now
+}
 
 /** Input for swap validation that does not depend on async quote or balance data. */
 type GetImmediateSwapValidationErrorInput = {
@@ -96,6 +149,7 @@ export const useSwapValidationQuery = () => {
   const firmSwapQuoteQuery = swapQuoteQuery.isPlaceholderData
     ? { ...swapQuoteQuery, data: undefined, isPending: true }
     : swapQuoteQuery
+  const now = useSwapQuoteExpiryClock(firmSwapQuoteQuery.data?.expiresAt)
 
   const combined = useCombineQueries({
     queries: {
@@ -105,7 +159,7 @@ export const useSwapValidationQuery = () => {
     joinData: ({ balance, swapQuote }) => {
       return (
         getSwapBalanceValidationError({ amount, balance }) ??
-        getSwapQuoteExpiryValidationError(swapQuote)
+        getSwapQuoteExpiryValidationError({ quote: swapQuote, now })
       )
     },
     eager: false,


### PR DESCRIPTION
Closes #4786.

## What & why

With a quote loaded, going offline, navigating away inside the extension and returning to the same pair and amount re-presented the cached quote as a firm, current one — countdown full, Continue enabled.

Five things lined up:

1. `gcTime` is 1 day, so the quote is still in memory
2. The query key is the pair plus the amount, so an unchanged pair and amount hits the same entry
3. The quote query sets `retry: false`, so the refetch fails at once when offline
4. react-query retains the previous `data` on a failed refetch and `isPlaceholderData` is false, so `ToAmount` treats it as **firm** rather than falling back to the indicative
5. `useRefreshSwapQuoteInterval` reset the countdown to a full 60s whenever data was merely present

And nothing caught it downstream: `useSwapValidationQuery` checked amount, balance, same-asset and recipient, but never compared the quote against the clock.

## Expiry validation

`BoundSwapQuote` carries `expiresAt` — an absolute expiry in milliseconds, present for both native and general quotes — so the check is uniform and needs no per-provider branching. `getSwapQuoteExpiryValidationError` is a pure function taking `now`, which keeps it testable without fake timers.

Submission is blocked through the validation path that already existed, so no new wiring reaches the Continue button.

## Countdown

Clamped to the quote's own remaining validity: `min(refreshInterval, secondsUntilExpiry)`.

A live quote whose expiry outlasts the interval still counts the interval down exactly as before — this is deliberately not a rewrite of the refresh cadence. An expired one reads `0:00` instead of looking freshly fetched.

## Test plan

`yarn check:all` — lint, typecheck, i18n integrity, secrets, go, docs, duplication, complexity all green; 1962 tests across 247 files pass. The one failure is `quality:architecture`, reporting circular imports inside the gitignored `clients/extension/dist-station/` build output — identical on an untouched tree, not a finding from this branch.

8 new unit tests: expiry accepted / rejected / exactly-now, and the countdown across live, expiring, expired and missing-expiry cases.

## Notes for review

- The boundary case is deliberate: a quote expiring exactly now is rejected, since it cannot be signed and broadcast in zero time.
- `gcTime` is untouched — it is shared by every query in the app.
- `placeholderData: keepPreviousData` is untouched — it is what prevents flicker on refresh (#4037).
- Not to be confused with #4780: there the amount changes, so the cache key changes and the cache is never involved. This only reproduces with the amount unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized messaging for expired swap quotes in supported languages.
  * Swap forms now indicate when a quote has expired and prompt users to refresh for the latest price.

* **Bug Fixes**
  * Refresh countdowns now accurately reflect the quote’s remaining validity.
  * Expired quotes are prevented from proceeding through swap validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->