### PR TITLE
fix(e2e): fail the swap specs when the pair they asked for was not selected

### DIFF
--- a/clients/extension/tests/e2e/page-objects/SwapFlow.po.ts
+++ b/clients/extension/tests/e2e/page-objects/SwapFlow.po.ts
@@ -229,6 +229,22 @@ export class SwapFlow extends BasePage {
     )
   }
 
+  /**
+   * Whether the option shows up within the budget. `Locator.isVisible` is an
+   * immediate check — its `timeout` does not wait — so an option rendered a
+   * beat late used to read as absent. That was survivable while a miss only
+   * logged; now that it throws, the wait has to be real.
+   */
+  private async becomesVisible(
+    locator: Locator,
+    timeout: number
+  ): Promise<boolean> {
+    return locator
+      .waitFor({ state: 'visible', timeout })
+      .then(() => true)
+      .catch(() => false)
+  }
+
   // Clicking a chain in the explorer's chain carousel switches chain AND selects its native token.
   async selectFromCoin(coin: string): Promise<void> {
     const chainName = SwapFlow.SYMBOL_TO_CHAIN[coin.toUpperCase()] || coin
@@ -249,7 +265,7 @@ export class SwapFlow extends BasePage {
     await this.page.waitForTimeout(800)
 
     const chainOption = this.getExplorerChainOption(chainName)
-    if (await chainOption.isVisible({ timeout: 3000 }).catch(() => false)) {
+    if (await this.becomesVisible(chainOption, 3000)) {
       await chainOption.click({ force: true })
       await waitForLoadingComplete(this.page)
       const nativeCoinOption = this.getCoinOption(coin).first()
@@ -261,7 +277,7 @@ export class SwapFlow extends BasePage {
     }
 
     const coinOption = this.getCoinOption(coin)
-    if (await coinOption.isVisible({ timeout: 2000 }).catch(() => false)) {
+    if (await this.becomesVisible(coinOption, 2000)) {
       await coinOption.click({ force: true })
       await this.page.waitForTimeout(500)
       console.log(`Selected ${coin} from coin options`)
@@ -294,7 +310,7 @@ export class SwapFlow extends BasePage {
     await this.page.waitForTimeout(800)
 
     const chainOption = this.getExplorerChainOption(chainName)
-    if (await chainOption.isVisible({ timeout: 3000 }).catch(() => false)) {
+    if (await this.becomesVisible(chainOption, 3000)) {
       await chainOption.click({ force: true })
       await waitForLoadingComplete(this.page)
       const nativeCoinOption = this.getCoinOption(coin).first()
@@ -306,7 +322,7 @@ export class SwapFlow extends BasePage {
     }
 
     const coinOption = this.getCoinOption(coin)
-    if (await coinOption.isVisible({ timeout: 2000 }).catch(() => false)) {
+    if (await this.becomesVisible(coinOption, 2000)) {
       await coinOption.click({ force: true })
       await this.page.waitForTimeout(500)
       console.log(`Selected ${coin} from coin options (to)`)
@@ -633,6 +649,7 @@ export class SwapFlow extends BasePage {
     )
     await this.selectFromCoin(fromSymbol)
     await this.selectToCoin(toSymbol)
+    await this.assertSelectionMatches({ fromSymbol, toSymbol })
     await this.clickPercentage(percent)
     await this.waitForQuote()
   }

--- a/clients/extension/tests/e2e/page-objects/SwapFlow.po.ts
+++ b/clients/extension/tests/e2e/page-objects/SwapFlow.po.ts
@@ -268,7 +268,11 @@ export class SwapFlow extends BasePage {
       return
     }
 
-    console.log(`Could not select from coin ${coin}`)
+    throw new Error(
+      `Could not select from coin ${coin} — neither the ${chainName} chain option ` +
+        `nor a ${coin} coin option was visible. Continuing would type the amount ` +
+        `into whichever pair the form happens to show.`
+    )
   }
 
   async selectToCoin(coin: string): Promise<void> {
@@ -309,7 +313,11 @@ export class SwapFlow extends BasePage {
       return
     }
 
-    console.log(`Could not select to coin ${coin}`)
+    throw new Error(
+      `Could not select to coin ${coin} — neither the ${chainName} chain option ` +
+        `nor a ${coin} coin option was visible. Continuing would assert against ` +
+        `whichever destination the form happens to show.`
+    )
   }
 
   async fillAmount(amount: string): Promise<void> {
@@ -551,8 +559,11 @@ export class SwapFlow extends BasePage {
   }
 
   /**
-   * Pre-broadcast safety gate: confirms the from/to coin selectors match the
-   * expected symbols before broadcast. Throws on mismatch.
+   * Confirms the from/to coin selectors match the expected symbols. Every
+   * `prepare*` path runs this before typing an amount, because the selection
+   * clicks can report success and still leave a different pair on screen —
+   * asserting past that point tests a swap the caller never asked for. Also a
+   * pre-broadcast safety gate. Throws on mismatch.
    */
   async assertSelectionMatches({
     fromSymbol,
@@ -600,6 +611,10 @@ export class SwapFlow extends BasePage {
   ): Promise<void> {
     await this.selectFromCoin(fromCoin)
     await this.selectToCoin(toCoin)
+    await this.assertSelectionMatches({
+      fromSymbol: fromCoin,
+      toSymbol: toCoin,
+    })
     await this.fillAmount(amount)
     await this.waitForQuote()
   }
@@ -661,6 +676,8 @@ export class SwapFlow extends BasePage {
     if (!this.hasSelectedSymbol({ text: updatedToText, symbol: toSymbol })) {
       await this.selectToCoin(toSymbol)
     }
+
+    await this.assertSelectionMatches({ fromSymbol, toSymbol })
 
     await this.fillAmount(amount)
     await this.waitForQuote()


### PR DESCRIPTION
Closes #4783.

## What & why

`selectFromCoin` / `selectToCoin` could not fail. Each logged `Could not select ... coin <X>` and returned normally, so the spec went on to type the amount into whatever pair the form happened to be showing and asserted against that.

Observed on a build of the `v1.0.72` tag:

```
Preparing swap: 0.005 ETH (ethereum) -> RUNE (thorchain)
Current selection: BTCNative -> ETHNative
Selected Ethereum from explorer carousel
Could not select to coin RUNE
```

The screenshot the spec attaches on success shows what actually ran:

```
intended:  0.005 ETH  -> RUNE     (~$15)
actual:    0.005 USDC -> ETH      (~$0.005)
```

At half a cent nothing routes, so both values the spec read were the price-ratio indicative rather than a firm quote:

```
$0.005 / $2440 per ETH   = 0.00000205 ETH
spec read as "firm quote": 0.00000204 ETH
```

`swap quote amount stays responsive while firm quote resolves` therefore passed 3/3 **without a firm quote ever existing** — halving the amount halved the indicative and the assertion was satisfied trivially. The tell was that the output stayed identical across runs even though the log claimed `thorchain` twice and `bsc` once.

## The fix was already written

`assertSelectionMatches` existed for exactly this, down to detecting the USDC fallback by name — and nothing called it. Both `prepare*` paths now run it before typing an amount, and the two select methods throw instead of logging.

## Verified against the real app

Re-run on the same tag build with the gate in place:

```
Selected Ethereum from explorer carousel
Selected BSC from explorer carousel (to)
Swap quote UX: 0.005 ETH quote=0.01773079; pasted 0.0025, immediate output=0.00890539
```

The pair resolved, a real firm quote arrived, and the responsiveness assertion exercised the transition it was written for. Note the pasted-half output is slightly **above** half the firm value — the indicative carries no fees while the firm quote does, which is the expected relationship and a useful signal that both readings are what we think they are.

## Test plan

`yarn check:all` — green except `quality:architecture`, which reports the same 5 circular imports inside the gitignored `clients/extension/dist-station/` build output on an untouched tree.

Live e2e run against the v1.0.72 build as above.

## Notes for review

- No assertions in `swap-flow.spec.ts` changed — the setup was broken, not the check.
- The 8 lint errors in these files are pre-existing SCREAMING_CASE naming violations, unchanged in count from the baseline.
- This is why #4780 could not be settled from harness output; that issue is closed as not-reproducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap validation by detecting when the requested source or destination asset has not been selected.
  * Added clearer error messages for coin-selection failures.
  * Prevented swap flows from continuing when required selections are missing.

* **Documentation**
  * Expanded guidance for validating asset selections before entering amount and quote details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->