### PR TITLE
fix(passcode): keep keyboard focus on the cells after a rejected entry

### DIFF
--- a/clients/extension/tests/unit/multiCharacterInputFocus.test.tsx
+++ b/clients/extension/tests/unit/multiCharacterInputFocus.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment happy-dom
+/**
+ * Guards https://github.com/vultisig/vultisig-windows/issues/4933: while the
+ * entry is being verified the cells are disabled, which drops keyboard focus.
+ * When they come back the user must be able to keep typing without clicking.
+ */
+import { MultiCharacterInput } from '@lib/ui/inputs/MultiCharacterInput'
+import { darkTheme } from '@lib/ui/theme/darkTheme'
+import { ThemeProvider } from '@lib/ui/theme/ThemeProvider'
+import { render } from '@testing-library/react'
+import { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+// The loading spinner is a Rive animation that fetches its runtime on import.
+vi.mock('@lib/ui/loaders/Spinner', () => ({ Spinner: () => null }))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+  Trans: ({ children }: { children?: ReactNode }) => children ?? null,
+}))
+
+const length = 6
+
+const renderInput = (props: {
+  value: string | null
+  validation: 'idle' | 'loading' | 'invalid' | 'valid'
+}) =>
+  render(
+    <ThemeProvider theme={darkTheme}>
+      <MultiCharacterInput
+        autoFocusFirst={false}
+        includePasteButton={false}
+        length={length}
+        onChange={() => {}}
+        {...props}
+      />
+    </ThemeProvider>
+  )
+
+const getCells = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll('input'))
+
+describe('MultiCharacterInput focus after verification', () => {
+  it('focuses the first cell when the entry was cleared on failure', () => {
+    const { container, rerender } = renderInput({
+      value: '123456',
+      validation: 'loading',
+    })
+    expect(document.activeElement).not.toBe(getCells(container)[0])
+
+    rerender(
+      <ThemeProvider theme={darkTheme}>
+        <MultiCharacterInput
+          autoFocusFirst={false}
+          includePasteButton={false}
+          length={length}
+          onChange={() => {}}
+          value={null}
+          validation="invalid"
+        />
+      </ThemeProvider>
+    )
+
+    expect(document.activeElement).toBe(getCells(container)[0])
+  })
+
+  it('focuses the last cell when the rejected entry is kept', () => {
+    const { container, rerender } = renderInput({
+      value: '123456',
+      validation: 'loading',
+    })
+
+    rerender(
+      <ThemeProvider theme={darkTheme}>
+        <MultiCharacterInput
+          autoFocusFirst={false}
+          includePasteButton={false}
+          length={length}
+          onChange={() => {}}
+          value="123456"
+          validation="invalid"
+        />
+      </ThemeProvider>
+    )
+
+    expect(document.activeElement).toBe(getCells(container)[length - 1])
+  })
+
+  it('does not move focus while the cells stay enabled', () => {
+    const { container, rerender } = renderInput({
+      value: null,
+      validation: 'idle',
+    })
+    const [, second] = getCells(container)
+    second.focus()
+
+    rerender(
+      <ThemeProvider theme={darkTheme}>
+        <MultiCharacterInput
+          autoFocusFirst={false}
+          includePasteButton={false}
+          length={length}
+          onChange={() => {}}
+          value="1"
+          validation="idle"
+        />
+      </ThemeProvider>
+    )
+
+    expect(document.activeElement).toBe(second)
+  })
+})

