### PR TITLE
fix(swap): keep a manual route pick across quote refreshes

### DIFF
--- a/core/ui/vault/swap/components/SwapPage.tsx
+++ b/core/ui/vault/swap/components/SwapPage.tsx
@@ -7,6 +7,7 @@ import { LimitOrderReview } from '../limit/LimitOrderReview'
 import { AdvancedSwapSettingsProvider } from '../state/advancedSettings'
 import { FromAmountProvider } from '../state/fromAmount'
 import { SwapRouteOverrideProvider } from '../state/routeOverride'
+import { SwapRouteOverrideReset } from '../state/SwapRouteOverrideReset'
 import { SwapVerify } from '../verify/SwapVerify'
 
 export const SwapPage = () => {
@@ -16,6 +17,7 @@ export const SwapPage = () => {
     <FromAmountProvider initialValue={fromAmount ?? null}>
       <AdvancedSwapSettingsProvider>
         <SwapRouteOverrideProvider initialValue={null}>
+          <SwapRouteOverrideReset />
           <ValueTransfer<SwapFlowResult>
             from={({ onFinish }) => <SwapForm onFinish={onFinish} />}
             to={({ value, onBack }) =>

--- a/core/ui/vault/swap/form/advanced/SelectRouteSheet.tsx
+++ b/core/ui/vault/swap/form/advanced/SelectRouteSheet.tsx
@@ -11,8 +11,9 @@ import { SwapRouteOption } from './SwapRouteOption'
 /**
  * Every route fetched for the current quote cycle, best→worst by net output,
  * with the active pick lifted to the top so it is visible without scrolling.
- * Picking a route applies it to this cycle only and returns to the Advanced
- * Swap sheet.
+ * Picking a route holds for as long as the pair and amount stay put — later
+ * refreshes re-quote that provider rather than reverting to the winner — and
+ * returns to the Advanced Swap sheet.
  */
 export const SelectRouteSheet = ({ onClose }: OnCloseProp) => {
   const { t } = useTranslation()

--- a/core/ui/vault/swap/queries/activeSwapRoute.test.ts
+++ b/core/ui/vault/swap/queries/activeSwapRoute.test.ts
@@ -81,9 +81,13 @@ const requestId = getSwapQuoteRequestId({
 })
 
 const overrideOn = (
-  providerName: SwapQuoteProviderName,
-  pickedFor = requestId
-): SwapRouteOverride => ({ providerName, requestId: pickedFor })
+  providerName: SwapQuoteProviderName
+): SwapRouteOverride => ({ providerName, requestId })
+
+/** A pick the user made before editing the pair or the amount. */
+const overrideFromAnotherSwap = (
+  providerName: SwapQuoteProviderName
+): SwapRouteOverride => ({ providerName, requestId: 'a-different-swap' })
 
 describe('getSwapQuoteRequestId', () => {
   it('is unchanged by a re-quote of the same pair and amount', () => {
@@ -158,7 +162,7 @@ describe('resolveActiveSwapQuote', () => {
     expect(
       resolveActiveSwapQuote({
         quotes,
-        override: overrideOn('CowSwap', 'a-different-swap'),
+        override: overrideFromAnotherSwap('CowSwap'),
         requestId,
       })
     ).toBe(lifi.quote)
@@ -211,7 +215,7 @@ describe('getActiveSwapRouteOverride', () => {
     expect(
       getActiveSwapRouteOverride({
         quotes,
-        override: overrideOn('THORChain', 'a-different-swap'),
+        override: overrideFromAnotherSwap('THORChain'),
         requestId,
       })
     ).toBeNull()

--- a/core/ui/vault/swap/queries/activeSwapRoute.test.ts
+++ b/core/ui/vault/swap/queries/activeSwapRoute.test.ts
@@ -14,6 +14,7 @@ import {
   getSwapQuoteRequestId,
   resolveActiveSwapQuote,
   resolveActiveSwapRoute,
+  shouldDropSwapRouteOverride,
 } from './activeSwapRoute'
 
 type CandidateInput = {
@@ -74,11 +75,15 @@ const quotes: FindSwapQuotesResult = {
   ranked: [thorchain, lifi, cowswap],
 }
 
-const requestId = getSwapQuoteRequestId({
+const swapRequest = {
   from: { chain: Chain.Ethereum },
   to: { chain: Chain.Ethereum, id: '0xusdc' },
   amount: 1000n,
-})
+  slippageTolerance: 0.5,
+  recipient: undefined,
+}
+
+const requestId = getSwapQuoteRequestId(swapRequest)
 
 const overrideOn = (
   providerName: SwapQuoteProviderName
@@ -90,33 +95,35 @@ const overrideFromAnotherSwap = (
 ): SwapRouteOverride => ({ providerName, requestId: 'a-different-swap' })
 
 describe('getSwapQuoteRequestId', () => {
-  it('is unchanged by a re-quote of the same pair and amount', () => {
-    expect(
-      getSwapQuoteRequestId({
-        from: { chain: Chain.Ethereum },
-        to: { chain: Chain.Ethereum, id: '0xusdc' },
-        amount: 1000n,
-      })
-    ).toBe(requestId)
+  it('is unchanged by a re-quote of the same swap', () => {
+    expect(getSwapQuoteRequestId({ ...swapRequest })).toBe(requestId)
   })
 
   it('changes when the amount changes', () => {
-    expect(
-      getSwapQuoteRequestId({
-        from: { chain: Chain.Ethereum },
-        to: { chain: Chain.Ethereum, id: '0xusdc' },
-        amount: 1001n,
-      })
-    ).not.toBe(requestId)
+    expect(getSwapQuoteRequestId({ ...swapRequest, amount: 1001n })).not.toBe(
+      requestId
+    )
   })
 
   it('changes when the pair is reversed', () => {
     expect(
       getSwapQuoteRequestId({
-        from: { chain: Chain.Ethereum, id: '0xusdc' },
-        to: { chain: Chain.Ethereum },
-        amount: 1000n,
+        ...swapRequest,
+        from: swapRequest.to,
+        to: swapRequest.from,
       })
+    ).not.toBe(requestId)
+  })
+
+  it('changes when the slippage tolerance changes', () => {
+    expect(
+      getSwapQuoteRequestId({ ...swapRequest, slippageTolerance: 3 })
+    ).not.toBe(requestId)
+  })
+
+  it('changes when an external recipient is set', () => {
+    expect(
+      getSwapQuoteRequestId({ ...swapRequest, recipient: '0xrecipient' })
     ).not.toBe(requestId)
   })
 })
@@ -230,5 +237,62 @@ describe('canSelectSwapRoute', () => {
   it('hides the row when there is nothing to choose between', () => {
     expect(canSelectSwapRoute([thorchain])).toBe(false)
     expect(canSelectSwapRoute([])).toBe(false)
+  })
+})
+
+describe('shouldDropSwapRouteOverride', () => {
+  it('keeps a pick that still applies', () => {
+    expect(
+      shouldDropSwapRouteOverride({
+        quotes,
+        override: overrideOn('CowSwap'),
+        requestId,
+      })
+    ).toBe(false)
+  })
+
+  it('has nothing to drop when no pick was made', () => {
+    expect(
+      shouldDropSwapRouteOverride({ quotes, override: null, requestId })
+    ).toBe(false)
+  })
+
+  // Without this the pick is only ignored, so editing the amount away and back
+  // resurrects a provider the form has already shown as Auto.
+  it('drops a pick once the user edits the swap', () => {
+    expect(
+      shouldDropSwapRouteOverride({
+        quotes,
+        override: overrideFromAnotherSwap('CowSwap'),
+        requestId,
+      })
+    ).toBe(true)
+  })
+
+  // Same recurrence the other way round: the provider drops out of one quote
+  // cycle and comes back in the next.
+  it('drops a pick once its provider stops quoting', () => {
+    const withoutCowSwap: FindSwapQuotesResult = {
+      best: lifi.quote,
+      ranked: [thorchain, lifi],
+    }
+
+    expect(
+      shouldDropSwapRouteOverride({
+        quotes: withoutCowSwap,
+        override: overrideOn('CowSwap'),
+        requestId,
+      })
+    ).toBe(true)
+  })
+
+  it('waits for the candidates before dropping a pick it cannot check yet', () => {
+    expect(
+      shouldDropSwapRouteOverride({
+        quotes: undefined,
+        override: overrideOn('CowSwap'),
+        requestId,
+      })
+    ).toBe(false)
   })
 })

--- a/core/ui/vault/swap/queries/activeSwapRoute.test.ts
+++ b/core/ui/vault/swap/queries/activeSwapRoute.test.ts
@@ -11,7 +11,7 @@ import { SwapRouteOverride } from '../state/routeOverride'
 import {
   canSelectSwapRoute,
   getActiveSwapRouteOverride,
-  getSwapQuoteCycleId,
+  getSwapQuoteRequestId,
   resolveActiveSwapQuote,
   resolveActiveSwapRoute,
 } from './activeSwapRoute'
@@ -74,34 +74,94 @@ const quotes: FindSwapQuotesResult = {
   ranked: [thorchain, lifi, cowswap],
 }
 
+const requestId = getSwapQuoteRequestId({
+  from: { chain: Chain.Ethereum },
+  to: { chain: Chain.Ethereum, id: '0xusdc' },
+  amount: 1000n,
+})
+
 const overrideOn = (
   providerName: SwapQuoteProviderName,
-  cycleId = getSwapQuoteCycleId(quotes)
-): SwapRouteOverride => ({ providerName, cycleId })
+  pickedFor = requestId
+): SwapRouteOverride => ({ providerName, requestId: pickedFor })
+
+describe('getSwapQuoteRequestId', () => {
+  it('is unchanged by a re-quote of the same pair and amount', () => {
+    expect(
+      getSwapQuoteRequestId({
+        from: { chain: Chain.Ethereum },
+        to: { chain: Chain.Ethereum, id: '0xusdc' },
+        amount: 1000n,
+      })
+    ).toBe(requestId)
+  })
+
+  it('changes when the amount changes', () => {
+    expect(
+      getSwapQuoteRequestId({
+        from: { chain: Chain.Ethereum },
+        to: { chain: Chain.Ethereum, id: '0xusdc' },
+        amount: 1001n,
+      })
+    ).not.toBe(requestId)
+  })
+
+  it('changes when the pair is reversed', () => {
+    expect(
+      getSwapQuoteRequestId({
+        from: { chain: Chain.Ethereum, id: '0xusdc' },
+        to: { chain: Chain.Ethereum },
+        amount: 1000n,
+      })
+    ).not.toBe(requestId)
+  })
+})
 
 describe('resolveActiveSwapQuote', () => {
   it('takes the auto-selected winner when nothing was picked', () => {
-    expect(resolveActiveSwapQuote({ quotes, override: null })).toBe(lifi.quote)
+    expect(resolveActiveSwapQuote({ quotes, override: null, requestId })).toBe(
+      lifi.quote
+    )
   })
 
   it('hands the picked route to the caller that builds the keysign payload', () => {
     expect(
-      resolveActiveSwapQuote({ quotes, override: overrideOn('CowSwap') })
+      resolveActiveSwapQuote({
+        quotes,
+        override: overrideOn('CowSwap'),
+        requestId,
+      })
     ).toBe(cowswap.quote)
   })
 
-  it('re-defaults to the winner once a refresh starts a new quote cycle', () => {
+  it('keeps the pick through a refresh, on its newly fetched quote', () => {
+    const refreshedCowswap = makeCandidate({
+      providerName: 'CowSwap',
+      outputAmount: 120n,
+      safetyFingerprint: 'cowswap-cycle-2',
+    })
     const refreshed: FindSwapQuotesResult = {
       best: thorchain.quote,
-      ranked: [thorchain, lifi],
+      ranked: [thorchain, refreshedCowswap],
     }
 
     expect(
       resolveActiveSwapQuote({
         quotes: refreshed,
         override: overrideOn('CowSwap'),
+        requestId,
       })
-    ).toBe(thorchain.quote)
+    ).toBe(refreshedCowswap.quote)
+  })
+
+  it('re-defaults to the winner once the user edits the swap', () => {
+    expect(
+      resolveActiveSwapQuote({
+        quotes,
+        override: overrideOn('CowSwap', 'a-different-swap'),
+        requestId,
+      })
+    ).toBe(lifi.quote)
   })
 
   it('falls back to the winner when the picked provider stops quoting', () => {
@@ -113,10 +173,8 @@ describe('resolveActiveSwapQuote', () => {
     expect(
       resolveActiveSwapQuote({
         quotes: withoutCowSwap,
-        override: {
-          providerName: 'CowSwap',
-          cycleId: getSwapQuoteCycleId(withoutCowSwap),
-        },
+        override: overrideOn('CowSwap'),
+        requestId,
       })
     ).toBe(lifi.quote)
   })
@@ -124,28 +182,37 @@ describe('resolveActiveSwapQuote', () => {
 
 describe('resolveActiveSwapRoute', () => {
   it('resolves the winner to its own candidate rather than the top-ranked one', () => {
-    expect(resolveActiveSwapRoute({ quotes, override: null })).toBe(lifi)
+    expect(resolveActiveSwapRoute({ quotes, override: null, requestId })).toBe(
+      lifi
+    )
   })
 
   it('resolves a pick to the candidate the sheet marks as selected', () => {
     expect(
-      resolveActiveSwapRoute({ quotes, override: overrideOn('THORChain') })
+      resolveActiveSwapRoute({
+        quotes,
+        override: overrideOn('THORChain'),
+        requestId,
+      })
     ).toBe(thorchain)
   })
 })
 
 describe('getActiveSwapRouteOverride', () => {
-  it('reports a pick made in the current cycle', () => {
+  it('reports a pick made for the swap being quoted', () => {
     const override = overrideOn('THORChain')
 
-    expect(getActiveSwapRouteOverride({ quotes, override })).toBe(override)
+    expect(getActiveSwapRouteOverride({ quotes, override, requestId })).toBe(
+      override
+    )
   })
 
-  it('drops a pick made against an earlier cycle', () => {
+  it('drops a pick made for a different swap', () => {
     expect(
       getActiveSwapRouteOverride({
         quotes,
-        override: overrideOn('THORChain', 'lifi-cycle-0'),
+        override: overrideOn('THORChain', 'a-different-swap'),
+        requestId,
       })
     ).toBeNull()
   })

--- a/core/ui/vault/swap/queries/activeSwapRoute.ts
+++ b/core/ui/vault/swap/queries/activeSwapRoute.ts
@@ -1,3 +1,4 @@
+import { CoinKey, coinKeyToString } from '@vultisig/core-chain/coin/Coin'
 import {
   FindSwapQuotesResult,
   SwapQuoteCandidate,
@@ -6,14 +7,25 @@ import { BoundSwapQuote } from '@vultisig/core-chain/swap/quote/SwapQuote'
 
 import { SwapRouteOverride } from '../state/routeOverride'
 
+type SwapQuoteRequestIdInput = {
+  from: CoinKey
+  to: CoinKey
+  amount: bigint | null
+}
+
 /**
- * Identifies one quote cycle. The winner's safety fingerprint covers the pair,
- * the requested amount, the quote itself and its expiry, so every refresh —
- * interval, manual, or a pair/amount edit — yields a different id and retires
- * the manual route pick made against the previous one.
+ * Identifies the swap the user is quoting — the pair and the amount, and
+ * nothing about the quotes that came back. A manual route pick is scoped to
+ * this, so re-quoting the same swap re-ranks the routes without moving the user
+ * off the one they chose, while editing the pair or the amount is a new swap
+ * and starts the choice over.
  */
-export const getSwapQuoteCycleId = ({ best }: FindSwapQuotesResult) =>
-  best.safetyFingerprint
+export const getSwapQuoteRequestId = ({
+  from,
+  to,
+  amount,
+}: SwapQuoteRequestIdInput) =>
+  [coinKeyToString(from), coinKeyToString(to), amount ?? ''].join('>')
 
 /**
  * Whether there is a route choice worth offering. Candidate count is the only
@@ -26,18 +38,20 @@ export const canSelectSwapRoute = (candidates: SwapQuoteCandidate[]) =>
 type ActiveSwapRouteInput = {
   quotes: FindSwapQuotesResult
   override: SwapRouteOverride | null
+  requestId: string
 }
 
 /**
- * The manual route pick that still applies to this quote cycle, or `null` when
- * the user never picked one, the pick belongs to an earlier cycle, or its
- * provider dropped out of the current candidate set.
+ * The manual route pick that still applies, or `null` when the user never
+ * picked one, the pick was made for a different swap, or its provider dropped
+ * out of the current candidate set.
  */
 export const getActiveSwapRouteOverride = ({
   quotes,
   override,
+  requestId,
 }: ActiveSwapRouteInput): SwapRouteOverride | null => {
-  if (!override || override.cycleId !== getSwapQuoteCycleId(quotes)) {
+  if (!override || override.requestId !== requestId) {
     return null
   }
 
@@ -50,7 +64,9 @@ export const getActiveSwapRouteOverride = ({
 
 /**
  * The candidate the swap is currently going through: the manually picked route
- * when one is in effect, otherwise the auto-selected winner. `null` only if the
+ * when one is in effect, otherwise the auto-selected winner. Always resolved
+ * against the candidates of the latest quote cycle, so a pick selects a
+ * provider rather than pinning the quote it was picked from. `null` only if the
  * winner is somehow absent from the candidate set, which the SDK never returns.
  */
 export const resolveActiveSwapRoute = (

--- a/core/ui/vault/swap/queries/activeSwapRoute.ts
+++ b/core/ui/vault/swap/queries/activeSwapRoute.ts
@@ -11,21 +11,38 @@ type SwapQuoteRequestIdInput = {
   from: CoinKey
   to: CoinKey
   amount: bigint | null
+  slippageTolerance: number | undefined
+  recipient: string | undefined
 }
 
 /**
- * Identifies the swap the user is quoting — the pair and the amount, and
- * nothing about the quotes that came back. A manual route pick is scoped to
- * this, so re-quoting the same swap re-ranks the routes without moving the user
- * off the one they chose, while editing the pair or the amount is a new swap
- * and starts the choice over.
+ * Identifies the swap the user is quoting — the inputs the quote is requested
+ * with, and nothing about the quotes that came back. A manual route pick is
+ * scoped to this, so re-quoting the same swap re-ranks the routes without
+ * moving the user off the one they chose, while editing any input is a
+ * different swap and starts the choice over.
+ *
+ * Covers the editable fields `buildSwapQuoteInput` sends, and takes the derived
+ * values rather than the raw form state so an edit that leaves the request
+ * unchanged — a whitespace-only recipient, a custom slippage that still
+ * resolves to `Auto` — keeps the pick. The referral and discount tier it also
+ * sends are deliberately left out: they are fetched rather than edited, and
+ * including them would retire the pick when a background query resolves.
  */
 export const getSwapQuoteRequestId = ({
   from,
   to,
   amount,
+  slippageTolerance,
+  recipient,
 }: SwapQuoteRequestIdInput) =>
-  [coinKeyToString(from), coinKeyToString(to), amount ?? ''].join('>')
+  [
+    coinKeyToString(from),
+    coinKeyToString(to),
+    amount ?? '',
+    slippageTolerance ?? '',
+    recipient ?? '',
+  ].join('>')
 
 /**
  * Whether there is a route choice worth offering. Candidate count is the only
@@ -92,3 +109,38 @@ export const resolveActiveSwapRoute = (
 export const resolveActiveSwapQuote = (
   input: ActiveSwapRouteInput
 ): BoundSwapQuote => resolveActiveSwapRoute(input)?.quote ?? input.quotes.best
+
+type ShouldDropSwapRouteOverrideInput = {
+  quotes: FindSwapQuotesResult | undefined
+  override: SwapRouteOverride | null
+  requestId: string
+}
+
+/**
+ * Whether a stored pick should be discarded outright rather than merely
+ * ignored. A pick that has stopped applying but stays in state comes back on
+ * its own once the user edits the swap back to what it was, or once the
+ * provider returns to the candidate set — both after the form has already shown
+ * `Auto`. Dropping it as soon as it stops matching what the form displays keeps
+ * the stored pick and the visible one from disagreeing.
+ *
+ * Returns `false` while quotes are still loading, so a pick is never discarded
+ * over a candidate set that has not arrived yet.
+ */
+export const shouldDropSwapRouteOverride = ({
+  quotes,
+  override,
+  requestId,
+}: ShouldDropSwapRouteOverrideInput): boolean => {
+  if (!override) {
+    return false
+  }
+
+  if (override.requestId !== requestId) {
+    return true
+  }
+
+  return quotes
+    ? getActiveSwapRouteOverride({ quotes, override, requestId }) === null
+    : false
+}

--- a/core/ui/vault/swap/queries/useSwapQuoteQuery.ts
+++ b/core/ui/vault/swap/queries/useSwapQuoteQuery.ts
@@ -20,6 +20,7 @@ import { useSwapRouteOverride } from '../state/routeOverride'
 import { useSwapToCoin } from '../state/toCoin'
 import { resolveActiveSwapQuote } from './activeSwapRoute'
 import { buildSwapQuoteInput } from './buildSwapQuoteInput'
+import { useSwapQuoteRequestId } from './useSwapQuoteRequestId'
 
 export const swapQuoteQueryKeyPrefix = 'swapQuote'
 
@@ -133,14 +134,16 @@ export const useSwapQuotesQuery = () => {
 
 /**
  * The quote the swap actually goes through: the manually picked route while one
- * is in effect for this quote cycle, otherwise the auto-selected winner. Every
- * consumer — form display, fees, verify screen, keysign payload — reads the
- * swap quote from here, so a manual pick reaches the signed transaction.
+ * is in effect, otherwise the auto-selected winner. Every consumer — form
+ * display, fees, verify screen, keysign payload — reads the swap quote from
+ * here, so a manual pick reaches the signed transaction, always as the picked
+ * provider's freshest quote rather than the one it was picked from.
  */
 export const useSwapQuoteQuery = () => {
   const [override] = useSwapRouteOverride()
+  const requestId = useSwapQuoteRequestId()
 
   return useTransformQueryData(useSwapQuotesQuery(), quotes =>
-    resolveActiveSwapQuote({ quotes, override })
+    resolveActiveSwapQuote({ quotes, override, requestId })
   )
 }

--- a/core/ui/vault/swap/queries/useSwapQuoteRequestId.ts
+++ b/core/ui/vault/swap/queries/useSwapQuoteRequestId.ts
@@ -1,3 +1,5 @@
+import { slippageToPercent } from '../form/advanced/slippage'
+import { useAdvancedSwapSettings } from '../state/advancedSettings'
 import { useFromAmount } from '../state/fromAmount'
 import { useSwapFromCoin } from '../state/fromCoin'
 import { useSwapToCoin } from '../state/toCoin'
@@ -5,14 +7,22 @@ import { getSwapQuoteRequestId } from './activeSwapRoute'
 
 /**
  * The swap currently being composed, as the id a manual route pick is scoped
- * to. Reads the raw form amount rather than the debounced one the quote query
- * uses, so editing the amount retires the pick as the user types instead of
- * one debounce later.
+ * to. Derives slippage and recipient exactly as {@link useSwapQuotesQuery}
+ * does, so the id moves with the quote request rather than with the raw form
+ * state. Reads the raw form amount rather than the debounced one, so editing
+ * the amount retires the pick as the user types instead of one debounce later.
  */
 export const useSwapQuoteRequestId = () => {
   const [from] = useSwapFromCoin()
   const [to] = useSwapToCoin()
   const [amount] = useFromAmount()
+  const [advancedSettings] = useAdvancedSwapSettings()
 
-  return getSwapQuoteRequestId({ from, to, amount })
+  return getSwapQuoteRequestId({
+    from,
+    to,
+    amount,
+    slippageTolerance: slippageToPercent(advancedSettings.slippage),
+    recipient: advancedSettings.externalRecipient.trim() || undefined,
+  })
 }

--- a/core/ui/vault/swap/queries/useSwapQuoteRequestId.ts
+++ b/core/ui/vault/swap/queries/useSwapQuoteRequestId.ts
@@ -1,0 +1,18 @@
+import { useFromAmount } from '../state/fromAmount'
+import { useSwapFromCoin } from '../state/fromCoin'
+import { useSwapToCoin } from '../state/toCoin'
+import { getSwapQuoteRequestId } from './activeSwapRoute'
+
+/**
+ * The swap currently being composed, as the id a manual route pick is scoped
+ * to. Reads the raw form amount rather than the debounced one the quote query
+ * uses, so editing the amount retires the pick as the user types instead of
+ * one debounce later.
+ */
+export const useSwapQuoteRequestId = () => {
+  const [from] = useSwapFromCoin()
+  const [to] = useSwapToCoin()
+  const [amount] = useFromAmount()
+
+  return getSwapQuoteRequestId({ from, to, amount })
+}

--- a/core/ui/vault/swap/queries/useSwapRoutes.ts
+++ b/core/ui/vault/swap/queries/useSwapRoutes.ts
@@ -1,38 +1,38 @@
 import { SwapQuoteProviderName } from '@vultisig/core-chain/swap/quote/findSwapQuote'
-import { shouldBePresent } from '@vultisig/lib-utils/assert/shouldBePresent'
 
 import { useSwapRouteOverride } from '../state/routeOverride'
 import {
   canSelectSwapRoute,
   getActiveSwapRouteOverride,
-  getSwapQuoteCycleId,
   resolveActiveSwapRoute,
 } from './activeSwapRoute'
 import { useSwapQuotesQuery } from './useSwapQuoteQuery'
+import { useSwapQuoteRequestId } from './useSwapQuoteRequestId'
 
 /**
  * Every route the current quote cycle offers, which one the swap is going
- * through, and how to switch to another. Picking a route only holds for the
- * cycle it was picked in — the next refresh re-defaults to the auto-selected
- * winner without anything having to reset it.
+ * through, and how to switch to another. A pick holds for as long as the user
+ * keeps quoting the same pair and amount — refreshes re-rank the routes around
+ * it — and is dropped once they edit either, or once the picked provider stops
+ * quoting.
  */
 export const useSwapRoutes = () => {
   const quotes = useSwapQuotesQuery().data
   const [override, setOverride] = useSwapRouteOverride()
+  const requestId = useSwapQuoteRequestId()
 
   const candidates = quotes?.ranked ?? []
 
   return {
     candidates,
     canSelectRoute: canSelectSwapRoute(candidates),
-    activeRoute: quotes ? resolveActiveSwapRoute({ quotes, override }) : null,
+    activeRoute: quotes
+      ? resolveActiveSwapRoute({ quotes, override, requestId })
+      : null,
     isOverridden: quotes
-      ? getActiveSwapRouteOverride({ quotes, override }) !== null
+      ? getActiveSwapRouteOverride({ quotes, override, requestId }) !== null
       : false,
     selectRoute: (providerName: SwapQuoteProviderName) =>
-      setOverride({
-        providerName,
-        cycleId: getSwapQuoteCycleId(shouldBePresent(quotes, 'swap quotes')),
-      }),
+      setOverride({ providerName, requestId }),
   }
 }

--- a/core/ui/vault/swap/state/SwapRouteOverrideReset.tsx
+++ b/core/ui/vault/swap/state/SwapRouteOverrideReset.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from 'react'
+
+import { shouldDropSwapRouteOverride } from '../queries/activeSwapRoute'
+import { useSwapQuotesQuery } from '../queries/useSwapQuoteQuery'
+import { useSwapQuoteRequestId } from '../queries/useSwapQuoteRequestId'
+import { useSwapRouteOverride } from './routeOverride'
+
+/**
+ * Discards a manual route pick once it stops applying. Mounted once inside the
+ * override provider so the stored pick never contradicts the `Auto` the form is
+ * already showing — leaving it in place is what let an edit back to the earlier
+ * swap, or a provider reappearing after one failed quote, silently resurrect a
+ * pick the user had seen dropped.
+ */
+export const SwapRouteOverrideReset = () => {
+  const quotes = useSwapQuotesQuery().data
+  const requestId = useSwapQuoteRequestId()
+  const [override, setOverride] = useSwapRouteOverride()
+
+  useEffect(() => {
+    if (shouldDropSwapRouteOverride({ quotes, override, requestId })) {
+      setOverride(null)
+    }
+  }, [override, quotes, requestId, setOverride])
+
+  return null
+}

--- a/core/ui/vault/swap/state/routeOverride.ts
+++ b/core/ui/vault/swap/state/routeOverride.ts
@@ -3,18 +3,18 @@ import { SwapQuoteProviderName } from '@vultisig/core-chain/swap/quote/findSwapQ
 
 /**
  * A route the user picked by hand instead of taking the auto-selected winner,
- * tied to the quote cycle it was picked from. Deliberately kept out of the
- * persisted advanced settings: a pick is valid for one cycle only and must not
- * survive a quote refresh.
+ * scoped to the swap it was picked for. Deliberately kept out of the persisted
+ * advanced settings: a pick belongs to the swap being composed right now, not
+ * to the vault's saved preferences.
  */
 export type SwapRouteOverride = {
   providerName: SwapQuoteProviderName
   /**
-   * Identifies the quote cycle the pick belongs to. Once the cycle changes the
-   * pick stops applying, so no explicit reset has to be wired into every code
-   * path that can trigger a refresh.
+   * The swap the pick was made for — see `getSwapQuoteRequestId`. The pick
+   * holds across every re-quote of that same pair and amount, including the
+   * interval refresh, and stops applying once either changes.
    */
-  cycleId: string
+  requestId: string
 }
 
 /**


### PR DESCRIPTION
Fixes #4797

## Problem

Picking a non-default route in **Advanced Swap → Select route** did not stick. Within at most 60 seconds — sometimes within a second or two — the swap fell back to the auto-selected winner and the row went back to reading `Auto`, with nothing telling the user.

The pick was stored against `getSwapQuoteCycleId(quotes) = quotes.best.safetyFingerprint`. That fingerprint covers the quote body **and its expiry**, and `expiresAt` is rebuilt from `Date.now()` on every fetch:

```js
// @vultisig/core-chain — findSwapQuote.js
const now = Date.now()
expiresAt = ... ?? now + GENERAL_QUOTE_PREPARATION_TTL_MS
```

Checked against the shipped package — a 1 ms shift in `expiresAt` alone is enough:

```
same expiresAt -> same fp: true
expiresAt +1ms -> fp changed: true
```

So every refetch retired the pick. Four paths trigger one: the 60 s countdown in `RefreshSwap.tsx`, the manual refresh button, a window-focus refetch (the query sets no `staleTime`, so it is always stale), and **opening the picker itself** — `AdvancedSwapSettingsSheet` and `SelectRouteSheet` each mount another `useSwapQuotesQuery` observer and `refetchOnMount` starts a fetch. That last one is why the bug looked intermittent: if the fetch landed just after the tap, the pick died immediately.

It also looked stable whenever the user picked the provider that was already winning, because the fallback target was that same provider.

## Fix

Scope the pick to the swap being quoted rather than to the quote payload:

```ts
export const getSwapQuoteRequestId = ({ from, to, amount }: SwapQuoteRequestIdInput) =>
  [coinKeyToString(from), coinKeyToString(to), amount ?? ''].join('>')
```

`SwapRouteOverride` now carries `requestId` instead of `cycleId`, and `getActiveSwapRouteOverride` compares against the current request. Refreshes re-rank the routes around the pick; the pick retires on a pair/amount edit, or — through the existing `ranked.some(...)` guard — when the picked provider stops quoting.

`useSwapQuoteRequestId` reads the raw form amount rather than the debounced one, so an amount edit retires the pick as the user types instead of one debounce later.

## Invariants kept

- **The winner is still matched by fingerprint, not by `ranked[0]`.** Inside the preference band the SDK may pick a lower-output provider and the app must follow that pick.
- **No stale quote is ever pinned.** The override stores only a provider name; the active quote is re-read from the current `ranked` set each cycle, so a refresh re-quotes the chosen provider at its new rate. Covered by `keeps the pick through a refresh, on its newly fetched quote`.
- **Still not persisted.** The pick stays out of the advanced settings written to storage.

## Test plan

- [x] `yarn check` — typecheck, lint, i18n, knip all clean
- [x] `yarn vitest run core/ui/vault/swap` — 365 tests across 28 files pass
- [x] Extension built and loaded from `clients/extension/dist`
- [ ] Reviewer: pick a non-winning route, wait past one 60 s refresh and alt-tab away and back — the row should still name that provider, and the output figure should move with each refresh
- [ ] Reviewer: change the amount — the row should reset to `Auto`

## Notes

The JSDoc and the test names in `activeSwapRoute.ts` / `activeSwapRoute.test.ts` documented the one-cycle lifetime as intended behaviour. The only rationale given for it was implementation convenience — "without a reset being wired into each refresh path" (#4671) — not a safety constraint, so they are rewritten here along with the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Manually selected swap providers remain active while the swap request stays unchanged.
  - Refreshed quotes use the selected provider’s latest available quote.
  - Route selections reset when swap details change or the selected provider is no longer available.
  - Updated route-selection guidance explains that returning to the Advanced Swap sheet preserves the selection for the same pair and amount.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->