### PR TITLE
fix(send): hide the memo field on Bittensor

### DIFF
--- a/core/ui/vault/send/memo/ManageMemo.tsx
+++ b/core/ui/vault/send/memo/ManageMemo.tsx
@@ -16,7 +16,12 @@ import styled from 'styled-components'
 
 import { TextInputWithPasteAction } from '../../../components/TextInputWithPasteAction'
 
-const chainsWithoutMemoSupport: Chain[] = [Chain.Sui]
+/**
+ * Chains whose transfer transaction has no field to carry a memo, so the
+ * input would silently be dropped at signing time. Bittensor's balance
+ * transfer extrinsic has no remark, and Sui transfers carry no memo.
+ */
+const chainsWithoutMemoSupport: Chain[] = [Chain.Sui, Chain.Bittensor]
 
 export const ManageMemo = () => {
   const [value, setValue] = useSendMemo()


### PR DESCRIPTION
Fixes #4846

## Problem

`ManageMemo` rendered the memo field for every chain except Sui. The Bittensor (TAO) balance transfer extrinsic has no remark field, so a memo entered on a TAO send was collected in the UI and then silently dropped at signing time.

Verified before changing anything: searching `@vultisig/core-chain` for memo consumption turns up only the THORChain/swap, Solana, UTXO and EVM paths. No Polkadot/Substrate code path reads the send memo — exactly the Sui situation the list already handles.

## Change

One line in `core/ui/vault/send/memo/ManageMemo.tsx` — add `Chain.Bittensor` to `chainsWithoutMemoSupport`, plus JSDoc stating the criterion for the list (no field in the transaction to carry a memo) so the next chain added has a stated rule rather than an unexplained list.

```ts
const chainsWithoutMemoSupport: Chain[] = [Chain.Sui, Chain.Bittensor]
```

The list is defined and used in this single file, so no other call site needed updating.

## Out of scope

Memo state lives in the `send` view state (`useSendMemo`), not in the component, so a memo typed on another chain persists in state if the user then switches to Bittensor. It is now invisible and unreachable, and since nothing on the Bittensor path reads it, it cannot reach the extrinsic. Clearing the memo on chain switch would be a separate change.

## Validation

`yarn check` passes — typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)