### PR TITLE
fix(referral): remove the horizontal scrollbar on the Your Referrals screen

### DIFF
--- a/core/ui/vault/settings/referral/components/Referrals.styled.tsx
+++ b/core/ui/vault/settings/referral/components/Referrals.styled.tsx
@@ -26,8 +26,14 @@ export const FormFieldLabel = styled.label`
   })}
 `
 
+/**
+ * The decorative glow (`Overlay`) is wider than the card it sits behind, so
+ * at the popup width it bleeds past the page. Clipping only one axis makes
+ * the browser turn the other into `auto`, which is where the horizontal
+ * scrollbar came from — clip both so the bleed is cut off, never scrolled.
+ */
 export const ReferralPageWrapper = styled(PageContent)`
-  overflow-y: hidden;
+  overflow: hidden;
 
   @media (${mediaQuery.tabletDeviceAndUp}) {
     max-width: 650px;


### PR DESCRIPTION
## Summary
- The `Overlay` glow behind the referral card is a fixed 374px wide, so at the 360px popup it sticks out 11px past the page on each side.
- `ReferralPageWrapper` only set `overflow-y: hidden`; per CSS, a lone non-`visible` axis makes the other compute to `auto`, so that bleed turned into a real horizontal scroll region with a scrollbar under **Edit Referral**.
- Clip both axes on the wrapper. The glow is cut off at the page edge — the same way the design frame clips it — instead of being scrollable. Desktop and the expanded view are unchanged since the glow already fits there.

Closes #4923

## Verification
Measured at 360×600 with a throwaway Playwright probe against the built extension (imported test vault, Settings → Referral Code → Your Referrals):

| | before | after |
|---|---|---|
| horizontally scrollable containers | 1 (`ReferralPageWrapper`, `overflow-x: auto`, scrollWidth 363 / clientWidth 352) | 0 |
| vertical scroller `scrollHeight` | 706 | 698 (the 8px horizontal scrollbar is gone) |

Also `yarn check` passes.

## Test plan
- [ ] Extension popup → Settings → Referral Code → land on **Your Referrals** (vault with a THORChain name)
- [ ] Scroll to the bottom: no horizontal scrollbar under **Edit Referral**, page can't be dragged sideways
- [ ] Glow behind the card still visible; same on the "no referral yet" variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated referral page layout behavior to prevent content from overflowing horizontally or vertically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->