### PR TITLE
fix(vault): keep the coin row's fiat value inside the row

### DIFF
--- a/clients/extension/src/pages/index.tsx
+++ b/clients/extension/src/pages/index.tsx
@@ -18,7 +18,7 @@ import {
 import { createGlobalStyle, css } from 'styled-components'
 
 const isPopup = isPopupView()
-const popupWidth = 480
+const popupWidth = 360
 const popupHeight = 600
 
 const ExtensionGlobalStyle = createGlobalStyle`

--- a/core/ui/vault/chain/VaultChainCoinItem.tsx
+++ b/core/ui/vault/chain/VaultChainCoinItem.tsx
@@ -31,6 +31,10 @@ const PriceBadge = styled.div`
   background: ${getColor('foregroundExtra')};
 `
 
+const ChevronWrapper = styled(IconWrapper)`
+  flex-shrink: 0;
+`
+
 type VaultChainCoinItemProps = ValueProp<
   Partial<EntityWithLogo> &
     EntityWithTicker &
@@ -82,7 +86,10 @@ export const VaultChainCoinItem = ({
               </Text>
             </PriceBadge>
           </VStack>
-          <HStack gap={8} alignItems="center" style={{ flexShrink: 0 }}>
+          {/* Shrinks rather than pushing the fiat value out of the row: the
+              native amount crops against whatever width is left, while the
+              fiat value keeps the column from collapsing past itself. */}
+          <HStack gap={8} alignItems="center">
             {onActivate ? (
               // Replaces the balance only: a zero that cannot move until the
               // trust line exists explains nothing, so the row offers the action
@@ -113,7 +120,7 @@ export const VaultChainCoinItem = ({
                   color="shy"
                   size={12}
                   cropped
-                  style={{ maxWidth: 160 }}
+                  style={{ maxWidth: '100%' }}
                 >
                   <BalanceVisibilityAware>
                     {formatAmount(balance, { precision: 'high' })} {ticker}
@@ -121,9 +128,9 @@ export const VaultChainCoinItem = ({
                 </Text>
               </VStack>
             )}
-            <IconWrapper>
+            <ChevronWrapper>
               <ChevronRightIcon />
-            </IconWrapper>
+            </ChevronWrapper>
           </HStack>
         </HStack>
       </VStack>

--- a/core/ui/vault/chain/VaultChainCoinItem.tsx
+++ b/core/ui/vault/chain/VaultChainCoinItem.tsx
@@ -31,8 +31,26 @@ const PriceBadge = styled.div`
   background: ${getColor('foregroundExtra')};
 `
 
-const ChevronWrapper = styled(IconWrapper)`
-  flex-shrink: 0;
+/**
+ * Everything to the right of the coin icon. `width: 100%` alone makes it a
+ * flex item that will not shrink below the full row, which pushed the balance
+ * column out past the panel; the row only has the width the icon leaves it.
+ */
+const RowBody = styled(VStack)`
+  min-width: 0;
+`
+
+/**
+ * Native balance under the fiat value. Its cap is what keeps the balance
+ * column bounded, so the ticker beside it still gets a share of the row: the
+ * popup leaves the row 296px, of which 96 goes to the icon, gaps and chevron.
+ */
+const NativeAmount = styled(Text)`
+  max-width: 160px;
+
+  @media (max-width: 400px) {
+    max-width: 100px;
+  }
 `
 
 type VaultChainCoinItemProps = ValueProp<
@@ -68,7 +86,7 @@ export const VaultChainCoinItem = ({
     <HStack fullWidth alignItems="center" gap={12}>
       <CoinIcon coin={value} style={{ fontSize: 32 }} />
 
-      <VStack fullWidth alignItems="start" gap={12}>
+      <RowBody fullWidth alignItems="start" gap={12}>
         <HStack
           fullWidth
           alignItems="center"
@@ -86,10 +104,7 @@ export const VaultChainCoinItem = ({
               </Text>
             </PriceBadge>
           </VStack>
-          {/* Shrinks rather than pushing the fiat value out of the row: the
-              native amount crops against whatever width is left, while the
-              fiat value keeps the column from collapsing past itself. */}
-          <HStack gap={8} alignItems="center">
+          <HStack gap={8} alignItems="center" style={{ flexShrink: 0 }}>
             {onActivate ? (
               // Replaces the balance only: a zero that cannot move until the
               // trust line exists explains nothing, so the row offers the action
@@ -115,25 +130,19 @@ export const VaultChainCoinItem = ({
                     {formatFiatAmount((price || 0) * balance)}
                   </BalanceVisibilityAware>
                 </Text>
-                <Text
-                  weight={500}
-                  color="shy"
-                  size={12}
-                  cropped
-                  style={{ maxWidth: '100%' }}
-                >
+                <NativeAmount weight={500} color="shy" size={12} cropped>
                   <BalanceVisibilityAware>
                     {formatAmount(balance, { precision: 'high' })} {ticker}
                   </BalanceVisibilityAware>
-                </Text>
+                </NativeAmount>
               </VStack>
             )}
-            <ChevronWrapper>
+            <IconWrapper>
               <ChevronRightIcon />
-            </ChevronWrapper>
+            </IconWrapper>
           </HStack>
         </HStack>
-      </VStack>
+      </RowBody>
     </HStack>
   )
 }


### PR DESCRIPTION
Sub-PR of #4861.

A coin row with a long ticker pushed its fiat value past the right edge — clipped mid-text, with the chevron pushed out of the row.

The balance column was `flex-shrink: 0` with its native-amount line capped at a fixed 160px. At 480 the row had room for that; at 360 it does not, and a column that refuses to shrink puts the overflow on the fiat value instead.

The column now shrinks and the amount crops against the width it actually gets. The fiat value is the shorter line, so it keeps the column from collapsing past itself and stays whole.

Closes #4858
