### PR TITLE
fix(e2e): report why the swap specs cannot run instead of skipping silently

### DIFF
--- a/clients/extension/tests/e2e/helpers/dynamic-swap.ts
+++ b/clients/extension/tests/e2e/helpers/dynamic-swap.ts
@@ -198,3 +198,54 @@ export function canSwap(balances: ChainBalance[]): boolean {
   const validSources = balances.filter(b => b.balanceUsd >= MIN_SWAP_USD)
   return validSources.length > 0 && balances.length >= 2
 }
+
+/**
+ * Why the swap specs cannot run against the configured vault, or `null` when
+ * they can. Test vaults spend down over time, so an underfunded run is the
+ * expected end state rather than an anomaly — it needs to report the shortfall
+ * and the knob that moves it, not a bare "insufficient balance".
+ */
+export function getSwapPreconditionFailure(
+  balances: ChainBalance[]
+): string | null {
+  if (canSwap(balances)) {
+    return null
+  }
+
+  if (balances.length < 2) {
+    return `Swap needs balances on at least 2 chains, found ${balances.length}. The test vault cannot exercise a swap.`
+  }
+
+  const richest = [...balances].sort((a, b) => b.balanceUsd - a.balanceUsd)[0]
+
+  return [
+    `No chain holds the $${MIN_SWAP_USD} needed to source a swap.`,
+    `Highest balance is ${richest.chainId} at $${richest.balanceUsd.toFixed(2)}.`,
+    `Top up the test vault, or lower SWAP_MIN_USD / SWAP_TARGET_USD —`,
+    `but note the protocol inbound minimum is roughly $5-10, below which no route quotes.`,
+  ].join(' ')
+}
+
+/**
+ * Enforces the swap preconditions. Locally an underfunded vault skips, so a
+ * developer without funds is not blocked. In CI it fails: a release run that
+ * silently drops swap coverage and still exits 0 is worse than a red build.
+ */
+export function requireSwapPreconditions(
+  balances: ChainBalance[],
+  skip: (condition: true, reason: string) => void
+): boolean {
+  const failure = getSwapPreconditionFailure(balances)
+  if (!failure) {
+    return true
+  }
+
+  console.log(`⚠️ Swap preconditions not met — ${failure}`)
+
+  if (process.env.CI) {
+    throw new Error(`Swap preconditions not met: ${failure}`)
+  }
+
+  skip(true, failure)
+  return false
+}

