### PR TITLE
fix(version): update version to 1.0.73 in configuration files

### DIFF
--- a/ci/deb/nfpm.yaml
+++ b/ci/deb/nfpm.yaml
@@ -1,7 +1,7 @@
 name: "vultisig"
 arch: "amd64"
 platform: "linux"
-version: "1.0.72"
+version: "1.0.73"
 section: "default"
 priority: "extra"
 maintainer: "Vultisig team <dev@vultisig.com>"

--- a/clients/desktop/build.json
+++ b/clients/desktop/build.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.0.72",
-  "build": 72
+  "version": "1.0.73",
+  "build": 73
 }


### PR DESCRIPTION
Bumps desktop build.json and nfpm.yaml to 1.0.73 for the v1.0.73 release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the desktop application and Debian package release metadata to version 1.0.73.
  - Incremented the desktop build number to 73.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->