--- a/lib/ui/inputs/MultiCharacterInput/index.tsx
+++ b/lib/ui/inputs/MultiCharacterInput/index.tsx
@@ -40,10 +40,9 @@ export const MultiCharacterInput = ({
   ...rest
 }: MultiCharacterInputProps) => {
   const { t } = useTranslation()
-  const { digits, handleChange, handleKeyDown, handlePaste, getRefCallback } =
-    useMultiCharacterInput({ length, value, onChange })
-
   const isDisabled = validation === 'loading'
+  const { digits, handleChange, handleKeyDown, handlePaste, getRefCallback } =
+    useMultiCharacterInput({ length, value, onChange, isDisabled })
 
   const derivedValidationMessages = {
     valid: validationMessages.valid ?? t('digit_input_success_validation'),

--- a/lib/ui/inputs/MultiCharacterInput/index.tsx
+++ b/lib/ui/inputs/MultiCharacterInput/index.tsx
@@ -27,6 +27,12 @@ export type MultiCharacterInputProps = InputProps<string | null> &
     secureEntry?: boolean
   }
 
+/**
+ * A row of single-character inputs for codes and passcodes. `loading`
+ * validation disables the cells; once it ends, focus returns to the first
+ * cell when the value was cleared and to the last one otherwise, so the user
+ * can keep typing without clicking.
+ */
 export const MultiCharacterInput = ({
   length,
   value,

--- a/lib/ui/inputs/MultiCharacterInput/useMultiCharacterInput.ts
+++ b/lib/ui/inputs/MultiCharacterInput/useMultiCharacterInput.ts
@@ -14,6 +14,12 @@ type UseMultiCharacterInputArgs = {
   isDisabled: boolean
 }
 
+/**
+ * Keyboard, paste and focus handling for a row of single-character inputs.
+ * Typing advances to the next cell and Backspace retreats. Pass `isDisabled`
+ * while the inputs are disabled: when they become enabled again focus is put
+ * back on the cell the user would type into next, since disabling drops it.
+ */
 export const useMultiCharacterInput = ({
   length,
   value,

--- a/lib/ui/inputs/MultiCharacterInput/useMultiCharacterInput.ts
+++ b/lib/ui/inputs/MultiCharacterInput/useMultiCharacterInput.ts
@@ -11,12 +11,14 @@ type UseMultiCharacterInputArgs = {
   length: number
   value: string | null
   onChange: (v: string | null) => void
+  isDisabled: boolean
 }
 
 export const useMultiCharacterInput = ({
   length,
   value,
   onChange,
+  isDisabled,
 }: UseMultiCharacterInputArgs) => {
   const inputRefs = useRef<Array<HTMLInputElement | null>>([])
 
@@ -44,6 +46,23 @@ export const useMultiCharacterInput = ({
   useEffect(() => {
     if (!value) setDigits(Array(length).fill(''))
   }, [value, length])
+
+  // Disabling the inputs while the parent verifies the entry drops focus from
+  // the cell being typed in. Once they are enabled again put it on the cell the
+  // user would type into next: the first one when the entry was cleared,
+  // otherwise the last one so Backspace works on a rejected entry. The target
+  // comes from the value prop, not the digits state, because the parent may
+  // clear the value in the same render that re-enables the inputs.
+  const wasDisabledRef = useRef(isDisabled)
+  useEffect(() => {
+    const wasDisabled = wasDisabledRef.current
+    wasDisabledRef.current = isDisabled
+
+    if (!wasDisabled || isDisabled) return
+
+    const idx = value ? Math.min(value.length, length - 1) : 0
+    inputRefs.current[idx]?.focus()
+  }, [isDisabled, length, value])
 
   const commit = (next: string[]) => {
     setDigits(next)


### PR DESCRIPTION
## Summary
- On the lock screen, a wrong passcode left the keyboard with nothing focused: while the entry is verified the cells are rendered `disabled` (`validation === 'loading'`), which makes the browser drop focus from the cell being typed in, and when the attempt fails the cells are cleared and re-enabled without anything focusing them again. Every failed attempt needed a click on the first dot before retyping. A throttling lockout ending had the same gap.
- Fixed where the focus is lost, in `MultiCharacterInput`: when its inputs come back from disabled it focuses the cell the user would type into next — the first one when the entry was cleared, otherwise the last one so Backspace works on a rejected but still-filled entry (fast vault backup keeps the email code on failure). The target is derived from the `value` prop rather than the internal `digits` state, because the parent may clear the value in the same render that re-enables the inputs, before the internal state has caught up.
- Nothing changes on initial mount (`autoFocusFirst` still owns that) and nothing changes in `EnterPasscode`'s verification, throttling or lockout logic.

Closes #4933

## Verification
- New unit test `clients/extension/tests/unit/multiCharacterInputFocus.test.tsx`: focus lands on the first cell when the value was cleared, on the last cell when a rejected value is kept, and does not move while the cells stay enabled.
- Built the extension (with #4932's dots lock screen merged in) and drove it at 360×600 with a throwaway Playwright probe: enable passcode → 1-minute auto-lock → lock by inactivity → type a wrong passcode → "Invalid passcode" shows → `document.activeElement` is the first cell → typing the right passcode with no click unlocks.
- `yarn check` passes.

## Test plan
- [ ] Lock the app, type a wrong passcode: dots clear, "Invalid passcode" shows, and typing again fills the first dot immediately
- [ ] Repeat until the throttle kicks in; when the countdown ends, typing fills the first dot immediately
- [ ] Fast vault backup → enter a wrong email code: focus stays in the code row so Backspace edits it
- [ ] Set / Change passcode flows unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved verification code input focus behavior after validation completes.
  - Focus returns to the first cell when an invalid entry is cleared.
  - Focus moves to the last populated cell when a rejected entry is retained.
  - Focus remains on the current cell while inputs are enabled.
  - Focus is restored appropriately when the input becomes available after loading.
  - Preserved the user’s editing position when verification inputs are re-enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->