### PR TITLE
fix(extension): resize the popup to the Figma width

### DIFF
--- a/clients/extension/src/pages/index.tsx
+++ b/clients/extension/src/pages/index.tsx
@@ -18,7 +18,7 @@ import {
 import { createGlobalStyle, css } from 'styled-components'
 
 const isPopup = isPopupView()
-const popupWidth = 480
+const popupWidth = 360
 const popupHeight = 600
 
 const ExtensionGlobalStyle = createGlobalStyle`

--- a/clients/extension/tests/e2e/playwright.config.ts
+++ b/clients/extension/tests/e2e/playwright.config.ts
@@ -116,7 +116,7 @@ export default defineConfig({
   use: {
     // Chrome extensions require headed Chromium
     headless: false,
-    viewport: { width: 480, height: 600 }, // Extension popup dimensions
+    viewport: { width: 360, height: 600 }, // Extension popup dimensions
     actionTimeout: 15_000,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',

--- a/clients/extension/tests/e2e/specs/viewport-fit.spec.ts
+++ b/clients/extension/tests/e2e/specs/viewport-fit.spec.ts
@@ -17,7 +17,7 @@ import type { Page } from '@playwright/test'
 import { expect, test } from '../fixtures/extension-loader'
 
 const viewports = [
-  { width: 480, height: 600 }, // popup baseline
+  { width: 480, height: 600 }, // wide side panel
   { width: 480, height: 500 }, // short side panel
   { width: 360, height: 500 }, // minimal side panel
 ]

--- a/core/ui/chain/coin/inputs/CoinOption.tsx
+++ b/core/ui/chain/coin/inputs/CoinOption.tsx
@@ -53,21 +53,13 @@ export const CoinOption = ({
           </PillWrapper>
         </CoinLabel>
       </CoinDetails>
-      <VStack
-        gap={4}
-        justifyContent="center"
-        alignItems="flex-end"
-        style={{
-          minWidth: 100,
-          height: 50,
-        }}
-      >
+      <BalanceColumn gap={4} justifyContent="center" alignItems="flex-end">
         {vaultCoin ? (
           <VaultCoinBalance value={vaultCoin} />
         ) : (
           <CoinOptionFiatValue value={0} />
         )}
-      </VStack>
+      </BalanceColumn>
     </Container>
   )
 }
@@ -102,6 +94,7 @@ const VaultCoinBalance = ({ value }: ValueProp<Coin>) => {
               size={12}
               color="contrast"
               weight={500}
+              cropped
             >
               {formatAmount(fromChainAmount(balance, decimals), { ticker })}
             </Text>
@@ -173,4 +166,23 @@ const PillWrapper = styled.div`
   padding: 8px 12px;
   ${borderRadius.pill};
   border: 1px solid ${getColor('foregroundExtra')};
+
+  @media (max-width: 400px) {
+    padding: 4px 8px;
+  }
+`
+
+/**
+ * Balance for the row. At the popup width it gives way to the ticker, which is
+ * what tells two rows apart: capped, a four-letter ticker stays whole; without
+ * a cap the ticker was down to two legible characters.
+ */
+const BalanceColumn = styled(VStack)`
+  min-width: 100px;
+  height: 50px;
+
+  @media (max-width: 400px) {
+    min-width: 0;
+    max-width: 90px;
+  }
 `

--- a/core/ui/chain/coin/inputs/CoinOption.tsx
+++ b/core/ui/chain/coin/inputs/CoinOption.tsx
@@ -1,6 +1,7 @@
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { useBalanceQuery } from '@core/ui/chain/coin/queries/useBalanceQuery'
 import { TokenVerificationBadge } from '@core/ui/chain/coin/verification/TokenVerificationBadge'
+import { CoinTicker } from '@core/ui/vault/chain/CoinTicker'
 import {
   useCurrentVaultAddress,
   useCurrentVaultCoins,
@@ -40,20 +41,18 @@ export const CoinOption = ({
       alignItems="center"
       data-testid={`coin-option-${ticker}`}
     >
-      <HStack alignItems="center" gap={12}>
+      <CoinDetails alignItems="center" gap={12}>
         <CoinIcon coin={value} style={{ fontSize: 32 }} />
-        <HStack gap={8} alignItems="center">
-          <Text color="contrast" size={13} weight="500">
-            {ticker}
-          </Text>
+        <CoinLabel gap={8} alignItems="center">
+          <CoinTicker ticker={ticker} size={13} weight="500" />
           <TokenVerificationBadge value={value} />
           <PillWrapper>
-            <Text color="shy" size={11} weight="500">
+            <Text color="shy" size={11} weight="500" nowrap>
               {chain}
             </Text>
           </PillWrapper>
-        </HStack>
-      </HStack>
+        </CoinLabel>
+      </CoinDetails>
       <VStack
         gap={4}
         justifyContent="center"
@@ -136,7 +135,7 @@ const Container = styled(HStack)`
     position: absolute;
     left: 50%;
     bottom: 0;
-    width: 320px;
+    width: min(320px, 100%);
     height: 1px;
     background: linear-gradient(90deg, #061b3a 0%, #284570 49.5%, #061b3a 100%);
     transform: translateX(-50%);
@@ -148,7 +147,27 @@ const Container = styled(HStack)`
   }
 `
 
+/**
+ * Icon, ticker and chain pill. It has to shrink, or a ticker that is a raw
+ * contract address makes the row wider than the modal — and because the list
+ * around it scrolls vertically, that overflow becomes a horizontal scrollbar
+ * rather than being clipped.
+ */
+const CoinDetails = styled(HStack)`
+  min-width: 0;
+
+  > svg,
+  > img {
+    flex-shrink: 0;
+  }
+`
+
+const CoinLabel = styled(HStack)`
+  min-width: 0;
+`
+
 const PillWrapper = styled.div`
+  flex-shrink: 0;
   display: grid;
   place-items: center;
   padding: 8px 12px;

--- a/core/ui/chain/coin/inputs/CoinOption.tsx
+++ b/core/ui/chain/coin/inputs/CoinOption.tsx
@@ -44,10 +44,12 @@ export const CoinOption = ({
       <CoinDetails alignItems="center" gap={12}>
         <CoinIcon coin={value} style={{ fontSize: 32 }} />
         <CoinLabel gap={8} alignItems="center">
-          <CoinTicker ticker={ticker} size={13} weight="500" />
+          <TickerSlot>
+            <CoinTicker ticker={ticker} size={13} weight="500" />
+          </TickerSlot>
           <TokenVerificationBadge value={value} />
           <PillWrapper>
-            <Text color="shy" size={11} weight="500" nowrap>
+            <Text color="shy" size={11} weight="500" cropped>
               {chain}
             </Text>
           </PillWrapper>
@@ -159,6 +161,20 @@ const CoinLabel = styled(HStack)`
   min-width: 0;
 `
 
+/**
+ * Reserves the ticker's width before the chain pill can claim it. `LUNC` next
+ * to a `TerraClassic` pill was cropping to 25px, because how much the ticker
+ * got depended on how long the chain happened to be called.
+ */
+const TickerSlot = styled.div`
+  min-width: 0;
+
+  @media (max-width: 400px) {
+    flex-shrink: 0;
+    max-width: 72px;
+  }
+`
+
 const PillWrapper = styled.div`
   flex-shrink: 0;
   display: grid;
@@ -168,6 +184,8 @@ const PillWrapper = styled.div`
   border: 1px solid ${getColor('foregroundExtra')};
 
   @media (max-width: 400px) {
+    flex-shrink: 1;
+    min-width: 0;
     padding: 4px 8px;
   }
 `
@@ -183,6 +201,6 @@ const BalanceColumn = styled(VStack)`
 
   @media (max-width: 400px) {
     min-width: 0;
-    max-width: 90px;
+    max-width: 80px;
   }
 `

--- a/core/ui/chain/coin/inputs/CoinPillButton.tsx
+++ b/core/ui/chain/coin/inputs/CoinPillButton.tsx
@@ -61,6 +61,7 @@ const Container = styled(UnstyledButton)`
   })}
   text-align: left;
   padding: 6px;
+  min-width: 0;
   ${borderRadius.pill};
   background-color: ${getColor('foregroundExtra')};
 

--- a/core/ui/chain/coin/inputs/CoinPillButton.tsx
+++ b/core/ui/chain/coin/inputs/CoinPillButton.tsx
@@ -1,5 +1,6 @@
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { TokenVerificationBadge } from '@core/ui/chain/coin/verification/TokenVerificationBadge'
+import { CoinTicker } from '@core/ui/vault/chain/CoinTicker'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
 import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ChevronRightIcon } from '@lib/ui/icons/ChevronRightIcon'
@@ -34,11 +35,9 @@ export const CoinPillButton = ({
   return (
     <Container onClick={onClick} data-testid={testId}>
       <CoinIcon coin={value} style={{ fontSize: 32 }} />
-      <HStack gap={4} alignItems="center">
+      <Body gap={4} alignItems="center">
         <VStack gap={2}>
-          <Text weight="500" size={16} color="contrast">
-            {value.ticker}
-          </Text>
+          <CoinTicker ticker={value.ticker} size={14} weight="500" />
           {isFeeCoin(value) ? (
             <Text weight="500" size={12} color="shy">
               {t('native')}
@@ -49,8 +48,8 @@ export const CoinPillButton = ({
             </HStack>
           )}
         </VStack>
-        <ChevronRightIcon />
-      </HStack>
+        <Chevron />
+      </Body>
     </Container>
   )
 }
@@ -64,4 +63,24 @@ const Container = styled(UnstyledButton)`
   padding: 6px;
   ${borderRadius.pill};
   background-color: ${getColor('foregroundExtra')};
+
+  > svg,
+  > img {
+    flex-shrink: 0;
+  }
+`
+
+const Body = styled(HStack)`
+  min-width: 0;
+`
+
+/**
+ * The chevron is what tells the pill it opens a picker, so it must survive the
+ * squeeze. Left to shrink it collapsed to nothing on the swap form's From
+ * pill, where the amount field takes more of the row than the read-only To
+ * amount does. The pill itself keeps its automatic minimum for the same
+ * reason: below it the chevron sits outside the pill and reads as missing.
+ */
+const Chevron = styled(ChevronRightIcon)`
+  flex-shrink: 0;
 `

--- a/core/ui/mpc/keysign/tx/TxOverviewAmount.tsx
+++ b/core/ui/mpc/keysign/tx/TxOverviewAmount.tsx
@@ -1,6 +1,7 @@
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { useCoinPriceQuery } from '@core/ui/chain/coin/price/queries/useCoinPriceQuery'
 import { TokenVerificationBadge } from '@core/ui/chain/coin/verification/TokenVerificationBadge'
+import { CoinTicker } from '@core/ui/vault/chain/CoinTicker'
 import { TriangleAlertIcon } from '@lib/ui/icons/TriangleAlertIcon'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Panel } from '@lib/ui/panel/Panel'
@@ -79,7 +80,8 @@ export const TxOverviewAmount = ({
             </HStack>
           ) : (
             <HStack alignItems="center" gap={6}>
-              <Text size={18}>{`${amount} ${value.ticker}`}</Text>
+              <Text size={18}>{amount}</Text>
+              <CoinTicker ticker={value.ticker} size={18} maxWidth={140} />
               <TokenVerificationBadge value={value} />
             </HStack>
           ))}

--- a/core/ui/vault/chain/CoinTicker.tsx
+++ b/core/ui/vault/chain/CoinTicker.tsx
@@ -3,6 +3,17 @@ import { useElementSize } from '@lib/ui/hooks/useElementSize'
 import { Text, TextColor } from '@lib/ui/text'
 import { Tooltip } from '@lib/ui/tooltips/Tooltip'
 import { CSSProperties, useState } from 'react'
+import styled from 'styled-components'
+
+/**
+ * A contract-address ticker has no spaces to break on, so it needs both an
+ * explicit break and a width — left alone the tooltip stretches past the popup.
+ */
+const FullTicker = styled.span`
+  display: block;
+  max-width: 240px;
+  word-break: break-all;
+`
 
 type CoinTickerProps = {
   ticker: string
@@ -33,11 +44,7 @@ export const CoinTicker = ({
 
   return (
     <Tooltip
-      content={
-        isTruncated ? (
-          <span style={{ wordBreak: 'break-all' }}>{ticker}</span>
-        ) : undefined
-      }
+      content={isTruncated ? <FullTicker>{ticker}</FullTicker> : undefined}
       renderOpener={({ ref, ...props }) => (
         <MergeRefs<HTMLParagraphElement>
           refs={[ref, setElement]}

--- a/core/ui/vault/chain/VaultChainCoinItem.tsx
+++ b/core/ui/vault/chain/VaultChainCoinItem.tsx
@@ -31,6 +31,28 @@ const PriceBadge = styled.div`
   background: ${getColor('foregroundExtra')};
 `
 
+/**
+ * Everything to the right of the coin icon. `width: 100%` alone makes it a
+ * flex item that will not shrink below the full row, which pushed the balance
+ * column out past the panel; the row only has the width the icon leaves it.
+ */
+const RowBody = styled(VStack)`
+  min-width: 0;
+`
+
+/**
+ * Native balance under the fiat value. Its cap is what keeps the balance
+ * column bounded, so the ticker beside it still gets a share of the row: the
+ * popup leaves the row 296px, of which 96 goes to the icon, gaps and chevron.
+ */
+const NativeAmount = styled(Text)`
+  max-width: 160px;
+
+  @media (max-width: 400px) {
+    max-width: 100px;
+  }
+`
+
 type VaultChainCoinItemProps = ValueProp<
   Partial<EntityWithLogo> &
     EntityWithTicker &
@@ -64,7 +86,7 @@ export const VaultChainCoinItem = ({
     <HStack fullWidth alignItems="center" gap={12}>
       <CoinIcon coin={value} style={{ fontSize: 32 }} />
 
-      <VStack fullWidth alignItems="start" gap={12}>
+      <RowBody fullWidth alignItems="start" gap={12}>
         <HStack
           fullWidth
           alignItems="center"
@@ -108,17 +130,11 @@ export const VaultChainCoinItem = ({
                     {formatFiatAmount((price || 0) * balance)}
                   </BalanceVisibilityAware>
                 </Text>
-                <Text
-                  weight={500}
-                  color="shy"
-                  size={12}
-                  cropped
-                  style={{ maxWidth: 160 }}
-                >
+                <NativeAmount weight={500} color="shy" size={12} cropped>
                   <BalanceVisibilityAware>
                     {formatAmount(balance, { precision: 'high' })} {ticker}
                   </BalanceVisibilityAware>
-                </Text>
+                </NativeAmount>
               </VStack>
             )}
             <IconWrapper>
@@ -126,7 +142,7 @@ export const VaultChainCoinItem = ({
             </IconWrapper>
           </HStack>
         </HStack>
-      </VStack>
+      </RowBody>
     </HStack>
   )
 }

--- a/core/ui/vault/chain/manage/shared/TokenItem.tsx
+++ b/core/ui/vault/chain/manage/shared/TokenItem.tsx
@@ -1,13 +1,13 @@
 import { ChainEntityIcon } from '@core/ui/chain/coin/icon/ChainEntityIcon'
 import { getCoinLogoSrc } from '@core/ui/chain/coin/icon/utils/getCoinLogoSrc'
 import { TokenVerificationBadge } from '@core/ui/chain/coin/verification/TokenVerificationBadge'
+import { CoinTicker } from '@core/ui/vault/chain/CoinTicker'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
 import { borderRadius } from '@lib/ui/css/borderRadius'
 import { CheckmarkIcon } from '@lib/ui/icons/CheckmarkIcon'
 import { IconWrapper } from '@lib/ui/icons/IconWrapper'
 import { vStack } from '@lib/ui/layout/Stack'
 import { IsActiveProp, ValueProp } from '@lib/ui/props'
-import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
 import { areEqualCoins, Coin } from '@vultisig/core-chain/coin/Coin'
 import { useMemo } from 'react'
@@ -54,9 +54,7 @@ export const TokenItem = ({
         )}
       </TokenIconWrapper>
       <TokenNameWrapper>
-        <Text cropped color="contrast" size={12} weight={500}>
-          {coin.ticker}
-        </Text>
+        <CoinTicker ticker={coin.ticker} size={12} weight={500} />
         <TokenVerificationBadge value={coin} />
       </TokenNameWrapper>
     </TokenCard>

--- a/core/ui/vault/send/amount/AmountSuggestion.tsx
+++ b/core/ui/vault/send/amount/AmountSuggestion.tsx
@@ -9,11 +9,24 @@ import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
+/**
+ * Fixed at 56px the four suggestions ask for more of the row than the popup
+ * has beside the coin pill, and Max wrapped onto a line of its own. Below the
+ * breakpoint they share whatever the row leaves them instead, which keeps them
+ * on one line without a width that has to be guessed.
+ */
 const Container = styled(UnstyledButton)<{
   isActive?: boolean
 }>`
   width: 56px;
   height: 30px;
+
+  @media (max-width: 400px) {
+    flex: 1 1 0;
+    width: auto;
+    min-width: 0;
+    max-width: 56px;
+  }
   ${borderRadius.sm};
   ${centerContent};
   background-color: ${({ isActive }) =>

--- a/core/ui/vault/send/coin/ManageSendCoin/components/ManageSendCoinCollapsedInputField.tsx
+++ b/core/ui/vault/send/coin/ManageSendCoin/components/ManageSendCoinCollapsedInputField.tsx
@@ -1,4 +1,5 @@
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
+import { CoinTicker } from '@core/ui/vault/chain/CoinTicker'
 import {
   ActionFormCheckBadge,
   ActionFormIconsWrapper,
@@ -37,15 +38,15 @@ export const ManageSendCoinCollapsedInputField = () => {
         }))
       }}
     >
