### PR TITLE
fix(extension): fit four columns in the chain and token pickers at 360px

### DIFF
--- a/core/ui/vault/chain/manage/shared/ItemGrid.tsx
+++ b/core/ui/vault/chain/manage/shared/ItemGrid.tsx
@@ -1,14 +1,14 @@
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 
+/**
+ * Grid for the 74px chain, token and DeFi tiles. Tracks are sized to the
+ * tile and the leftover width is shared between them, so the row lines up
+ * with the content edges and the 360px popup fits four columns.
+ */
 export const ItemGrid = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(74px, 1fr));
-  column-gap: 16px;
+  grid-template-columns: repeat(auto-fill, 74px);
+  justify-content: space-between;
+  column-gap: 8px;
   row-gap: 16px;
-
-  ${({ theme }) =>
-    theme.iconStyle === 'station' &&
-    css`
-      grid-template-columns: repeat(auto-fill, 74px);
-    `}
 `


### PR DESCRIPTION
Closes #4904. Sub-issue of #4881.

At the 360px popup, Select chains and Choose Tokens showed three columns where the design draws four.

`ItemGrid` laid its 74px tiles out in `minmax(74px, 1fr)` tracks with a 16px column gap. The scrolling page leaves 320px of content at the popup — 360 less the page's 16px a side and the 8px themed scrollbar — and four tiles with three 16px gaps need 344, so `auto-fill` fitted three. Those three also sat at the start of 96px tracks, so the grid ended 22px short of the search field's right edge.

The tracks are now sized to the tile and `justify-content: space-between` shares the leftover, so the row fills the content edge to edge at every width. With an 8px minimum gap the popup fits four columns exactly:

```
4 × 74 + 3 × 8 = 320
```

Wider surfaces keep fitting as many 74px columns as they have room for, as before. The Station variant had the same three columns for the same reason and takes the same rule, so its override goes. The DeFi chain and position pickers and the seed-phrase import's chain step share this grid and pick up the change with it.

Measured in the built extension at 360x600, on both pickers:

| | `main` | with this |
|---|---|---|
| columns | 3 | 4 |
| tile width | 74px | 74px |
| gap between tiles | 38px | 8px |
| grid right edge vs. search field | 22px short | level |
| horizontal scroll | none | none |

The `main` row is computed from the old rule at 320px; the new row is read off the DOM with a Playwright probe that also checked `scrollWidth - clientWidth` on every element.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated item grid spacing and alignment for a more consistent layout.
  - Standardized item columns at 74px with reduced column gaps.
  - Improved distribution of available horizontal space between items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->