### PR TITLE
fix(send): crop the asset name on the collapsed field

### DIFF
--- a/clients/extension/src/pages/index.tsx
+++ b/clients/extension/src/pages/index.tsx
@@ -18,7 +18,7 @@ import {
 import { createGlobalStyle, css } from 'styled-components'
 
 const isPopup = isPopupView()
-const popupWidth = 480
+const popupWidth = 360
 const popupHeight = 600
 
 const ExtensionGlobalStyle = createGlobalStyle`

--- a/core/ui/vault/send/coin/ManageSendCoin/components/ManageSendCoinCollapsedInputField.tsx
+++ b/core/ui/vault/send/coin/ManageSendCoin/components/ManageSendCoinCollapsedInputField.tsx
@@ -1,4 +1,5 @@
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
+import { CoinTicker } from '@core/ui/vault/chain/CoinTicker'
 import {
   ActionFormCheckBadge,
   ActionFormIconsWrapper,
@@ -37,15 +38,15 @@ export const ManageSendCoinCollapsedInputField = () => {
         }))
       }}
     >
-      <HStack gap={12} alignItems="center">
-        <Text size={14}>{t('asset')}</Text>
-        <HStack gap={4} alignItems="center">
+      <AssetRow gap={12} alignItems="center">
+        <Text size={14} nowrap>
+          {t('asset')}
+        </Text>
+        <CoinRow gap={4} alignItems="center">
           <CoinIcon coin={coin} style={{ fontSize: 20 }} />
-          <Text size={12} color="shy">
-            {ticker}
-          </Text>
-        </HStack>
-      </HStack>
+          <CoinTicker ticker={ticker} size={12} color="shy" />
+        </CoinRow>
+      </AssetRow>
       <ActionFormIconsWrapper gap={12}>
         {isChecked && (
           <>
@@ -69,6 +70,23 @@ const CollapsedCoinInputContainer = styled(SendInputContainer)`
     justifyContent: 'space-between',
     alignItems: 'center',
   })}
+`
+
+/**
+ * Holds the label and the coin. It has to be allowed to shrink, or the ticker
+ * beside it has no width to be cropped against.
+ */
+const AssetRow = styled(HStack)`
+  min-width: 0;
+`
+
+const CoinRow = styled(HStack)`
+  min-width: 0;
+
+  svg,
+  img {
+    flex-shrink: 0;
+  }
 `
 
 const PencilIconWrapper = styled.div`


### PR DESCRIPTION
Sub-PR of #4861.

The collapsed Asset row printed the ticker in a plain `Text`, so a Terra Classic token — whose ticker is a raw contract address — ran out of the field and off the popup.

It now uses `CoinTicker`, which the codebase already has for exactly this: it crops with an ellipsis and puts the full value in a tooltip. The stacks around it are allowed to shrink, or the cropped text would have nothing to crop against.

Closes #4857
