### PR TITLE
fix(ton): forward a TonConnect valid_until to the signed expiry

### DIFF
--- a/clients/extension/src/inpage/providers/tonConnect/index.ts
+++ b/clients/extension/src/inpage/providers/tonConnect/index.ts
@@ -642,6 +642,7 @@ export class TonConnectBridge {
           },
           data: firstMessage.payload,
           tonMessages,
+          tonValidUntil: validUntil,
         },
       },
     }

--- a/clients/extension/tests/unit/tonConnect-send.test.ts
+++ b/clients/extension/tests/unit/tonConnect-send.test.ts
@@ -51,22 +51,16 @@ vi.mock(
   })
 )
 
-vi.mock(
-  '@clients/extension/src/inpage/providers/tonConnect/tonProof',
-  () => ({
-    buildTonProofPayload: vi.fn(),
-    formatTonProofReply: vi.fn(),
-    getTonProofHash: vi.fn(),
-  })
-)
+vi.mock('@clients/extension/src/inpage/providers/tonConnect/tonProof', () => ({
+  buildTonProofPayload: vi.fn(),
+  formatTonProofReply: vi.fn(),
+  getTonProofHash: vi.fn(),
+}))
 
-vi.mock(
-  '@clients/extension/src/inpage/providers/tonConnect/signData',
-  () => ({
-    buildSignDataTextBinaryHash: vi.fn(),
-    buildSignDataCellHash: vi.fn(),
-  })
-)
+vi.mock('@clients/extension/src/inpage/providers/tonConnect/signData', () => ({
+  buildSignDataTextBinaryHash: vi.fn(),
+  buildSignDataCellHash: vi.fn(),
+}))
 
 vi.mock(
   '@clients/extension/src/inpage/providers/tonConnect/getWalletStateInit',
@@ -140,9 +134,7 @@ describe('TonConnectBridge.send', () => {
       const result = await bridge.send(
         makeSendTxRequest({
           valid_until: Math.floor(Date.now() / 1000) - 10,
-          messages: [
-            { address: 'EQTest', amount: '100000000' },
-          ],
+          messages: [{ address: 'EQTest', amount: '100000000' }],
         })
       )
 
@@ -258,7 +250,8 @@ describe('TonConnectBridge.send', () => {
 
       expect(mockCallPopup).toHaveBeenCalled()
       const popupCall = mockCallPopup.mock.calls[0][0]
-      const tonMessages = popupCall.sendTx.keysign.transactionDetails.tonMessages
+      const tonMessages =
+        popupCall.sendTx.keysign.transactionDetails.tonMessages
 
       expect(tonMessages).toHaveLength(1)
       expect(tonMessages[0].stateInit).toBe(stateInitBoc)
@@ -284,7 +277,8 @@ describe('TonConnectBridge.send', () => {
 
       expect(mockCallPopup).toHaveBeenCalled()
       const popupCall = mockCallPopup.mock.calls[0][0]
-      const tonMessages = popupCall.sendTx.keysign.transactionDetails.tonMessages
+      const tonMessages =
+        popupCall.sendTx.keysign.transactionDetails.tonMessages
 
       expect(tonMessages).toHaveLength(1)
       expect(tonMessages[0].stateInit).toBeUndefined()
@@ -318,7 +312,8 @@ describe('TonConnectBridge.send', () => {
       )
 
       const popupCall = mockCallPopup.mock.calls[0][0]
-      const tonMessages = popupCall.sendTx.keysign.transactionDetails.tonMessages
+      const tonMessages =
+        popupCall.sendTx.keysign.transactionDetails.tonMessages
 
       expect(tonMessages).toHaveLength(3)
       expect(tonMessages[0].stateInit).toBe('state-init-1')
@@ -331,9 +326,7 @@ describe('TonConnectBridge.send', () => {
     it('should return signed BOC on success', async () => {
       const bocResult = 'te6cckEBAgSignedBoc'
 
-      mockCallPopup.mockResolvedValue([
-        { data: { encoded: bocResult } },
-      ])
+      mockCallPopup.mockResolvedValue([{ data: { encoded: bocResult } }])
 
       const result = await bridge.send(
         makeSendTxRequest({
@@ -351,9 +344,7 @@ describe('TonConnectBridge.send', () => {
     })
 
     it('should pass chain as Ton in the keysign payload', async () => {
-      mockCallPopup.mockResolvedValue([
-        { data: { encoded: 'mock-boc' } },
-      ])
+      mockCallPopup.mockResolvedValue([{ data: { encoded: 'mock-boc' } }])
 
       await bridge.send(
         makeSendTxRequest({
@@ -411,6 +402,36 @@ describe('TonConnectBridge.send', () => {
 
       expect((result as any).error.code).toBe(100)
       expect((result as any).error.message).toBe('Failed to get account')
+    })
+  })
+
+  describe('valid_until passthrough', () => {
+    // The bridge already rejects an expired deadline; the accepted one has to
+    // travel with the messages so the signed expiry can be clamped to it.
+    it('forwards the validated deadline to the popup', async () => {
+      const deadline = validUntil()
+
+      mockCallPopup.mockResolvedValue([
+        { data: { encoded: 'mock-boc-result' } },
+      ])
+
+      await bridge.send(
+        makeSendTxRequest({
+          valid_until: deadline,
+          messages: [
+            {
+              address: 'EQARULUYsmJq1RiZ-YiH-IJLcAZUVkVff-KBPwEmmaQGH6aC',
+              amount: '100000000',
+            },
+          ],
+        })
+      )
+
+      const popupCall = mockCallPopup.mock.calls[0][0]
+
+      expect(popupCall.sendTx.keysign.transactionDetails.tonValidUntil).toBe(
+        deadline
+      )
     })
   })
 })

--- a/core/inpage-provider/popup/view/resolvers/sendTx/interfaces.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/interfaces.ts
@@ -188,6 +188,8 @@ export type TransactionDetails = {
     payload?: string
     stateInit?: string
   }>
+  /** Deadline (unix seconds) the dApp attached to a TonConnect `sendTransaction` (`valid_until`). */
+  tonValidUntil?: number
 }
 
 export type DepositTransactionDetails = {

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/build.test.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/build.test.ts
@@ -1,5 +1,6 @@
 import { Chain } from '@vultisig/core-chain/Chain'
 import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+import { getChainSpecific } from '@vultisig/core-mpc/keysign/chainSpecific'
 import { describe, expect, it, vi } from 'vitest'
 
 import { buildSendTxKeysignPayload } from './build'
@@ -111,5 +112,43 @@ describe('buildSendTxKeysignPayload', () => {
         : []
 
     expect(secondMessage?.stateInit).toBeUndefined()
+  })
+
+  // The dApp's `valid_until` is the only expiry the dApp sees. It has to reach the
+  // chain-specific resolver, which clamps the signed expiry to it.
+  it('passes a TonConnect deadline through to the chain-specific resolver', async () => {
+    const tonValidUntil = 1_753_579_060
+    const message = {
+      to: 'EQDmLe6ticcY_uLZsfurdYONshNuCn8IS81KcJ8p6M6ISJrE',
+      amount: '50000000',
+    }
+
+    await buildSendTxKeysignPayload({
+      parsedTx: {
+        coin: tonCoin,
+        customTxData: {
+          regular: {
+            chain: Chain.Ton,
+            coin: tonCoin,
+            transactionDetails: {
+              from: tonCoin.address,
+              to: message.to,
+              asset: { ticker: tonCoin.ticker },
+              amount: { amount: message.amount, decimals: tonCoin.decimals },
+              tonMessages: [message],
+              tonValidUntil,
+            },
+          },
+        },
+      },
+      publicKey: publicKey as never,
+      walletCore: {} as never,
+      vaultId: 'vault-id',
+      localPartyId: 'local-party',
+    })
+
+    expect(vi.mocked(getChainSpecific)).toHaveBeenLastCalledWith(
+      expect.objectContaining({ validUntil: tonValidUntil })
+    )
   })
 })

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/build.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/build.ts
@@ -134,6 +134,12 @@ export const buildSendTxKeysignPayload = async ({
     }
   }
 
+  const getTonValidUntil = () => {
+    if ('regular' in customTxData) {
+      return customTxData.regular.transactionDetails.tonValidUntil
+    }
+  }
+
   const getTronMeta = () => {
     if ('regular' in customTxData) {
       const { regular } = customTxData
@@ -605,6 +611,7 @@ export const buildSendTxKeysignPayload = async ({
       }),
       transactionType: getTransactionType(),
       timeoutTimestamp: getTimeoutTimestamp(),
+      validUntil: getTonValidUntil(),
       ...getTronMeta(),
       psbt: 'psbt' in customTxData ? customTxData.psbt : undefined,
     })


### PR DESCRIPTION
Fixes #4810

> **Draft until the SDK side ships.** This consumes the `validUntil` input added to `getChainSpecific` in vultisig/vultisig-sdk#2310. Typecheck fails on exactly one line (`build.ts` — `validUntil` is not yet in `GetChainSpecificInput`) until `@vultisig/core-mpc` is released with it and the pin is bumped (#4735). Everything else is green.

## Problem

The TonConnect bridge validates a `sendTransaction` request's `valid_until` (missing, non-finite or already-expired deadlines are rejected) and then drops it: the popup payload carries only the messages, and the keysign build lets the SDK's `getTonChainSpecific` sign `expireAt = now + 600`. The dApp's deadline never reaches the signed wallet message. A request with `valid_until` 60 s out is signed with a ten-minute expiry; if broadcast lands after the dApp's window (slow approval, secure-vault co-signing), the dApp treats it as expired and may retry or re-quote while the chain still accepts the first one.

## Change

- `TransactionDetails.tonValidUntil` — the bridge forwards the validated deadline next to `tonMessages`.
- `buildSendTxKeysignPayload` passes it to `getChainSpecific` as `validUntil`; the SDK resolver signs `min(now + 600, validUntil)` and fails the build for a deadline already in the past. No clamp logic lives in the app.
- Tests: the bridge test asserts the deadline reaches the popup; `build.test.ts` asserts it reaches the chain-specific resolver.

## Which feature is affected?

- [x] Sending — TON dApp (`signTon`) transactions with a `valid_until`

## Parity

- iOS: n/a — no TonConnect connector; co-signers read `expireAt` from the payload, which is what changes here on the initiator.
- Android: n/a — same.
- SDK: linked: vultisig/vultisig-sdk#2310 (the clamp itself).

## Verification

- `yarn workspace @clients/extension vitest run tests/unit/tonConnect-send.test.ts` — 17/17 (new `valid_until passthrough` case included)
- `yarn vitest run core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/build.test.ts` — 3/3
- ESLint clean on all touched files
- `yarn typecheck` — the single expected `TS2353 'validUntil' does not exist in type 'GetChainSpecificInput'` at `build.ts:614`, gone once the SDK pin is bumped

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
