### PR TITLE
fix(folder): drop the signer pill and truncate long vault names in folder rows

### DIFF
--- a/clients/extension/tests/e2e/playwright.config.ts
+++ b/clients/extension/tests/e2e/playwright.config.ts
@@ -150,6 +150,7 @@ export default defineConfig({
         '**/viewport-fit.spec.ts',
         '**/undecryptable-vault.spec.ts',
         '**/swap-custom-token-empty-state.spec.ts',
+        '**/folder-vault-rows.spec.ts',
       ],
       use: {
         launchOptions: {

--- a/clients/extension/tests/e2e/specs/folder-vault-rows.spec.ts
+++ b/clients/extension/tests/e2e/specs/folder-vault-rows.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * Guards the Add Folder / Edit Folder vault rows against a long vault name
+ * pushing the toggle out of the card (#4906). The shared `VaultListRow` used
+ * to keep its title side at `flex-shrink: 0`, so the name never truncated and
+ * the trailing switch overflowed the row at the 360px popup width. The rows
+ * also no longer render the signer pill — the leading icon already conveys
+ * the vault type.
+ */
+
+import { mkdir } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import type { BrowserContext, Page } from '@playwright/test'
+
+import { expect, test } from '../fixtures/extension-loader'
+import { writeChromeStorageMultiple } from '../helpers/chrome-storage'
+import { createSeededVault } from '../helpers/seeded-vault'
+
+const longVaultName = 'Ahmad-Ehsan Family Treasury Vault With A Long Name'
+const folderId = 'family-folder'
+const popup = { width: 360, height: 600 }
+
+type Screen = {
+  title: string
+  initialView: Record<string, unknown>
+  vaultFolderId?: string
+}
+
+const screens: Screen[] = [
+  {
+    title: 'Add Folder',
+    initialView: { id: 'createVaultFolder' },
+  },
+  {
+    title: 'Edit Folder',
+    initialView: { id: 'updateVaultFolder', state: { id: folderId } },
+    vaultFolderId: folderId,
+  },
+]
+
+const seedScreen = async (context: BrowserContext, screen: Screen) => {
+  const { vaultId, vault } = await createSeededVault({ name: longVaultName })
+
+  await writeChromeStorageMultiple(context, {
+    currentVaultId: vaultId,
+    hasFinishedOnboarding: true,
+    initialView: screen.initialView,
+    vaultFolders: [{ id: folderId, name: 'Family', order: 0 }],
+    vaults: [{ ...vault, folderId: screen.vaultFolderId }],
+    vaultsCoins: { [vaultId]: [] },
+  })
+}
+
+const getRowGeometry = (page: Page) =>
+  page
+    .getByTestId('vault-list-row')
+    .first()
+    .evaluate(row => {
+      const title = row.querySelector('p')
+      const toggle = [
+        ...row.querySelectorAll<HTMLElement>('[tabindex="0"]'),
+      ].at(-1)
+      if (!title || !toggle) {
+        throw new Error('Vault row is missing its title or toggle')
+      }
+
+      const rowBox = row.getBoundingClientRect()
+      const titleBox = title.getBoundingClientRect()
+      const toggleBox = toggle.getBoundingClientRect()
+      const root = document.documentElement
+
+      return {
+        titleEllipsized: title.scrollWidth > title.clientWidth,
+        titleEndsBeforeToggle: titleBox.right <= toggleBox.left,
+        toggleInsideRow:
+          toggleBox.left >= rowBox.left - 0.5 &&
+          toggleBox.right <= rowBox.right + 0.5,
+        rowInsideViewport: rowBox.right <= root.clientWidth + 0.5,
+        pageHorizontalScroll: root.scrollWidth - root.clientWidth,
+      }
+    })
+
+for (const screen of screens) {
+  test(`${screen.title}: a long vault name keeps the toggle inside the row at 360px`, async ({
+    context,
+    extensionId,
+  }) => {
+    await seedScreen(context, screen)
+
+    const page = await context.newPage()
+    await page.setViewportSize(popup)
+    await page.goto(`chrome-extension://${extensionId}/index.html`)
+
+    const row = page.getByTestId('vault-list-row').first()
+    await expect(row).toBeVisible({ timeout: 30_000 })
+    await expect(row).toContainText(longVaultName)
+    await expect(row.getByText(/^fast$/i)).toHaveCount(0)
+    await expect(row.getByText(/part \d+-of-\d+/i)).toHaveCount(0)
+
+    await expect
+      .poll(() => getRowGeometry(page))
+      .toEqual({
+        titleEllipsized: true,
+        titleEndsBeforeToggle: true,
+        toggleInsideRow: true,
+        rowInsideViewport: true,
+        pageHorizontalScroll: 0,
+      })
+
+    const artifactDirectory = process.env.EXTENSION_FOLDER_QA_ARTIFACT_DIR
+    if (artifactDirectory) {
+      await mkdir(artifactDirectory, { recursive: true })
+      await page.screenshot({
+        path: join(artifactDirectory, `${screen.title.replace(/ /g, '-')}.png`),
+      })
+    }
+
+    await page.close()
+  })
+}

--- a/core/ui/vaultsOrganisation/components/VaultListRow.tsx
+++ b/core/ui/vaultsOrganisation/components/VaultListRow.tsx
@@ -31,6 +31,7 @@ export const VaultListRow = ({
 }: VaultListRowProps) => {
   return (
     <Row
+      data-testid="vault-list-row"
       clickable={!!onClick}
       selected={selected}
       disabled={disabled}
@@ -49,9 +50,9 @@ export const VaultListRow = ({
             }
       }
     >
-      <RowContent gap={14} alignItems="center">
+      <MainContent gap={14} alignItems="center">
         {leading && <LeadingSlot>{leading}</LeadingSlot>}
-        <VStack gap={4} alignItems="flex-start">
+        <TextContent gap={4}>
           <Text size={16} weight={600} color="contrast" cropped>
             {title}
           </Text>
@@ -60,12 +61,14 @@ export const VaultListRow = ({
               {subtitle}
             </Text>
           )}
-        </VStack>
-      </RowContent>
-      <RowContent gap={12} alignItems="center">
-        {meta}
-        {trailing}
-      </RowContent>
+        </TextContent>
+      </MainContent>
+      {meta || trailing ? (
+        <TrailingContent gap={12} alignItems="center">
+          {meta}
+          {trailing}
+        </TrailingContent>
+      ) : null}
     </Row>
   )
 }
@@ -88,6 +91,7 @@ const Row = styled.div.withConfig({
   border: 1px solid
     ${({ theme }) => theme.colors.foregroundExtra.withAlpha(0.7).toCssValue()};
   display: flex;
+  gap: 12px;
   justify-content: space-between;
   padding: 16px 20px;
   transition:
@@ -126,13 +130,25 @@ const Row = styled.div.withConfig({
     `}
 `
 
-const RowContent = styled(HStack)`
+// The title side owns the leftover width and is allowed to shrink so a long
+// vault name ellipsizes instead of pushing the trailing control out of the row.
+const MainContent = styled(HStack)`
+  flex: 1;
+  min-width: 0;
+`
+
+const TextContent = styled(VStack)`
+  min-width: 0;
+`
+
+const TrailingContent = styled(HStack)`
   flex-shrink: 0;
 `
 
 const LeadingSlot = styled.div`
   display: flex;
   align-items: center;
+  flex-shrink: 0;
 `
 
 type LeadingIconProps = {

--- a/core/ui/vaultsOrganisation/folder/create/index.tsx
+++ b/core/ui/vaultsOrganisation/folder/create/index.tsx
@@ -6,7 +6,6 @@ import {
 } from '@core/ui/storage/vaultFolders'
 import { useFolderlessVaults } from '@core/ui/storage/vaults'
 import { DoneButton } from '@core/ui/vault/chain/manage/shared/DoneButton'
-import { VaultSigners } from '@core/ui/vault/signers'
 import {
   LeadingIconBadge,
   VaultListRow,
@@ -151,7 +150,6 @@ export const CreateVaultFolderPage = () => {
                         ? formatFiatAmount(value)
                         : undefined
                     }
-                    meta={<VaultSigners vault={vault} />}
                     trailing={
                       <SwitchWrapper
                         onClick={event => event.stopPropagation()}

--- a/core/ui/vaultsOrganisation/folder/update/index.tsx
+++ b/core/ui/vaultsOrganisation/folder/update/index.tsx
@@ -7,7 +7,6 @@ import {
 import { useFolderlessVaults, useFolderVaults } from '@core/ui/storage/vaults'
 import { DoneButton } from '@core/ui/vault/chain/manage/shared/DoneButton'
 import { useUpdateVaultMutation } from '@core/ui/vault/mutations/useUpdateVaultMutation'
-import { VaultSigners } from '@core/ui/vault/signers'
 import {
   LeadingIconBadge,
   VaultListRow,
@@ -156,7 +155,6 @@ const AddVaultsToFolder = ({ totals, isTotalsPending }: AddVaultsProps) => {
                   ? formatFiatAmount(value)
                   : undefined
               }
-              meta={<VaultSigners vault={vault} />}
               trailing={
                 <SwitchWrapper onClick={event => event.stopPropagation()}>
                   <Switch checked={false} onChange={handleToggle} />
@@ -269,7 +267,6 @@ const ManageFolderVaults = ({
                   ? formatFiatAmount(value)
                   : undefined
               }
-              meta={<VaultSigners vault={item} />}
               trailing={
                 <SwitchWrapper onClick={event => event.stopPropagation()}>
                   <Switch checked onChange={handleRemove} />


### PR DESCRIPTION
Closes #4906.

## What

On **Add Folder** and **Edit Folder** every vault row showed a "Fast" / "part 2-of-2" pill between the name and the toggle. The leading icon already tells the vault type (bolt = fast, shield = secure) and the Figma design has no pill — and because the shared `VaultListRow` kept its title side at `flex-shrink: 0`, a long vault name never truncated and pushed the switch outside the card at the 360px popup width.

- `VaultListRow`: the title side now owns the leftover width and can shrink (`flex: 1; min-width: 0`), so `Text cropped` actually ellipsizes the name; the trailing slot stays `flex-shrink: 0`, and the leading icon is protected from shrinking. A `gap` on the row keeps the name clear of the trailing control when it is truncated. The trailing container is only rendered when there is something to put in it.
- Add Folder / Edit Folder (both "Active vaults" and "Available"): the `VaultSigners` pill is gone.
- The row gets a `data-testid="vault-list-row"` for the spec below.

The layout fix lives in the shared row, so the folder view and the manage-vaults/folders lists also stop overflowing on long names. The vault switcher (`VaultListItem`) and the backup vault picker keep their pill — they use a different design and were not touched.

## After (360px popup, vault named `Ahmad-Ehsan Family Treasury Vault With A Long Name`)

<!-- 👇 Paste the two screenshots here: Add Folder (left) and Edit Folder (right). Both come from the spec run with EXTENSION_FOLDER_QA_ARTIFACT_DIR set. -->

## Test

New `ui-isolated` spec `clients/extension/tests/e2e/specs/folder-vault-rows.spec.ts`: seeds a vault with a long name (and, for Edit Folder, a folder containing it), opens each screen at 360×600 via `initialView`, and asserts that the name is ellipsized, the toggle sits inside the row, the row sits inside the viewport, there is no page-level horizontal scroll, and no "Fast" / "part N-of-M" text is rendered. Set `EXTENSION_FOLDER_QA_ARTIFACT_DIR` to also save a screenshot per screen.

Sanity-checked the assertions by re-applying the old `flex: none` on the title side via an injected style: `toggleInsideRow` flips to `false`, so the spec really guards the regression.

## Verification

- `yarn check` green (typecheck, lint, i18n integrity, knip).
- `yarn build:extension` succeeds; the new spec passes on that build (2/2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
