### PR TITLE
fix(storage): enforce foreign keys on every pooled connection and make vault deletion atomic

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -536,21 +536,36 @@ func (s *Store) GetVaults() ([]*Vault, error) {
 
 // DeleteVault deletes a vault and its coins
 func (s *Store) DeleteVault(publicKeyECDSA string) error {
-	if _, err := s.db.Exec("DELETE FROM coins WHERE public_key_ecdsa = ?", publicKeyECDSA); err != nil {
+	// Every delete is one unit: a failure part-way through must not strip a
+	// vault of its keyshares while leaving the vault itself in place, because
+	// no retry can restore that key material.
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("could not begin vault deletion transaction, err: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.Exec("DELETE FROM coins WHERE public_key_ecdsa = ?", publicKeyECDSA); err != nil {
 		return fmt.Errorf("could not delete vault coins: %w", err)
 	}
 	// The ON DELETE CASCADE on these tables already covers them once foreign
 	// keys are on for every pooled connection. Deleting them explicitly keeps
 	// key material from outliving its vault even on a database whose rows
 	// predate that fix, or if the pragma ever regresses again.
-	if _, err := s.db.Exec("DELETE FROM keyshares WHERE public_key_ecdsa = ?", publicKeyECDSA); err != nil {
+	if _, err := tx.Exec("DELETE FROM keyshares WHERE public_key_ecdsa = ?", publicKeyECDSA); err != nil {
 		return fmt.Errorf("could not delete vault keyshares: %w", err)
 	}
-	if _, err := s.db.Exec("DELETE FROM transaction_history WHERE vault_id = ?", publicKeyECDSA); err != nil {
+	if _, err := tx.Exec("DELETE FROM transaction_history WHERE vault_id = ?", publicKeyECDSA); err != nil {
 		return fmt.Errorf("could not delete vault transaction history: %w", err)
 	}
-	_, err := s.db.Exec("DELETE FROM vaults WHERE public_key_ecdsa = ?", publicKeyECDSA)
-	return err
+	if _, err := tx.Exec("DELETE FROM vaults WHERE public_key_ecdsa = ?", publicKeyECDSA); err != nil {
+		return fmt.Errorf("could not delete vault: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("could not commit vault deletion, err: %w", err)
+	}
+	return nil
 }
 
 func (s *Store) GetCoins() (map[string][]Coin, error) {

--- a/storage/store.go
+++ b/storage/store.go
@@ -43,14 +43,15 @@ func NewStore() (*Store, error) {
 		return nil, err
 	}
 
-	db, err := sql.Open("sqlite3", dbFilePath+"?_journal_mode=WAL")
+	// foreign_keys belongs in the DSN rather than a one-off Exec: database/sql
+	// hands out a pool of connections and the pragma is per-connection, so
+	// running it once only configures whichever connection happened to serve
+	// it. Every connection the pool opened later would default to
+	// foreign_keys=off and silently skip the ON DELETE CASCADE that clears a
+	// deleted vault's keyshares, agent tokens and transaction history.
+	db, err := sql.Open("sqlite3", dbFilePath+"?_journal_mode=WAL&_foreign_keys=on")
 	if err != nil {
 		return nil, fmt.Errorf("fail to open sqlite db, err: %w", err)
-	}
-
-	_, err = db.Exec("PRAGMA foreign_keys = ON;")
-	if err != nil {
-		return nil, fmt.Errorf("could not enable foreign key constraints: %w", err)
 	}
 
 	return &Store{
@@ -537,6 +538,16 @@ func (s *Store) GetVaults() ([]*Vault, error) {
 func (s *Store) DeleteVault(publicKeyECDSA string) error {
 	if _, err := s.db.Exec("DELETE FROM coins WHERE public_key_ecdsa = ?", publicKeyECDSA); err != nil {
 		return fmt.Errorf("could not delete vault coins: %w", err)
+	}
+	// The ON DELETE CASCADE on these tables already covers them once foreign
+	// keys are on for every pooled connection. Deleting them explicitly keeps
+	// key material from outliving its vault even on a database whose rows
+	// predate that fix, or if the pragma ever regresses again.
+	if _, err := s.db.Exec("DELETE FROM keyshares WHERE public_key_ecdsa = ?", publicKeyECDSA); err != nil {
+		return fmt.Errorf("could not delete vault keyshares: %w", err)
+	}
+	if _, err := s.db.Exec("DELETE FROM transaction_history WHERE vault_id = ?", publicKeyECDSA); err != nil {
+		return fmt.Errorf("could not delete vault transaction history: %w", err)
 	}
 	_, err := s.db.Exec("DELETE FROM vaults WHERE public_key_ecdsa = ?", publicKeyECDSA)
 	return err

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -461,3 +461,37 @@ func TestForeignKeysEnabledOnEveryPooledConnection(t *testing.T) {
 		}
 	}
 }
+
+func TestDeleteVaultRollsBackWhenTheVaultDeleteFails(t *testing.T) {
+	store := newTestStore(t)
+
+	vault := testVault()
+	if err := store.SaveVault(vault); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fail the final vault delete so the keyshare delete before it has already
+	// landed. Un-transacted, that is the window where a vault survives without
+	// the key material it needs and no retry can bring it back.
+	if _, err := store.db.Exec(`CREATE TRIGGER fail_vault_delete BEFORE DELETE ON vaults
+		BEGIN SELECT RAISE(ABORT, 'forced delete failure'); END;`); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.DeleteVault(vault.PublicKeyECDSA); err == nil {
+		t.Fatal("expected the vault delete to fail")
+	}
+
+	if _, err := store.db.Exec("DROP TRIGGER fail_vault_delete"); err != nil {
+		t.Fatal(err)
+	}
+
+	saved, err := store.GetVault(vault.PublicKeyECDSA)
+	if err != nil {
+		t.Fatalf("vault should still exist after a failed delete: %v", err)
+	}
+	if len(saved.KeyShares) != len(vault.KeyShares) {
+		t.Fatalf("keyshares destroyed by a failed delete: expected %d, got %d",
+			len(vault.KeyShares), len(saved.KeyShares))
+	}
+}

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"database/sql"
 	"path/filepath"
 	"testing"
 	"time"
@@ -341,5 +342,122 @@ func testVault() *Vault {
 		},
 		LocalPartyID: "test-party",
 		LibType:      "DKLS",
+	}
+}
+
+func TestDeleteVaultRemovesChildRowsAcrossPooledConnections(t *testing.T) {
+	store := newTestStore(t)
+
+	// The pragma that enables foreign keys is per-connection, so a pool
+	// serving more than one connection is what exposes the bug: the delete
+	// can land on a connection that never ran it and silently skip the
+	// cascade. Hold several connections open so the pool is forced to grow
+	// past the one that happened to be configured first.
+	const connections = 8
+	store.db.SetMaxOpenConns(connections)
+	store.db.SetMaxIdleConns(connections)
+
+	ctx := context.Background()
+	held := make([]*sql.Conn, 0, connections)
+	for i := 0; i < connections; i++ {
+		conn, err := store.db.Conn(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		held = append(held, conn)
+	}
+	for _, conn := range held {
+		if err := conn.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	vault := testVault()
+	if err := store.SaveVault(vault); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.SaveCoin(vault.PublicKeyECDSA, Coin{
+		ID:              "coin-1",
+		Chain:           "Bitcoin",
+		Address:         "bc1qtest",
+		Ticker:          "BTC",
+		IsNativeToken:   true,
+		Logo:            "btc.png",
+		PriceProviderID: "bitcoin",
+		Decimals:        8,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveTransactionRecord(TransactionRecord{
+		ID:        "tx-1",
+		VaultID:   vault.PublicKeyECDSA,
+		Type:      "send",
+		Status:    "pending",
+		Chain:     "Bitcoin",
+		Timestamp: "2026-06-14T00:00:00Z",
+		TxHash:    "tx-hash-1",
+		Data:      "{}",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.DeleteVault(vault.PublicKeyECDSA); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, table := range []struct {
+		name  string
+		query string
+	}{
+		{"vaults", "SELECT COUNT(*) FROM vaults WHERE public_key_ecdsa = ?"},
+		{"keyshares", "SELECT COUNT(*) FROM keyshares WHERE public_key_ecdsa = ?"},
+		{"coins", "SELECT COUNT(*) FROM coins WHERE public_key_ecdsa = ?"},
+		{"transaction_history", "SELECT COUNT(*) FROM transaction_history WHERE vault_id = ?"},
+	} {
+		var count int
+		if err := store.db.QueryRow(table.query, vault.PublicKeyECDSA).Scan(&count); err != nil {
+			t.Fatal(err)
+		}
+		if count != 0 {
+			t.Errorf("%s left %d orphaned row(s) behind after deleting the vault", table.name, count)
+		}
+	}
+}
+
+func TestForeignKeysEnabledOnEveryPooledConnection(t *testing.T) {
+	store := newTestStore(t)
+
+	const connections = 8
+	store.db.SetMaxOpenConns(connections)
+	store.db.SetMaxIdleConns(connections)
+
+	ctx := context.Background()
+	held := make([]*sql.Conn, 0, connections)
+	t.Cleanup(func() {
+		for _, conn := range held {
+			if err := conn.Close(); err != nil {
+				t.Errorf("could not close probe connection: %v", err)
+			}
+		}
+	})
+
+	// Holding the connections open at once guarantees these are distinct
+	// connections rather than the same one handed back repeatedly.
+	for i := 0; i < connections; i++ {
+		conn, err := store.db.Conn(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		held = append(held, conn)
+	}
+
+	for i, conn := range held {
+		var foreignKeys int
+		if err := conn.QueryRowContext(ctx, "PRAGMA foreign_keys;").Scan(&foreignKeys); err != nil {
+			t.Fatal(err)
+		}
+		if foreignKeys != 1 {
+			t.Errorf("connection %d has foreign_keys off, ON DELETE CASCADE will not run on it", i)
+		}
 	}
 }


### PR DESCRIPTION
Fixes #4822

## Problem

`PRAGMA foreign_keys` is per-connection, but it was executed once against the `database/sql` pool:

```go
db, err := sql.Open("sqlite3", dbFilePath+"?_journal_mode=WAL")
_, err = db.Exec("PRAGMA foreign_keys = ON;")
```

Only whichever connection happened to serve that `Exec` had enforcement on. Every connection the pool opened afterwards defaulted to `foreign_keys=off`.

`DeleteVault` relies on `ON DELETE CASCADE` to clear a vault's keyshares and transaction history, so a delete routed to any other connection silently left those rows behind — key material outliving the vault it belonged to. The failure is probabilistic: it only appears once concurrent queries have grown the pool past one connection, which is why it survived until now.

## Changes

- **`NewStore`** — move the pragma into the DSN as `_foreign_keys=on` (mattn/go-sqlite3 applies it per connection) and drop the one-off `Exec`.
- **`DeleteVault`** — delete `keyshares` and `transaction_history` rows explicitly, as defense in depth, so cleanup no longer depends on a connection-level pragma at all. This also covers databases that already accumulated orphaned rows before this fix.
- **`DeleteVault` atomicity** — those explicit deletes take the function from two statements to four, widening the window where a partial failure strips a vault of its keyshares while the vault row survives. No retry can restore that key material, so the whole deletion now runs in a transaction, following the `Begin` / `defer Rollback` convention `SaveVault` and `ReplaceVault` already use.

## Tests

Three tests, each of which **fails against the code it fixes**:

- `TestDeleteVaultRemovesChildRowsAcrossPooledConnections` — deletes a vault with `SetMaxOpenConns` > 1 and asserts no keyshare, coin or transaction_history rows remain.
- `TestForeignKeysEnabledOnEveryPooledConnection` — holds 8 connections open at once and probes `PRAGMA foreign_keys` on each.
- `TestDeleteVaultRollsBackWhenTheVaultDeleteFails` — forces the final vault delete to fail and asserts the vault and its keyshares survive intact.

Against `main`, the first two report exactly the bug described in the issue:

```
connection 1..7 has foreign_keys off, ON DELETE CASCADE will not run on it
keyshares left 2 orphaned row(s) behind after deleting the vault
transaction_history left 1 orphaned row(s) behind after deleting the vault
```

And against the non-atomic version, the third confirms the data-loss window CodeRabbit flagged:

```
keyshares destroyed by a failed delete: expected 2, got 0
```

## Verification

- `yarn check:all` — exit 0
- `go test ./storage/...` — pass, also under `-race`
- `go build ./...` and `go test ./...` — green

Scoped to the issue: no migration files or unrelated queries touched. The transaction is confined to `DeleteVault` — no shared helper introduced, and the rest of `store.go` is left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vault deletion to consistently remove associated coins, keyshares, and transaction history.
  * Enabled foreign-key enforcement across all database connections to improve data integrity.
  * Ensured incomplete deletion attempts are rolled back, preserving vault data when cleanup fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->