### PR TITLE
fix(extension): bind XRPL Payment amount for keysign

### DIFF
--- a/clients/extension/tests/unit/sanitizeRippleDappTx.test.ts
+++ b/clients/extension/tests/unit/sanitizeRippleDappTx.test.ts
@@ -70,6 +70,20 @@ describe('sanitizeRippleDappTx', () => {
     }
   })
 
+  it('rejects issued-currency Payments before confirmation', () => {
+    expect(() =>
+      sanitize({
+        TransactionType: 'Payment',
+        Destination: vaultAddress,
+        Amount: {
+          currency: 'USD',
+          issuer: 'rIssuer00000000000000000000000000000',
+          value: '1',
+        },
+      })
+    ).toThrow(/issued-currency Payments are not supported/)
+  })
+
   it('rejects a transaction type outside the allowlist', () => {
     // SetRegularKey could hand account control to an attacker key — exactly the
     // kind of request that must never ride in on a "sign this swap" prompt.
@@ -160,21 +174,13 @@ describe('sanitizeRippleDappTx', () => {
     }
   )
 
-  it('accepts a partial payment floored by an issued-currency DeliverMin', () => {
-    const deliverMin = {
-      currency: '524C555344000000000000000000000000000000',
-      issuer: 'rIssuer00000000000000000000000000000',
-      value: '1.5',
-    }
+  it('accepts a partial payment floored by a positive native DeliverMin', () => {
+    const deliverMin = '1500000'
 
     const result = sanitize({
       TransactionType: 'Payment',
       Destination: vaultAddress,
-      Amount: {
-        currency: '524C555344000000000000000000000000000000',
-        issuer: 'rIssuer00000000000000000000000000000',
-        value: '2',
-      },
+      Amount: '2000000',
       SendMax: '1200000',
       DeliverMin: deliverMin,
       Flags: 131072,

--- a/clients/extension/tests/unit/sanitizeRippleDappTx.test.ts
+++ b/clients/extension/tests/unit/sanitizeRippleDappTx.test.ts
@@ -64,7 +64,7 @@ describe('sanitizeRippleDappTx', () => {
       'OfferCancel',
       'TrustSet',
     ]) {
-      expect(sanitize({ TransactionType }).TransactionType).toBe(
+      expect(sanitize({ TransactionType, Amount: '1' }).TransactionType).toBe(
         TransactionType
       )
     }
@@ -84,6 +84,40 @@ describe('sanitizeRippleDappTx', () => {
     ).toThrow(/issued-currency Payments are not supported/)
   })
 
+  it.each([
+    '1.5',
+    '-1',
+    '+1',
+    '1e6',
+    '0x10',
+    '',
+    ' ',
+    ' 1',
+    '1\n',
+    'NaN',
+    'Infinity',
+    null,
+    undefined,
+    1,
+    true,
+  ])(
+    'rejects malformed native Payment Amount %j before confirmation',
+    Amount => {
+      expect(() => sanitize({ TransactionType: 'Payment', Amount })).toThrow(
+        /Amount must be a non-negative integer drops string/
+      )
+    }
+  )
+
+  it.each(['0', '1', '0001', '100000000000000000'])(
+    'preserves native Payment Amount %s without coercion',
+    Amount => {
+      expect(sanitize({ TransactionType: 'Payment', Amount }).Amount).toBe(
+        Amount
+      )
+    }
+  )
+
   it('rejects a transaction type outside the allowlist', () => {
     // SetRegularKey could hand account control to an attacker key — exactly the
     // kind of request that must never ride in on a "sign this swap" prompt.
@@ -98,10 +132,16 @@ describe('sanitizeRippleDappTx', () => {
 
   it('rejects non-object and non-JSON input', () => {
     expect(() =>
-      sanitizeRippleDappTx({ rawJson: '"just a string"', accountAddress: vaultAddress })
+      sanitizeRippleDappTx({
+        rawJson: '"just a string"',
+        accountAddress: vaultAddress,
+      })
     ).toThrow(/must be a JSON object/)
     expect(() =>
-      sanitizeRippleDappTx({ rawJson: 'not json', accountAddress: vaultAddress })
+      sanitizeRippleDappTx({
+        rawJson: 'not json',
+        accountAddress: vaultAddress,
+      })
     ).toThrow(/not valid JSON/)
   })
 

--- a/core/inpage-provider/popup/view/resolvers/sendTx/core/amount.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/core/amount.ts
@@ -6,7 +6,7 @@ import { CustomTxData } from './customTxData'
 import { ParsedTx } from './parsedTx'
 
 export const getTxAmount = ({ coin, customTxData }: ParsedTx) =>
-  matchRecordUnion<CustomTxData, bigint>(customTxData, {
+  matchRecordUnion<CustomTxData, bigint | string>(customTxData, {
     regular: ({ transactionDetails }) =>
       BigInt(transactionDetails.amount?.amount ?? 0),
     solana: tx => {
@@ -20,7 +20,13 @@ export const getTxAmount = ({ coin, customTxData }: ParsedTx) =>
     polkadot: () => BigInt(0),
     // Pre-built PTB: the amount is encoded in the bytes, not surfaced here.
     sui: () => BigInt(0),
-    // Amounts live inside the raw XRPL transaction (and an offer has two of
-    // them); the decoded confirmation view renders them, not this scalar.
-    ripple: () => BigInt(0),
+    // A Payment is the one raw XRPL transaction whose reviewed scalar must be
+    // bound to the signed bytes. Keep the drops string verbatim because the
+    // signer compares it exactly; offers and trust lines have no equivalent
+    // scalar representation in the keysign payload.
+    ripple: ({ transaction }) =>
+      transaction.TransactionType === 'Payment' &&
+      typeof transaction.Amount === 'string'
+        ? transaction.Amount
+        : BigInt(0),
   })

--- a/core/inpage-provider/popup/view/resolvers/sendTx/core/amount.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/core/amount.ts
@@ -5,6 +5,7 @@ import { getRecordUnionValue } from '@vultisig/lib-utils/record/union/getRecordU
 import { CustomTxData } from './customTxData'
 import { ParsedTx } from './parsedTx'
 
+/** Returns native XRPL Payment drops verbatim; other routes return a bigint. */
 export const getTxAmount = ({ coin, customTxData }: ParsedTx) =>
   matchRecordUnion<CustomTxData, bigint | string>(customTxData, {
     regular: ({ transactionDetails }) =>

--- a/core/inpage-provider/popup/view/resolvers/sendTx/core/ripple/sanitizeRippleDappTx.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/core/ripple/sanitizeRippleDappTx.ts
@@ -157,6 +157,21 @@ export const sanitizeRippleDappTx = ({
     )
   }
 
+  // Serialized XRPL requests currently use the native XRP coin in the
+  // keysign payload. The signer requires an issued-currency Payment to carry
+  // that exact issued coin (currency + issuer), so letting an Amount object
+  // reach confirmation would only fail later in keysign after misleading the
+  // user that the request was signable.
+  if (
+    transactionType === 'Payment' &&
+    typeof record.Amount === 'object' &&
+    record.Amount !== null
+  ) {
+    throw new Error(
+      'Ripple issued-currency Payments are not supported; use a native XRP amount'
+    )
+  }
+
   const sanitized: Record<string, unknown> = {}
   for (const [key, value] of Object.entries(record)) {
     if (!strippedFields.includes(key)) {

--- a/core/inpage-provider/popup/view/resolvers/sendTx/core/ripple/sanitizeRippleDappTx.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/core/ripple/sanitizeRippleDappTx.ts
@@ -84,7 +84,8 @@ type SanitizeInput = {
  * out from under the user. `Flags` must decode as a uint32, and a `Payment`
  * carrying `tfPartialPayment` without a positive `DeliverMin` is refused: its
  * `Amount` is a ceiling, so no confirmation screen could state what the user
- * receives.
+ * receives. Payment `Amount` must be a non-negative integer drops string;
+ * issued-currency Payments are not supported by this native-XRP route.
  *
  * `Paths` is left intact — it is legitimate on a cross-currency payment — and
  * is instead surfaced to the user by the confirmation display. The result is
@@ -169,6 +170,15 @@ export const sanitizeRippleDappTx = ({
   ) {
     throw new Error(
       'Ripple issued-currency Payments are not supported; use a native XRP amount'
+    )
+  }
+
+  if (
+    transactionType === 'Payment' &&
+    (typeof record.Amount !== 'string' || !/^\d+$/.test(record.Amount))
+  ) {
+    throw new Error(
+      'Ripple Payment Amount must be a non-negative integer drops string'
     )
   }
 

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/build.test.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/build.test.ts
@@ -1,11 +1,24 @@
 import { Chain } from '@vultisig/core-chain/Chain'
 import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
+import { getRippleSigningInputs } from '@vultisig/core-mpc/keysign/signingInputs/resolvers/ripple'
 import { describe, expect, it, vi } from 'vitest'
 
 import { buildSendTxKeysignPayload } from './build'
 
 vi.mock('@vultisig/core-mpc/keysign/chainSpecific', () => ({
-  getChainSpecific: vi.fn(async () => undefined),
+  getChainSpecific: vi.fn(async ({ keysignPayload }) =>
+    keysignPayload.coin?.chain === Chain.Ripple
+      ? {
+          case: 'rippleSpecific',
+          value: {
+            gas: 12n,
+            sequence: 10n,
+            lastLedgerSequence: 20n,
+          },
+        }
+      : undefined
+  ),
 }))
 
 const solanaCoin: AccountCoin = {
@@ -26,6 +39,29 @@ const tonCoin: AccountCoin = {
 const publicKey = {
   data: () => new Uint8Array([1, 2, 3, 4]),
 }
+
+const rippleAccount = 'rPEPPER7kfTD9w2To4CQk6UCfuHM9c6GDY'
+const rippleDestination = 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh'
+const rippleCoin: AccountCoin = {
+  ...chainFeeCoin[Chain.Ripple],
+  address: rippleAccount,
+}
+
+const buildRipplePayload = (
+  transaction: Record<string, unknown>,
+  skipBroadcast = false
+) =>
+  buildSendTxKeysignPayload({
+    parsedTx: {
+      coin: rippleCoin,
+      customTxData: { ripple: { transaction: transaction as never } },
+      skipBroadcast,
+    },
+    publicKey: publicKey as never,
+    walletCore: {} as never,
+    vaultId: 'vault-id',
+    localPartyId: 'local-party',
+  })
 
 describe('buildSendTxKeysignPayload', () => {
   it('preserves every raw Solana transaction in the signing payload', async () => {
@@ -112,4 +148,79 @@ describe('buildSendTxKeysignPayload', () => {
 
     expect(secondMessage?.stateInit).toBeUndefined()
   })
+  it.each([false, true])(
+    'binds a native XRPL Payment amount with skipBroadcast=%s',
+    async skipBroadcast => {
+      const amount = '1'
+      const payload = await buildRipplePayload(
+        {
+          TransactionType: 'Payment',
+          Account: rippleAccount,
+          Destination: rippleDestination,
+          Amount: amount,
+        },
+        skipBroadcast
+      )
+
+      expect(payload).toMatchObject({
+        toAddress: rippleDestination,
+        toAmount: amount,
+        skipBroadcast,
+        signData: { case: 'signRipple' },
+      })
+
+      const [signingInput] = await getRippleSigningInputs({
+        keysignPayload: payload,
+        walletCore: {} as never,
+      })
+
+      expect(signingInput.rawJson).toBe(
+        payload.signData.case === 'signRipple'
+          ? payload.signData.value.rawJson
+          : undefined
+      )
+    }
+  )
+
+  it.each([
+    [
+      'OfferCreate',
+      {
+        TakerGets: '1000000',
+        TakerPays: {
+          currency: 'USD',
+          issuer: rippleDestination,
+          value: '1',
+        },
+      },
+    ],
+    ['OfferCancel', { OfferSequence: 7 }],
+    [
+      'TrustSet',
+      {
+        LimitAmount: {
+          currency: 'USD',
+          issuer: rippleDestination,
+          value: '10',
+        },
+      },
+    ],
+  ])(
+    'keeps XRPL %s signable without a reviewed scalar',
+    async (type, fields) => {
+      const payload = await buildRipplePayload({
+        TransactionType: type,
+        Account: rippleAccount,
+        ...fields,
+      })
+
+      expect(payload.toAmount).toBe('0')
+      expect(
+        getRippleSigningInputs({
+          keysignPayload: payload,
+          walletCore: {} as never,
+        })
+      ).toHaveLength(1)
+    }
+  )
 })

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/build.test.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/build.test.ts
@@ -1,9 +1,12 @@
+import { initWasm, WalletCore } from '@trustwallet/wallet-core'
+import { PublicKey } from '@trustwallet/wallet-core/dist/src/wallet-core'
 import { Chain } from '@vultisig/core-chain/Chain'
 import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
 import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
 import { getRippleSigningInputs } from '@vultisig/core-mpc/keysign/signingInputs/resolvers/ripple'
-import { describe, expect, it, vi } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
+import { RippleTransaction } from '../core/ripple/sanitizeRippleDappTx'
 import { buildSendTxKeysignPayload } from './build'
 
 vi.mock('@vultisig/core-mpc/keysign/chainSpecific', () => ({
@@ -36,9 +39,19 @@ const tonCoin: AccountCoin = {
   ticker: 'GRAM',
 }
 
-const publicKey = {
-  data: () => new Uint8Array([1, 2, 3, 4]),
-}
+let walletCore: WalletCore
+let publicKey: PublicKey
+
+beforeAll(async () => {
+  walletCore = await initWasm()
+  const privateKey = walletCore.PrivateKey.createWithData(
+    new Uint8Array(32).fill(1)
+  )
+  publicKey = privateKey.getPublicKeySecp256k1(true)
+  privateKey.delete()
+})
+
+afterAll(() => publicKey?.delete())
 
 const rippleAccount = 'rPEPPER7kfTD9w2To4CQk6UCfuHM9c6GDY'
 const rippleDestination = 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh'
@@ -47,18 +60,23 @@ const rippleCoin: AccountCoin = {
   address: rippleAccount,
 }
 
-const buildRipplePayload = (
-  transaction: Record<string, unknown>,
-  skipBroadcast = false
-) =>
+type BuildRipplePayloadInput = {
+  transaction: RippleTransaction
+  skipBroadcast?: boolean
+}
+
+const buildRipplePayload = ({
+  transaction,
+  skipBroadcast = false,
+}: BuildRipplePayloadInput) =>
   buildSendTxKeysignPayload({
     parsedTx: {
       coin: rippleCoin,
-      customTxData: { ripple: { transaction: transaction as never } },
+      customTxData: { ripple: { transaction } },
       skipBroadcast,
     },
-    publicKey: publicKey as never,
-    walletCore: {} as never,
+    publicKey,
+    walletCore,
     vaultId: 'vault-id',
     localPartyId: 'local-party',
   })
@@ -80,8 +98,8 @@ describe('buildSendTxKeysignPayload', () => {
           },
         },
       },
-      publicKey: publicKey as never,
-      walletCore: {} as never,
+      publicKey,
+      walletCore,
       vaultId: 'vault-id',
       localPartyId: 'local-party',
     })
@@ -130,8 +148,8 @@ describe('buildSendTxKeysignPayload', () => {
           },
         },
       },
-      publicKey: publicKey as never,
-      walletCore: {} as never,
+      publicKey,
+      walletCore,
       vaultId: 'vault-id',
       localPartyId: 'local-party',
     })
@@ -152,15 +170,15 @@ describe('buildSendTxKeysignPayload', () => {
     'binds a native XRPL Payment amount with skipBroadcast=%s',
     async skipBroadcast => {
       const amount = '1'
-      const payload = await buildRipplePayload(
-        {
+      const payload = await buildRipplePayload({
+        transaction: {
           TransactionType: 'Payment',
           Account: rippleAccount,
           Destination: rippleDestination,
           Amount: amount,
         },
-        skipBroadcast
-      )
+        skipBroadcast,
+      })
 
       expect(payload).toMatchObject({
         toAddress: rippleDestination,
@@ -171,7 +189,7 @@ describe('buildSendTxKeysignPayload', () => {
 
       const [signingInput] = await getRippleSigningInputs({
         keysignPayload: payload,
-        walletCore: {} as never,
+        walletCore,
       })
 
       expect(signingInput.rawJson).toBe(
@@ -183,9 +201,9 @@ describe('buildSendTxKeysignPayload', () => {
   )
 
   it.each([
-    [
-      'OfferCreate',
-      {
+    {
+      type: 'OfferCreate',
+      fields: {
         TakerGets: '1000000',
         TakerPays: {
           currency: 'USD',
@@ -193,32 +211,34 @@ describe('buildSendTxKeysignPayload', () => {
           value: '1',
         },
       },
-    ],
-    ['OfferCancel', { OfferSequence: 7 }],
-    [
-      'TrustSet',
-      {
+    },
+    { type: 'OfferCancel', fields: { OfferSequence: 7 } },
+    {
+      type: 'TrustSet',
+      fields: {
         LimitAmount: {
           currency: 'USD',
           issuer: rippleDestination,
           value: '10',
         },
       },
-    ],
+    },
   ])(
-    'keeps XRPL %s signable without a reviewed scalar',
-    async (type, fields) => {
+    'keeps XRPL $type signable without a reviewed scalar',
+    async ({ type, fields }) => {
       const payload = await buildRipplePayload({
-        TransactionType: type,
-        Account: rippleAccount,
-        ...fields,
+        transaction: {
+          TransactionType: type,
+          Account: rippleAccount,
+          ...fields,
+        },
       })
 
       expect(payload.toAmount).toBe('0')
       expect(
         getRippleSigningInputs({
           keysignPayload: payload,
-          walletCore: {} as never,
+          walletCore,
         })
       ).toHaveLength(1)
     }


### PR DESCRIPTION
Closes #4712
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved native XRP payment amount processing and display.
  - Enhanced signing support for Ripple transactions, including OfferCreate, OfferCancel, and TrustSet.
  - Improved handling of transactions with broadcast settings and payment delivery limits.

- **Bug Fixes**
  - Issued-currency payments are now rejected before confirmation or signing.
  - Invalid, negative, or malformed native XRP payment amounts are rejected.
  - Valid native XRP amount strings are preserved accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Native XRPL Payments bind the exact reviewed drops string into toAmount. Malformed native amounts and unsupported issued-currency Payments are rejected before confirmation. OfferCreate, OfferCancel, and TrustSet retain their existing resolver behavior. Live two-device QA completed sign-only and provider submission for a one-drop Payment; ledger validation is not claimed. The extension shows an explicit validation error for Amount 1.5.

![screenshot-1](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/4712-fix-xrpl-payment-toamount/screenshot-1-1788361271046.png)
![screenshot-2](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/4712-fix-xrpl-payment-toamount/screenshot-2-1788361271046.png)
![screenshot-3](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/4712-fix-xrpl-payment-toamount/screenshot-3-1788361271046.png)
![screenshot-4](https://raw.githubusercontent.com/vultisig/vultisig-windows/pr-assets/4712-fix-xrpl-payment-toamount/screenshot-4-1788361271046.png)