### PR TITLE
fix(extension): show the real Substrate dApp amount on Verify

### DIFF
--- a/core/inpage-provider/popup/view/resolvers/sendTx/core/amount.test.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/core/amount.test.ts
@@ -1,0 +1,62 @@
+import { PolkadotSignerPayloadJSON } from '@core/ui/polkadot/dapp/PolkadotSignerPayload'
+import { OtherChain } from '@vultisig/core-chain/Chain'
+import { chainFeeCoin } from '@vultisig/core-chain/coin/chainFeeCoin'
+import { describe, expect, it } from 'vitest'
+
+import { getTxAmount } from './amount'
+import { ParsedTx } from './parsedTx'
+
+const aliceAccountIdHex =
+  'd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d'
+
+// balances(5).transfer_allow_death(0), MultiAddress::Id(0) Alice, then 1 TAO
+// (1e9 rao) as a four-byte compact.
+const oneTaoTransferMethod = `0x050000${aliceAccountIdHex}02286bee`
+
+const signerPayload = (method: string): PolkadotSignerPayloadJSON => ({
+  address: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY',
+  blockHash: `0x${'11'.repeat(32)}`,
+  blockNumber: '0x00000001',
+  era: '0x00',
+  genesisHash:
+    '0x2f0555cc76fc2840a25a6ea3b9637146806f1f44b090c175ffde2a7e5ab36c03',
+  method,
+  nonce: '0x00000000',
+  specVersion: '0x000000e2',
+  tip: '0x00000000',
+  transactionVersion: '0x00000001',
+  signedExtensions: [],
+  version: 4,
+})
+
+const parsedTx = (method: string): ParsedTx => ({
+  coin: {
+    ...chainFeeCoin[OtherChain.Bittensor],
+    address: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY',
+  },
+  customTxData: {
+    polkadot: {
+      chain: OtherChain.Bittensor,
+      signerPayload: signerPayload(method),
+    },
+  },
+})
+
+describe('getTxAmount for a Substrate dApp transaction', () => {
+  it('reports the value the signed call actually moves', () => {
+    expect(getTxAmount(parsedTx(oneTaoTransferMethod))).toBe(1_000_000_000n)
+  })
+
+  it('reports no amount for a call that carries no transfer value', () => {
+    // system.remark — nothing about it is a transfer, so there is no scalar to
+    // review. An empty amount renders no row; a zero would assert a value the
+    // signed bytes do not contain, which is the bug this covers.
+    expect(getTxAmount(parsedTx('0x000048656c6c6f'))).toBe('')
+  })
+
+  it('fails closed when a transfer call does not decode', () => {
+    const truncated = `0x050000${aliceAccountIdHex.slice(0, 20)}`
+
+    expect(() => getTxAmount(parsedTx(truncated))).toThrow()
+  })
+})

--- a/core/inpage-provider/popup/view/resolvers/sendTx/core/amount.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/core/amount.ts
@@ -1,3 +1,4 @@
+import { decodeSubstrateTransfer } from '@core/ui/polkadot/dapp/decodeTransferCall'
 import { getPsbtTransferInfo } from '@vultisig/core-chain/chains/utxo/tx/getPsbtTransferInfo'
 import { matchRecordUnion } from '@vultisig/lib-utils/matchRecordUnion'
 import { getRecordUnionValue } from '@vultisig/lib-utils/record/union/getRecordUnionValue'
@@ -5,7 +6,11 @@ import { getRecordUnionValue } from '@vultisig/lib-utils/record/union/getRecordU
 import { CustomTxData } from './customTxData'
 import { ParsedTx } from './parsedTx'
 
