### PR TITLE
fix(swap): price a fee coin the signer does not hold

### DIFF
--- a/core/ui/vault/swap/queries/toPriceableCoin.test.ts
+++ b/core/ui/vault/swap/queries/toPriceableCoin.test.ts
@@ -1,0 +1,79 @@
+import { Chain } from '@vultisig/core-chain/Chain'
+import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+import { describe, expect, it } from 'vitest'
+
+import { toPriceableCoin } from './toPriceableCoin'
+
+const tronInVault: AccountCoin = {
+  chain: Chain.Tron,
+  address: 'TDestination',
+  ticker: 'TRX',
+  decimals: 6,
+  priceProviderId: 'tron-from-vault',
+}
+
+describe('toPriceableCoin', () => {
+  it('prices through the vault coin when the vault holds it', () => {
+    const coin = toPriceableCoin({
+      fee: { chain: Chain.Tron, amount: 143_000_000n, decimals: 8 },
+      vaultCoins: [tronInVault],
+    })
+
+    expect(coin).toBe(tronInVault)
+  })
+
+  it('prices a native fee coin the vault does not hold through the chain fee coin', () => {
+    // A THORChain swap charges its fee in the destination coin, which the
+    // signer often has not added. Dropped from the lookup, the fee priced at
+    // zero and the total lost it (#4815).
+    const coin = toPriceableCoin({
+      fee: { chain: Chain.Tron, amount: 143_000_000n, decimals: 8 },
+      vaultCoins: [],
+    })
+
+    expect(coin).toEqual({
+      chain: Chain.Tron,
+      id: undefined,
+      priceProviderId: 'tron',
+    })
+  })
+
+  it('leaves a token the vault does not hold on its key alone', () => {
+    // No provider id exists to invent for it; the ERC-20 lookup resolves it
+    // from chain and address.
+    const coin = toPriceableCoin({
+      fee: {
+        chain: Chain.Ethereum,
+        id: '0xusdc',
+        amount: 40_000n,
+        decimals: 6,
+      },
+      vaultCoins: [],
+    })
+
+    expect(coin).toEqual({ chain: Chain.Ethereum, id: '0xusdc' })
+  })
+
+  it('matches the vault coin by chain and id, not by chain alone', () => {
+    const usdcInVault: AccountCoin = {
+      chain: Chain.Ethereum,
+      id: '0xusdc',
+      address: '0xsigner',
+      ticker: 'USDC',
+      decimals: 6,
+      priceProviderId: 'usd-coin',
+    }
+
+    const coin = toPriceableCoin({
+      fee: {
+        chain: Chain.Ethereum,
+        id: '0xdai',
+        amount: 40_000n,
+        decimals: 18,
+      },
+      vaultCoins: [usdcInVault],
+    })
+
+    expect(coin).toEqual({ chain: Chain.Ethereum, id: '0xdai' })
+  })
+})

--- a/core/ui/vault/swap/queries/toPriceableCoin.ts
+++ b/core/ui/vault/swap/queries/toPriceableCoin.ts
@@ -1,0 +1,42 @@
+import { AccountCoin } from '@vultisig/core-chain/coin/AccountCoin'
+import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
+import {
+  areEqualCoins,
+  CoinKey,
+  extractCoinKey,
+} from '@vultisig/core-chain/coin/Coin'
+import { SwapFee } from '@vultisig/core-chain/swap/SwapFee'
+
+type PriceableCoin = CoinKey & { priceProviderId?: string }
+
+type ToPriceableCoinInput = {
+  fee: SwapFee
+  vaultCoins: AccountCoin[]
+}
+
+/**
+ * The coin key a swap fee is priced through.
+ *
+ * A fee coin the vault holds carries its own `priceProviderId`. One it does not
+ * hold still has to be priced: a native swap charges its fee in the destination
+ * coin, and a signer approving the swap often has not added that coin yet.
+ * Fees on those coins used to be dropped from the price lookup, which valued
+ * them at zero and quietly shrank the total the signer was shown.
+ *
+ * The chain's fee coin supplies the provider id for a native fee coin. A token
+ * the vault does not hold falls through on its key alone — no provider id is
+ * invented for it — which is what the ERC-20 lookup wants anyway.
+ */
+export const toPriceableCoin = ({
+  fee,
+  vaultCoins,
+}: ToPriceableCoinInput): PriceableCoin => {
+  const vaultCoin = vaultCoins.find(coin => areEqualCoins(coin, fee))
+  if (vaultCoin) return vaultCoin
+
+  const key = extractCoinKey(fee)
+
+  return key.id
+    ? key
+    : { ...key, priceProviderId: chainFeeCoin[key.chain].priceProviderId }
+}

