### PR TITLE
fix(extension): keep the coin pill's chevron on the swap form

### DIFF
--- a/clients/extension/src/pages/index.tsx
+++ b/clients/extension/src/pages/index.tsx
@@ -18,7 +18,7 @@ import {
 import { createGlobalStyle, css } from 'styled-components'
 
 const isPopup = isPopupView()
-const popupWidth = 480
+const popupWidth = 360
 const popupHeight = 600
 
 const ExtensionGlobalStyle = createGlobalStyle`

--- a/core/ui/chain/coin/inputs/CoinPillButton.tsx
+++ b/core/ui/chain/coin/inputs/CoinPillButton.tsx
@@ -61,7 +61,6 @@ const Container = styled(UnstyledButton)`
   })}
   text-align: left;
   padding: 6px;
-  min-width: 0;
   ${borderRadius.pill};
   background-color: ${getColor('foregroundExtra')};
 
@@ -79,7 +78,8 @@ const Body = styled(HStack)`
  * The chevron is what tells the pill it opens a picker, so it must survive the
  * squeeze. Left to shrink it collapsed to nothing on the swap form's From
  * pill, where the amount field takes more of the row than the read-only To
- * amount does.
+ * amount does. The pill itself keeps its automatic minimum for the same
+ * reason: below it the chevron sits outside the pill and reads as missing.
  */
 const Chevron = styled(ChevronRightIcon)`
   flex-shrink: 0;

--- a/core/ui/chain/coin/inputs/CoinPillButton.tsx
+++ b/core/ui/chain/coin/inputs/CoinPillButton.tsx
@@ -1,5 +1,6 @@
 import { CoinIcon } from '@core/ui/chain/coin/icon/CoinIcon'
 import { TokenVerificationBadge } from '@core/ui/chain/coin/verification/TokenVerificationBadge'
+import { CoinTicker } from '@core/ui/vault/chain/CoinTicker'
 import { UnstyledButton } from '@lib/ui/buttons/UnstyledButton'
 import { borderRadius } from '@lib/ui/css/borderRadius'
 import { ChevronRightIcon } from '@lib/ui/icons/ChevronRightIcon'
@@ -34,11 +35,9 @@ export const CoinPillButton = ({
   return (
     <Container onClick={onClick} data-testid={testId}>
       <CoinIcon coin={value} style={{ fontSize: 32 }} />
-      <HStack gap={4} alignItems="center">
+      <Body gap={4} alignItems="center">
         <VStack gap={2}>
-          <Text weight="500" size={16} color="contrast">
-            {value.ticker}
-          </Text>
+          <CoinTicker ticker={value.ticker} size={14} weight="500" />
           {isFeeCoin(value) ? (
             <Text weight="500" size={12} color="shy">
               {t('native')}
@@ -49,8 +48,8 @@ export const CoinPillButton = ({
             </HStack>
           )}
         </VStack>
-        <ChevronRightIcon />
-      </HStack>
+        <Chevron />
+      </Body>
     </Container>
   )
 }
@@ -62,6 +61,26 @@ const Container = styled(UnstyledButton)`
   })}
   text-align: left;
   padding: 6px;
+  min-width: 0;
   ${borderRadius.pill};
   background-color: ${getColor('foregroundExtra')};
+
+  > svg,
+  > img {
+    flex-shrink: 0;
+  }
+`
+
+const Body = styled(HStack)`
+  min-width: 0;
+`
+
+/**
+ * The chevron is what tells the pill it opens a picker, so it must survive the
+ * squeeze. Left to shrink it collapsed to nothing on the swap form's From
+ * pill, where the amount field takes more of the row than the read-only To
+ * amount does.
+ */
+const Chevron = styled(ChevronRightIcon)`
+  flex-shrink: 0;
 `


### PR DESCRIPTION
Sub-PR of #4861.

The swap From pill had lost the chevron the design gives it, while To kept one.

Nothing hides it. The chevron is an `svg` flex item with the default shrink factor, so once the From pill is squeezed — the amount field beside it takes more of the row than the read-only To amount does — the chevron is the part that collapses. The ticker did not crop either, so the pill had no other way to give.

It no longer shrinks, and the ticker crops instead.

The ticker also drops from 16px to 14px. That size is read off the screenshot the design was compared against rather than from the Figma node, so it is worth a second look if the exact value is to hand.

The pill is shared with the send form, so both surfaces change together.

Closes #4868
