### PR TITLE
feat(history): name both legs on swap and limit history cards

### DIFF
--- a/core/ui/transaction-history/TransactionHistoryCard/TransactionHistoryCard.stories.tsx
+++ b/core/ui/transaction-history/TransactionHistoryCard/TransactionHistoryCard.stories.tsx
@@ -32,8 +32,7 @@ const solAddress = 'HN7cABqLq46Es1jh92dQQisAq662SmxELLLsHHe4YWrH'
 
 /**
  * The pill icon the app always supplies, which is what makes a provider pill
- * stand a full icon slot tall. A story without it renders a shorter pill and
- * cannot show whether the error message clears one.
+ * stand a full icon slot tall. A story without it renders a shorter pill.
  */
 const providerPillIcon = (
   <ChainEntityIcon
@@ -71,7 +70,7 @@ export const AllCards: Story = {
       <TransactionHistoryCard
         tagType="send"
         status="successful"
-        amountUsd="$1,000.54"
+        subAmount="$1,000.54"
         amountCrypto="1,000.12"
         symbol="RUNE"
         pill={{ direction: 'to', address: ethAddress }}
@@ -80,7 +79,7 @@ export const AllCards: Story = {
       <TransactionHistoryCard
         tagType="receive"
         status="successful"
-        amountUsd="$12,204.56"
+        subAmount="$12,204.56"
         amountCrypto="200.50"
         symbol="SOL"
         pill={{ direction: 'from', address: solAddress }}
@@ -89,16 +88,16 @@ export const AllCards: Story = {
       <TransactionHistoryCard
         tagType="swap"
         status="successful"
-        amountUsd="$34,752.57"
-        amountCrypto="20.50"
+        subAmount="-34,752.57 USDC"
+        amountCrypto="+20.50"
         symbol="ETH"
-        pill={{ providerName: 'THORChain' }}
+        pill={{ fromTicker: 'USDC', toTicker: 'ETH' }}
         coin={ethCoin}
       />
       <TransactionHistoryCard
         tagType="send"
         status="error"
-        amountUsd="$1,000.54"
+        subAmount="$1,000.54"
         amountCrypto="1,000.12"
         symbol="RUNE"
         pill={{ direction: 'to', address: ethAddress }}
@@ -108,20 +107,19 @@ export const AllCards: Story = {
       <TransactionHistoryCard
         tagType="swap"
         status="error"
-        amountUsd="$34,752.57"
-        amountCrypto="20.50"
+        subAmount="-34,752.57 USDC"
+        amountCrypto="+20.50"
         symbol="ETH"
-        pill={{ providerName: 'THORChain' }}
+        pill={{ fromTicker: 'USDC', toTicker: 'ETH' }}
+        errorMessage="Slippage tolerance exceeded"
         coin={ethCoin}
       />
       <TransactionHistoryCard
-        tagType="swap"
-        status="error"
-        amountUsd="$34,752.57"
-        amountCrypto="20.50"
-        symbol="ETH"
+        tagType="approve"
+        status="successful"
+        amountCrypto="0.05"
+        symbol="TRX"
         pill={{ providerName: 'LI.FI', pillIcon: providerPillIcon }}
-        errorMessage="Price moved past slippage tolerance"
         coin={ethCoin}
       />
     </div>
@@ -133,10 +131,10 @@ export const TokenWithChainBadge: Story = {
   args: {
     tagType: 'swap',
     status: 'successful',
-    amountUsd: '$39.99',
-    amountCrypto: '40',
+    subAmount: '-0.02 ETH',
+    amountCrypto: '+40',
     symbol: 'USDC',
-    pill: { providerName: 'THORChain' },
+    pill: { fromTicker: 'ETH', toTicker: 'USDC' },
   },
   render: args => <TransactionHistoryCard {...args} coin={usdcCoin} />,
 }
@@ -145,7 +143,7 @@ export const SuccessfulSend: Story = {
   args: {
     tagType: 'send' as TransactionHistoryTagType,
     status: 'successful',
-    amountUsd: '$1,000.54',
+    subAmount: '$1,000.54',
     amountCrypto: '1,000.12',
     symbol: 'RUNE',
     pill: { direction: 'to' as const, address: ethAddress },
@@ -157,7 +155,7 @@ export const ErrorWithMessage: Story = {
   args: {
     tagType: 'send',
     status: 'error',
-    amountUsd: '$1,000.54',
+    subAmount: '$1,000.54',
     amountCrypto: '1,000.12',
     symbol: 'RUNE',
     pill: { direction: 'to', address: ethAddress },
@@ -166,17 +164,32 @@ export const ErrorWithMessage: Story = {
   render: args => <TransactionHistoryCard {...args} coin={runeCoin} />,
 }
 
-/** A failed swap explains itself while the provider pill still owns the card's
- *  bottom-right corner — the one combination where the two can collide. */
-export const ErrorWithMessageAndProviderPill: Story = {
+/** A swap names both legs: what it bought on top, what it gave up beneath, and
+ *  the pair in the pill. The failure reason stacks under the status. */
+export const FailedSwapWithBothLegs: Story = {
   args: {
     tagType: 'swap',
     status: 'error',
-    amountUsd: '$34,752.57',
-    amountCrypto: '20.50',
+    subAmount: '-34,752.57 USDC',
+    amountCrypto: '+20.50',
     symbol: 'ETH',
-    pill: { providerName: 'LI.FI', pillIcon: providerPillIcon },
+    pill: { fromTicker: 'USDC', toTicker: 'ETH' },
     errorMessage: 'Price moved past slippage tolerance',
   },
   render: args => <TransactionHistoryCard {...args} coin={ethCoin} />,
+}
+
+/** A limit order still resting: nothing has been paid out, so the row prints
+ *  what it put up and its fiat value, while the pill still names the pair. */
+export const RestingLimitOrder: Story = {
+  args: {
+    tagType: 'swap',
+    status: 'pending',
+    statusLabel: 'Open',
+    subAmount: '$34,752.57',
+    amountCrypto: '34,752.57',
+    symbol: 'USDC',
+    pill: { fromTicker: 'USDC', toTicker: 'ETH' },
+  },
+  render: args => <TransactionHistoryCard {...args} coin={usdcCoin} />,
 }

--- a/core/ui/transaction-history/TransactionHistoryCard/TransactionHistoryCard.tsx
+++ b/core/ui/transaction-history/TransactionHistoryCard/TransactionHistoryCard.tsx
@@ -10,15 +10,15 @@ import {
   type TransactionHistoryTagType,
 } from '../TransactionHistoryTag'
 import {
-  AddressPill,
   AmountBlock,
   AmountTextStack,
   Card,
   DetailsRow,
-  ErrorMessageRow,
   IconSlot,
+  InlinePill,
   ProviderPill,
   StatusLabel,
+  StatusStack,
   TopRow,
 } from './styles'
 
@@ -47,6 +47,12 @@ export type TransactionHistoryCardPill =
       /** Optional icon shown before the label. */
       pillIcon?: ReactNode
     }
+  | {
+      /** Ticker sold, e.g. "USDC". */
+      fromTicker: string
+      /** Ticker bought, e.g. "SOL". */
+      toTicker: string
+    }
 
 export type TransactionHistoryCardProps = {
   /** Transaction type shown in the tag (send, receive, swap, approve). */
@@ -62,17 +68,18 @@ export type TransactionHistoryCardProps = {
    */
   statusLabel?: string
   /**
-   * USD amount, e.g. "$1,000.54". Omit for records that move no value — the
-   * line is dropped entirely rather than rendered blank.
+   * The line under the amount: a transfer prints its fiat value ("$1,000.54"),
+   * a swap prints the leg it gave up ("-220.192 USDC"). Omit for records that
+   * move no value — the line is dropped entirely rather than rendered blank.
    */
-  amountUsd?: string
-  /** Crypto amount without symbol, e.g. "1,000.12". */
+  subAmount?: string
+  /** Crypto amount without symbol, e.g. "1,000.12". May carry a leading sign. */
   amountCrypto: string
   /** Symbol, e.g. "RUNE", "SOL", "ETH". */
   symbol: string
   /** Content for the info pill. */
   pill: TransactionHistoryCardPill
-  /** Optional error message shown below details when status is "error" (aligned right). */
+  /** Optional failure reason, shown under the status label when status is "error". */
   errorMessage?: string
   /**
    * Optional coin for the 24px asset icon (same approach as CoinIcon in codebase).
@@ -88,7 +95,7 @@ export const TransactionHistoryCard = ({
   tagLabel,
   status,
   statusLabel,
-  amountUsd,
+  subAmount,
   amountCrypto,
   symbol,
   pill,
@@ -107,13 +114,18 @@ export const TransactionHistoryCard = ({
   const assetIcon =
     coin != null ? <CoinIcon coin={coin} style={{ fontSize: 24 }} /> : icon
 
-  const isProviderPill = 'providerName' in pill
-
   return (
     <Card>
       <TopRow>
         <TransactionHistoryTag type={tagType} label={tagLabel} />
-        <StatusLabel $status={status}>{resolvedStatusLabel}</StatusLabel>
+        <StatusStack>
+          <StatusLabel $status={status}>{resolvedStatusLabel}</StatusLabel>
+          {status === 'error' && errorMessage ? (
+            <Text variant="caption" color="danger">
+              {errorMessage}
+            </Text>
+          ) : null}
+        </StatusStack>
       </TopRow>
 
       <DetailsRow>
@@ -126,34 +138,33 @@ export const TransactionHistoryCard = ({
                 {symbol}
               </Text>
             </Text>
-            {amountUsd ? (
+            {subAmount ? (
               <Text variant="footnote" color="shy">
-                {amountUsd}
+                {subAmount}
               </Text>
             ) : null}
           </AmountTextStack>
         </AmountBlock>
         {'direction' in pill && (
-          <AddressPill>
+          <InlinePill>
             <Text variant="caption" color="shy">
               {`${t(pill.direction)} `}
             </Text>
             <Text variant="caption" color="regular">
               {truncateId(pill.address)}
             </Text>
-          </AddressPill>
+          </InlinePill>
+        )}
+        {'fromTicker' in pill && (
+          <InlinePill>
+            <Text variant="caption" color="regular">
+              {`${pill.fromTicker} → ${pill.toTicker}`}
+            </Text>
+          </InlinePill>
         )}
       </DetailsRow>
 
-      {status === 'error' && errorMessage != null && errorMessage !== '' && (
-        <ErrorMessageRow $clearsProviderPill={isProviderPill}>
-          <Text variant="caption" color="danger">
-            {errorMessage}
-          </Text>
-        </ErrorMessageRow>
-      )}
-
-      {isProviderPill && (
+      {'providerName' in pill && (
         <ProviderPill>
           {pill.pillIcon != null && <IconSlot>{pill.pillIcon}</IconSlot>}
           <Text variant="caption" color="shy">

--- a/core/ui/transaction-history/TransactionHistoryCard/styles.ts
+++ b/core/ui/transaction-history/TransactionHistoryCard/styles.ts
@@ -1,7 +1,7 @@
 import { borderRadius, borderRadiusPx } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { getColor, matchColor } from '@lib/ui/theme/getters'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 
 import type { TransactionHistoryCardStatus } from './TransactionHistoryCard'
 
@@ -9,17 +9,6 @@ const cardPaddingPx = 16
 const iconSlotPx = 24
 const providerPillPaddingYPx = 8
 const providerPillBorderPx = 1
-
-// The icon slot is the tallest thing the pill ever holds, so it sets the pill's
-// height — and the pill is absolutely positioned over the card's bottom-right
-// corner, overhanging the card's own bottom padding by the difference.
-const providerPillHeightPx =
-  providerPillPaddingYPx * 2 + iconSlotPx + providerPillBorderPx
-
-const errorRowPillGapPx = 8
-
-const errorRowPillClearancePx =
-  providerPillHeightPx - cardPaddingPx + errorRowPillGapPx
 
 /** Card: foreground bg, foregroundExtra border, 16px padding, 16px radius. Figma: surface-1 #061b3a, borders/light #11284a */
 export const Card = styled(VStack).attrs({
@@ -37,13 +26,28 @@ export const Card = styled(VStack).attrs({
   overflow: hidden;
 `
 
-/** Row 1: tag (left) + status (right). Space-between, align center. */
+/** Row 1: tag (left) + status stack (right). Space-between, align center. */
 export const TopRow = styled(HStack).attrs({
   direction: 'horizontal',
   alignItems: 'center',
   justifyContent: 'space-between',
+  gap: 8,
 })`
   width: 100%;
+`
+
+/**
+ * Right side of the top row: the status label and, when there is one, the
+ * reason it failed. The reason belongs to the status rather than to the
+ * amounts, so it is stacked under it instead of trailing the card.
+ */
+export const StatusStack = styled(VStack).attrs({
+  direction: 'vertical',
+  alignItems: 'end',
+  gap: 2,
+})`
+  min-width: 0;
+  text-align: right;
 `
 
 /** Status label: 12px caption. Successful = green, Pending = neutral, Error = red. */
@@ -61,11 +65,12 @@ export const StatusLabel = styled.span<{
   })};
 `
 
-/** Row 2: amount block (left) + address pill (right). Space-between. */
+/** Row 2: amount block (left) + inline pill (right). Space-between. */
 export const DetailsRow = styled(HStack).attrs({
   direction: 'horizontal',
   alignItems: 'center',
   justifyContent: 'space-between',
+  gap: 8,
 })`
   width: 100%;
 `
@@ -102,8 +107,8 @@ export const AmountTextStack = styled(VStack).attrs({
   gap: 0,
 })``
 
-/** Address pill: surface-2 bg, borders/normal border. px 16 py 8, radius 99px. Gap between prefix and address (Figma ~4px). */
-export const AddressPill = styled(HStack).attrs({
+/** Pill sitting on the right of the details row — a counterparty address or a swap's asset pair. surface-2 bg, borders/normal border, px 16 py 8. */
+export const InlinePill = styled(HStack).attrs({
   direction: 'horizontal',
   alignItems: 'center',
   gap: 4,
@@ -113,27 +118,6 @@ export const AddressPill = styled(HStack).attrs({
   background: ${getColor('buttonSecondary')};
   border: 1px solid ${getColor('foregroundExtra')};
   flex-shrink: 0;
-`
-
-/**
- * Error message row: aligned to the right, and lifted clear of the provider
- * pill when there is one. The pill is absolutely positioned over the card's
- * bottom-right corner, so a last flow child sitting on the card's own padding
- * would be printed underneath it — the clearance is measured off the pill
- * itself rather than eyeballed, because a pill carrying an icon stands taller
- * than one that does not.
- */
-export const ErrorMessageRow = styled(HStack).attrs({
-  direction: 'horizontal',
-  alignItems: 'center',
-  justifyContent: 'flex-end',
-})<{ $clearsProviderPill: boolean }>`
-  width: 100%;
-  ${({ $clearsProviderPill }) =>
-    $clearsProviderPill &&
-    css`
-      margin-bottom: ${errorRowPillClearancePx}px;
-    `}
 `
 
 /** Provider pill: anchored to the bottom-right corner of the card with asymmetric border radius. */

--- a/core/ui/transaction-history/list/TransactionRecordCard.tsx
+++ b/core/ui/transaction-history/list/TransactionRecordCard.tsx
@@ -2,9 +2,11 @@ import { ChainEntityIcon } from '@core/ui/chain/coin/icon/ChainEntityIcon'
 import { useCoinPricesQuery } from '@core/ui/chain/coin/price/queries/useCoinPricesQuery'
 import { useFormatFiatAmount } from '@core/ui/chain/hooks/useFormatFiatAmount'
 import { getChainLogoSrc } from '@core/ui/chain/metadata/getChainLogoSrc'
+import { getLimitOrderBuyCoin } from '@core/ui/mpc/keysign/join/tx/limitOrderBuyCoin'
 import { useCoreNavigate } from '@core/ui/navigation/hooks/useCoreNavigate'
 import { getTronClaimChainAmountDisplay } from '@core/ui/vault/deposit/tron/withdrawExpireUnfreeze'
 import { useCurrentVaultCoins } from '@core/ui/vault/state/currentVaultCoins'
+import { fromThorchainFixedPoint } from '@core/ui/vault/swap/limit/amount'
 import { useLimitOrderStatusLabels } from '@core/ui/vault/swap/limit/tracking/presentation'
 import { fromChainAmount } from '@vultisig/core-chain/amount/fromChainAmount'
 import { Chain } from '@vultisig/core-chain/Chain'
@@ -63,8 +65,14 @@ const statusToCardStatus: Record<
 type TransactionDisplayData = {
   tagType: TransactionHistoryTagType
   amountCrypto: string
+  /** The amount the fiat line prices, denominated in `getCoinKey`'s coin. */
   cryptoAmount: number
   symbol: string
+  /**
+   * The line under the amount, when the row prints one of its own instead of
+   * a fiat value. A swap prints the leg it gave up here.
+   */
+  subAmount?: string
   pill: TransactionHistoryCardPill
   coin: (CoinKey & { logo: string }) | undefined
   /** Cosmos message typeUrl driving the tag label, when present. */
@@ -100,57 +108,82 @@ const getProviderPill = ({
 
 const getDisplayData = (record: TransactionRecord): TransactionDisplayData => {
   if (record.type === 'swap') {
-    const rawAmount = Number(
-      fromChainAmount(BigInt(record.data.fromAmount), record.data.fromDecimals)
+    const { data } = record
+    const soldAmount = Number(
+      fromChainAmount(BigInt(data.fromAmount), data.fromDecimals)
     )
-
-    const pill: TransactionHistoryCardPill = record.data.provider
-      ? getProviderPill({
-          provider: record.data.provider,
-          fromChain: record.data.fromChain,
-        })
-      : getProviderPill({
-          provider: record.data.toChain,
-          fromChain: record.data.fromChain,
-        })
+    // Already a decimal string in the buy asset's own units, unlike the sell
+    // side, which the payload carries in the sell coin's smallest units.
+    const boughtAmount = Number(data.toAmount)
 
     return {
       tagType: 'swap',
-      amountCrypto: formatCryptoAmount(rawAmount),
-      cryptoAmount: rawAmount,
-      symbol: record.data.fromToken,
-      pill,
-      coin: record.data.fromTokenLogo
+      amountCrypto: `+${formatCryptoAmount(boughtAmount)}`,
+      cryptoAmount: soldAmount,
+      symbol: data.toToken,
+      subAmount: `-${formatCryptoAmount(soldAmount)} ${data.fromToken}`,
+      pill: { fromTicker: data.fromToken, toTicker: data.toToken },
+      coin: data.toTokenLogo
         ? {
-            chain: record.data.fromChain,
-            id: record.data.fromTokenId,
-            logo: record.data.fromTokenLogo,
+            chain: data.toChain,
+            id: data.toTokenId,
+            logo: data.toTokenLogo,
           }
         : undefined,
     }
   }
 
   if (record.type === 'limitSwap') {
-    const rawAmount = Number(
-      fromChainAmount(BigInt(record.data.fromAmount), record.data.fromDecimals)
+    const { data } = record
+    const soldAmount = Number(
+      fromChainAmount(BigInt(data.fromAmount), data.fromDecimals)
     )
+    const sellCoin = data.fromTokenLogo
+      ? {
+          chain: data.fromChain,
+          id: data.fromTokenId,
+          logo: data.fromTokenLogo,
+        }
+      : undefined
+    // The pill names both assets whatever the order did — an open order still
+    // says which pair it is for.
+    const pill: TransactionHistoryCardPill = {
+      fromTicker: data.fromToken,
+      toTicker: data.buyTicker,
+    }
+
+    // Only the queue's own payout accounting counts as received. An order that
+    // has not filled keeps printing what it put up, because `minimumReceived`
+    // is a floor it may never reach, and printing it as the buy leg would read
+    // as a payout that has already happened.
+    const filledAmount =
+      data.amountOut && data.amountOut !== '0'
+        ? fromThorchainFixedPoint(data.amountOut)
+        : undefined
+
+    if (filledAmount === undefined) {
+      return {
+        tagType: 'swap',
+        amountCrypto: formatCryptoAmount(soldAmount),
+        cryptoAmount: soldAmount,
+        symbol: data.fromToken,
+        pill,
+        coin: sellCoin,
+      }
+    }
+
+    const buyCoin = getLimitOrderBuyCoin({ targetAsset: data.targetAsset })
 
     return {
       tagType: 'swap',
-      amountCrypto: formatCryptoAmount(rawAmount),
-      cryptoAmount: rawAmount,
-      symbol: record.data.fromToken,
-      pill: getProviderPill({
-        provider: Chain.THORChain,
-        fromChain: record.data.fromChain,
-      }),
-      coin: record.data.fromTokenLogo
-        ? {
-            chain: record.data.fromChain,
-            id: record.data.fromTokenId,
-            logo: record.data.fromTokenLogo,
-          }
-        : undefined,
+      amountCrypto: `+${formatCryptoAmount(filledAmount)}`,
+      cryptoAmount: soldAmount,
+      symbol: data.buyTicker,
+      subAmount: `-${formatCryptoAmount(soldAmount)} ${data.fromToken}`,
+      pill,
+      coin: buyCoin?.logo
+        ? { chain: buyCoin.chain, id: buyCoin.id, logo: buyCoin.logo }
+        : sellCoin,
     }
   }
 
@@ -267,7 +300,7 @@ export const TransactionRecordCard = ({
   const isTronClaim =
     record.type === 'send' &&
     record.data.operation === 'tronWithdrawExpireUnfreeze'
-  const amountUsd = useFiatDisplay(record, display.cryptoAmount)
+  const fiatAmount = useFiatDisplay(record, display.cryptoAmount)
   // `send` and `swap` defer to the Cosmos message label, which turns an
   // otherwise-generic send into "Delegate"/"Vote" when the payload says so.
   const tagLabel = match(record.type, {
@@ -317,7 +350,7 @@ export const TransactionRecordCard = ({
         tagLabel={tagLabel}
         status={cardStatus}
         statusLabel={statusLabelOverride}
-        amountUsd={amountUsd}
+        subAmount={display.subAmount ?? fiatAmount}
         amountCrypto={display.amountCrypto}
         symbol={display.symbol}
         pill={display.pill}


### PR DESCRIPTION
Closes #4844

## Why

A swap row printed only what it sold, and its pill carried the provider brand. Nothing on the card said what the swap actually bought — the one thing a swap row has to answer — so reading a pair meant opening the detail page.

## What changed

**Both legs on the row.** A swap prints the buy leg on top (`+200.50 SOL`) and the sell leg beneath it (`-220.192 USDC`), replacing the fiat line. The 24px icon follows the buy leg so it matches the line above it.

**The pill names the pair.** `USDC → SOL` instead of `via THORChain`. The provider keeps its own row on the detail page, where there is room to name it. `TransactionHistoryCardPill` gains a third variant for this, rendered inline on the right of the details row like the address pill — the corner-anchored provider pill stays for the Tron claim row that still uses it.

**Limit orders claim a buy leg only once one exists.** `minimumReceived` is a floor the order may never reach, so printing it as the buy leg would read as a payout that has already happened. A limit row prints `+{amountOut}` only when the queue has reported a payout; until then it keeps printing what it put up, with its fiat value, exactly as before. The pill names the pair either way — an open order is for a pair whether or not it has filled.

**The failure reason moved to the top-right**, stacked under the status label. It explains the status, not the amounts. That also retires `ErrorMessageRow` and the clearance math that had to lift it clear of the absolutely-positioned provider pill.

`amountUsd` is renamed `subAmount`, since for a swap that line now holds the other leg rather than a fiat value.

## One thing worth a second opinion

A **failed** swap row still prints `+20.50 ETH`, because `toAmount` is the quote's expected output and the design frame shows the error card with both legs. The row is clearly marked `Error` with the reason beside it, but the `+` on a swap that received nothing is arguably misleading. Happy to drop the sign (or the buy line entirely) on failed rows if design prefers that.

## Test plan

- `yarn test` — 1568 pass
- `yarn lint` / `yarn knip` — clean
- `yarn typecheck` — clean for these files (two pre-existing `slippage_bps` errors in `core/ui/vault/swap/form/info/priceImpact.ts` are on `main` already and untouched here)
- Storybook `Transaction History/TransactionHistoryCard` covers the new states: a successful swap with both legs, a failed swap with its reason, and a resting limit order

## Parity

vultisig-ios#5325 · vultisig-android#5841

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Transaction history cards now show both sides of swap transactions with asset tickers and signed amounts.
  - Added clearer support for failed swaps, approvals, and pending limit orders.
  - Limit orders distinguish between unfilled orders and completed payouts.
- **Improvements**
  - Amount details now adapt to the relevant assets and currencies.
  - Failure messages appear directly beneath the transaction status.
  - Updated spacing and inline details improve readability across transaction cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->