-      <HStack gap={12} alignItems="center">
-        <Text size={14}>{t('asset')}</Text>
-        <HStack gap={4} alignItems="center">
+      <AssetRow gap={12} alignItems="center">
+        <Text size={14} nowrap>
+          {t('asset')}
+        </Text>
+        <CoinRow gap={4} alignItems="center">
           <CoinIcon coin={coin} style={{ fontSize: 20 }} />
-          <Text size={12} color="shy">
-            {ticker}
-          </Text>
-        </HStack>
-      </HStack>
+          <CoinTicker ticker={ticker} size={12} color="shy" />
+        </CoinRow>
+      </AssetRow>
       <ActionFormIconsWrapper gap={12}>
         {isChecked && (
           <>
@@ -69,6 +70,23 @@ const CollapsedCoinInputContainer = styled(SendInputContainer)`
     justifyContent: 'space-between',
     alignItems: 'center',
   })}
+`
+
+/**
+ * Holds the label and the coin. It has to be allowed to shrink, or the ticker
+ * beside it has no width to be cropped against.
+ */
+const AssetRow = styled(HStack)`
+  min-width: 0;
+`
+
+const CoinRow = styled(HStack)`
+  min-width: 0;
+
+  svg,
+  img {
+    flex-shrink: 0;
+  }
 `
 
 const PencilIconWrapper = styled.div`

--- a/core/ui/vault/send/components/ChainOption.tsx
+++ b/core/ui/vault/send/components/ChainOption.tsx
@@ -33,7 +33,7 @@ export const ChainOption = ({
       onClick={onClick}
     >
       <HStack alignItems="center" justifyContent="space-between">
-        <HStack fullWidth alignItems="center" gap={12}>
+        <ChainDetails fullWidth alignItems="center" gap={12}>
           <ChainEntityIcon
             value={getChainLogoSrc(chain)}
             style={{ fontSize: 32 }}
@@ -43,7 +43,7 @@ export const ChainOption = ({
               {chain}
             </Text>
           </VStack>
-        </HStack>
+        </ChainDetails>
 
         <Text size={12} color="shy" weight="500">
           {formatFiatAmount(totalFiatAmount)}
@@ -52,6 +52,15 @@ export const ChainOption = ({
     </Container>
   )
 }
+
+/**
+ * `width: 100%` alone makes this a flex item that will not shrink below the
+ * whole row, so the balance beside it pushed the row 8px wider than the list
+ * and the list turned that into a horizontal scrollbar.
+ */
+const ChainDetails = styled(HStack)`
+  min-width: 0;
+`
 
 const Container = styled('div')<{ isSelected?: boolean }>`
   ${panel()};
@@ -71,7 +80,7 @@ const Container = styled('div')<{ isSelected?: boolean }>`
     position: absolute;
     left: 50%;
     bottom: 0;
-    width: 320px;
+    width: min(320px, 100%);
     height: 1px;
     background: linear-gradient(90deg, #061b3a 0%, #284570 49.5%, #061b3a 100%);
     transform: translateX(-50%);

--- a/core/ui/vault/settings/advanced/customRpc/index.tsx
+++ b/core/ui/vault/settings/advanced/customRpc/index.tsx
@@ -93,7 +93,7 @@ export const CustomRpcPage = () => {
                         </EditBadge>
                       )}
                     </ChainIconFrame>
-                    <ChainName variant="caption" centerHorizontally nowrap>
+                    <ChainName variant="caption" centerHorizontally>
                       {getCustomRpcChainName(chain)}
                     </ChainName>
                   </ChainTile>
@@ -177,12 +177,17 @@ const StyledSearchInput = styled.input`
   }
 `
 
+/**
+ * Four columns that share whatever width the page gives them. Fixed 74px
+ * tracks came to more than the popup can show and overflowed into a sideways
+ * scroll; `minmax(0, …)` also stops a long chain name widening its own track.
+ */
 const ChainGrid = styled.div`
   display: grid;
   gap: 16px;
-  grid-template-columns: repeat(4, 74px);
-  width: 344px;
-  max-width: calc(100vw - 32px);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  width: 100%;
+  max-width: 344px;
 `
 
 const ChainTile = styled.button`
@@ -195,7 +200,8 @@ const ChainTile = styled.button`
   flex-direction: column;
   gap: 11px;
   padding: 0;
-  width: 74px;
+  min-width: 0;
+  width: 100%;
 `
 
 const ChainIconFrame = styled.div<{ $isCustom: boolean }>`
@@ -231,5 +237,5 @@ const EditBadge = styled.div`
 const ChainName = styled(Text)`
   align-self: center;
   letter-spacing: 0.12px;
-  max-width: 88px;
+  max-width: 100%;
 `

--- a/core/ui/vault/swap/components/ChainOption.tsx
+++ b/core/ui/vault/swap/components/ChainOption.tsx
@@ -34,7 +34,7 @@ export const ChainOption = ({
       data-testid={`swap-chain-option-${chain}`}
     >
       <HStack alignItems="center" justifyContent="space-between">
-        <HStack fullWidth alignItems="center" gap={12}>
+        <ChainDetails fullWidth alignItems="center" gap={12}>
           <ChainEntityIcon
             value={getChainLogoSrc(chain)}
             style={{ fontSize: 32 }}
@@ -44,7 +44,7 @@ export const ChainOption = ({
               {chain}
             </Text>
           </VStack>
-        </HStack>
+        </ChainDetails>
 
         <Text size={12} color="shy" weight="500">
           {formatFiatAmount(totalFiatAmount)}
@@ -53,6 +53,15 @@ export const ChainOption = ({
     </Container>
   )
 }
+
+/**
+ * `width: 100%` alone makes this a flex item that will not shrink below the
+ * whole row, so the balance beside it pushed the row 8px wider than the list
+ * and the list turned that into a horizontal scrollbar.
+ */
+const ChainDetails = styled(HStack)`
+  min-width: 0;
+`
 
 const Container = styled('div')<{ isSelected?: boolean }>`
   ${panel()};
@@ -72,7 +81,7 @@ const Container = styled('div')<{ isSelected?: boolean }>`
     position: absolute;
     left: 50%;
     bottom: 0;
-    width: 320px;
+    width: min(320px, 100%);
     height: 1px;
     background: linear-gradient(90deg, #061b3a 0%, #284570 49.5%, #061b3a 100%);
     transform: translateX(-50%);


### PR DESCRIPTION
## What

Narrows the extension popup from 480×600 to the 360×600 the design asks for, and collects the layout fixes that width exposes.

Chrome caps action popups at 600px tall, so only the width moves. The dApp sign window still opens at 480 — that is a separate file and a separate change.

## Why the sub-PRs

The popup losing 120px of width breaks several screens that were only ever laid out against 480. Each of those is its own sub-issue and its own PR into this branch, so they stay small and can be reviewed and reverted on their own:

- #4855 — the five chain-detail actions wrapped onto two rows
- #4857 — the send form's asset name ran off the field
- #4858 — the coin row's fiat value was clipped and its chevron pushed out
- #4859 — the Custom RPCs chain grid scrolled sideways
- #4860 — the Select asset modal grew a horizontal scrollbar

## Still to do before this merges

The e2e suite hardcodes a 480px viewport in several specs and in the Playwright config. Those need to follow the popup down to 360.

Closes #4687


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reduced the extension popup width from 480px to 360px for a more compact layout.
  * Improved coin fields and selection controls with standardized tickers, preserved icon sizing, and cleaner handling of long ticker text.
  * Improved coin and chain list layouts by constraining flexible content and balance widths to prevent horizontal overflow.
  * Updated custom RPC chain grids to fit available space while accommodating longer chain names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->