### PR TITLE
fix(defi): shorten the staked card's headline amount

### DIFF
--- a/core/ui/defi/chain/components/stake/StakeCard.tsx
+++ b/core/ui/defi/chain/components/stake/StakeCard.tsx
@@ -206,8 +206,9 @@ export const StakeCard = ({
                     color="contrast"
                   >
                     {formatAmount(fromChainAmount(amount, coin.decimals), {
-                      ticker: coin.ticker,
-                    })}
+                      precision: 'medium',
+                    })}{' '}
+                    {coin.ticker}
                   </Text>
                   <Text size={12} color="shy">
                     {formatFiatAmount(fiat)}


### PR DESCRIPTION
Sub-PR of the second pass (#4881). Stacked on the base branch, which already carries the card's text-spec fix.

Matching the design's spec was not enough on its own. Measured, `2.95319259 bRUNE` needs 246.6px against the 236px the design leaves it — the frame is drawn with `500 TCY`, and an eight-decimal headline was never in it.

The headline now shows three fraction digits, which is what a number read at a glance can carry. The fiat value sits below it, and the exact amount is on the transfer action. `formatAmount` takes either a ticker or a precision, not both, so the ticker is rendered alongside instead.

Measured at the design's spec (Brockmann 28px, weight 500, -0.64px tracking), against the 236px available:

| | width |
|---|---|
| `2.953 bRUNE` | 169.6px |
| `3.991 sTCY` | 141.1px |
| `1,234.567 RUJI` | 187.7px |
| `123,456.789 RUNE` | 233.0px |

Above a million the formatter abbreviates to M/B, so the worst case is covered.

Closes #4882