--- a/core/ui/vault/swap/queries/useSwapFiatFeesQuery.ts
+++ b/core/ui/vault/swap/queries/useSwapFiatFeesQuery.ts
@@ -9,15 +9,14 @@ import { sum } from '@vultisig/lib-utils/array/sum'
 import { withoutDuplicates } from '@vultisig/lib-utils/array/withoutDuplicates'
 import { useCallback, useMemo } from 'react'
 
+import { toPriceableCoin } from './toPriceableCoin'
+
 export const useSwapFiatFeesQuery = (value: SwapFee[]) => {
   const vaultCoins = usePortfolioVaultCoins()
   const coins = useMemo(
     () =>
       withoutDuplicates(
-        value.flatMap(key => {
-          const coin = vaultCoins.find(coin => areEqualCoins(coin, key))
-          return coin ? [coin] : []
-        }),
+        value.map(fee => toPriceableCoin({ fee, vaultCoins })),
         areEqualCoins
       ),
     [value, vaultCoins]


### PR DESCRIPTION
## Problem

The swap-fee rows priced a coin only if the vault already held it. `useSwapFiatFeesQuery` looked each `SwapFee` up among the portfolio coins and dropped the ones it could not find, so their price fell to `0` and was summed in silently.

Native swaps charge their fee in the **destination** coin, which a signer approving the swap very often has not added yet — so this was the common case, not an edge one. Observed on a BTC → TRX swap through THORChain, both devices on the same build, TRX absent from the joiner's asset list:

| Row | Initiator | Joiner |
|---|---|---|
| Network Fee | 0.00001035 BTC / $0.80 | 0.00001035 BTC / $0.80 |
| Swap Fee | Protocol Fee $0.47 (+ $0.01 product fee) | **$0.00** |
| Max. Total Fee | **$1.28** | **$0.80** |

A co-signer approved a swap believing it cost $0.48 less than it did.

Closes #4815, a sub-issue of #4362.

## Change

Fees are priced through the coin they name, via `toPriceableCoin`:

- a coin the vault holds still supplies its own `priceProviderId`, so nothing changes for the rows that already worked;
- a **native** fee coin takes the chain fee coin's provider id, which is known statically;
- a **token** the vault does not hold goes through on its key alone — no provider id is invented — which is what the ERC-20 lookup reads anyway.

One row up, `SwapVerifyFiatAmount` already prices whatever coin it is handed, and says so in its JSDoc: "so the joiner, who holds only the payload's coins, renders through the same component as the initiator". The fee query never got that treatment. This closes the gap.

## Deliberately not changed

**An unresolvable price still renders as `$0.00`.** With this fix the observed case resolves, but a coin no price source covers will still read as a definite zero rather than as unknown, and the total will still absorb it silently. That is a product-wide decision about how every fee row states an unknown — it touches the initiator's screens too — so it is left alone here rather than settled as a side effect of a bug fix. Worth its own issue.

## Testing

`toPriceableCoin` is covered directly: vault hit, native miss, token miss, and a same-chain different-token miss (so the match is by chain *and* id, not chain alone). `yarn check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fiat fee pricing for swaps when fee coins are not present in the vault.
  * Native fee coins now use the appropriate price provider, while token fees remain accurately identified without fabricated provider details.
  * Prevented valid swap fees from being omitted when an exact vault-coin match is unavailable.

* **Tests**
  * Added coverage for native coins, missing fee coins, token fees, and chain-and-ID matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->