### PR TITLE
docs(chain): add JSDoc to VaultChainTokensEmptyState

### DIFF
--- a/core/ui/vault/chain/tabs/VaultChainTokensEmptyState.tsx
+++ b/core/ui/vault/chain/tabs/VaultChainTokensEmptyState.tsx
@@ -15,6 +15,12 @@ type VaultChainTokensEmptyStateProps = {
   isSearchResult?: boolean
 }
 
+/**
+ * Card shown on the chain page's Tokens tab when the list has nothing to
+ * render. With `isSearchResult` the copy says the search matched nothing;
+ * otherwise it says every token is disabled. Either way it points the user at
+ * the manage-tokens screen for the current chain.
+ */
 export const VaultChainTokensEmptyState = ({
   isSearchResult = false,
 }: VaultChainTokensEmptyStateProps) => {


### PR DESCRIPTION
Follow-up to #4913.

## Problem
CodeRabbit flagged on #4913 that `VaultChainTokensEmptyState` ships without JSDoc (https://github.com/vultisig/vultisig-windows/pull/4913#discussion_r3994481462). The first commit of that PR had one; it was dropped when the component was reworked to take `isSearchResult`, and the PR merged before the comment was addressed.

## What changed
- Restores the `/** ... */` on the exported component, describing both copy variants (search matched nothing vs. every token disabled) and the manage-tokens shortcut.
- `VaultChainTokensEmptyStateProps` is not exported, so the JSDoc rule does not apply to it and it is left as is.

## Verification
- `yarn check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the empty-state behavior for vault chain tokens when searches return no matches or when no tokens are selected.
  - Documented the available navigation path to token management, helping users understand how to manage their token selection from the empty state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->