### PR TITLE
fix(vault): fit the reshare graphic to the height it is given

### DIFF
--- a/core/ui/mpc/keygen/reshare/ReshareVaultIntroStep.tsx
+++ b/core/ui/mpc/keygen/reshare/ReshareVaultIntroStep.tsx
@@ -17,6 +17,7 @@ const Wrapper = styled.div`
   display: flex;
   flex: 1;
   flex-direction: column;
+  min-height: 0;
   position: relative;
 `
 
@@ -35,6 +36,7 @@ const GlowLayer = styled.div`
 
 const Foreground = styled(VStack)`
   flex: 1;
+  min-height: 0;
   position: relative;
   z-index: 1;
 `

--- a/core/ui/mpc/keygen/reshare/ReshareVaultIntroStep.tsx
+++ b/core/ui/mpc/keygen/reshare/ReshareVaultIntroStep.tsx
@@ -39,9 +39,24 @@ const Foreground = styled(VStack)`
   z-index: 1;
 `
 
-const GraphicWrapper = styled.div`
-  width: 100%;
-  max-width: 300px;
+/**
+ * Takes the room the heading and the option cards leave and scales the
+ * illustration into it. The SVG carries a 300x200 viewBox and no height of its
+ * own, so left alone it always drew 200px tall and the popup clipped it.
+ */
+const GraphicArea = styled.div`
+  align-items: center;
+  display: flex;
+  flex: 1;
+  justify-content: center;
+  min-height: 0;
+
+  > svg {
+    height: 100%;
+    max-height: 200px;
+    max-width: min(100%, 300px);
+    width: auto;
+  }
 `
 
 export const ReshareVaultIntroStep = ({
@@ -80,11 +95,9 @@ export const ReshareVaultIntroStep = ({
               {t('reshare_vault_subtitle')}
             </Text>
           </VStack>
-          <VStack flexGrow alignItems="center" justifyContent="center">
-            <GraphicWrapper>
-              <ReshareDevicesGraphic />
-            </GraphicWrapper>
-          </VStack>
+          <GraphicArea>
+            <ReshareDevicesGraphic />
+          </GraphicArea>
         </Foreground>
       </Wrapper>
     </ScreenLayout>

--- a/lib/ui/layout/ScreenLayout/ScreenLayout.tsx
+++ b/lib/ui/layout/ScreenLayout/ScreenLayout.tsx
@@ -109,6 +109,14 @@ const Content = styled.div`
   display: flex;
   flex-direction: column;
   flex: 1;
+
+  /*
+   * Without this the automatic minimum keeps the column at its content's
+   * height, so a child that could scale into the space available — an
+   * illustration, say — has no smaller size to take and the screen scrolls
+   * instead. Content that genuinely does not fit still overflows and scrolls.
+   */
+  min-height: 0;
 `
 
 const Footer = styled.footer`


### PR DESCRIPTION
Sub-PR of the second pass (#4881).

On the Reshare your vault screen the devices graphic is cut off: the bottom device is clipped and the page has to be scrolled to see the whole illustration.

The SVG carries a `0 0 300 200` viewBox and nothing bounded its height, so it always drew 200px tall whatever room the screen had. At 360x600 the heading, the subtitle and the two option cards leave it less than that.

It now takes the room those leave and scales into it, capped at the 300x200 it draws today. A taller window is therefore unchanged — only a screen too short for the full size shrinks it, which is the case being fixed.

Closes #4893
