### PR TITLE
fix(extension): keep dApp tx details visible when Blockaid skips the chain

### DIFF
--- a/core/inpage-provider/popup/view/resolvers/sendTx/blockaid/BlockaidSimulationContent.tsx
+++ b/core/inpage-provider/popup/view/resolvers/sendTx/blockaid/BlockaidSimulationContent.tsx
@@ -345,7 +345,10 @@ const BlockaidEvmSimulationContent = ({
       }}
       error={() => fallback}
       pending={() => fallback}
-      inactive={() => null}
+      // Blockaid does not simulate every EVM chain (e.g. CronosChain), so the
+      // simulation query never activates there. Fall back to calldata decoding
+      // instead of hiding the transaction details.
+      inactive={() => fallback}
     />
   )
 }


### PR DESCRIPTION
## Description

Swapping on app.uniswap.org with Robinhood chain selected opened the Sign Transaction popup with only the "Request from" banner and an enabled Sign button. The installed `@vultisig/core-chain` 5.2.0 leaves Robinhood out of `blockaidEvmChain`, so `getBlockaidTxSimulationInput` returns `null`, the simulation query sits in the inactive state, and `BlockaidEvmSimulationContent` rendered `null` for that state. Everything below the banner disappeared: from/to, the decoded Universal Router swap, and the network fee.

This renders the existing `EvmCalldataFallback` for the inactive state, the same as `pending` and `error` already do. The fallback decodes the Uniswap Universal Router calldata, so the popup shows "You're swapping 0.0001 ETH to USDG" plus the fee. It also covers any other EVM chain Blockaid does not simulate (CronosChain today).

Blockaid does support Robinhood; the SDK map is stale. That is fixed in vultisig/vultisig-sdk#2346, and this repo needs a `@vultisig/core-chain` bump once that release publishes, which will bring the simulated balance changes on Robinhood like on Ethereum. This change stays useful regardless, since it stops the blank panel for uncovered chains.

Fixes #4854

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Parity

- iOS: n/a: extension dApp sign popup rendering; there is no equivalent inpage-provider popup in the native apps
- Android: n/a: same as iOS
- SDK: filed: vultisig/vultisig-sdk#2346 (Robinhood added to the Blockaid EVM chain map)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

No component test harness exists for this popup; verified manually by rebuilding the extension and checking the bundle, and `yarn check` passes.

## Screenshots (if applicable):

Before: popup shows only the "Request from" banner for a Robinhood Uniswap swap (see #4854).