### PR TITLE
fix(swap): give the reverse button room between the two cards

### DIFF
--- a/core/ui/vault/swap/components/SwapCoinInputField/SwapCoinInputField.styled.tsx
+++ b/core/ui/vault/swap/components/SwapCoinInputField/SwapCoinInputField.styled.tsx
@@ -16,11 +16,11 @@ export const Container = styled(VStack)<{
     size: 16,
     weight: 700,
   })}
-  padding: clamp(12px, 3.33vw, 16px);
+  padding: 16px;
 
   /*
-   * The reverse button floats over the seam between the two cards: it is 54px
-   * tall and centred in the 8px gap, so it reaches 23px up into the From card.
+   * The reverse button floats over the seam between the two cards: its ring is
+   * 48px and centred in the 8px gap, so it reaches 20px up into the From card.
    * Without room for it the suggestions run underneath it.
    */
   ${({ side }) =>

--- a/core/ui/vault/swap/components/SwapCoinInputField/SwapCoinInputField.styled.tsx
+++ b/core/ui/vault/swap/components/SwapCoinInputField/SwapCoinInputField.styled.tsx
@@ -4,7 +4,7 @@ import { VStack } from '@lib/ui/layout/Stack'
 import { text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
 import { TransferDirection } from '@vultisig/lib-utils/TransferDirection'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 export const Container = styled(VStack)<{
   side: TransferDirection
@@ -17,6 +17,17 @@ export const Container = styled(VStack)<{
     weight: 700,
   })}
   padding: clamp(12px, 3.33vw, 16px);
+
+  /*
+   * The reverse button floats over the seam between the two cards: it is 54px
+   * tall and centred in the 8px gap, so it reaches 23px up into the From card.
+   * Without room for it the suggestions run underneath it.
+   */
+  ${({ side }) =>
+    side === 'from' &&
+    css`
+      padding-bottom: 24px;
+    `}
   border-radius: ${({ side }) =>
     side === 'to'
       ? `${borderRadiusPx.md}px ${borderRadiusPx.md}px ${borderRadiusPx.xl}px ${borderRadiusPx.xl}px`

--- a/core/ui/vault/swap/form/ReverseSwap.tsx
+++ b/core/ui/vault/swap/form/ReverseSwap.tsx
@@ -74,10 +74,14 @@ export const ReverseSwap = ({ errorMessage }: ReverseSwapProps) => {
   )
 }
 
+/**
+ * The design's control is a 32px button inside a 48px ring of page background,
+ * which is what separates it from the two cards it floats between.
+ */
 const Wrapper = styled(HStack)`
   background-color: ${getColor('background')};
   ${borderRadius.pill};
-  padding: 7px;
+  padding: 8px;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -86,7 +90,7 @@ const Wrapper = styled(HStack)`
   &::before {
     content: '';
     position: absolute;
-    width: 54px;
+    width: 48px;
     top: 0;
     height: 19px;
     ${borderRadius.pill};
@@ -99,7 +103,7 @@ const Wrapper = styled(HStack)`
   &::after {
     content: '';
     position: absolute;
-    width: 54px;
+    width: 48px;
     bottom: 0px;
     height: 19px;
     ${borderRadius.pill};
@@ -111,7 +115,7 @@ const Wrapper = styled(HStack)`
 `
 
 const Button = styled(UnstyledButton)<{ $hasError: boolean }>`
-  ${sameDimensions(40)};
+  ${sameDimensions(32)};
   background: ${({ $hasError }) =>
     $hasError ? getColor('danger') : getColor('buttonPrimary')};
   ${({ $hasError }) => ($hasError ? borderRadius.lg : borderRadius.pill)};

--- a/core/ui/vault/swap/form/ReverseSwap.tsx
+++ b/core/ui/vault/swap/form/ReverseSwap.tsx
@@ -74,10 +74,15 @@ export const ReverseSwap = ({ errorMessage }: ReverseSwapProps) => {
   )
 }
 
+/**
+ * The ring of page background around the button is what separates it from the
+ * two cards it sits between. At 7px the cards read as touching it, so it takes
+ * the 69px the design gives the whole control.
+ */
 const Wrapper = styled(HStack)`
   background-color: ${getColor('background')};
   ${borderRadius.pill};
-  padding: 7px;
+  padding: 14px;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -86,7 +91,8 @@ const Wrapper = styled(HStack)`
   &::before {
     content: '';
     position: absolute;
-    width: 54px;
+    left: 0;
+    width: 100%;
     top: 0;
     height: 19px;
     ${borderRadius.pill};
@@ -99,7 +105,8 @@ const Wrapper = styled(HStack)`
   &::after {
     content: '';
     position: absolute;
-    width: 54px;
+    left: 0;
+    width: 100%;
     bottom: 0px;
     height: 19px;
     ${borderRadius.pill};

--- a/core/ui/vault/swap/form/ReverseSwap.tsx
+++ b/core/ui/vault/swap/form/ReverseSwap.tsx
@@ -74,15 +74,10 @@ export const ReverseSwap = ({ errorMessage }: ReverseSwapProps) => {
   )
 }
 
-/**
- * The ring of page background around the button is what separates it from the
- * two cards it sits between. At 7px the cards read as touching it, so it takes
- * the 69px the design gives the whole control.
- */
 const Wrapper = styled(HStack)`
   background-color: ${getColor('background')};
   ${borderRadius.pill};
-  padding: 14px;
+  padding: 7px;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -91,8 +86,7 @@ const Wrapper = styled(HStack)`
   &::before {
     content: '';
     position: absolute;
-    left: 0;
-    width: 100%;
+    width: 54px;
     top: 0;
     height: 19px;
     ${borderRadius.pill};
@@ -105,8 +99,7 @@ const Wrapper = styled(HStack)`
   &::after {
     content: '';
     position: absolute;
-    left: 0;
-    width: 100%;
+    width: 54px;
     bottom: 0px;
     height: 19px;
     ${borderRadius.pill};


### PR DESCRIPTION
Sub-PR of the second pass (#4881).

The reverse button between the From and To cards reads as touching both of them.

What separates them is the ring of page background the button carries — a 40px button with 7px of padding, 54px in all. The design gives the whole control 69px: the same button with 14px of ring.

The two notch halves that carve the gap out of the cards traced that wrapper with a hardcoded 54px, so they now follow it instead of repeating the number.

Closes #4888
