### PR TITLE
fix(passcode): keep passcode inputs inside the 360px popup and match App Locked to the design

### DIFF
--- a/core/ui/passcodeEncryption/guard/EnterPasscode.tsx
+++ b/core/ui/passcodeEncryption/guard/EnterPasscode.tsx
@@ -1,13 +1,13 @@
 import { Button } from '@lib/ui/buttons/Button'
+import { borderRadius } from '@lib/ui/css/borderRadius'
 import { takeWholeSpace } from '@lib/ui/css/takeWholeSpace'
 import { VStack, vStack } from '@lib/ui/layout/Stack'
-import { panel } from '@lib/ui/panel/Panel'
 import { useRefetchQueries } from '@lib/ui/query/hooks/useRefetchQueries'
 import { Text } from '@lib/ui/text'
 import { getColor } from '@lib/ui/theme/getters'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import { useCore } from '../../state/core'
 import { usePasscodeEncryption } from '../../storage/passcodeEncryption'
@@ -28,17 +28,51 @@ import { usePasscode } from '../state/passcode'
 
 const Wrapper = styled.div`
   ${takeWholeSpace}
+  position: relative;
+  overflow: hidden;
   background: ${getColor('background')};
 `
 
-const Container = styled.div`
-  background: radial-gradient(
-    50% 50% at 50% 50%,
-    rgba(4, 57, 199, 0.57) 0%,
-    rgba(2, 18, 42, 0.41) 100%
-  );
+// The design's backdrop: a blurred 648px glow and a faint 590px ring sharing
+// a centre 20px right of and 50px below the frame's centre.
+const glowDiameter = 648
+const ringDiameter = 590.8
 
+const backdropCircle = css`
+  position: absolute;
+  left: calc(50% + 20px);
+  top: calc(50% + 50px);
+  transform: translate(-50%, -50%);
+  ${borderRadius.pill};
+  pointer-events: none;
+`
+
+const Glow = styled.div`
+  ${backdropCircle};
+  width: ${glowDiameter}px;
+  height: ${glowDiameter}px;
+  background: ${({ theme }) => `radial-gradient(
+    circle,
+    ${theme.colors.primaryAccentTwo.getVariant({ a: () => 0.57 }).toCssValue()} 0%,
+    ${theme.colors.background.getVariant({ a: () => 0.41 }).toCssValue()} 100%
+  )`};
+  opacity: 0.5;
+  filter: blur(4.4px);
+`
+
+const Ring = styled.div`
+  ${backdropCircle};
+  width: ${ringDiameter}px;
+  height: ${ringDiameter}px;
+  border: 0.7px solid
+    ${({ theme }) =>
+      theme.colors.primary.getVariant({ a: () => 0.05 }).toCssValue()};
+`
+
+const Container = styled.div`
   ${takeWholeSpace};
