### PR TITLE
fix(extension): remove the Select asset modal's horizontal scrollbar

### DIFF
--- a/clients/extension/src/pages/index.tsx
+++ b/clients/extension/src/pages/index.tsx
@@ -18,7 +18,7 @@ import {
 import { createGlobalStyle, css } from 'styled-components'
 
 const isPopup = isPopupView()
-const popupWidth = 480
+const popupWidth = 360
 const popupHeight = 600
 
 const ExtensionGlobalStyle = createGlobalStyle`

--- a/core/ui/chain/coin/inputs/CoinOption.tsx
+++ b/core/ui/chain/coin/inputs/CoinOption.tsx
@@ -1,6 +1,7 @@
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { useBalanceQuery } from '@core/ui/chain/coin/queries/useBalanceQuery'
 import { TokenVerificationBadge } from '@core/ui/chain/coin/verification/TokenVerificationBadge'
+import { CoinTicker } from '@core/ui/vault/chain/CoinTicker'
 import {
   useCurrentVaultAddress,
   useCurrentVaultCoins,
@@ -40,20 +41,18 @@ export const CoinOption = ({
       alignItems="center"
       data-testid={`coin-option-${ticker}`}
     >
-      <HStack alignItems="center" gap={12}>
+      <CoinDetails alignItems="center" gap={12}>
         <CoinIcon coin={value} style={{ fontSize: 32 }} />
-        <HStack gap={8} alignItems="center">
-          <Text color="contrast" size={13} weight="500">
-            {ticker}
-          </Text>
+        <CoinLabel gap={8} alignItems="center">
+          <CoinTicker ticker={ticker} size={13} weight="500" />
           <TokenVerificationBadge value={value} />
           <PillWrapper>
-            <Text color="shy" size={11} weight="500">
+            <Text color="shy" size={11} weight="500" nowrap>
               {chain}
             </Text>
           </PillWrapper>
-        </HStack>
-      </HStack>
+        </CoinLabel>
+      </CoinDetails>
       <VStack
         gap={4}
         justifyContent="center"
@@ -136,7 +135,7 @@ const Container = styled(HStack)`
     position: absolute;
     left: 50%;
     bottom: 0;
-    width: 320px;
+    width: min(320px, 100%);
     height: 1px;
     background: linear-gradient(90deg, #061b3a 0%, #284570 49.5%, #061b3a 100%);
     transform: translateX(-50%);
@@ -148,7 +147,27 @@ const Container = styled(HStack)`
   }
 `
 
+/**
+ * Icon, ticker and chain pill. It has to shrink, or a ticker that is a raw
+ * contract address makes the row wider than the modal — and because the list
+ * around it scrolls vertically, that overflow becomes a horizontal scrollbar
+ * rather than being clipped.
+ */
+const CoinDetails = styled(HStack)`
+  min-width: 0;
+
+  > svg,
+  > img {
+    flex-shrink: 0;
+  }
+`
+
+const CoinLabel = styled(HStack)`
+  min-width: 0;
+`
+
 const PillWrapper = styled.div`
+  flex-shrink: 0;
   display: grid;
   place-items: center;
   padding: 8px 12px;

--- a/core/ui/vault/send/components/ChainOption.tsx
+++ b/core/ui/vault/send/components/ChainOption.tsx
@@ -71,7 +71,7 @@ const Container = styled('div')<{ isSelected?: boolean }>`
     position: absolute;
     left: 50%;
     bottom: 0;
-    width: 320px;
+    width: min(320px, 100%);
     height: 1px;
     background: linear-gradient(90deg, #061b3a 0%, #284570 49.5%, #061b3a 100%);
     transform: translateX(-50%);

--- a/core/ui/vault/send/components/ChainOption.tsx
+++ b/core/ui/vault/send/components/ChainOption.tsx
@@ -33,7 +33,7 @@ export const ChainOption = ({
       onClick={onClick}
     >
       <HStack alignItems="center" justifyContent="space-between">
-        <HStack fullWidth alignItems="center" gap={12}>
+        <ChainDetails fullWidth alignItems="center" gap={12}>
           <ChainEntityIcon
             value={getChainLogoSrc(chain)}
             style={{ fontSize: 32 }}
@@ -43,7 +43,7 @@ export const ChainOption = ({
               {chain}
             </Text>
           </VStack>
-        </HStack>
+        </ChainDetails>
 
         <Text size={12} color="shy" weight="500">
           {formatFiatAmount(totalFiatAmount)}
@@ -52,6 +52,15 @@ export const ChainOption = ({
     </Container>
   )
 }
+
+/**
+ * `width: 100%` alone makes this a flex item that will not shrink below the
+ * whole row, so the balance beside it pushed the row 8px wider than the list
+ * and the list turned that into a horizontal scrollbar.
+ */
+const ChainDetails = styled(HStack)`
+  min-width: 0;
+`
 
 const Container = styled('div')<{ isSelected?: boolean }>`
   ${panel()};

--- a/core/ui/vault/swap/components/ChainOption.tsx
+++ b/core/ui/vault/swap/components/ChainOption.tsx
@@ -34,7 +34,7 @@ export const ChainOption = ({
       data-testid={`swap-chain-option-${chain}`}
     >
       <HStack alignItems="center" justifyContent="space-between">
-        <HStack fullWidth alignItems="center" gap={12}>
+        <ChainDetails fullWidth alignItems="center" gap={12}>
           <ChainEntityIcon
             value={getChainLogoSrc(chain)}
             style={{ fontSize: 32 }}
@@ -44,7 +44,7 @@ export const ChainOption = ({
               {chain}
             </Text>
           </VStack>
-        </HStack>
+        </ChainDetails>
 
         <Text size={12} color="shy" weight="500">
           {formatFiatAmount(totalFiatAmount)}
@@ -53,6 +53,15 @@ export const ChainOption = ({
     </Container>
   )
 }
+
+/**
+ * `width: 100%` alone makes this a flex item that will not shrink below the
+ * whole row, so the balance beside it pushed the row 8px wider than the list
+ * and the list turned that into a horizontal scrollbar.
+ */
+const ChainDetails = styled(HStack)`
+  min-width: 0;
+`
 
 const Container = styled('div')<{ isSelected?: boolean }>`
   ${panel()};

--- a/core/ui/vault/swap/components/ChainOption.tsx
+++ b/core/ui/vault/swap/components/ChainOption.tsx
@@ -72,7 +72,7 @@ const Container = styled('div')<{ isSelected?: boolean }>`
     position: absolute;
     left: 50%;
     bottom: 0;
-    width: 320px;
+    width: min(320px, 100%);
     height: 1px;
     background: linear-gradient(90deg, #061b3a 0%, #284570 49.5%, #061b3a 100%);
     transform: translateX(-50%);


### PR DESCRIPTION
Sub-PR of #4861.

The Select asset modal had a horizontal scrollbar.

Two things reached past the modal at 360px: a `CoinOption` row whose ticker is a raw contract address, and the row divider, pinned at a fixed 320px inside a row the popup makes narrower than that. The list wrapper sets `overflow-y: auto`, which makes the other axis compute to `auto` as well — so neither was clipped, both became a scrollbar.

The ticker crops, the left group shrinks, the chain pill does not, and the divider is bounded by the row.

Closes #4860