--- a/clients/extension/tests/e2e/helpers/dynamic-swap.ts
+++ b/clients/extension/tests/e2e/helpers/dynamic-swap.ts
@@ -231,10 +231,15 @@ export function getSwapPreconditionFailure(
  * developer without funds is not blocked. In CI it fails: a release run that
  * silently drops swap coverage and still exits 0 is worse than a red build.
  */
-export function requireSwapPreconditions(
-  balances: ChainBalance[],
+type RequireSwapPreconditionsInput = {
+  balances: ChainBalance[]
   skip: (condition: true, reason: string) => void
-): boolean {
+}
+
+export function requireSwapPreconditions({
+  balances,
+  skip,
+}: RequireSwapPreconditionsInput): boolean {
   const failure = getSwapPreconditionFailure(balances)
   if (!failure) {
     return true

--- a/clients/extension/tests/e2e/specs/swap-flow.spec.ts
+++ b/clients/extension/tests/e2e/specs/swap-flow.spec.ts
@@ -31,9 +31,9 @@ import {
 } from '../helpers/chain-rotation'
 import { readChromeStorage } from '../helpers/chrome-storage'
 import {
-  canSwap,
   CHAIN_SYMBOLS,
   getVaultBalances,
+  requireSwapPreconditions,
   selectSwapPair,
   SYMBOL_FALLBACK_AMOUNTS,
 } from '../helpers/dynamic-swap'
@@ -255,9 +255,11 @@ test.describe('Swap Flow', () => {
       console.log('\n📊 Reading vault balances...')
       const balances = await getVaultBalances(page)
 
-      if (!canSwap(balances)) {
-        console.log('⚠️ Insufficient balance for swap - skipping')
-        test.skip()
+      if (
+        !requireSwapPreconditions(balances, (condition, reason) =>
+          test.skip(condition, reason)
+        )
+      ) {
         return
       }
 
@@ -595,8 +597,11 @@ test.describe('Swap Flow', () => {
       await vaultPage.waitForView(15_000)
 
       const balances = await getVaultBalances(page)
-      if (!canSwap(balances)) {
-        test.skip(true, 'Insufficient balance for swap quote UX')
+      if (
+        !requireSwapPreconditions(balances, (condition, reason) =>
+          test.skip(condition, reason)
+        )
+      ) {
         return
       }
 

--- a/clients/extension/tests/e2e/specs/swap-flow.spec.ts
+++ b/clients/extension/tests/e2e/specs/swap-flow.spec.ts
@@ -256,9 +256,10 @@ test.describe('Swap Flow', () => {
       const balances = await getVaultBalances(page)
 
       if (
-        !requireSwapPreconditions(balances, (condition, reason) =>
-          test.skip(condition, reason)
-        )
+        !requireSwapPreconditions({
+          balances,
+          skip: (condition, reason) => test.skip(condition, reason),
+        })
       ) {
         return
       }
@@ -598,9 +599,10 @@ test.describe('Swap Flow', () => {
 
       const balances = await getVaultBalances(page)
       if (
-        !requireSwapPreconditions(balances, (condition, reason) =>
-          test.skip(condition, reason)
-        )
+        !requireSwapPreconditions({
+          balances,
+          skip: (condition, reason) => test.skip(condition, reason),
+        })
       ) {
         return
       }

--- a/clients/extension/tests/unit/swapPreconditions.test.ts
+++ b/clients/extension/tests/unit/swapPreconditions.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  type ChainBalance,
+  getSwapPreconditionFailure,
+} from '../e2e/helpers/dynamic-swap'
+
+const balance = (
+  chainId: string,
+  balanceUsd: number,
+  symbol = chainId.toUpperCase()
+): ChainBalance => ({ chainId, symbol, balance: 1, balanceUsd })
+
+describe('getSwapPreconditionFailure', () => {
+  it('passes when one chain clears the default threshold', () => {
+    expect(
+      getSwapPreconditionFailure([
+        balance('ethereum', 20),
+        balance('bitcoin', 1),
+      ])
+    ).toBeNull()
+  })
+
+  it('names the shortfall and the richest chain when nothing clears it', () => {
+    const failure = getSwapPreconditionFailure([
+      balance('solana', 5.94),
+      balance('bitcoin', 3.38),
+      balance('ethereum', 1.64),
+    ])
+
+    expect(failure).toContain('$15')
+    expect(failure).toContain('solana')
+    expect(failure).toContain('5.94')
+  })
+
+  it('points at the knob rather than leaving the reader guessing', () => {
+    const failure = getSwapPreconditionFailure([
+      balance('solana', 5.94),
+      balance('bitcoin', 3.38),
+    ])
+
+    expect(failure).toContain('SWAP_MIN_USD')
+  })
+
+  it('reports too few chains separately from too little money', () => {
+    expect(getSwapPreconditionFailure([balance('ethereum', 500)])).toContain(
+      'at least 2 chains'
+    )
+  })
+})

--- a/clients/extension/tests/unit/swapPreconditions.test.ts
+++ b/clients/extension/tests/unit/swapPreconditions.test.ts
@@ -5,27 +5,33 @@ import {
   getSwapPreconditionFailure,
 } from '../e2e/helpers/dynamic-swap'
 
-const balance = (
-  chainId: string,
-  balanceUsd: number,
-  symbol = chainId.toUpperCase()
-): ChainBalance => ({ chainId, symbol, balance: 1, balanceUsd })
+type BalanceInput = {
+  chainId: string
+  balanceUsd: number
+  symbol?: string
+}
+
+const balance = ({
+  chainId,
+  balanceUsd,
+  symbol = chainId.toUpperCase(),
+}: BalanceInput): ChainBalance => ({ chainId, symbol, balance: 1, balanceUsd })
 
 describe('getSwapPreconditionFailure', () => {
   it('passes when one chain clears the default threshold', () => {
     expect(
       getSwapPreconditionFailure([
-        balance('ethereum', 20),
-        balance('bitcoin', 1),
+        balance({ chainId: 'ethereum', balanceUsd: 20 }),
+        balance({ chainId: 'bitcoin', balanceUsd: 1 }),
       ])
     ).toBeNull()
   })
 
   it('names the shortfall and the richest chain when nothing clears it', () => {
     const failure = getSwapPreconditionFailure([
-      balance('solana', 5.94),
-      balance('bitcoin', 3.38),
-      balance('ethereum', 1.64),
+      balance({ chainId: 'solana', balanceUsd: 5.94 }),
+      balance({ chainId: 'bitcoin', balanceUsd: 3.38 }),
+      balance({ chainId: 'ethereum', balanceUsd: 1.64 }),
     ])
 
     expect(failure).toContain('$15')
@@ -35,16 +41,18 @@ describe('getSwapPreconditionFailure', () => {
 
   it('points at the knob rather than leaving the reader guessing', () => {
     const failure = getSwapPreconditionFailure([
-      balance('solana', 5.94),
-      balance('bitcoin', 3.38),
+      balance({ chainId: 'solana', balanceUsd: 5.94 }),
+      balance({ chainId: 'bitcoin', balanceUsd: 3.38 }),
     ])
 
     expect(failure).toContain('SWAP_MIN_USD')
   })
 
   it('reports too few chains separately from too little money', () => {
-    expect(getSwapPreconditionFailure([balance('ethereum', 500)])).toContain(
-      'at least 2 chains'
-    )
+    expect(
+      getSwapPreconditionFailure([
+        balance({ chainId: 'ethereum', balanceUsd: 500 }),
+      ])
+    ).toContain('at least 2 chains')
   })
 })


### PR DESCRIPTION
Closes #4784.

## What & why

An underfunded test vault produced a bare `test.skip(true, 'Insufficient balance for swap quote UX')`, and Playwright exited **0**. Measured directly, with no pipe masking the exit code:

```
PLAYWRIGHT EXIT CODE: 0
  1 skipped
```

The fund-dependent project spends real funds, so a vault drifting below the threshold is the expected end state rather than an anomaly. When it happens, swap coverage disappears from an otherwise green run and the only trace is a skip count nobody reads.

## What changed

`getSwapPreconditionFailure` names the threshold, the chain that came closest, and the env var that moves it:

```
No chain holds the $15 needed to source a swap. Highest balance is solana at $5.94.
Top up the test vault, or lower SWAP_MIN_USD / SWAP_TARGET_USD — but note the
protocol inbound minimum is roughly $5-10, below which no route quotes.
```

Too few chains is reported separately from too little money, since they need different fixes.

`requireSwapPreconditions` then splits the behaviour by environment:

- **Locally** it still skips — a developer without test funds should not be blocked
- **Under CI** it throws — a release run that silently drops swap coverage and still exits 0 is worse than a red build

## What deliberately did not change

The `$15` default stays. It exists because the protocol inbound minimum is roughly $5-10 and nothing routes below it — lowering it to make runs pass would trade a visible skip for a confusing failure. Verified while investigating: forcing `SWAP_MIN_USD=5` produced a $5 SOL -> RUNE pair whose quote errored, and the spec died at `expect(firmOutput).toBeGreaterThan(0)` before reaching anything it meant to test.

## Test plan

`yarn check:all` — green except `quality:architecture`, which reports the same 5 circular imports inside the gitignored `clients/extension/dist-station/` build output on an untouched tree.

4 new unit tests covering the pass case, the shortfall message, the env-var hint, and the too-few-chains case.

## Notes for review

- `test.skip` is passed as a closure rather than a bare reference, so it keeps its receiver.
- Whether CI should be strict here is the one judgement call in this PR — happy to gate it differently if the release pipeline would rather see a distinct non-zero code or a report annotation instead of a thrown error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap test handling when fewer than two chains are available or balances do not meet the minimum swap threshold.
  * Added clearer diagnostics identifying insufficient balances, the richest available chain, and relevant configuration guidance.
  * Underfunded local test scenarios are now skipped gracefully, while CI reports a failure.
* **Tests**
  * Added coverage for swap precondition checks, threshold validation, chain-count requirements, and diagnostic messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->