### PR TITLE
fix(swap): show a co-signer the swap's price impact

### DIFF
--- a/core/ui/mpc/keysign/join/tx/JoinKeysignSwapVerify.tsx
+++ b/core/ui/mpc/keysign/join/tx/JoinKeysignSwapVerify.tsx
@@ -1,6 +1,9 @@
 import { ChainEntityIcon } from '@core/ui/chain/coin/icon/ChainEntityIcon'
 import { getSwapProviderLogoSrc } from '@core/ui/chain/metadata/getSwapProviderLogoSrc'
 import { getSwapFeeFromPayload } from '@core/ui/mpc/keysign/tx/swap/getSwapFeeFromPayload'
+import { getSwapPriceImpactFromPayload } from '@core/ui/mpc/keysign/tx/swap/getSwapPriceImpactFromPayload'
+import { formatPriceImpact } from '@core/ui/vault/swap/form/info/priceImpact'
+import { PriceImpactValue } from '@core/ui/vault/swap/form/info/PriceImpactValue'
 import { SwapFeeFiatValue } from '@core/ui/vault/swap/form/info/SwapTotalFeeFiatValue'
 import { getSwapToAmountLimit } from '@core/ui/vault/swap/keysignPayload/getSwapToAmountLimit'
 import { SwapVerifyAmount } from '@core/ui/vault/swap/verify/SwapVerify/SwapVerifyAmount'
@@ -36,7 +39,8 @@ const logoSize = 14
  * The swap fee and the total that includes it render only when the payload
  * carries a fee. An initiator that predates that field leaves it empty, and a
  * co-signer holds no quote to recover it from — showing a total over gas alone
