### PR TITLE
fix: navigate to vault list after deleting a vault

### DIFF
--- a/core/ui/vault/settings/delete/index.tsx
+++ b/core/ui/vault/settings/delete/index.tsx
@@ -42,7 +42,7 @@ export const DeleteVaultPage = () => {
     if (!isDisabled && !isPending) {
       const isLastVault = vaults.length <= 1
       deleteVault(getVaultId(vault), {
-        onSuccess: () => navigate({ id: isLastVault ? 'newVault' : 'vault' }),
+        onSuccess: () => navigate({ id: isLastVault ? 'newVault' : 'vaults' }),
       })
     }
   }


### PR DESCRIPTION
## Summary
- After deleting a vault, the app previously navigated to the `vault` dashboard route (landing on whichever vault became current next) instead of returning the user to the vault list. Now it navigates to `vaults` (the vault list screen), matching the pattern used elsewhere (e.g. vault folder deletion).
- Deleting the last remaining vault still navigates to `newVault`, since there is nothing to list at that point.

## Test Plan
- [ ] Create at least two vaults, delete one, verify the app lands on the vault list screen
- [ ] Delete the last remaining vault, verify the app lands on the new-vault screen
- [x] `yarn check` passes

https://claude.ai/code/session_011b5JnpeKLB9UG2eYWbK7ZU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - After deleting the final vault, the app now navigates to the new-vault setup screen.
  - Deleting a vault when other vaults remain continues to return to the vault list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->