### PR TITLE
fix(quality): bump fast-uri to close new npm audit findings

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "axios": "1.18.1",
     "flatted": "3.4.2",
     "form-data": "4.0.6",
-    "fast-uri@^3.0.1": "3.1.5",
+    "fast-uri@^3.0.1": "3.1.6",
     "linkify-it@^5.0.0": "5.0.2",
     "path-to-regexp": "8.4.2",
     "postcss": "8.5.18",

--- a/scripts/quality-audit.mjs
+++ b/scripts/quality-audit.mjs
@@ -50,26 +50,6 @@ const suppressions = [
     reviewBy: '2026-10-01',
   },
   {
-    id: 1124015,
-    advisory: 'GHSA-4c8g-83qw-93j6',
-    package: 'fast-uri',
-    path: 'ajv > fast-uri',
-    reason:
-      'Host confusion via failed IDN canonicalization. fast-uri is a transitive dep of ajv (JSON-schema tooling); the affected URI host-parsing path is not exercised by our usage. No patched fast-uri (>3.1.3) is resolvable in our dependency tree yet.',
-    owner: 'vultisig/windows',
-    reviewBy: '2026-10-01',
-  },
-  {
-    id: 1124064,
-    advisory: 'GHSA-v2hh-gcrm-f6hx',
-    package: 'fast-uri',
-    path: 'ajv > fast-uri',
-    reason:
-      'Host confusion via a literal backslash authority delimiter — same package and path as 1124015; suppressed together pending the same fast-uri upgrade.',
-    owner: 'vultisig/windows',
-    reviewBy: '2026-10-01',
-  },
-  {
     id: 1124334,
     advisory: 'GHSA-mh99-v99m-4gvg',
     package: 'brace-expansion',

--- a/yarn.lock
+++ b/yarn.lock
@@ -9462,10 +9462,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:3.1.5":
-  version: 3.1.5
-  resolution: "fast-uri@npm:3.1.5"
-  checksum: 10c0/2bf60eb800dd610c65e17be436425dcb21c92aff3a87d442a8bccab0b7b071e88cf1a5d7d1ea946370b937e6fc0375c405c0296c10587e57de4f78be4646d1d0
+"fast-uri@npm:3.1.6":
+  version: 3.1.6
+  resolution: "fast-uri@npm:3.1.6"
+  checksum: 10c0/77fa4f966f7d2cf83c34af2d3eb88882872fe90634f27a6bd309551db65377d3ca55616467c7cb4dcc57e33523d149e2fec1952d51cc2f00bfce68a66c3711ea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- `yarn quality:health` was failing on `quality:audit`: npm audit surfaced 4 new high-severity advisories against `fast-uri@3.1.5` (host confusion / SSRF, reachable via `ajv > fast-uri`)
- Bump the `fast-uri` resolution pin from `3.1.5` to `3.1.6`, which fixes all four
- Drop the now-stale `1124015`/`1124064` suppressions in `scripts/quality-audit.mjs` — those older fast-uri advisories are also resolved by 3.1.6

## Test plan
- [x] `yarn quality:audit` — passes (`No audit suggestions`)
- [x] `yarn quality:health` — all checks exit 0
- [x] `yarn check` — passes

https://claude.ai/code/session_01CBVz7zYbYpcUEgyvnLri5r

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Updated the `fast-uri` package resolution to version 3.1.6.
  - Removed audit suppressions for two advisories affecting `fast-uri`, so they will now be reported by security audits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->