### PR TITLE
fix(referral): let the referrals hero shrink so both actions fit the popup

### DIFF
--- a/core/ui/vault/settings/referral/components/ManageReferrals.tsx
+++ b/core/ui/vault/settings/referral/components/ManageReferrals.tsx
@@ -175,11 +175,20 @@ const DiscoveryContent = styled(VStack)`
   min-height: 100%;
 `
 
+/**
+ * Scales the illustration into whatever height the two action cards leave.
+ * The webp is 375x405, so drawn at the popup's width it alone outgrows the
+ * 600px viewport; without `min-height: 0` a flex item never shrinks below
+ * its content height and the screen scrolls instead. Where there is room
+ * (desktop, expanded view) it still draws at full size.
+ */
 const HeroIllustration = styled.img`
   align-self: center;
   display: block;
   height: auto;
   max-width: 375px;
+  min-height: 0;
+  object-fit: contain;
   width: 100%;
 `
 


### PR DESCRIPTION
Closes #4919

## Problem

On the 360×600 extension popup, the **Vultisig Referrals** manage screen paints `referral-hero.webp` (375×405) at the popup's full width — ~354px tall. That alone leaves no room for the two action cards: **Save Referral** is visible, **Create Referral** sits below the fold and the screen scrolls.

## What changed

One styled component, [`HeroIllustration` in `ManageReferrals.tsx`](https://github.com/vultisig/vultisig-windows/blob/4919-fit-referrals-hero-both-actions-on-screen/core/ui/vault/settings/referral/components/ManageReferrals.tsx#L178-L193):

```diff
 const HeroIllustration = styled.img`
   align-self: center;
   display: block;
   height: auto;
   max-width: 375px;
+  min-height: 0;
+  object-fit: contain;
   width: 100%;
 `
```

The column the image sits in is already height-bounded (`DiscoveryContent` has `min-height: 100%` inside a `scrollable` `PageContent`), so the flex algorithm *wants* to shrink the image — but a flex item never shrinks below its content height unless it opts in. `min-height: 0` lets it give up height; `object-fit: contain` keeps the artwork in proportion inside the smaller box. Same mechanism as the reshare graphic fit (#4894).

No fixed `max-height`: the image takes exactly whatever the two cards leave, so it adapts to any viewport and still draws at full size on desktop / expanded view where there is room.

## Measured

Replica of the real height chain (popup 360×600 → header → scrollable `PageContent` → `DiscoveryContent` → hero + two cards) in headless Chromium:

|        | scroll overflow | image height | 2nd card bottom |
|--------|----------------:|-------------:|----------------:|
| before | 88px            | 354px        | 688px (off-screen) |
| after  | 0px             | 250px        | 584px           |

## Scope

- Illustration kept, only scaled
- No copy / i18n / flow changes
- Popup height untouched

## Verification

- [x] `yarn check` passes
- [ ] Manual: extension popup → Settings → Referrals — hero + both cards visible, no vertical scroll
- [ ] Manual: expanded view / desktop — illustration still draws at full size

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved referral illustration sizing in narrow layouts, preserving its aspect ratio and preventing overflow.
  * Ensured the illustration retains its full size when sufficient space is available.

* **Documentation**
  * Added guidance explaining the illustration’s responsive sizing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->