### PR TITLE
fix(deps): bump smol-toml resolution to fix quality:health audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@vultisig/mpc-types": "0.3.0",
     "@vultisig/mpc-wasm": "0.1.8",
     "tar": ">=7.5.21",
+    "smol-toml@1.6.1": ">=1.7.1",
     "js-yaml@4.1.1": "4.3.2",
     "js-yaml@^4.1.1": "4.3.2",
     "js-yaml@4.3.1": "4.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15194,14 +15194,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"smol-toml@npm:1.6.1":
-  version: 1.6.1
-  resolution: "smol-toml@npm:1.6.1"
-  checksum: 10c0/511a78722f99c7616fdb46af708de3d7e81434b5a3d58061166da73f28bfc6cae4f0cd04683f60515b9c490cd10152fce72287c960b337419c0299cc1f0f2a22
-  languageName: node
-  linkType: hard
-
-"smol-toml@npm:^1.5.2":
+"smol-toml@npm:>=1.7.1, smol-toml@npm:^1.5.2":
   version: 1.8.0
   resolution: "smol-toml@npm:1.8.0"
   checksum: 10c0/4e01dbfb7c7af142176b037ebedaccccafb8229cc873feaa47c184ee31073d86e30b4b1b0fe9a5a6d083ed3ce21615eda9e81d1f5d779ad8b2e2e9459b900aea


### PR DESCRIPTION
## Summary
- `yarn quality:audit` (part of `yarn quality:health`) was failing on a high-severity DoS advisory in `smol-toml` (GHSA-7w5x-hrqm-74c2), pulled in transitively at 1.6.1 via `markdownlint-cli2`.
- Added a `smol-toml@1.6.1` resolution to `>=1.7.1` (a fixed version), matching the existing pattern used for the prior `js-yaml` audit fix.

## Test plan
- [x] `yarn install`
- [x] `yarn quality:audit` passes with "No audit suggestions"
- [x] `yarn quality:health` passes end to end

https://claude.ai/code/session_016kTcjggP8UqRwswdYEJ6UW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolution to require `smol-toml` version 1.7.1 or newer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->