### PR TITLE
fix(extension): drop the chain pill from the Select asset rows

### DIFF
--- a/core/ui/chain/coin/inputs/CoinOption.tsx
+++ b/core/ui/chain/coin/inputs/CoinOption.tsx
@@ -6,7 +6,6 @@ import {
   useCurrentVaultAddress,
   useCurrentVaultCoins,
 } from '@core/ui/vault/state/currentVaultCoins'
-import { borderRadius } from '@lib/ui/css/borderRadius'
 import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { Skeleton } from '@lib/ui/loaders/Skeleton'
 import { panel } from '@lib/ui/panel/Panel'
@@ -27,7 +26,7 @@ export const CoinOption = ({
   value,
   onClick,
 }: ValueProp<Coin> & OnClickProp & IsActiveProp) => {
-  const { chain, ticker } = value
+  const { ticker } = value
   const coins = useCurrentVaultCoins()
   const vaultCoin = coins.find(c => areEqualCoins(c, value))
 
@@ -44,15 +43,8 @@ export const CoinOption = ({
       <CoinDetails alignItems="center" gap={12}>
         <CoinIcon coin={value} style={{ fontSize: 32 }} />
         <CoinLabel gap={8} alignItems="center">
-          <TickerSlot>
-            <CoinTicker ticker={ticker} size={13} weight="500" />
-          </TickerSlot>
+          <CoinTicker ticker={ticker} size={13} weight="500" />
           <TokenVerificationBadge value={value} />
-          <PillWrapper>
-            <Text color="shy" size={11} weight="500" cropped>
-              {chain}
-            </Text>
-          </PillWrapper>
         </CoinLabel>
       </CoinDetails>
       <BalanceColumn gap={4} justifyContent="center" alignItems="flex-end">
@@ -143,7 +135,7 @@ const Container = styled(HStack)`
 `
 
 /**
- * Icon, ticker and chain pill. It has to shrink, or a ticker that is a raw
+ * Icon and ticker. It has to shrink, or a ticker that is a raw
  * contract address makes the row wider than the modal — and because the list
  * around it scrolls vertically, that overflow becomes a horizontal scrollbar
  * rather than being clipped.
@@ -162,38 +154,9 @@ const CoinLabel = styled(HStack)`
 `
 
 /**
- * Reserves the ticker's width before the chain pill can claim it. `LUNC` next
- * to a `TerraClassic` pill was cropping to 25px, because how much the ticker
- * got depended on how long the chain happened to be called.
- */
-const TickerSlot = styled.div`
-  min-width: 0;
-
-  @media (max-width: 400px) {
-    flex-shrink: 0;
-    max-width: 72px;
-  }
-`
-
-const PillWrapper = styled.div`
-  flex-shrink: 0;
-  display: grid;
-  place-items: center;
-  padding: 8px 12px;
-  ${borderRadius.pill};
-  border: 1px solid ${getColor('foregroundExtra')};
-
-  @media (max-width: 400px) {
-    flex-shrink: 1;
-    min-width: 0;
-    padding: 4px 8px;
-  }
-`
-
-/**
- * Balance for the row. At the popup width it gives way to the ticker, which is
- * what tells two rows apart: capped, a four-letter ticker stays whole; without
- * a cap the ticker was down to two legible characters.
+ * Balance for the row. At the popup width it still yields to the ticker, which
+ * is what tells two rows apart, but with the chain pill gone there is more to
+ * share and the cap can be looser.
  */
 const BalanceColumn = styled(VStack)`
   min-width: 100px;
@@ -201,6 +164,6 @@ const BalanceColumn = styled(VStack)`
 
   @media (max-width: 400px) {
     min-width: 0;
-    max-width: 80px;
+    max-width: 120px;
   }
 `


### PR DESCRIPTION
Sub-PR of the second pass (#4881).

Every row in the Select asset list carried the chain twice: as a badge on the coin icon, and again as a text pill beside the ticker. At the popup width there was no room for both, and the balance ran into the pill.

The pill dates from a layout that had no chain badge under the coin icon, when spelling the chain out was the only way to say which one a row belonged to. That is no longer the case:

- a token gets a chain badge on its icon, from `shouldDisplayChainLogo`
- a chain's own fee coin gets no badge, because its logo *is* the chain's logo

It is redundant a third time over: the picker shows one chain at a time and names it in the `Select chain` footer, so the pill repeated the same word on every row.

Measured at 360px, where the row has 272px of content:

| | before | after |
|---|---|---|
| ticker `RUNE` | cropped | 35.9px, whole |
| contract-address ticker | 72px | 106px |
| balance cap | 80px | 120px |

Closes #4896
