### PR TITLE
fix(swap): keep the amount suggestions on one line

### DIFF
--- a/clients/extension/src/pages/index.tsx
+++ b/clients/extension/src/pages/index.tsx
@@ -18,7 +18,7 @@ import {
 import { createGlobalStyle, css } from 'styled-components'
 
 const isPopup = isPopupView()
-const popupWidth = 480
+const popupWidth = 360
 const popupHeight = 600
 
 const ExtensionGlobalStyle = createGlobalStyle`

--- a/core/ui/vault/send/amount/AmountSuggestion.tsx
+++ b/core/ui/vault/send/amount/AmountSuggestion.tsx
@@ -9,11 +9,24 @@ import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
+/**
+ * Fixed at 56px the four suggestions ask for more of the row than the popup
+ * has beside the coin pill, and Max wrapped onto a line of its own. Below the
+ * breakpoint they share whatever the row leaves them instead, which keeps them
+ * on one line without a width that has to be guessed.
+ */
 const Container = styled(UnstyledButton)<{
   isActive?: boolean
 }>`
   width: 56px;
   height: 30px;
+
+  @media (max-width: 400px) {
+    flex: 1 1 0;
+    width: auto;
+    min-width: 0;
+    max-width: 56px;
+  }
   ${borderRadius.sm};
   ${centerContent};
   background-color: ${({ isActive }) =>


### PR DESCRIPTION
Sub-PR of #4861.

The swap amount suggestions wrapped onto two lines at the popup width — `25% 50% 75%` on one, `Max` alone on the next. `Max` is offered only when the From coin is not the chain's fee coin, which is why the wrap needs a token to reproduce.

Four fixed 56px buttons and their gaps ask for 236px, and the row shares its line with the coin pill. Below the breakpoint the buttons share whatever the row leaves them instead, so they stay on one line whatever the pill beside them needs — with a flex basis of zero they cannot force a wrap at any count.

Measured in the built extension at 360px, four buttons in the real row under the real stylesheet:

```
{"count":4,"rows":1,"widths":[29.6,29.6,29.6,29.6]}
```

Closes #4875
