### PR TITLE
fix(ton): keep TonConnect stateInit in the keysign payload

### DIFF
--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/build.test.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/build.test.ts
@@ -16,6 +16,13 @@ const solanaCoin: AccountCoin = {
   ticker: 'SOL',
 }
 
+const tonCoin: AccountCoin = {
+  chain: Chain.Ton,
+  address: 'UQCc9iCgP_b5RMJcFE5XD8zStfjtNHLhDWfUqC5m1SjSer95',
+  decimals: 9,
+  ticker: 'GRAM',
+}
+
 const publicKey = {
   data: () => new Uint8Array([1, 2, 3, 4]),
 }
@@ -49,5 +56,60 @@ describe('buildSendTxKeysignPayload', () => {
         rawTransactions,
       },
     })
+  })
+
+  // A TonConnect message may deploy a contract: its `stateInit` is the code the
+  // destination does not have yet. Dropping it here signs a plain transfer to an
+  // address with no code, so every message must reach the signer with its own.
+  it('keeps each TonConnect message stateInit in the signTon payload', async () => {
+    const deployMessage = {
+      to: 'EQARULUYsmJq1RiZ-YiH-IJLcAZUVkVff-KBPwEmmaQGH6aC',
+      amount: '50000000',
+      payload: 'te6cckEBAQEABgAACAAAAA==',
+      stateInit: 'te6cckEBAQEAJAAAQ4ABase64EncodedStateInit',
+    }
+    const plainMessage = {
+      to: 'EQDmLe6ticcY_uLZsfurdYONshNuCn8IS81KcJ8p6M6ISJrE',
+      amount: '50000000',
+    }
+
+    const payload = await buildSendTxKeysignPayload({
+      parsedTx: {
+        coin: tonCoin,
+        customTxData: {
+          regular: {
+            chain: Chain.Ton,
+            coin: tonCoin,
+            transactionDetails: {
+              from: tonCoin.address,
+              to: deployMessage.to,
+              asset: { ticker: tonCoin.ticker },
+              amount: {
+                amount: deployMessage.amount,
+                decimals: tonCoin.decimals,
+              },
+              data: deployMessage.payload,
+              tonMessages: [deployMessage, plainMessage],
+            },
+          },
+        },
+      },
+      publicKey: publicKey as never,
+      walletCore: {} as never,
+      vaultId: 'vault-id',
+      localPartyId: 'local-party',
+    })
+
+    expect(payload.signData).toMatchObject({
+      case: 'signTon',
+      value: { tonMessages: [deployMessage, plainMessage] },
+    })
+
+    const [, secondMessage] =
+      payload.signData.case === 'signTon'
+        ? payload.signData.value.tonMessages
+        : []
+
+    expect(secondMessage?.stateInit).toBeUndefined()
   })
 })

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/build.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/build.ts
@@ -484,6 +484,7 @@ export const buildSendTxKeysignPayload = async ({
               to: msg.to,
               amount: msg.amount,
               payload: msg.payload,
+              stateInit: msg.stateInit,
             })
           ),
         }


### PR DESCRIPTION
Fixes #4791

## Problem

A TonConnect `sendTransaction` message may carry a `stateInit` — a contract deployment, where the destination has no code yet and this BOC supplies it. The bridge validates it and forwards it to the popup, the popup's `tonMessages` type declares it, `TonMessage` has `state_init = 4`, and the signer's `buildNativeTonTransferFromMessage` applies it. But `buildSendTxKeysignPayload` created every `TonMessageSchema` from `to`/`amount`/`payload` only, so the field never reached the keysign payload: the user approved a deployment and signed a plain transfer to an address with no code — dropped or bounced if bounceable, or funds parked on an account that can never run if not (the usual shape for deployments).

This is a regression. #3703 threaded `stateInit` through `build.ts`; #3717 removed the line while the proto field was still pending, and it was never restored once the field shipped. The existing unit test only asserts that `stateInit` reaches the popup, one layer above the drop.

## Change

- `build.ts`: pass `stateInit: msg.stateInit` when creating each `TonMessageSchema` (one line).
- `build.test.ts`: a `signTon` case with two messages — one deployment carrying `stateInit`, one plain — asserting each `TonMessage` keeps exactly its own field.

## Which feature is affected?

- [x] Sending — TON dApp (`signTon`) messages that deploy a contract

## Parity

- iOS: n/a — the iOS signer already applies `stateInit` from `SignTon.tonMessages`; this is the extension popup's payload build, which has no iOS counterpart.
- Android: n/a — same; `TonHelper` applies each message's `stateInit` from the payload.
- SDK: n/a — `@vultisig/core-mpc` `buildNativeTonTransferFromMessage` already honours `TonMessage.stateInit`; nothing to change there.

## Verification

- `build.test.ts` — 2/2 (new case fails on `main`, passes here)
- `yarn check` (typecheck, lint, knip) clean against the SDK versions pinned by #4776 (core-chain 4.1.0 / core-mpc 2.1.0). A stale `node_modules` on the older pins shows unrelated `ruji`/`cosmosWasm` type errors in `core/ui/vault/swap` — not caused by this change.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * TON transaction signing now preserves optional contract initialization data (`stateInit`) in messages.
  * Messages without initialization data continue to work unchanged.
* **Tests**
  * Added coverage for TON messages with and without initialization data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->