### PR TITLE
fix(transaction-history): stop the card's icon slot from slicing the chain badge

### DIFF
--- a/core/ui/transaction-history/TransactionHistoryCard/TransactionHistoryCard.stories.tsx
+++ b/core/ui/transaction-history/TransactionHistoryCard/TransactionHistoryCard.stories.tsx
@@ -107,7 +107,7 @@ export const AllCards: Story = {
 /** Token transfer: the coin icon carries a chain badge on its bottom-right. */
 export const TokenWithChainBadge: Story = {
   args: {
-    tagType: 'swap' as TransactionHistoryTagType,
+    tagType: 'swap',
     status: 'successful',
     amountUsd: '$39.99',
     amountCrypto: '40',

--- a/core/ui/transaction-history/TransactionHistoryCard/TransactionHistoryCard.stories.tsx
+++ b/core/ui/transaction-history/TransactionHistoryCard/TransactionHistoryCard.stories.tsx
@@ -33,6 +33,16 @@ const runeCoin = { chain: Chain.THORChain, logo: 'rune' as const }
 const solCoin = { chain: Chain.Solana, logo: 'solana' as const }
 const ethCoin = { chain: Chain.Ethereum, logo: 'eth' as const }
 
+/**
+ * A non-fee token, so `CoinIcon` overlays the chain badge that fee coins never
+ * render. The card's icon slot has to leave that badge room.
+ */
+const usdcCoin = {
+  chain: Chain.Ethereum,
+  id: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+  logo: 'usdc' as const,
+}
+
 /** Single story page: all card variants (successful Send/Receive/Swap, error with and without message) for quick glance. */
 export const AllCards: Story = {
   render: () => (
@@ -92,6 +102,19 @@ export const AllCards: Story = {
       />
     </div>
   ),
+}
+
+/** Token transfer: the coin icon carries a chain badge on its bottom-right. */
+export const TokenWithChainBadge: Story = {
+  args: {
+    tagType: 'swap' as TransactionHistoryTagType,
+    status: 'successful',
+    amountUsd: '$39.99',
+    amountCrypto: '40',
+    symbol: 'USDC',
+    pill: { providerName: 'THORChain' },
+  },
+  render: args => <TransactionHistoryCard {...args} coin={usdcCoin} />,
 }
 
 export const SuccessfulSend: Story = {

--- a/core/ui/transaction-history/TransactionHistoryCard/styles.ts
+++ b/core/ui/transaction-history/TransactionHistoryCard/styles.ts
@@ -64,7 +64,12 @@ export const AmountBlock = styled(HStack).attrs({
   flex: 1;
 `
 
-/** Icon slot: 24x24. */
+/**
+ * Icon slot: reserves 24x24 in the row but never clips. `CoinIcon` hangs its
+ * chain badge outside the icon's box, so a slot that clipped would slice the
+ * badge; the badge is absolutely positioned, so letting it paint out costs no
+ * layout.
+ */
 export const IconSlot = styled.div`
   width: 24px;
   height: 24px;
@@ -72,8 +77,6 @@ export const IconSlot = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  overflow: hidden;
-  ${borderRadius.md};
 `
 
 /** USD + crypto stack. Minimal gap (Figma ~0 between lines in some frames). */


### PR DESCRIPTION
Fixes #4805

## Problem

On a Transaction History row, the chain badge that `CoinIcon` overlays on a token logo rendered as a wedge — its bottom-right sliced flat by a rounded edge, so the chain mark looked pushed *inside* the token logo instead of sitting on its corner.

`IconSlot` wrapped the icon in a hard `24x24` box with `overflow: hidden` and a `12px` radius. `WithChainIcon` deliberately hangs its badge outside the icon's box (`bottom: -0.32em; right: -0.32em`), so the slot clipped exactly the part meant to overhang. Measured on the rendered card: slot `24x24`, badge `14.47x14.47` overflowing `~4px` past both the right and bottom edges — roughly 40% of the badge cut, with the slot's radius rounding the cut.

Every other `CoinIcon` call site in the app renders it unwrapped, so this was the only place that clipped.

## Why it was invisible in Storybook

`shouldDisplayChainLogo` returns `false` for a chain's fee coin, and all three story coins were fee coins (RUNE, SOL, ETH) — they render no badge at all. Only token rows (USDC, USDT, …) were affected.

## Change

- Drop `overflow: hidden` and the `border-radius` from `IconSlot`. The badge is absolutely positioned, so letting it paint outside costs no layout; the slot keeps its `24x24` and `flex-shrink: 0`, so row spacing is byte-identical. The `8px` gap to the amount text leaves ~4px of clearance.
- Add a `TokenWithChainBadge` story using USDC on Ethereum, so the badge case is exercised from now on.

`WithChainIcon`'s offsets are untouched — every other call site already renders it correctly. `Card`'s own `overflow: hidden` is untouched too; the `ProviderPill` corner depends on it.

## Verification

Rendered the new story in Storybook before and after:

- **Before** — the Ethereum badge is a sliced wedge with a flat, rounded bottom-right cut.
- **After** — the badge is a complete circle overhanging the USDC logo's corner.

Re-measured the DOM after the change: the slot is still `24x24` at the same coordinates, `overflow` now `visible`, `border-radius` `0`. The `AllCards` story (the fee-coin rows) is pixel-unchanged.

`yarn check` passes — typecheck, lint, i18n integrity, knip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Storybook example showcasing a successful USDC swap with an Ethereum chain badge.

* **Bug Fixes**
  * Updated transaction history icon styling to prevent content from being clipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->