- * would misstate the cost rather than admit it is unknown.
+ * would misstate the cost rather than admit it is unknown. Price impact is
+ * hidden on the same terms, and for the same reason.
  */
 export const JoinKeysignSwapVerify = ({ value }: ValueProp<KeysignPayload>) => {
   const { t } = useTranslation()
@@ -68,6 +72,7 @@ export const JoinKeysignSwapVerify = ({ value }: ValueProp<KeysignPayload>) => {
   const provider = getKeysignSwapProviderName(swapPayload)
   const providerLogoSrc = getSwapProviderLogoSrc(provider)
   const swapFee = getSwapFeeFromPayload(value)
+  const priceImpact = formatPriceImpact(getSwapPriceImpactFromPayload(value))
 
   return (
     <>
@@ -115,6 +120,12 @@ export const JoinKeysignSwapVerify = ({ value }: ValueProp<KeysignPayload>) => {
           label={t('network_fee')}
           value={<JoinKeysignNetworkFeeValue value={value} />}
         />
+        {priceImpact && (
+          <SwapVerifyRow
+            label={t('price_impact')}
+            value={<PriceImpactValue value={priceImpact} />}
+          />
+        )}
         {swapFee && (
           <>
             <SwapVerifyRow

--- a/core/ui/mpc/keysign/tx/swap/getSwapPriceImpactFromPayload.test.ts
+++ b/core/ui/mpc/keysign/tx/swap/getSwapPriceImpactFromPayload.test.ts
@@ -1,0 +1,60 @@
+import { create } from '@bufbuild/protobuf'
+import { OneInchSwapPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/1inch_swap_payload_pb'
+import { KeysignPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { THORChainSwapPayloadSchema } from '@vultisig/core-mpc/types/vultisig/keysign/v1/thorchain_swap_payload_pb'
+import { describe, expect, it } from 'vitest'
+
+import { getSwapPriceImpactFromPayload } from './getSwapPriceImpactFromPayload'
+
+// `slippage_bps` is field 14, added in vultisig/commondata#104. Until the SDK
+// publishes the regenerated type, `create` does not accept it by name, so the
+// fixture attaches it the way a decoded payload carries it.
+const nativePayload = (slippageBps: number | undefined) =>
+  create(KeysignPayloadSchema, {
+    swapPayload: {
+      case: 'thorchainSwapPayload',
+      value: Object.assign(
+        create(THORChainSwapPayloadSchema, { fromAmount: '1000' }),
+        slippageBps === undefined ? {} : { slippageBps }
+      ),
+    },
+  })
+
+describe('getSwapPriceImpactFromPayload', () => {
+  it('reads a native payload as a fraction, matching what the quote produces', () => {
+    // The live ETH.ETH -> BTC.BTC quote the initiator saw: 19 bps.
+    expect(getSwapPriceImpactFromPayload(nativePayload(19))).toBeCloseTo(
+      0.0019,
+      10
+    )
+  })
+
+  it('reports nothing when the payload omits the field', () => {
+    // An initiator on an older build, or on a platform that has not shipped
+    // the field yet. The row has to hide rather than read absence as zero.
+    expect(
+      getSwapPriceImpactFromPayload(nativePayload(undefined))
+    ).toBeUndefined()
+  })
+
+  it('separates an absent impact from a zero one', () => {
+    expect(getSwapPriceImpactFromPayload(nativePayload(0))).toBe(0)
+  })
+
+  it('reports nothing for a general swap, which carries no impact field', () => {
+    const payload = create(KeysignPayloadSchema, {
+      swapPayload: {
+        case: 'oneinchSwapPayload',
+        value: create(OneInchSwapPayloadSchema, { fromAmount: '1000' }),
+      },
+    })
+
+    expect(getSwapPriceImpactFromPayload(payload)).toBeUndefined()
+  })
+
+  it('reports nothing for a payload that is not a swap at all', () => {
+    expect(
+      getSwapPriceImpactFromPayload(create(KeysignPayloadSchema, {}))
+    ).toBeUndefined()
+  })
+})

--- a/core/ui/mpc/keysign/tx/swap/getSwapPriceImpactFromPayload.ts
+++ b/core/ui/mpc/keysign/tx/swap/getSwapPriceImpactFromPayload.ts
@@ -1,0 +1,52 @@
+import { getKeysignSwapPayload } from '@vultisig/core-mpc/keysign/swap/getKeysignSwapPayload'
+import { KeysignSwapPayload } from '@vultisig/core-mpc/keysign/swap/KeysignSwapPayload'
+import { KeysignPayload } from '@vultisig/core-mpc/types/vultisig/keysign/v1/keysign_message_pb'
+import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
+
+const bpsPerUnit = 10_000
+
+type NativeSwapPayload = Extract<
+  KeysignSwapPayload,
+  { native: unknown }
+>['native']
+
+// `slippage_bps` was added to the .proto in vultisig/commondata#104 and is
+// populated by vultisig-sdk#2330. It will appear on the generated
+// `THORChainSwapPayload` type once the SDK publishes a version bundling those
+// regenerated files. Intersecting it in here keeps this compiling against the
+// currently-published @vultisig/core-mpc without an `as` cast: a payload that
+// predates the field is still assignable, and simply reads `undefined`.
+type NativeSwapPayloadWithSlippage = NativeSwapPayload & {
+  slippageBps?: number
+}
+
+const readNativeSlippageBps = ({
+  slippageBps,
+}: NativeSwapPayloadWithSlippage) => slippageBps
+
+/**
+ * Fractional price impact a built `KeysignPayload` carries (`0.0019` == 0.19%
+ * of output lost), in the same units {@link getSwapPriceImpact} produces from a
+ * quote, or `undefined` when the payload does not state one.
+ *
+ * This is the only source available to a co-signer, which holds no quote. The
+ * figure is deliberately not re-derived from the payload's amounts or a fresh
+ * provider call: pools move between initiating and joining, so a second quote
+ * disagrees with the one the initiator approved.
+ *
+ * General swaps carry no impact field yet, so they always report nothing.
+ */
+export const getSwapPriceImpactFromPayload = (
+  payload: KeysignPayload
+): number | undefined => {
+  const swapPayload = getKeysignSwapPayload(payload)
+  if (!swapPayload) return undefined
+
+  return matchRecordUnion<KeysignSwapPayload, number | undefined>(swapPayload, {
+    native: native => {
+      const slippageBps = readNativeSlippageBps(native)
+      return slippageBps === undefined ? undefined : slippageBps / bpsPerUnit
+    },
+    general: () => undefined,
+  })
+}

--- a/core/ui/vault/swap/form/info/PriceImpactValue.tsx
+++ b/core/ui/vault/swap/form/info/PriceImpactValue.tsx
@@ -1,0 +1,43 @@
+import { ValueProp } from '@lib/ui/props'
+import { Text, TextColor } from '@lib/ui/text'
+import { match } from '@vultisig/lib-utils/match'
+import { TFunction } from 'i18next'
+import { useTranslation } from 'react-i18next'
+
+import { PriceImpactDisplay, PriceImpactLevel } from './priceImpact'
+
+const priceImpactColors: Record<PriceImpactLevel, TextColor> = {
+  good: 'primary',
+  average: 'idle',
+  high: 'danger',
+}
+
+type GetPriceImpactLabelInput = {
+  level: PriceImpactLevel
+  t: TFunction
+}
+
+// Keys stay literal so the i18n integrity check can resolve them statically.
+const getPriceImpactLabel = ({ level, t }: GetPriceImpactLabelInput) =>
+  match(level, {
+    good: () => t('price_impact_good'),
+    average: () => t('price_impact_average'),
+    high: () => t('price_impact_high'),
+  })
+
+/**
+ * A formatted price impact with the colour and wording of its band.
+ *
+ * Shared because the initiator reads this figure from the quote it holds and a
+ * co-signer reads it from the keysign payload. Two renderings of one value that
+ * the two devices are meant to agree on cannot be allowed to drift apart.
+ */
+export const PriceImpactValue = ({ value }: ValueProp<PriceImpactDisplay>) => {
+  const { t } = useTranslation()
+
+  return (
+    <Text as="span" color={priceImpactColors[value.level]}>
+      {value.percent} ({getPriceImpactLabel({ level: value.level, t })})
+    </Text>
+  )
+}

--- a/core/ui/vault/swap/form/info/SwapPriceImpactRow.tsx
+++ b/core/ui/vault/swap/form/info/SwapPriceImpactRow.tsx
@@ -1,34 +1,9 @@
-import { Text, TextColor } from '@lib/ui/text'
 import { SwapQuoteResult } from '@vultisig/core-chain/swap/quote/SwapQuote'
-import { match } from '@vultisig/lib-utils/match'
-import { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
 
-import {
-  formatPriceImpact,
-  getSwapPriceImpact,
-  PriceImpactLevel,
-} from './priceImpact'
+import { formatPriceImpact, getSwapPriceImpact } from './priceImpact'
+import { PriceImpactValue } from './PriceImpactValue'
 import { SwapFeeRowRenderer } from './swapFeeRow'
-
-const priceImpactColors: Record<PriceImpactLevel, TextColor> = {
-  good: 'primary',
-  average: 'idle',
-  high: 'danger',
-}
-
-type GetPriceImpactLabelInput = {
-  level: PriceImpactLevel
-  t: TFunction
-}
-
-// Keys stay literal so the i18n integrity check can resolve them statically.
-const getPriceImpactLabel = ({ level, t }: GetPriceImpactLabelInput) =>
-  match(level, {
-    good: () => t('price_impact_good'),
-    average: () => t('price_impact_average'),
-    high: () => t('price_impact_high'),
-  })
 
 type SwapPriceImpactRowProps = {
   renderRow: SwapFeeRowRenderer
@@ -52,12 +27,7 @@ export const SwapPriceImpactRow = ({
     <>
       {renderRow({
         label: t('price_impact'),
-        value: (
-          <Text as="span" color={priceImpactColors[priceImpact.level]}>
-            {priceImpact.percent} (
-            {getPriceImpactLabel({ level: priceImpact.level, t })})
-          </Text>
-        ),
+        value: <PriceImpactValue value={priceImpact} />,
       })}
     </>
   )

--- a/core/ui/vault/swap/form/info/priceImpact.ts
+++ b/core/ui/vault/swap/form/info/priceImpact.ts
@@ -29,7 +29,8 @@ const readNativeSlippageBps = ({
   slippage_bps: slippageBps,
 }: NativeSwapFeesWithSlippage) => slippageBps
 
-type PriceImpactDisplay = {
+/** A price impact rendered for display: signed percentage plus its band. */
+export type PriceImpactDisplay = {
   percent: string
   level: PriceImpactLevel
 }


### PR DESCRIPTION
Closes #4835.

> **Stacked on #4836.** Base is `4831-thorchain-price-impact-slippage`. Retarget to `main` once that merges.

## Problem

A device joining a keysign renders `JoinKeysignSwapVerify` entirely from the `KeysignPayload` — it holds no quote — so every term it shows has to arrive on the wire. Price impact never did:

```
grep -inE "slippage|impact|_bps"  proto/vultisig/keysign/v1/*.proto   ->  0 hits (13 files)
```

So the initiator shows a `Price Impact` row and the joining device shows nothing, on the one screen whose purpose is for both parties to confirm they are approving the same swap.

## Change

- `getSwapPriceImpactFromPayload` reads `slippage_bps` off the native swap payload and returns it in the same fractional units `getSwapPriceImpact` produces from a quote
- `JoinKeysignSwapVerify` renders the row directly under `Network Fee`, matching the initiator's order
- `PriceImpactValue` is extracted from `SwapPriceImpactRow` so the colour and band wording live in one place

The field ships in vultisig/commondata#104 and is populated by vultisig-sdk#2330. It is read through a local type intersection so this compiles against the currently-published `@vultisig/core-mpc` — the same pattern [`getSwapFeeFromPayload`](https://github.com/vultisig/vultisig-windows/blob/main/core/ui/mpc/keysign/tx/swap/getSwapFeeFromPayload.ts) already documents for the swap-fee coin fields. The intersection avoids an `as` cast: a payload predating the field stays assignable and simply reads `undefined`.

MayaChain shares `THORChainSwapPayload`, so one field covers both native swap chains.

## Why carried, not re-fetched

The joiner has everything needed to rebuild the quote request and the screen is not offline — it already runs `useCoinPriceQuery` and `useSwapFiatFeesQuery`. Fetching its own quote would need no proto change and no cross-platform dependency.

It was rejected because pools move between initiating and joining, so a fresh quote returns a different `slippage_bps` than the initiator saw. Price impact would become the only term on that screen where the two devices legitimately disagree, and it would break the invariant the screen is built on: every transaction term comes from the payload, never from a provider. `JoinKeysignSwapTotalFee` states the intent outright — *"so both devices arrive at one figure"*.

## Absence stays absent

An initiator on an older build, or on a platform that has not shipped the field, sends nothing and the row hides. A `uint32 optional` reads back as `undefined`, not `0`, so a missing impact is never rendered as a zero-impact route. The general-swap path carries no impact field yet and reports nothing.

## Verification

`yarn lint`, `yarn knip` clean. `yarn vitest run core/ui/vault/swap core/ui/mpc/keysign` — 634 tests across 51 files, all passing, including 5 new cases covering a payload with the field, one without, a zero impact distinguished from an absent one, a general swap, and a non-swap payload.

`yarn check` passes clean, and `yarn test` is green at 1535 tests across 203 files.

`yarn quality:architecture` reports 5 circular-dependency errors, all inside `clients/extension/dist-station/` — a gitignored local build artifact, not source. CI cruises a clean checkout and does not see it.

## Follow-up

The general-swap path (1inch / LI.FI / SwapKit / KyberSwap) carries its quote in `OneInchTransaction` and would need a parallel field. Most of those providers publish no price impact, so it is deferred rather than overlooked. iOS and Android still need to populate `slippage_bps`; until they do, a swap they initiate leaves the row hidden on our side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

