### PR TITLE
fix(extension): provide a navigation stack to the dApp popup

### DIFF
--- a/core/inpage-provider/popup/app.tsx
+++ b/core/inpage-provider/popup/app.tsx
@@ -3,6 +3,7 @@ import { callNotFoundPopupResult } from '@core/inpage-provider/popup/error'
 import { PopupMethod } from '@core/inpage-provider/popup/interface'
 import { Center } from '@lib/ui/layout/Center'
 import { Spinner } from '@lib/ui/loaders/Spinner'
+import { NavigationProvider } from '@lib/ui/navigation/state'
 import { MatchQuery } from '@lib/ui/query/components/MatchQuery'
 import { useMutation } from '@tanstack/react-query'
 import { getRecordUnionKey } from '@vultisig/lib-utils/record/union/getRecordUnionKey'
@@ -44,44 +45,51 @@ export const PopupApp = () => {
   }, [mutate])
 
   return (
-    <MatchQuery
-      value={mutationState}
-      success={({ call, context }) => {
-        const method = getRecordUnionKey(call) as PopupMethod
-        const input = getRecordUnionValue(call)
+    // The popup has no navigation stack: it renders a single resolver and its
+    // goBack/goHome close the window. The stack is still provided because the
+    // core app shell below reads it, and empty is the honest value — no view
+    // is current here, so the main-app-only branches keyed off the top of the
+    // history correctly do not apply.
+    <NavigationProvider initialValue={{ history: [] }}>
+      <MatchQuery
+        value={mutationState}
+        success={({ call, context }) => {
+          const method = getRecordUnionKey(call) as PopupMethod
+          const input = getRecordUnionValue(call)
 
-        const Resolver = PopupResolvers[method]
+          const Resolver = PopupResolvers[method]
 
-        return (
-          <ExtensionCoreApp
-            goBack={() => window.close()}
-            goHome={() => window.close()}
-            popNavigationHistory={() => {
-              // No navigation stack in this popup; ignore steps and close.
-              window.close()
-            }}
-            targetVaultId={context?.appSession?.vaultId}
-            isLimited={true}
-          >
-            <VaultsOnly>
-              <PopupContextProvider value={context}>
-                <PopupInputProvider value={input}>
-                  <Resolver
-                    input={input}
-                    context={context as any}
-                    onFinish={resolvePopupCall}
-                  />
-                </PopupInputProvider>
-              </PopupContextProvider>
-            </VaultsOnly>
-          </ExtensionCoreApp>
-        )
-      }}
-      pending={() => (
-        <Center>
-          <Spinner />
-        </Center>
-      )}
-    />
+          return (
+            <ExtensionCoreApp
+              goBack={() => window.close()}
+              goHome={() => window.close()}
+              popNavigationHistory={() => {
+                // No navigation stack in this popup; ignore steps and close.
+                window.close()
+              }}
+              targetVaultId={context?.appSession?.vaultId}
+              isLimited={true}
+            >
+              <VaultsOnly>
+                <PopupContextProvider value={context}>
+                  <PopupInputProvider value={input}>
+                    <Resolver
+                      input={input}
+                      context={context as any}
+                      onFinish={resolvePopupCall}
+                    />
+                  </PopupInputProvider>
+                </PopupContextProvider>
+              </VaultsOnly>
+            </ExtensionCoreApp>
+          )
+        }}
+        pending={() => (
+          <Center>
+            <Spinner />
+          </Center>
+        )}
+      />
+    </NavigationProvider>
   )
 }


### PR DESCRIPTION
Fixes #4848

## Problem

The dApp extension popup crashed on mount with `No context provided for Navigation`, on every chain and every popup route.

`RootCurrentVaultProvider` began reading the navigation stack in d1c9ac8 (#4820):

```ts
// core/ui/vault/state/currentVault.tsx:110
const [navigation] = useNavigation()
```

That provider is mounted unconditionally — `CoreApp` → `StorageDependant` → `RootCurrentVaultProvider` — and neither `CoreApp` nor `ExtensionCoreApp` supplies a `NavigationProvider`.

The extension's main entry (`pages/index.tsx`) wraps its app in one, but `pages/popup.tsx` renders `<PopupApp />` bare. The only `NavigationProvider` on the popup path lives inside the sendTx resolver, one level *below* where the throw happens.

## Fix

Wrap the tree `PopupApp` returns in `<NavigationProvider initialValue={{ history: [] }}>`. This sits in `core/inpage-provider/popup/app.tsx` rather than the extension entry file, so every consumer of `PopupApp` is covered.

Empty history is the correct value, not a placeholder: the popup has no navigation stack (its own `popNavigationHistory` says `// No navigation stack in this popup`), and the branches keyed off the top of the history — `isImportView` and `isVaultWritingView` — are main-app-only concerns that must be false here.

Deliberately **not** done:
- `RootCurrentVaultProvider` is untouched, and `useNavigation()` still fails fast on a missing provider — making it tolerant would convert a loud error into a silently wrong branch.
- #4820's fail-closed behavior is unchanged.
- The resolver-level `NavigationProvider` in `sendTx/index.tsx` is left alone; it legitimately shadows the outer one.

## Verification

`yarn lint` ✅ · `yarn test` ✅ 1568 passed (208 files) · `yarn workspace @clients/extension test` ✅ 15 passed · `yarn knip` ✅

A/B against the real dApp approval popup (`specs/dapp-provider.spec.ts`, `network` project, seeded vault):

| | `eth_requestAccounts - grant closure and original account response` |
|---|---|
| **with this fix** | ✅ passes (7 passed in the spec) |
| **without it** | ❌ fails — `popupClosure: "pending"`, popup renders blank and never becomes usable |

Two tests in that spec fail in both states for an unrelated environmental reason: `personal_sign` and the Solana `signTransaction` gate both hang at `Waiting on devices...` / `Resend notification`, which is the MPC co-signing step downstream of popup rendering.

> [!NOTE]
> `yarn check:all` and `yarn build:extension` do not currently pass on `origin/main`, independent of this change: `core/ui/vault/swap/form/info/priceImpact.ts:32` and its test read `slippage_bps`, which the pinned `@vultisig/core-chain@5.2.0` does not declare on `NativeSwapQuote`. Verified by typechecking a clean `origin/main` checkout. To build the extension for the e2e run I applied a temporary local shim for that error and reverted it — this branch contains only the popup fix. With the shim in place, `tsgo --noEmit` was fully clean, confirming this change introduces no type errors.

> [!IMPORTANT]
> #4843 (`fix/4842-popup-navigation-context`) targets the same crash with the opposite approach — a `useOptionalNavigationHistory()` that lets `RootCurrentVaultProvider` tolerate a missing provider, plus a `UnreadableVaultRecovery` split. These two PRs are mutually exclusive and one should be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)