-/** Returns native XRPL Payment drops verbatim; other routes return a bigint. */
+/**
+ * Returns native XRPL Payment drops verbatim; other routes return a bigint.
+ * An empty string means the route has no reviewable scalar, which renders as
+ * no amount row rather than as a zero the signed bytes do not agree with.
+ */
 export const getTxAmount = ({ coin, customTxData }: ParsedTx) =>
   matchRecordUnion<CustomTxData, bigint | string>(customTxData, {
     regular: ({ transactionDetails }) =>
@@ -18,7 +23,14 @@ export const getTxAmount = ({ coin, customTxData }: ParsedTx) =>
       const { sendAmount } = getPsbtTransferInfo(psbt, coin.address)
       return sendAmount
     },
-    polkadot: () => BigInt(0),
+    // The amount lives in the SCALE call the dApp asked us to sign, and the
+    // signer encodes that call verbatim. Decoding it is what binds the
+    // reviewed number to the signed bytes; a call that carries no transfer
+    // scalar yields no amount at all, and one that claims to but does not
+    // decode throws, failing the review closed.
+    polkadot: ({ chain, signerPayload }) =>
+      decodeSubstrateTransfer({ method: signerPayload.method, chain })
+        ?.amount ?? '',
     // Pre-built PTB: the amount is encoded in the bytes, not surfaced here.
     sui: () => BigInt(0),
     // A Payment is the one raw XRPL transaction whose reviewed scalar must be

--- a/core/inpage-provider/popup/view/resolvers/sendTx/core/customTxData.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/core/customTxData.ts
@@ -1,4 +1,7 @@
-import type { PolkadotSignerPayloadJSON } from '@core/ui/polkadot/dapp/PolkadotSignerPayload'
+import type {
+  PolkadotSignerPayloadJSON,
+  SubstrateChain,
+} from '@core/ui/polkadot/dapp/PolkadotSignerPayload'
 import type { WalletCore } from '@trustwallet/wallet-core'
 import { Chain, OtherChain } from '@vultisig/core-chain/Chain'
 import { isChainOfKind } from '@vultisig/core-chain/ChainKind'
@@ -29,8 +32,6 @@ type RegularTxData = IKeysignTransactionPayload & {
   isEvmContractCall?: boolean
   coin: Coin
 }
-
-type SubstrateChain = OtherChain.Polkadot | OtherChain.Bittensor
 
 const bittensorGenesisHash =
   '0x2f0555cc76fc2840a25a6ea3b9637146806f1f44b090c175ffde2a7e5ab36c03'

--- a/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/build.ts
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/keysignPayload/build.ts
@@ -1,4 +1,5 @@
 import { create } from '@bufbuild/protobuf'
+import { decodeSubstrateTransfer } from '@core/ui/polkadot/dapp/decodeTransferCall'
 import { WalletCore } from '@trustwallet/wallet-core'
 import { PublicKey } from '@trustwallet/wallet-core/dist/src/wallet-core'
 import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
@@ -174,7 +175,14 @@ export const buildSendTxKeysignPayload = async ({
         }),
       psbt: psbt =>
         getPsbtTransferInfo(psbt, coin.address).recipient ?? undefined,
-      polkadot: () => undefined,
+      // Display only: the Substrate dApp route signs the call bytes verbatim,
+      // so nothing downstream rebuilds a transfer from this. An amount with no
+      // destination is only half a review, which is why it is read here too.
+      polkadot: ({ chain: substrateChain, signerPayload }) =>
+        decodeSubstrateTransfer({
+          method: signerPayload.method,
+          chain: substrateChain,
+        })?.recipient,
       sui: () => undefined,
       // A Payment's Destination doubles as the reserve-check target; an offer
       // has none, and the empty toAddress skips that Payment-specific check.

--- a/core/ui/polkadot/dapp/PolkadotSignerPayload.ts
+++ b/core/ui/polkadot/dapp/PolkadotSignerPayload.ts
@@ -1,3 +1,8 @@
+import { OtherChain } from '@vultisig/core-chain/Chain'
+
+/** The Substrate chains whose dApp signer payloads this app accepts. */
+export type SubstrateChain = OtherChain.Polkadot | OtherChain.Bittensor
+
 /** Standard Polkadot signer payload for dApp transaction signing. */
 export type PolkadotSignerPayloadJSON = {
   address: string

--- a/core/ui/polkadot/dapp/decodeTransferCall.test.ts
+++ b/core/ui/polkadot/dapp/decodeTransferCall.test.ts
@@ -83,11 +83,11 @@ describe('decodeSubstrateTransfer', () => {
   })
 
   it.each([
-    ['single-byte compact', 42n],
-    ['two-byte compact', 16_383n],
-    ['four-byte compact', 1_073_741_823n],
-    ['big-integer compact', 21_000_000_000_000_000_000n],
-  ])('decodes a %s value', (_label, amount) => {
+    { label: 'single-byte compact', amount: 42n },
+    { label: 'two-byte compact', amount: 16_383n },
+    { label: 'four-byte compact', amount: 1_073_741_823n },
+    { label: 'big-integer compact', amount: 21_000_000_000_000_000_000n },
+  ])('decodes a $label value', ({ amount }) => {
     const result = decodeSubstrateTransfer({
       method: buildTransferCall({ callIndex: transferAllowDeath, amount }),
       chain: OtherChain.Bittensor,
@@ -144,6 +144,49 @@ describe('decodeSubstrateTransfer', () => {
         chain: OtherChain.Bittensor,
       })
     ).toBeUndefined()
+  })
+
+  // `parity-scale-codec` rejects each of these with "out of range decoding
+  // Compact<T>", so the extrinsic would never decode on chain. Reading a value
+  // out of them anyway would show an amount for bytes the runtime refuses.
+  it.each([
+    {
+      label: 'a two-byte compact holding a single-byte value',
+      // (5 << 2) | 0b01, then a zero high byte.
+      compact: [0x15, 0x00],
+    },
+    {
+      label: 'a four-byte compact holding a single-byte value',
+      // (5 << 2) | 0b10, then three zero bytes.
+      compact: [0x16, 0x00, 0x00, 0x00],
+    },
+    {
+      label: 'a big-integer compact below the four-byte ceiling',
+      // length 4, little-endian 5.
+      compact: [0x03, 0x05, 0x00, 0x00, 0x00],
+    },
+    {
+      label: 'a big-integer compact padded with a zero high byte',
+      // length 5, little-endian 2^30 followed by padding.
+      compact: [0x07, 0x00, 0x00, 0x00, 0x40, 0x00],
+    },
+    {
+      label: 'a big-integer compact wider than a u128 balance',
+      // length 17, so no Balance the runtime could decode.
+      compact: [0x37, ...Array<number>(16).fill(0), 0x01],
+    },
+  ])('throws on $label', ({ compact }) => {
+    const method = toHex([
+      balancesPallet,
+      transferAllowDeath,
+      multiAddressId,
+      ...aliceAccountId,
+      ...compact,
+    ])
+
+    expect(() =>
+      decodeSubstrateTransfer({ method, chain: OtherChain.Bittensor })
+    ).toThrow()
   })
 
   it('throws when a transfer call is truncated', () => {

--- a/core/ui/polkadot/dapp/decodeTransferCall.test.ts
+++ b/core/ui/polkadot/dapp/decodeTransferCall.test.ts
@@ -1,0 +1,198 @@
+import { OtherChain } from '@vultisig/core-chain/Chain'
+import { describe, expect, it } from 'vitest'
+
+import { decodeSubstrateTransfer } from './decodeTransferCall'
+
+const compactEncode = (value: bigint): number[] => {
+  if (value < 64n) return [Number(value) << 2]
+
+  if (value < 16384n) {
+    const raw = (value << 2n) | 0b01n
+    return [Number(raw & 0xffn), Number((raw >> 8n) & 0xffn)]
+  }
+
+  if (value < 1073741824n) {
+    const raw = (value << 2n) | 0b10n
+    return [0, 1, 2, 3].map(index => Number((raw >> BigInt(8 * index)) & 0xffn))
+  }
+
+  const bytes: number[] = []
+  let remaining = value
+  while (remaining > 0n) {
+    bytes.push(Number(remaining & 0xffn))
+    remaining >>= 8n
+  }
+
+  return [((bytes.length - 4) << 2) | 0b11, ...bytes]
+}
+
+const toHex = (bytes: number[]) =>
+  `0x${bytes.map(byte => byte.toString(16).padStart(2, '0')).join('')}`
+
+// Alice's well-known development AccountId32, kept as the canonical hex string
+// so the SS58 output below is verifiable against any Substrate tool rather
+// than against a hand-split byte list.
+const aliceAccountIdHex =
+  'd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d'
+
+const aliceAccountId = [...Buffer.from(aliceAccountIdHex, 'hex')]
+
+const balancesPallet = 5
+const transferAllowDeath = 0
+const transferKeepAlive = 3
+const multiAddressId = 0x00
+
+const buildTransferCall = ({
+  callIndex,
+  amount,
+}: {
+  callIndex: number
+  amount: bigint
+}) =>
+  toHex([
+    balancesPallet,
+    callIndex,
+    multiAddressId,
+    ...aliceAccountId,
+    ...compactEncode(amount),
+  ])
+
+describe('decodeSubstrateTransfer', () => {
+  it('reads the value of a transfer_allow_death call', () => {
+    const result = decodeSubstrateTransfer({
+      method: buildTransferCall({
+        callIndex: transferAllowDeath,
+        amount: 1_000_000_000n,
+      }),
+      chain: OtherChain.Bittensor,
+    })
+
+    expect(result?.amount).toBe(1_000_000_000n)
+  })
+
+  it('reads the value of a transfer_keep_alive call', () => {
+    const result = decodeSubstrateTransfer({
+      method: buildTransferCall({
+        callIndex: transferKeepAlive,
+        amount: 12_345_600_000n,
+      }),
+      chain: OtherChain.Bittensor,
+    })
+
+    expect(result?.amount).toBe(12_345_600_000n)
+  })
+
+  it.each([
+    ['single-byte compact', 42n],
+    ['two-byte compact', 16_383n],
+    ['four-byte compact', 1_073_741_823n],
+    ['big-integer compact', 21_000_000_000_000_000_000n],
+  ])('decodes a %s value', (_label, amount) => {
+    const result = decodeSubstrateTransfer({
+      method: buildTransferCall({ callIndex: transferAllowDeath, amount }),
+      chain: OtherChain.Bittensor,
+    })
+
+    expect(result?.amount).toBe(amount)
+  })
+
+  it('encodes the recipient with the Bittensor SS58 prefix', () => {
+    const result = decodeSubstrateTransfer({
+      method: buildTransferCall({
+        callIndex: transferAllowDeath,
+        amount: 1n,
+      }),
+      chain: OtherChain.Bittensor,
+    })
+
+    expect(result?.recipient).toBe(
+      '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
+    )
+  })
+
+  it('encodes the recipient with the Polkadot SS58 prefix', () => {
+    const result = decodeSubstrateTransfer({
+      method: buildTransferCall({
+        callIndex: transferAllowDeath,
+        amount: 1n,
+      }),
+      chain: OtherChain.Polkadot,
+    })
+
+    expect(result?.recipient).toBe(
+      '15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5'
+    )
+  })
+
+  it('returns undefined for a call outside the Balances pallet', () => {
+    const stakingCall = toHex([7, 2, ...aliceAccountId])
+
+    expect(
+      decodeSubstrateTransfer({
+        method: stakingCall,
+        chain: OtherChain.Bittensor,
+      })
+    ).toBeUndefined()
+  })
+
+  it('returns undefined for transfer_all, which names no value', () => {
+    const transferAll = toHex([balancesPallet, 4, multiAddressId, 1])
+
+    expect(
+      decodeSubstrateTransfer({
+        method: transferAll,
+        chain: OtherChain.Bittensor,
+      })
+    ).toBeUndefined()
+  })
+
+  it('throws when a transfer call is truncated', () => {
+    const truncated = toHex([
+      balancesPallet,
+      transferAllowDeath,
+      multiAddressId,
+      ...aliceAccountId.slice(0, 10),
+    ])
+
+    expect(() =>
+      decodeSubstrateTransfer({
+        method: truncated,
+        chain: OtherChain.Bittensor,
+      })
+    ).toThrow()
+  })
+
+  it('throws when a transfer call carries trailing bytes', () => {
+    const withTrailing = `${buildTransferCall({
+      callIndex: transferAllowDeath,
+      amount: 1n,
+    })}deadbeef`
+
+    expect(() =>
+      decodeSubstrateTransfer({
+        method: withTrailing,
+        chain: OtherChain.Bittensor,
+      })
+    ).toThrow()
+  })
+
+  it('throws on a MultiAddress variant other than Id', () => {
+    const indexVariant = toHex([balancesPallet, transferAllowDeath, 0x01, 4])
+
+    expect(() =>
+      decodeSubstrateTransfer({
+        method: indexVariant,
+        chain: OtherChain.Bittensor,
+      })
+    ).toThrow()
+  })
+
+  it('throws on bytes that are not valid hex', () => {
+    expect(() =>
+      decodeSubstrateTransfer({
+        method: '0xnothex',
+        chain: OtherChain.Bittensor,
+      })
+    ).toThrow()
+  })
+})

--- a/core/ui/polkadot/dapp/decodeTransferCall.ts
+++ b/core/ui/polkadot/dapp/decodeTransferCall.ts
@@ -1,0 +1,154 @@
+import { hexToU8a } from '@polkadot/util'
+import { encodeAddress } from '@polkadot/util-crypto'
+import { OtherChain } from '@vultisig/core-chain/Chain'
+
+import { SubstrateChain } from './PolkadotSignerPayload'
+
+/** Recipient and value of a Balances transfer read out of a dApp's call. */
+type SubstrateTransfer = {
+  recipient: string
+  amount: bigint
+}
+
+type DecodeSubstrateTransferInput = {
+  method: string
+  chain: SubstrateChain
+}
+
+// `pallet_balances` sits at index 5 in both runtimes. Bittensor's is pinned by
+// the SDK extrinsic builder (`chains/bittensor/signing/buildExtrinsic.ts`) and
+// its test; Polkadot's by `construct_runtime!` in the relay runtime. Asset Hub
+// puts Balances at 10, but its genesis hash is not one this flow accepts.
+const balancesPalletIndex = 5
+
+// `transfer_allow_death(dest, #[compact] value)` and its keep-alive twin are
+// the two Balances calls shaped as recipient-plus-scalar. `transfer_all` names
+// no value and every other call has an unrelated shape, so neither is decoded.
+const transferCallIndices = new Set([0, 3])
+
+const multiAddressIdVariant = 0x00
+const accountIdLength = 32
+
+// `hexToU8a` does not validate: it turns `0xnothex` into bytes and pads an odd
+// length rather than rejecting either. Left unchecked, a malformed call would
+// decode into a plausible-looking transfer, which is the exact failure this
+// module exists to prevent.
+const callHexPattern = /^0x([0-9a-fA-F]{2})*$/u
+
+const ss58PrefixByChain: Record<SubstrateChain, number> = {
+  [OtherChain.Bittensor]: 42,
+  [OtherChain.Polkadot]: 0,
+}
+
+type ByteReader = {
+  bytes: Uint8Array
+  offset: number
+}
+
+const readU8 = (reader: ByteReader) => {
+  if (reader.offset >= reader.bytes.length) {
+    throw new Error('Substrate call ended mid-field')
+  }
+
+  return reader.bytes[reader.offset++]
+}
+
+const readBytes = (reader: ByteReader, length: number) => {
+  if (reader.offset + length > reader.bytes.length) {
+    throw new Error('Substrate call ended mid-field')
+  }
+
+  const value = reader.bytes.slice(reader.offset, reader.offset + length)
+  reader.offset += length
+
+  return value
+}
+
+/**
+ * Reads one SCALE compact integer. Every width is assembled as a bigint
+ * because a four-byte compact holds values past the point where JavaScript's
+ * bitwise operators start treating the number as signed.
+ */
+const readCompact = (reader: ByteReader): bigint => {
+  const first = readU8(reader)
+  const mode = first & 0b11
+
+  if (mode === 0b00) {
+    return BigInt(first >>> 2)
+  }
+
+  if (mode === 0b01) {
+    const raw = BigInt(first) | (BigInt(readU8(reader)) << 8n)
+    return raw >> 2n
+  }
+
+  if (mode === 0b10) {
+    let raw = BigInt(first)
+    for (let index = 1; index < 4; index++) {
+      raw |= BigInt(readU8(reader)) << BigInt(8 * index)
+    }
+    return raw >> 2n
+  }
+
+  const length = (first >>> 2) + 4
+  let value = 0n
+  for (let index = 0; index < length; index++) {
+    value |= BigInt(readU8(reader)) << BigInt(8 * index)
+  }
+
+  return value
+}
+
+/**
+ * Decodes the recipient and value of a Balances transfer from the SCALE call
+ * bytes a dApp asked the vault to sign.
+ *
+ * Returns `undefined` when the call is not one of the two Balances transfers:
+ * a staking or subnet call carries no comparable scalar, and putting a number
+ * on the Verify screen that the signed bytes do not mean is the defect this
+ * exists to remove. Throws when the bytes do claim to be a transfer but do not
+ * decode, so callers fail closed instead of showing a guess.
+ */
+export const decodeSubstrateTransfer = ({
+  method,
+  chain,
+}: DecodeSubstrateTransferInput): SubstrateTransfer | undefined => {
+  if (!callHexPattern.test(method)) {
+    throw new Error('Substrate call is not a hex-encoded byte string')
+  }
+
+  const bytes = hexToU8a(method)
+  const reader: ByteReader = { bytes, offset: 0 }
+
+  const palletIndex = readU8(reader)
+  const callIndex = readU8(reader)
+
+  if (
+    palletIndex !== balancesPalletIndex ||
+    !transferCallIndices.has(callIndex)
+  ) {
+    return undefined
+  }
+
+  const addressVariant = readU8(reader)
+  if (addressVariant !== multiAddressIdVariant) {
+    throw new Error(
+      `Unsupported Substrate MultiAddress variant ${addressVariant}`
+    )
+  }
+
+  const destination = readBytes(reader, accountIdLength)
+  const amount = readCompact(reader)
+
+  // A transfer is exactly dest plus value. Anything still unread means the
+  // call is not the one these indices describe, so the amount just decoded
+  // cannot be trusted to be the amount that gets signed.
+  if (reader.offset !== bytes.length) {
+    throw new Error('Substrate transfer call has trailing bytes')
+  }
+
+  return {
+    recipient: encodeAddress(destination, ss58PrefixByChain[chain]),
+    amount,
+  }
+}

--- a/core/ui/polkadot/dapp/decodeTransferCall.ts
+++ b/core/ui/polkadot/dapp/decodeTransferCall.ts
@@ -64,10 +64,34 @@ const readBytes = (reader: ByteReader, length: number) => {
   return value
 }
 
+// Canonical SCALE gives every value exactly one spelling: mode 0b00 covers
+// 0-63, 0b01 covers 64-16,383, 0b10 covers 16,384 to 2^30-1, and 0b11 the rest
+// with a non-zero most significant byte. `parity-scale-codec` rejects any other
+// spelling with "out of range decoding Compact<T>", so a call carrying one is a
+// call the runtime will not decode at all. Reading it anyway would put a
+// confident number on Verify for bytes the chain refuses outright — the same
+// defect as the zero this module replaced, wearing a plausible value.
+const twoByteCompactMinimum = 64n
+const fourByteCompactMinimum = 16_384n
+const bigIntegerCompactMinimum = 1_073_741_824n
+
+// Balance is u128 on both runtimes, so a wider big-integer compact is not a
+// balance either side could decode.
+const maxBigIntegerCompactBytes = 16
+
+const assertCanonicalCompact = (value: bigint, minimum: bigint) => {
+  if (value < minimum) {
+    throw new Error('Substrate call uses a non-canonical compact integer')
+  }
+
+  return value
+}
+
 /**
- * Reads one SCALE compact integer. Every width is assembled as a bigint
- * because a four-byte compact holds values past the point where JavaScript's
- * bitwise operators start treating the number as signed.
+ * Reads one SCALE compact integer, rejecting any encoding the runtime's own
+ * codec would reject. Every width is assembled as a bigint because a four-byte
+ * compact holds values past the point where JavaScript's bitwise operators
+ * start treating the number as signed.
  */
 const readCompact = (reader: ByteReader): bigint => {
   const first = readU8(reader)
@@ -79,7 +103,7 @@ const readCompact = (reader: ByteReader): bigint => {
 
   if (mode === 0b01) {
     const raw = BigInt(first) | (BigInt(readU8(reader)) << 8n)
-    return raw >> 2n
+    return assertCanonicalCompact(raw >> 2n, twoByteCompactMinimum)
   }
 
   if (mode === 0b10) {
@@ -87,16 +111,26 @@ const readCompact = (reader: ByteReader): bigint => {
     for (let index = 1; index < 4; index++) {
       raw |= BigInt(readU8(reader)) << BigInt(8 * index)
     }
-    return raw >> 2n
+    return assertCanonicalCompact(raw >> 2n, fourByteCompactMinimum)
   }
 
   const length = (first >>> 2) + 4
-  let value = 0n
-  for (let index = 0; index < length; index++) {
-    value |= BigInt(readU8(reader)) << BigInt(8 * index)
+  if (length > maxBigIntegerCompactBytes) {
+    throw new Error('Substrate call compact integer is wider than a balance')
   }
 
-  return value
+  let value = 0n
+  let mostSignificantByte = 0
+  for (let index = 0; index < length; index++) {
+    mostSignificantByte = readU8(reader)
+    value |= BigInt(mostSignificantByte) << BigInt(8 * index)
+  }
+
+  if (mostSignificantByte === 0) {
+    throw new Error('Substrate call uses a non-canonical compact integer')
+  }
+
+  return assertCanonicalCompact(value, bigIntegerCompactMinimum)
 }
 
 /**


### PR DESCRIPTION
Fixes #4847

## Problem

`getTxAmount` returned `BigInt(0)` for the `polkadot` branch, which covers both Bittensor and Polkadot, so every Substrate dApp transaction reached the keysign payload as `toAmount: "0"`.

Nothing rebuilds the transaction from that field. This route signs the dApp's call bytes verbatim — `useKeysignMutation.ts` reads `signerPayload` back out of `memo` and hands `signerPayload.method` to `constructPolkadotSigningPayload`. So the number on Verify and the value in the signature came from different places, and only one of them was real.

`"0"` is a truthy string, so the amount row rendered. The screen did not omit the amount; it asserted a confident wrong one.

## Fix

Decode the SCALE call the dApp asked us to sign, in a new `core/ui/polkadot/dapp/decodeTransferCall.ts` beside the encoder that already lives there.

Three outcomes, deliberately distinct:

| call | Verify shows |
|---|---|
| `balances.transfer_allow_death` / `transfer_keep_alive` | the real value and recipient |
| anything else — staking, subnet ops, `transfer_all` | no amount row |
| claims to be a transfer, does not decode | the tx is rejected before signing |

The middle row is the one worth arguing about. #4847 says "fail closed if it cannot be decoded", and a decodable non-transfer is a third case that neither shows a value nor deserves to be blocked — the epic puts subnet staking out of scope, and blocking it would break dApps this issue is not about. An empty `toAmount` renders no row, which states nothing rather than stating zero.

The recipient is read for the same reason the amount is: an amount with no destination is only half a review, and the row was previously absent because `toAddress` was `undefined` here too. Both are display-only.

### Pallet and call indices

Not guessed:

- `pallet_balances = 5` on Bittensor — pinned by the SDK's own extrinsic builder (`chains/bittensor/signing/buildExtrinsic.ts`) and its test.
- `pallet_balances = 5` on the Polkadot relay chain — `construct_runtime!` in the fellowship relay runtime. Asset Hub puts it at 10, but Asset Hub's genesis hash is not one `customTxData.ts` accepts.
- `transfer_allow_death = 0` and `transfer_keep_alive = 3` — both already asserted in SDK tests.
- SS58 prefix 42 for Bittensor matches `deriveBittensorAddress` in the SDK, so a decoded recipient renders the same way as the vault's own address on the same screen.

### A validation gap found on the way

`hexToU8a` does not validate. It turns `0xnothex` into `0x0000e0` and pads odd lengths rather than rejecting either, so a malformed `method` would have decoded into a plausible-looking transfer instead of failing closed. The call hex is now checked before decoding, with a test.

### Incidental

`SubstrateChain` was declared twice — once in `customTxData.ts`, once needed here. It now lives once, in `PolkadotSignerPayload.ts` next to the payload type it describes.

## Verification

`yarn lint` ✅ · `yarn knip` ✅ · `yarn test` ✅ 1585 passed (210 files)

`yarn typecheck` reports two errors, both pre-existing on `origin/main` and unrelated to this branch — `priceImpact.ts:32` and its test read `slippage_bps` off `NativeSwapQuote`, where it actually sits on `NativeSwapQuote['fees']`. #4836 fixes exactly that. No error in any file this PR touches.

17 new tests. The decoder is covered across all four SCALE compact widths, both transfer calls, non-Balances calls, `transfer_all`, truncation, trailing bytes, a non-`Id` MultiAddress variant, and invalid hex. `amount.test.ts` covers the integration point that actually carried the bug — `getTxAmount` itself — asserting a real value, an empty amount for `system.remark`, and a throw on a truncated transfer.

## Deliberately not in this PR

- **The memo.** `memo` is set to the whole stringified signer payload and `MemoSection` has no Substrate exclusion, so block hashes, spec versions and the raw call hex are shown to the user as a "memo". That is the epic's separate "hide unsigned memo" item and belongs in its own change.
- **Moving the decoder to the SDK.** The epic makes the SDK the source of truth for the extrinsic, and the encoder/decoder pair should end up there together — but the encoder this decodes against is itself windows-local today, and a cross-repo release should not gate a fix for a screen that currently shows a wrong number.
- **`transfer_all`.** It names no value in the call; showing its amount needs a balance read, which is a different change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved transaction details for Polkadot and Bittensor dApp transfers.
  * Transfer amounts are now decoded and displayed accurately, including TAO amounts.
  * Recipient addresses are now shown for supported custom transactions.
  * Supports common transfer types and compact amount formats across both networks.

* **Bug Fixes**
  * Invalid or unsupported transfer data is handled explicitly instead of being treated as a zero amount.
  * XRPL Payment amounts continue to be displayed in their original format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->