+  position: relative;
+  padding: 0 16px;
 
   ${vStack({
     alignItems: 'center',
@@ -47,15 +81,23 @@ const Container = styled.div`
   })}
 `
 
+// The design's 360px frame minus its 16px side margins.
+const panelMaxWidth = 328
+
 const Content = styled.div`
-  ${panel()}
-  padding: 26px;
-  ${vStack({
-    gap: 24,
-  })}
+  width: 100%;
+  max-width: ${panelMaxWidth}px;
+  padding: 16px;
+  ${borderRadius.xl};
   background: ${({ theme }) =>
     theme.colors.foregroundSuper.getVariant({ a: () => 0.1 }).toCssValue()};
-  border: 1px solid ${getColor('mistExtra')};
+  border: 1px solid
+    ${({ theme }) =>
+      theme.colors.contrast.getVariant({ a: () => 0.1 }).toCssValue()};
+  ${vStack({
+    alignItems: 'center',
+    gap: 24,
+  })}
 `
 
 export const EnterPasscode = () => {
@@ -242,17 +284,27 @@ export const EnterPasscode = () => {
 
   return (
     <Wrapper>
+      <Glow />
+      <Ring />
       <Container>
-        <VStack alignItems="center" gap={16}>
-          <Text size={34} color="contrast">
+        {/* 15 lands the subtitle baseline 37px under the title's, as designed */}
+        <VStack alignItems="center" gap={15}>
+          <Text
+            size={34}
+            weight={500}
+            letterSpacing={-1}
+            color="regular"
+            centerHorizontally
+          >
             {t('app_locked')}
           </Text>
-          <Text size={13} color="supporting">
+          <Text variant="footnote" color="shy" centerHorizontally>
             {t('app_locked_description')}
           </Text>
         </VStack>
         <Content>
           <PasscodeInput
+            appearance="dots"
             length={passcodeLength}
             onChange={value => {
               setInputValue(value)

--- a/core/ui/passcodeEncryption/guard/EnterPasscode.tsx
+++ b/core/ui/passcodeEncryption/guard/EnterPasscode.tsx
@@ -100,6 +100,10 @@ const Content = styled.div`
   })}
 `
 
+/**
+ * The App Locked screen. Verifies the entered passcode once it reaches the
+ * stored length, throttles repeated failures, and unlocks the app on success.
+ */
 export const EnterPasscode = () => {
   const { i18n, t } = useTranslation()
   const { getPasscodeEncryption, getVaults, setPasscodeEncryption } = useCore()

--- a/core/ui/passcodeEncryption/manage/PasscodeInput.tsx
+++ b/core/ui/passcodeEncryption/manage/PasscodeInput.tsx
@@ -18,6 +18,10 @@ type PasscodeInputProps = InputProps<string | null> &
     length?: number
   }
 
+/**
+ * A masked numeric passcode field built on `MultiCharacterInput`, defaulting
+ * to the configured passcode length and never offering a paste button.
+ */
 export const PasscodeInput = ({
   autoFocus = false,
   value,

--- a/core/ui/passcodeEncryption/manage/PasscodeInput.tsx
+++ b/core/ui/passcodeEncryption/manage/PasscodeInput.tsx
@@ -9,7 +9,10 @@ import { InputProps, LabelProp } from '@lib/ui/props'
 type PasscodeInputProps = InputProps<string | null> &
   Partial<LabelProp> &
   Partial<
-    Pick<MultiCharacterInputProps, 'validation' | 'validationMessages'>
+    Pick<
+      MultiCharacterInputProps,
+      'validation' | 'validationMessages' | 'appearance'
+    >
   > & {
     autoFocus?: boolean
     length?: number
@@ -22,12 +25,14 @@ export const PasscodeInput = ({
   label,
   validation,
   validationMessages,
+  appearance,
   length = passcodeEncryptionConfig.passcodeLength,
 }: PasscodeInputProps) => {
   return (
     <>
       {label && <InputLabel>{label}</InputLabel>}
       <MultiCharacterInput
+        appearance={appearance}
         autoFocusFirst={autoFocus}
         includePasteButton={false}
         length={length}

--- a/lib/ui/inputs/MultiCharacterInput/MultiCharacterInput.stories.tsx
+++ b/lib/ui/inputs/MultiCharacterInput/MultiCharacterInput.stories.tsx
@@ -20,6 +20,10 @@ const meta: Meta<typeof MultiCharacterInput> = {
       },
       description: 'Visual validation state',
     },
+    appearance: {
+      control: { type: 'radio', options: ['boxes', 'dots'] },
+      description: 'Visible input boxes, or lock-screen ring indicators',
+    },
     includePasteButton: { control: 'boolean' },
     autoFocusFirst: { control: 'boolean' },
     onChange: { action: 'value change' },
@@ -69,6 +73,17 @@ export const LoadingState: Story = {
 export const NoPasteButton: Story = {
   name: 'Without “Paste”',
   args: { includePasteButton: false },
+}
+
+export const Dots: Story = {
+  name: 'Dots (lock screen)',
+  args: {
+    appearance: 'dots',
+    length: 6,
+    includePasteButton: false,
+    secureEntry: true,
+    value: '135',
+  },
 }
 
 export const ControlledExample: Story = {

--- a/lib/ui/inputs/MultiCharacterInput/index.tsx
+++ b/lib/ui/inputs/MultiCharacterInput/index.tsx
@@ -36,6 +36,12 @@ export type MultiCharacterInputProps = InputProps<string | null> &
     appearance?: MultiCharacterInputAppearance
   }
 
+/**
+ * A fixed-length code entry split into one single-character input per
+ * position, with paste, backspace and auto-advance handled across them.
+ * `appearance="boxes"` shows the inputs; `appearance="dots"` hides them
+ * behind lock-screen ring indicators that fill as characters are entered.
+ */
 export const MultiCharacterInput = ({
   length,
   value,
@@ -197,16 +203,6 @@ const dotCellHeight = 43
 const dotSize = 15
 const dotStrokeWidth = 1.5
 
-const DotCell = styled.div`
-  position: relative;
-  flex-shrink: 0;
-  width: ${dotCellWidth}px;
-  height: ${dotCellHeight}px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-`
-
 const Dot = styled.div<{
   validation: DigitGroupInputValidationState
   filled: boolean
@@ -235,6 +231,23 @@ const Dot = styled.div<{
     css`
       background: currentColor;
     `}
+`
+
+// The native input over the ring is invisible, so the ring has to show which
+// digit is active — the same focus treatment Checkbox gives its box.
+const DotCell = styled.div`
+  position: relative;
+  flex-shrink: 0;
+  width: ${dotCellWidth}px;
+  height: ${dotCellHeight}px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:has(:focus-visible) ${Dot} {
+    outline: 2px solid ${getColor('primary')};
+    outline-offset: 2px;
+  }
 `
 
 // Sits invisibly over its ring so clicking the ring focuses the input and the

--- a/lib/ui/inputs/MultiCharacterInput/index.tsx
+++ b/lib/ui/inputs/MultiCharacterInput/index.tsx
@@ -3,6 +3,7 @@ import { HStack, VStack } from '@lib/ui/layout/Stack'
 import { getColor } from '@lib/ui/theme/getters'
 import { capitalizeFirstLetter } from '@vultisig/lib-utils/capitalizeFirstLetter'
 import { match } from '@vultisig/lib-utils/match'
+import { ComponentPropsWithRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
 
@@ -17,6 +18,13 @@ type ValidationMessages = Partial<
   Record<Exclude<DigitGroupInputValidationState, 'idle'>, string>
 >
 
+/**
+ * `boxes` renders each character in a visible input box; `dots` hides the
+ * inputs behind small ring indicators that fill as characters are entered,
+ * the way a lock screen shows a passcode.
+ */
+export type MultiCharacterInputAppearance = 'boxes' | 'dots'
+
 export type MultiCharacterInputProps = InputProps<string | null> &
   Pick<UiProps, 'className'> & {
     length: number
@@ -25,6 +33,7 @@ export type MultiCharacterInputProps = InputProps<string | null> &
     autoFocusFirst?: boolean
     validationMessages?: ValidationMessages
     secureEntry?: boolean
+    appearance?: MultiCharacterInputAppearance
   }
 
 export const MultiCharacterInput = ({
@@ -37,6 +46,7 @@ export const MultiCharacterInput = ({
   autoFocusFirst = true,
   className,
   secureEntry = false,
+  appearance = 'boxes',
   ...rest
 }: MultiCharacterInputProps) => {
   const { t } = useTranslation()
@@ -52,26 +62,40 @@ export const MultiCharacterInput = ({
   }
 
   return (
-    <VStack gap={12}>
-      <DigitInputWrapper alignItems="center" gap={12} className={className}>
-        {digits.map((digit, idx) => (
-          <DigitInput
-            key={idx}
-            type={secureEntry ? 'password' : 'text'}
-            inputMode="numeric"
-            pattern="[0-9]*"
-            maxLength={1}
-            value={digit}
-            validation={validation}
-            autoFocus={autoFocusFirst && idx === 0}
-            onChange={e => handleChange(e, idx)}
-            disabled={isDisabled}
-            onKeyDown={e => handleKeyDown(e, idx)}
-            onPaste={handlePaste}
-            ref={getRefCallback(idx)}
-            {...rest}
-          />
-        ))}
+    <VStack gap={12} alignItems={appearance === 'dots' ? 'center' : undefined}>
+      <DigitInputWrapper
+        alignItems="center"
+        gap={appearance === 'dots' ? 0 : 12}
+        className={className}
+      >
+        {digits.map((digit, idx) => {
+          const inputProps: ComponentPropsWithRef<'input'> = {
+            type: secureEntry ? 'password' : 'text',
+            inputMode: 'numeric',
+            pattern: '[0-9]*',
+            maxLength: 1,
+            value: digit,
+            autoFocus: autoFocusFirst && idx === 0,
+            onChange: e => handleChange(e, idx),
+            disabled: isDisabled,
+            onKeyDown: e => handleKeyDown(e, idx),
+            onPaste: handlePaste,
+            ref: getRefCallback(idx),
+            ...rest,
+          }
+
+          return match(appearance, {
+            boxes: () => (
+              <DigitInput key={idx} validation={validation} {...inputProps} />
+            ),
+            dots: () => (
+              <DotCell key={idx}>
+                <Dot validation={validation} filled={!!digit} />
+                <DotInput {...inputProps} />
+              </DotCell>
+            ),
+          })
+        })}
 
         {includePasteButton && (
           <PasteButton
@@ -112,15 +136,20 @@ const DigitInputWrapper = styled(HStack)`
   max-width: fit-content;
 `
 
+const digitBoxSize = 46
+
+// Boxes shrink evenly when the container is narrower than the full row, so the
+// last box is never clipped in the 360px popup; they never grow past 46px.
 const DigitInput = styled.input.attrs({
   autoComplete: 'one-time-code',
   name: 'one-time-code',
 })<{
   validation: DigitGroupInputValidationState
 }>`
-  flex: 1;
-  width: 46px;
-  height: 46px;
+  flex: 1 1 ${digitBoxSize}px;
+  min-width: 0;
+  max-width: ${digitBoxSize}px;
+  aspect-ratio: 1;
   text-align: center;
   font-size: 18px;
   border: 2px solid transparent;
@@ -160,6 +189,66 @@ const DigitInput = styled.input.attrs({
         color: ${getColor('buttonTextDisabled')};
       `,
     })}
+`
+
+// A 35px pitch between 15px rings, with the cell tall enough to tap.
+const dotCellWidth = 35
+const dotCellHeight = 43
+const dotSize = 15
+const dotStrokeWidth = 1.5
+
+const DotCell = styled.div`
+  position: relative;
+  flex-shrink: 0;
+  width: ${dotCellWidth}px;
+  height: ${dotCellHeight}px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`
+
+const Dot = styled.div<{
+  validation: DigitGroupInputValidationState
+  filled: boolean
+}>`
+  width: ${dotSize}px;
+  height: ${dotSize}px;
+  ${borderRadius.pill};
+  border: ${dotStrokeWidth}px solid;
+
+  ${({ validation }) => {
+    const color = match(validation, {
+      idle: () => getColor('contrast'),
+      valid: () => getColor('primary'),
+      invalid: () => getColor('danger'),
+      loading: () => getColor('buttonTextDisabled'),
+    })
+
+    return css`
+      border-color: ${color};
+      color: ${color};
+    `
+  }}
+
+  ${({ filled }) =>
+    filled &&
+    css`
+      background: currentColor;
+    `}
+`
+
+// Sits invisibly over its ring so clicking the ring focuses the input and the
+// caret, the masking character and the browser's own styling never show.
+const DotInput = styled.input.attrs({
+  autoComplete: 'one-time-code',
+  name: 'one-time-code',
+})`
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: text;
 `
 
 const PasteButton = styled(Button)`


### PR DESCRIPTION
Closes #4931

## Problem
`MultiCharacterInput` renders six 46px boxes with 12px gaps — a fixed 336px row that never shrinks. In the 360px popup it was clipped on **App Locked** (the wrapping panel was 390px wide, running off both edges) and inside the **Change Passcode** modal (310px of content, last box cut by `overflow-x: hidden`).

App Locked also didn't match the design, which uses 15px ring indicators inside a full-width 77px panel rather than input boxes.

## Changes
- **`MultiCharacterInput`** (`@lib/ui`)
  - Boxes now `flex: 1 1 46px; min-width: 0; max-width: 46px; aspect-ratio: 1` — they shrink evenly when the container is narrower than the row and never exceed 46px. Fixes Change Passcode and Set Passcode without touching the call sites.
  - New `appearance="dots"`: each digit is a 35×43 cell with a 15px / 1.5px ring that fills when a digit is entered (danger on `invalid`, primary on `valid`, dimmed on `loading`). The per-digit `<input>` sits invisibly over the ring, so the existing hook's paste / backspace / auto-advance behaviour is unchanged. Story added.
- **`PasscodeInput`** threads `appearance` through.
- **`EnterPasscode`** rebuilt on the design geometry (extracted from the Figma SVG export):
  - panel: 16px side margins (328px max), 16px padding, 77px tall incl. border, `borderRadius.xl`, `foregroundSuper` @ 10%, 1px `contrast` @ 10% border
  - dots: 15px rings on a 35px pitch, centred
  - title `34 / 500 / -1px tracking / text`, subtitle `variant="footnote" color="shy"`, 15px between them (37px baseline-to-baseline), 36px to the panel
  - backdrop: 648px blurred glow (`primaryAccentTwo` @ 0.57 → `background` @ 0.41, 50% opacity) and a faint `primary` @ 5% ring, centred 20px right / 50px below the frame centre as in the design

Design: https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=38132-58881&t=XzIeKyiWHc6C01Co-0

## Not included
- The design's **"Use touch ID"** row — there is no biometric unlock in the extension or desktop app, so a control for it would be a feature, not a style fix.
- Set / Change Passcode keep the box appearance (only the overflow is fixed); no design reference for them was in scope.

## Verification
- `yarn check` passes.
- Playwright probe at 360×600 against the built extension:
  - Change Passcode: all 18 boxes at 41.67px, last box ends at x=335; `scrollWidth === 360`.
  - App Locked: panel `x=16 w=328 h=77 radius=24px`, dots at 35px pitch centred on x=180, title `34px/500 ls -1px`, subtitle `13px/500 ls 0.06px lh 18px`; `scrollWidth === 360`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Passcode inputs now support two visual styles: boxes and dots.
  - Dot-style passcode entry provides a masked, secure six-character input experience.
  - Passcode appearance can be configured across supported passcode screens.

- **Style**
  - Refined passcode screen layout, typography, spacing, backdrop effects, and input visuals.
  - Improved responsive sizing and visual states, including validation, filled states, and keyboard focus indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->